### PR TITLE
Add Azure Pipeline Test Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,19 +28,24 @@ endif()
 option(QUIC_BUILD_TOOLS "Builds the tools code" ON)
 option(QUIC_BUILD_TEST "Builds the test code" ON)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/artifacts/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bld/obj)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/artifacts/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/artifacts/obj)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/artifacts/bin)
+file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/artifacts/logs)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Generate the MsQuicEtw header file.
     file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/bld/inc)
+    file(WRITE ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.rc)
     include_directories(${CMAKE_SOURCE_DIR}/bld/inc)
     add_custom_command(
         OUTPUT ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.h
+        OUTPUT ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.rc
         COMMAND mc.exe -um -h ${CMAKE_SOURCE_DIR}/bld/inc -r ${CMAKE_SOURCE_DIR}/bld/inc ${CMAKE_SOURCE_DIR}/manifest/MsQuicEtw.man)
-    add_custom_target(MsQuicEtw DEPENDS ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.h)
-    
+    add_custom_target(MsQuicEtw
+        DEPENDS ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.h
+        DEPENDS ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.rc)
+
     # Custom build flags.
     set(QUIC_C_FLAGS "-DWIN32_LEAN_AND_MEAN -DSECURITY_WIN32 -DQUIC_EVENTS_MANIFEST_ETW -DQUIC_LOGS_STUB -DQUIC_NO_TAEF -DQUIC_0RTT_UNSUPPORTED /W4 /wd4100 /wd4101 /wd4189 /wd4458 /wd4459 /wd4702 /wd26451 /wd26812 /sdl")
     set(QUIC_CXX_FLAGS "${QUIC_C_FLAGS}")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-# Builds the code for Linux and Windows.
+# Continuous integration for Linux and Windows.
 # https://aka.ms/yaml
 
 trigger:
@@ -6,14 +6,21 @@ trigger:
 
 strategy:
   matrix:
-    linux:
+    linux-stub:
+      platform: 'Linux-Stub'
       imageName: 'ubuntu-latest'
-      cmakeArgs: '-g ''Linux Makefiles'''
-      testCmd: './artifacts/bin/msquictest'
-    windows-x64:
+      cmakeArgs: '-g ''Linux Makefiles'' -DQUIC_TLS=stub'
+      testCmd: 'bash ./test/run_linux.sh'
+    windows-x64-stub:
+      platform: 'Windows-x64-Stub'
       imageName: 'windows-latest'
-      cmakeArgs: '-g ''Visual Studio 16 2019'' -A x64'
-      testCmd: '.\artifacts\bin\Release\msquictest.exe'
+      cmakeArgs: '-g ''Visual Studio 16 2019'' -A x64 -DQUIC_TLS=stub'
+      testCmd: '.\test\run_windows.cmd'
+    windows-x64-schannel:
+      platform: 'Windows-x64-Schannel'
+      imageName: 'windows-latest'
+      cmakeArgs: '-g ''Visual Studio 16 2019'' -A x64 -DQUIC_TLS=schannel'
+      testCmd: 'echo Not supported yet'
 
 pool:
   vmImage: $(imageName)
@@ -33,7 +40,20 @@ steps:
   inputs:
     cmakeArgs: '--build . --config RELEASE'
 
-#- task: CmdLine@2
-#  displayName: 'Run Tests'
-#  inputs:
-#    script: '$(testCmd)'
+- task: CmdLine@2
+  displayName: 'Run Tests'
+  inputs:
+    script: '$(testCmd)'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/*test-results.xml'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifacts'
+  inputs:
+    PathtoPublish: 'artifacts'
+    ArtifactName: '$(platform)-Artifacts'
+    publishLocation: 'Container'

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    set(SOURCES winuser/dllmain.c winuser/msquic.rc)
+    set(SOURCES winuser/dllmain.c winuser/msquic.rc ${CMAKE_SOURCE_DIR}/bld/inc/MsQuicEtw.rc)
 else()
     set(SOURCES linux/init.c)
 endif()

--- a/test/run_linux.sh
+++ b/test/run_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Setup logs.
+echo "Making sure syslog is running..."
+sudo service rsyslog start
+echo "Clearing syslog file..."
+sudo truncate -s 0 /var/log/syslog
+
+# Run the tests.
+./artifacts/bin/msquictest \
+    --gtest_filter=Handshake*:Basic* \
+    --gtest_output=xml:artifacts/logs/linux-test-results.xml
+
+# Copy logs to log folder (with correct permsissions).
+echo "Copying logs..."
+cd ./artifacts/logs
+sudo cp /var/log/syslog .
+sudo chmod -R 0777 .

--- a/test/run_windows.cmd
+++ b/test/run_windows.cmd
@@ -1,0 +1,26 @@
+
+:: Import our ETW manifest.
+wevtutil im manifest\MsQuicEtw.man ^
+    /rf:%cd%\artifacts\bin\Release\msquic.dll ^
+    /mf:%cd%\artifacts\bin\Release\msquic.dll
+
+:: Start log collection.
+mkdir artifacts\logs\wfp
+netsh trace start sessionname=quic ^
+    overwrite=yes report=dis correlation=dis maxSize=1024 ^
+    traceFile=artifacts\logs\quic.etl ^
+    provider=Microsoft-Quic level=0x5
+
+:: Run the tests.
+artifacts\bin\Release\msquictest.exe ^
+    --gtest_filter=Handshake*:Basic* ^
+    --gtest_output=xml:artifacts\logs\windows-test-results.xml
+
+:: Stop log collection.
+netsh trace stop sessionname=quic
+
+:: Convert ETW logs to text.
+netsh trace convert ^
+    artifacts\logs\quic.etl ^
+    output=artifacts\logs\quic.log ^
+    overwrite=yes


### PR DESCRIPTION
This PR integrates test support to Azure Pipeline builds, currently using stub TLS. Other TLS implementations will have tests come online in the future.