### PR TITLE
Bail on NULL Key in QuicPacketBuilderPrepare

### DIFF
--- a/core/packet_builder.c
+++ b/core/packet_builder.c
@@ -128,7 +128,19 @@ QuicPacketBuilderPrepare(
         DatagramSize = (uint16_t)Builder->Path->Allowance;
     }
     QUIC_DBG_ASSERT(!IsPathMtuDiscovery || !IsTailLossProbe); // Never both.
-    QUIC_DBG_ASSERT(NewPacketKey != NULL);
+
+    if (NewPacketKey == NULL) {
+        //
+        // A NULL key here usually means the connection had a fatal error in
+        // such a way that resulted in the key not getting created. The
+        // connection is most likely trying to send a connection close frame,
+        // but without the key, nothing can be done. Just silently kill the
+        // connection.
+        //
+        QuicTraceEvent(ConnError, Connection, "NULL key in builder prepare");
+        QuicConnSilentlyAbort(Connection);
+        return FALSE;
+    }
 
     //
     // Next, make sure the current QUIC packet matches the new packet type. If


### PR DESCRIPTION
There are cases (i.e. OOM) where the connection tries to fatal error (which normally results in a connection close being sent to the peer) but wasn't able to create the key necessary to send it. This PR just silently aborts the connection in this case.