### PR TITLE
Retire Prior To Support & CID Rename

### DIFF
--- a/core/binding.h
+++ b/core/binding.h
@@ -48,12 +48,12 @@ typedef struct QUIC_RECV_PACKET {
     //
     // Destination connection ID.
     //
-    const uint8_t* DestCID;
+    const uint8_t* DestCid;
 
     //
     // Sources connection ID. Only valid for long header packets.
     //
-    const uint8_t* SourceCID;
+    const uint8_t* SourceCid;
 
     //
     // Length of the Buffer array.
@@ -73,8 +73,8 @@ typedef struct QUIC_RECV_PACKET {
     //
     // Lengths of the destination and source connection IDs
     //
-    uint8_t DestCIDLen;
-    uint8_t SourceCIDLen;
+    uint8_t DestCidLen;
+    uint8_t SourceCidLen;
 
     //
     // The type of key used to decrypt the packet.
@@ -318,7 +318,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicBindingAddSourceConnectionID(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCID
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid
     );
 
 //
@@ -328,7 +328,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicBindingRemoveSourceConnectionID(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCID
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid
     );
 
 //
@@ -430,7 +430,7 @@ QuicRetryTokenDecrypt(
     QuicCopyMemory(Token, TokenBuffer, sizeof(QUIC_RETRY_TOKEN_CONTENTS));
 
     uint8_t Iv[QUIC_IV_LENGTH];
-    QuicCopyMemory(Iv, Packet->DestCID, MSQUIC_CONNECTION_ID_LENGTH);
+    QuicCopyMemory(Iv, Packet->DestCid, MSQUIC_CONNECTION_ID_LENGTH);
     QuicZeroMemory(
         Iv + MSQUIC_CONNECTION_ID_LENGTH,
         QUIC_IV_LENGTH - MSQUIC_CONNECTION_ID_LENGTH);

--- a/core/connection.c
+++ b/core/connection.c
@@ -92,7 +92,7 @@ QuicConnAlloc(
     Connection->PeerTransportParams.AckDelayExponent = QUIC_DEFAULT_ACK_DELAY_EXPONENT;
     Connection->ReceiveQueueTail = &Connection->ReceiveQueue;
     QuicDispatchLockInitialize(&Connection->ReceiveQueueLock);
-    QuicListInitializeHead(&Connection->DestCIDs);
+    QuicListInitializeHead(&Connection->DestCids);
     QuicStreamSetInitialize(&Connection->Streams);
     QuicSendBufferInitialize(&Connection->SendBuffer);
     QuicOperationQueueInitialize(&Connection->OperQ);
@@ -121,7 +121,7 @@ QuicConnAlloc(
             QuicDataPathRecvDatagramToRecvPacket(Datagram);
 
         Connection->Type = QUIC_HANDLE_TYPE_CHILD;
-        Connection->ServerID = Packet->DestCID[QUIC_CID_SID_INDEX];
+        Connection->ServerID = Packet->DestCid[QUIC_CID_SID_INDEX];
         Connection->PartitionID = AllocProcIndex; // Used in tuple RSS modes.
 
         Connection->Stats.QuicVersion = Packet->Invariant->LONG_HDR.Version;
@@ -142,25 +142,25 @@ QuicConnAlloc(
             (const uint8_t*)&Path->RemoteAddress);
 
         Path->DestCid =
-            QuicCidNewDestination(Packet->SourceCIDLen, Packet->SourceCID);
+            QuicCidNewDestination(Packet->SourceCidLen, Packet->SourceCid);
         if (Path->DestCid == NULL) {
             goto Error;
         }
         Path->DestCid->CID.UsedLocally = TRUE;
-        QuicListInsertTail(&Connection->DestCIDs, &Path->DestCid->Link);
+        QuicListInsertTail(&Connection->DestCids, &Path->DestCid->Link);
         QuicTraceEvent(ConnDestCidAdded,
             Connection, Path->DestCid->CID.Length, Path->DestCid->CID.Data);
 
-        QUIC_CID_HASH_ENTRY* SourceCID =
-            QuicCidNewSource(Connection, Packet->DestCIDLen, Packet->DestCID);
-        if (SourceCID == NULL) {
+        QUIC_CID_HASH_ENTRY* SourceCid =
+            QuicCidNewSource(Connection, Packet->DestCidLen, Packet->DestCid);
+        if (SourceCid == NULL) {
             goto Error;
         }
-        SourceCID->CID.IsInitial = TRUE;
-        SourceCID->CID.UsedByPeer = TRUE;
-        QuicListPushEntry(&Connection->SourceCIDs, &SourceCID->Link);
+        SourceCid->CID.IsInitial = TRUE;
+        SourceCid->CID.UsedByPeer = TRUE;
+        QuicListPushEntry(&Connection->SourceCids, &SourceCid->Link);
         QuicTraceEvent(ConnSourceCidAdded,
-            Connection, SourceCID->CID.Length, SourceCID->CID.Data);
+            Connection, SourceCid->CID.Length, SourceCid->CID.Data);
 
     } else {
         Connection->Type = QUIC_HANDLE_TYPE_CLIENT;
@@ -173,8 +173,8 @@ QuicConnAlloc(
             goto Error;
         }
         Path->DestCid->CID.UsedLocally = TRUE;
-        Connection->DestCIDCount++;
-        QuicListInsertTail(&Connection->DestCIDs, &Path->DestCid->Link);
+        Connection->DestCidCount++;
+        QuicListInsertTail(&Connection->DestCids, &Path->DestCid->Link);
         QuicTraceEvent(ConnDestCidAdded,
             Connection, Path->DestCid->CID.Length, Path->DestCid->CID.Data);
     }
@@ -264,10 +264,10 @@ Error:
         if (Datagram != NULL) {
             QUIC_FREE(
                 QUIC_CONTAINING_RECORD(
-                    Connection->SourceCIDs.Next,
+                    Connection->SourceCids.Next,
                     QUIC_CID_HASH_ENTRY,
                     Link));
-            Connection->SourceCIDs.Next = NULL;
+            Connection->SourceCids.Next = NULL;
         }
         QuicConnRelease(Connection, QUIC_CONN_REF_HANDLE_OWNER);
         break;
@@ -288,14 +288,14 @@ QuicConnFree(
         QUIC_TEL_ASSERT(Connection->State.HandleClosed);
         QUIC_TEL_ASSERT(Connection->State.Uninitialized);
     }
-    QUIC_TEL_ASSERT(Connection->SourceCIDs.Next == NULL);
+    QUIC_TEL_ASSERT(Connection->SourceCids.Next == NULL);
     QUIC_TEL_ASSERT(QuicListIsEmpty(&Connection->Streams.ClosedStreams));
     QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
-    while (!QuicListIsEmpty(&Connection->DestCIDs)) {
+    while (!QuicListIsEmpty(&Connection->DestCids)) {
         QUIC_CID_QUIC_LIST_ENTRY *CID =
             QUIC_CONTAINING_RECORD(
-                QuicListRemoveHead(&Connection->DestCIDs),
+                QuicListRemoveHead(&Connection->DestCids),
                 QUIC_CID_QUIC_LIST_ENTRY,
                 Link);
         QUIC_FREE(CID);
@@ -522,27 +522,27 @@ QuicConnTraceRundownOper(
                     (const uint8_t*)&Connection->Paths[i].RemoteAddress);
             }
         }
-        for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCIDs.Next;
+        for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCids.Next;
                 Entry != NULL;
                 Entry = Entry->Next) {
-            const QUIC_CID_HASH_ENTRY* SourceCID =
+            const QUIC_CID_HASH_ENTRY* SourceCid =
                 QUIC_CONTAINING_RECORD(
                     Entry,
                     QUIC_CID_HASH_ENTRY,
                     Link);
             QuicTraceEvent(ConnSourceCidAdded,
-                Connection, SourceCID->CID.Length, SourceCID->CID.Data);
+                Connection, SourceCid->CID.Length, SourceCid->CID.Data);
         }
-        for (QUIC_LIST_ENTRY* Entry = Connection->DestCIDs.Flink;
-                Entry != &Connection->DestCIDs;
+        for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+                Entry != &Connection->DestCids;
                 Entry = Entry->Flink) {
-            const QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+            const QUIC_CID_QUIC_LIST_ENTRY* DestCid =
                 QUIC_CONTAINING_RECORD(
                     Entry,
                     QUIC_CID_QUIC_LIST_ENTRY,
                     Link);
             QuicTraceEvent(ConnDestCidAdded,
-                Connection, DestCID->CID.Length, DestCID->CID.Data);
+                Connection, DestCid->CID.Length, DestCid->CID.Data);
         }
     }
     if (Connection->State.Connected) {
@@ -683,7 +683,7 @@ QuicConnGenerateNewSourceCid(
     )
 {
     uint8_t TryCount = 0;
-    QUIC_CID_HASH_ENTRY* SourceCID;
+    QUIC_CID_HASH_ENTRY* SourceCid;
 
     if (!Connection->State.ShareBinding) {
         //
@@ -699,7 +699,7 @@ QuicConnGenerateNewSourceCid(
     //
 
     do {
-        SourceCID =
+        SourceCid =
             QuicCidNewRandomSource(
                 Connection,
                 Connection->ServerID,
@@ -707,42 +707,42 @@ QuicConnGenerateNewSourceCid(
                 Connection->Registration->CidPrefixLength,
                 Connection->Registration->CidPrefix,
                 MSQUIC_CONNECTION_ID_LENGTH);
-        if (SourceCID == NULL) {
+        if (SourceCid == NULL) {
             QuicTraceEvent(AllocFailure, "new Src CID", sizeof(QUIC_CID_HASH_ENTRY) + MSQUIC_CONNECTION_ID_LENGTH);
             return NULL;
         }
-        if (!QuicBindingAddSourceConnectionID(Connection->Paths[0].Binding, SourceCID)) {
-            QUIC_FREE(SourceCID);
-            SourceCID = NULL;
+        if (!QuicBindingAddSourceConnectionID(Connection->Paths[0].Binding, SourceCid)) {
+            QUIC_FREE(SourceCid);
+            SourceCid = NULL;
             if (++TryCount > QUIC_CID_MAX_COLLISION_RETRY) {
                 QuicTraceEvent(ConnError, Connection, "Too many CID collisions");
                 return NULL;
             }
             QuicTraceLogConnVerbose(NewSrcCidNameCollision, Connection, "CID collision, trying again.");
         }
-    } while (SourceCID == NULL);
+    } while (SourceCid == NULL);
 
-    QuicTraceEvent(ConnSourceCidAdded, Connection, SourceCID->CID.Length, SourceCID->CID.Data);
+    QuicTraceEvent(ConnSourceCidAdded, Connection, SourceCid->CID.Length, SourceCid->CID.Data);
 
-    SourceCID->CID.SequenceNumber = Connection->NextSourceCidSequenceNumber++;
-    if (SourceCID->CID.SequenceNumber > 0) {
-        SourceCID->CID.NeedsToSend = TRUE;
+    SourceCid->CID.SequenceNumber = Connection->NextSourceCidSequenceNumber++;
+    if (SourceCid->CID.SequenceNumber > 0) {
+        SourceCid->CID.NeedsToSend = TRUE;
         QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_NEW_CONNECTION_ID);
     }
 
     if (IsInitial) {
-        SourceCID->CID.IsInitial = TRUE;
-        QuicListPushEntry(&Connection->SourceCIDs, &SourceCID->Link);
+        SourceCid->CID.IsInitial = TRUE;
+        QuicListPushEntry(&Connection->SourceCids, &SourceCid->Link);
     } else {
-        QUIC_SINGLE_LIST_ENTRY** Tail = &Connection->SourceCIDs.Next;
+        QUIC_SINGLE_LIST_ENTRY** Tail = &Connection->SourceCids.Next;
         while (*Tail != NULL) {
             Tail = &(*Tail)->Next;
         }
-        *Tail = &SourceCID->Link;
-        SourceCID->Link.Next = NULL;
+        *Tail = &SourceCid->Link;
+        SourceCid->Link.Next = NULL;
     }
 
-    return SourceCID;
+    return SourceCid;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -751,8 +751,8 @@ QuicConnGetUnusedDestCid(
     _In_ const QUIC_CONNECTION* Connection
     )
 {
-    for (QUIC_LIST_ENTRY* Entry = Connection->DestCIDs.Flink;
-            Entry != &Connection->DestCIDs;
+    for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+            Entry != &Connection->DestCids;
             Entry = Entry->Flink) {
         QUIC_CID_QUIC_LIST_ENTRY* DestCid =
             QUIC_CONTAINING_RECORD(
@@ -764,6 +764,20 @@ QuicConnGetUnusedDestCid(
         }
     }
     return NULL;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicConnRetireCid(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_CID_QUIC_LIST_ENTRY* DestCid
+    )
+{
+    QuicTraceEvent(ConnDestCidRemoved, Connection, DestCid->CID.Length, DestCid->CID.Data);
+    Connection->DestCidCount--;
+    DestCid->CID.Retired = TRUE;
+    DestCid->CID.NeedsToSend = TRUE;
+    QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_RETIRE_CONNECTION_ID);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -784,16 +798,73 @@ QuicConnRetireCurrentDestCid(
         return FALSE;
     }
 
-    QuicTraceEvent(ConnDestCidRemoved,
-        Connection, Path->DestCid->CID.Length, Path->DestCid->CID.Data);
-    Connection->DestCIDCount--;
-    Path->DestCid->CID.Retired = TRUE;
-    Path->DestCid->CID.NeedsToSend = TRUE;
-    QuicSendSetSendFlag(
-        &Connection->Send, QUIC_CONN_SEND_FLAG_RETIRE_CONNECTION_ID);
-
+    QuicConnRetireCid(Connection, Path->DestCid);
     Path->DestCid = NewDestCid;
     Path->DestCid->CID.UsedLocally = TRUE;
+
+    return TRUE;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicConnOnRetirePriorToUpdated(
+    _In_ QUIC_CONNECTION* Connection
+    )
+{
+    BOOLEAN ReplaceRetiredCids = FALSE;
+
+    for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+            Entry != &Connection->DestCids;
+            Entry = Entry->Flink) {
+        QUIC_CID_QUIC_LIST_ENTRY* DestCid =
+            QUIC_CONTAINING_RECORD(
+                Entry,
+                QUIC_CID_QUIC_LIST_ENTRY,
+                Link);
+        if (DestCid->CID.SequenceNumber >= Connection->RetirePriorTo ||
+            DestCid->CID.Retired) {
+            continue;
+        }
+
+        if (DestCid->CID.UsedLocally) {
+            ReplaceRetiredCids = TRUE;
+        }
+
+        QuicConnRetireCid(Connection, DestCid);
+    }
+
+    return ReplaceRetiredCids;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicConnReplaceRetiredCids(
+    _In_ QUIC_CONNECTION* Connection
+    )
+{
+    QUIC_DBG_ASSERT(Connection->PathsCount <= QUIC_MAX_PATH_COUNT);
+    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+        QUIC_PATH* Path = &Connection->Paths[i];
+        if (!Path->DestCid->CID.Retired) {
+            continue;
+        }
+
+        QUIC_CID_QUIC_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
+        if (NewDestCid == NULL) {
+            if (Path->IsActive) {
+                QuicTraceEvent(ConnError, Connection, "Active path has no replacement for retired CID");
+                QuicConnSilentlyAbort(Connection); // Must silently abort because we can't send anything now.
+                return FALSE;
+            }
+            QuicTraceLogConnWarning(NonActivePathCidRetired, Connection, "Non-active path has no replacement for retired CID.");
+            QUIC_DBG_ASSERT(i != 0);
+            QuicPathRemove(Connection, i--);
+            continue;
+        }
+
+        Path->DestCid = NewDestCid;
+        Path->DestCid->CID.UsedLocally = TRUE;
+    }
 
     return TRUE;
 }
@@ -1425,7 +1496,7 @@ QuicConnStart(
     // Clients only need to generate a non-zero length source CID if it
     // intends to share the UDP binding.
     //
-    QUIC_CID_HASH_ENTRY* SourceCID =
+    QUIC_CID_HASH_ENTRY* SourceCid =
         QuicCidNewRandomSource(
             Connection,
             0,
@@ -1434,16 +1505,16 @@ QuicConnStart(
             Connection->Registration->CidPrefix,
             Connection->State.ShareBinding ?
                 MSQUIC_CONNECTION_ID_LENGTH : 0);
-    if (SourceCID == NULL) {
+    if (SourceCid == NULL) {
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Exit;
     }
 
     Connection->NextSourceCidSequenceNumber++;
-    QuicTraceEvent(ConnSourceCidAdded, Connection, SourceCID->CID.Length, SourceCID->CID.Data);
-    QuicListPushEntry(&Connection->SourceCIDs, &SourceCID->Link);
+    QuicTraceEvent(ConnSourceCidAdded, Connection, SourceCid->CID.Length, SourceCid->CID.Data);
+    QuicListPushEntry(&Connection->SourceCids, &SourceCid->Link);
 
-    if (!QuicBindingAddSourceConnectionID(Path->Binding, SourceCID)) {
+    if (!QuicBindingAddSourceConnectionID(Path->Binding, SourceCid)) {
         InterlockedDecrement(&Path->Binding->HandshakeConnections);
         InterlockedExchangeAdd64(
             (int64_t*)&MsQuicLib.CurrentHandshakeMemoryUsage,
@@ -1616,16 +1687,16 @@ QuicConnHandshakeConfigure(
         LocalTP.MaxAckDelay =
             Connection->MaxAckDelayMs + (uint32_t)MsQuicLib.TimerResolutionMs;
 
-        const QUIC_CID_HASH_ENTRY* SourceCID =
+        const QUIC_CID_HASH_ENTRY* SourceCid =
             QUIC_CONTAINING_RECORD(
-                Connection->SourceCIDs.Next,
+                Connection->SourceCids.Next,
                 QUIC_CID_HASH_ENTRY,
                 Link);
         LocalTP.Flags |= QUIC_TP_FLAG_STATELESS_RESET_TOKEN;
         Status =
             QuicBindingGenerateStatelessResetToken(
                 Connection->Paths[0].Binding,
-                SourceCID->CID.Data,
+                SourceCid->CID.Data,
                 LocalTP.StatelessResetToken);
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(ConnErrorStatus, Connection, Status,
@@ -1763,18 +1834,18 @@ QuicConnProcessPeerTransportParameters(
     QuicTraceLogConnInfo(PeerTPSet, Connection, "Peer Transport Parameters Set");
 
     if (Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_STATELESS_RESET_TOKEN) {
-        QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCIDs));
+        QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCids));
         QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
-        QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+        QUIC_CID_QUIC_LIST_ENTRY* DestCid =
             QUIC_CONTAINING_RECORD(
-                Connection->DestCIDs.Flink,
+                Connection->DestCids.Flink,
                 QUIC_CID_QUIC_LIST_ENTRY,
                 Link);
         QuicCopyMemory(
-            DestCID->ResetToken,
+            DestCid->ResetToken,
             Connection->PeerTransportParams.StatelessResetToken,
             QUIC_STATELESS_RESET_TOKEN_LENGTH);
-        DestCID->CID.HasResetToken = TRUE;
+        DestCid->CID.HasResetToken = TRUE;
     }
 
     if (Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_PREFERRED_ADDRESS) {
@@ -1937,7 +2008,7 @@ QuicConnQueueUnreachable(
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
-QuicConnUpdateDestCID(
+QuicConnUpdateDestCid(
     _In_ QUIC_CONNECTION* Connection,
     _In_ const QUIC_RECV_PACKET* const Packet
     )
@@ -1945,59 +2016,59 @@ QuicConnUpdateDestCID(
     QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
     QUIC_DBG_ASSERT(!Connection->State.Connected);
 
-    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCIDs));
-    QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCids));
+    QUIC_CID_QUIC_LIST_ENTRY* DestCid =
         QUIC_CONTAINING_RECORD(
-            Connection->DestCIDs.Flink,
+            Connection->DestCids.Flink,
             QUIC_CID_QUIC_LIST_ENTRY,
             Link);
-    QUIC_DBG_ASSERT(Connection->Paths[0].DestCid == DestCID);
+    QUIC_DBG_ASSERT(Connection->Paths[0].DestCid == DestCid);
 
-    if (Packet->SourceCIDLen != DestCID->CID.Length ||
-        memcmp(Packet->SourceCID, DestCID->CID.Data, DestCID->CID.Length) != 0) {
+    if (Packet->SourceCidLen != DestCid->CID.Length ||
+        memcmp(Packet->SourceCid, DestCid->CID.Data, DestCid->CID.Length) != 0) {
 
         // TODO - Only update for the first packet of each type (Initial and Retry).
 
-        QuicTraceEvent(ConnDestCidRemoved, Connection, DestCID->CID.Length, DestCID->CID.Data);
+        QuicTraceEvent(ConnDestCidRemoved, Connection, DestCid->CID.Length, DestCid->CID.Data);
 
         //
         // We have just received the a packet from a new source CID
-        // from the server. Remove the current DestCID we have for the
+        // from the server. Remove the current DestCid we have for the
         // server (which we randomly generated) and replace it with
         // the one we have just received.
         //
-        if (Packet->SourceCIDLen <= DestCID->CID.Length) {
+        if (Packet->SourceCidLen <= DestCid->CID.Length) {
             //
             // Since the current structure has enough room for the
             // new CID, we will just reuse it.
             //
-            DestCID->CID.IsInitial = FALSE;
-            DestCID->CID.Length = Packet->SourceCIDLen;
-            QuicCopyMemory(DestCID->CID.Data, Packet->SourceCID, DestCID->CID.Length);
+            DestCid->CID.IsInitial = FALSE;
+            DestCid->CID.Length = Packet->SourceCidLen;
+            QuicCopyMemory(DestCid->CID.Data, Packet->SourceCid, DestCid->CID.Length);
         } else {
             //
             // There isn't enough room in the existing structure,
             // so we must allocate a new one and free the old one.
             //
-            QuicListEntryRemove(&DestCID->Link);
-            QUIC_FREE(DestCID);
-            DestCID =
+            QuicListEntryRemove(&DestCid->Link);
+            QUIC_FREE(DestCid);
+            DestCid =
                 QuicCidNewDestination(
-                    Packet->SourceCIDLen,
-                    Packet->SourceCID);
-            if (DestCID == NULL) {
-                Connection->DestCIDCount--;
+                    Packet->SourceCidLen,
+                    Packet->SourceCid);
+            if (DestCid == NULL) {
+                Connection->DestCidCount--;
                 QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, "Out of memory");
                 return FALSE;
             } else {
-                Connection->Paths[0].DestCid = DestCID;
-                DestCID->CID.UsedLocally = TRUE;
-                QuicListInsertHead(&Connection->DestCIDs, &DestCID->Link);
+                Connection->Paths[0].DestCid = DestCid;
+                DestCid->CID.UsedLocally = TRUE;
+                QuicListInsertHead(&Connection->DestCids, &DestCid->Link);
             }
         }
 
-        if (DestCID != NULL) {
-            QuicTraceEvent(ConnDestCidAdded, Connection, DestCID->CID.Length, DestCID->CID.Data);
+        if (DestCid != NULL) {
+            QuicTraceEvent(ConnDestCidAdded, Connection, DestCid->CID.Length, DestCid->CID.Data);
         }
     }
 
@@ -2019,13 +2090,13 @@ QuicConnRecvVerNeg(
 {
     uint32_t SupportedVersion = 0;
 
-    // TODO - Validate the packet's SourceCID is equal to our DestCID.
+    // TODO - Validate the packet's SourceCid is equal to our DestCid.
 
     const uint32_t* ServerVersionList =
         (const uint32_t*)(
-        Packet->VerNeg->DestCID +
-        QuicCidDecodeLength(Packet->VerNeg->SourceCIDLength) +
-        QuicCidDecodeLength(Packet->VerNeg->DestCIDLength));
+        Packet->VerNeg->DestCid +
+        QuicCidDecodeLength(Packet->VerNeg->SourceCidLength) +
+        QuicCidDecodeLength(Packet->VerNeg->DestCidLength));
     uint16_t ServerVersionListLength =
         (Packet->BufferLength - (uint16_t)((uint8_t*)ServerVersionList - Packet->Buffer)) / sizeof(uint32_t);
 
@@ -2117,10 +2188,10 @@ QuicConnRecvRetry(
     //
 
     uint16_t Offset = Packet->HeaderLength;
-    uint8_t OrigDestCIDLength = *(Packet->Buffer + Offset);
+    uint8_t OrigDestCidLength = *(Packet->Buffer + Offset);
     Offset += sizeof(uint8_t);
 
-    if (Packet->BufferLength < Offset + OrigDestCIDLength) {
+    if (Packet->BufferLength < Offset + OrigDestCidLength) {
         QuicPacketLogDrop(Connection, Packet, "No room for ODCID");
         return;
     }
@@ -2134,23 +2205,23 @@ QuicConnRecvRetry(
         Packet->Buffer,
         0);
 
-    const uint8_t* OrigDestCID = Packet->Buffer + Offset;
-    Offset += OrigDestCIDLength;
+    const uint8_t* OrigDestCid = Packet->Buffer + Offset;
+    Offset += OrigDestCidLength;
 
-    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCIDs));
-    QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCids));
+    QUIC_CID_QUIC_LIST_ENTRY* DestCid =
         QUIC_CONTAINING_RECORD(
-            Connection->DestCIDs.Flink,
+            Connection->DestCids.Flink,
             QUIC_CID_QUIC_LIST_ENTRY,
             Link);
 
-    if (OrigDestCIDLength != DestCID->CID.Length ||
-        memcmp(DestCID->CID.Data, OrigDestCID, OrigDestCIDLength) != 0) {
+    if (OrigDestCidLength != DestCid->CID.Length ||
+        memcmp(DestCid->CID.Data, OrigDestCid, OrigDestCidLength) != 0) {
         QuicPacketLogDrop(Connection, Packet, "Invalid ODCID");
         return;
     }
 
-    QUIC_DBG_ASSERT(OrigDestCIDLength <= QUIC_MAX_CONNECTION_ID_LENGTH_V1);
+    QUIC_DBG_ASSERT(OrigDestCidLength <= QUIC_MAX_CONNECTION_ID_LENGTH_V1);
 
     //
     // Cache the Retry token.
@@ -2175,23 +2246,23 @@ QuicConnRecvRetry(
     Connection->OrigCID =
         QUIC_ALLOC_NONPAGED(
             sizeof(QUIC_CID) +
-            OrigDestCIDLength);
+            OrigDestCidLength);
     if (Connection->OrigCID == NULL) {
         QuicTraceEvent(AllocFailure, "OrigCID", TokenLength);
         QuicPacketLogDrop(Connection, Packet, "OrigCID alloc failed");
         return;
     }
 
-    Connection->OrigCID->Length = OrigDestCIDLength;
+    Connection->OrigCID->Length = OrigDestCidLength;
     QuicCopyMemory(
         Connection->OrigCID->Data,
-        OrigDestCID,
-        OrigDestCIDLength);
+        OrigDestCid,
+        OrigDestCidLength);
 
     //
     // Update the (destination) server's CID.
     //
-    if (!QuicConnUpdateDestCID(Connection, Packet)) {
+    if (!QuicConnUpdateDestCid(Connection, Packet)) {
         return;
     }
 
@@ -2206,10 +2277,10 @@ QuicConnRecvRetry(
     Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_INITIAL] = NULL;
     Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_INITIAL] = NULL;
 
-    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCIDs));
-    DestCID =
+    QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCids));
+    DestCid =
         QUIC_CONTAINING_RECORD(
-            Connection->DestCIDs.Flink,
+            Connection->DestCids.Flink,
             QUIC_CID_QUIC_LIST_ENTRY,
             Link);
 
@@ -2219,8 +2290,8 @@ QuicConnRecvRetry(
         QuicPacketKeyCreateInitial(
             QuicConnIsServer(Connection),
             QuicInitialSaltVersion1,
-            DestCID->CID.Length,
-            DestCID->CID.Data,
+            DestCid->CID.Length,
+            DestCid->CID.Data,
             &Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_INITIAL],
             &Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_INITIAL]))) {
         QuicConnFatalError(Connection, Status, "Failed to create initial keys");
@@ -2639,21 +2710,21 @@ QuicConnRecvDecryptAndAuthenticate(
         // Check for a stateless reset packet.
         //
         if (CanCheckForStatelessReset) {
-            for (QUIC_LIST_ENTRY* Entry = Connection->DestCIDs.Flink;
-                    Entry != &Connection->DestCIDs;
+            for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+                    Entry != &Connection->DestCids;
                     Entry = Entry->Flink) {
                 //
                 // Loop through all our stored stateless reset tokens to see if
                 // we have a match.
                 //
-                QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+                QUIC_CID_QUIC_LIST_ENTRY* DestCid =
                     QUIC_CONTAINING_RECORD(
                         Entry,
                         QUIC_CID_QUIC_LIST_ENTRY,
                         Link);
-                if (DestCID->CID.HasResetToken &&
+                if (DestCid->CID.HasResetToken &&
                     memcmp(
-                        DestCID->ResetToken,
+                        DestCid->ResetToken,
                         PacketResetToken,
                         QUIC_STATELESS_RESET_TOKEN_LENGTH) == 0) {
                     QuicTraceLogVerbose("[S][RX][-] SR %s",
@@ -2777,7 +2848,7 @@ QuicConnRecvDecryptAndAuthenticate(
         case QUIC_INITIAL:
             if (!Connection->State.Connected &&
                 !QuicConnIsServer(Connection) &&
-                !QuicConnUpdateDestCID(Connection, Packet)) {
+                !QuicConnUpdateDestCid(Connection, Packet)) {
                 //
                 // Client side needs to respond to the server's new source
                 // connection ID that is received in the first Initial packet.
@@ -3243,26 +3314,41 @@ QuicConnRecvPayload(
                 break; // Ignore frame if we are closed.
             }
 
-            if (Connection->DestCIDCount < QUIC_ACTIVE_CONNECTION_ID_LIMIT) {
-                QUIC_CID_QUIC_LIST_ENTRY* DestCID =
-                    QuicCidNewDestination(
-                        Frame.Length,
-                        Frame.Buffer);
-                if (DestCID == NULL) {
-                    QuicTraceEvent(AllocFailure, "new DestCID", sizeof(QUIC_CID_QUIC_LIST_ENTRY) + Frame.Length);
-                } else {
-                    DestCID->CID.HasResetToken = TRUE;
-                    DestCID->CID.SequenceNumber = Frame.Sequence;
-                    QuicCopyMemory(
-                        DestCID->ResetToken,
-                        Frame.Buffer + Frame.Length,
-                        QUIC_STATELESS_RESET_TOKEN_LENGTH);
-                    QuicTraceEvent(ConnDestCidAdded, Connection, DestCID->CID.Length, DestCID->CID.Data);
-                    QuicListInsertTail(&Connection->DestCIDs, &DestCID->Link);
-                    Connection->DestCIDCount++;
-                }
-            } else {
-                QuicTraceLogConnWarning(CidLimitReached, Connection, "Ignoring new CID from peer, as we have hit our limit (%hu).", QUIC_ACTIVE_CONNECTION_ID_LIMIT);
+            BOOLEAN ReplaceRetiredCids = FALSE;
+            if (Connection->RetirePriorTo < Frame.RetirePriorTo) {
+                Connection->RetirePriorTo = Frame.RetirePriorTo;
+                ReplaceRetiredCids = QuicConnOnRetirePriorToUpdated(Connection);
+            }
+
+            QUIC_CID_QUIC_LIST_ENTRY* DestCid =
+                QuicCidNewDestination(Frame.Length, Frame.Buffer);
+            if (DestCid == NULL) {
+                QuicTraceEvent(AllocFailure, "new DestCid", sizeof(QUIC_CID_QUIC_LIST_ENTRY) + Frame.Length);
+                return FALSE;
+            }
+
+            DestCid->CID.HasResetToken = TRUE;
+            DestCid->CID.SequenceNumber = Frame.Sequence;
+            QuicCopyMemory(
+                DestCid->ResetToken,
+                Frame.Buffer + Frame.Length,
+                QUIC_STATELESS_RESET_TOKEN_LENGTH);
+            QuicTraceEvent(ConnDestCidAdded, Connection, DestCid->CID.Length, DestCid->CID.Data);
+            QuicListInsertTail(&Connection->DestCids, &DestCid->Link);
+            Connection->DestCidCount++;
+
+            if (DestCid->CID.SequenceNumber < Connection->RetirePriorTo) {
+                QuicConnRetireCid(Connection, DestCid);
+            }
+
+            if (Connection->DestCidCount > QUIC_ACTIVE_CONNECTION_ID_LIMIT) {
+                QuicTraceEvent(ConnError, Connection, "Peer exceeded CID limit");
+                QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+                return FALSE;
+            }
+
+            if (ReplaceRetiredCids && !QuicConnReplaceRetiredCids(Connection)) {
+                return FALSE;
             }
 
             AckPacketImmediately = TRUE;
@@ -3438,15 +3524,15 @@ QuicConnRecvPostProcessing(
     )
 {
     BOOLEAN PeerUpdatedCid = FALSE;
-    if (Packet->DestCIDLen != 0) {
+    if (Packet->DestCidLen != 0) {
         QUIC_CID_HASH_ENTRY* SourceCid =
             QuicConnGetSourceCidFromBuf(
                 Connection,
-                Packet->DestCIDLen,
-                Packet->DestCID);
+                Packet->DestCidLen,
+                Packet->DestCid);
         if (SourceCid != NULL && !SourceCid->CID.UsedByPeer) {
-            QuicTraceLogConnInfo(FirstCidUsage, Connection, "First usage of SrcCID: %s",
-                QuicCidBufToStr(Packet->DestCID, Packet->DestCIDLen).Buffer);
+            QuicTraceLogConnInfo(FirstCidUsage, Connection, "First usage of SrcCid: %s",
+                QuicCidBufToStr(Packet->DestCid, Packet->DestCidLen).Buffer);
             SourceCid->CID.UsedByPeer = TRUE;
             if (SourceCid->CID.IsInitial) {
                 if (QuicConnIsServer(Connection) && SourceCid->Link.Next != NULL) {

--- a/core/connection.h
+++ b/core/connection.h
@@ -321,7 +321,7 @@ typedef struct QUIC_CONNECTION {
     //
     // Number of non-retired desintation CIDs we currently have cached.
     //
-    uint8_t DestCIDCount;
+    uint8_t DestCidCount;
 
     //
     // Number of paths the connection is currently tracking.
@@ -385,6 +385,12 @@ typedef struct QUIC_CONNECTION {
     QUIC_VAR_INT NextSourceCidSequenceNumber;
 
     //
+    // The most recent Retire Prior To field received in a NEW_CONNECTION_ID
+    // frame.
+    //
+    QUIC_VAR_INT RetirePriorTo;
+
+    //
     // Per-path state. The first entry in the list is the active path. All the
     // rest (if any) are other tracked paths, sorted from most to least recently
     // used.
@@ -394,12 +400,12 @@ typedef struct QUIC_CONNECTION {
     //
     // The list of connection IDs used for receiving.
     //
-    QUIC_SINGLE_LIST_ENTRY SourceCIDs;
+    QUIC_SINGLE_LIST_ENTRY SourceCids;
 
     //
     // The list of connection IDs used for sending. Given to us by the peer.
     //
-    QUIC_LIST_ENTRY DestCIDs;
+    QUIC_LIST_ENTRY DestCids;
 
     //
     // The original CID used by the Client in its first Initial packet.
@@ -970,7 +976,7 @@ QuicConnGetSourceCidFromSeq(
     _Out_ BOOLEAN* IsLastCid
     )
 {
-    for (QUIC_SINGLE_LIST_ENTRY** Entry = &Connection->SourceCIDs.Next;
+    for (QUIC_SINGLE_LIST_ENTRY** Entry = &Connection->SourceCids.Next;
             *Entry != NULL;
             Entry = &(*Entry)->Next) {
         QUIC_CID_HASH_ENTRY* SourceCid =
@@ -982,7 +988,7 @@ QuicConnGetSourceCidFromSeq(
             if (RemoveFromList) {
                 *Entry = (*Entry)->Next;
             }
-            *IsLastCid = Connection->SourceCIDs.Next == NULL;
+            *IsLastCid = Connection->SourceCids.Next == NULL;
             return SourceCid;
         }
     }
@@ -1002,7 +1008,7 @@ QuicConnGetSourceCidFromBuf(
         const uint8_t* CidBuffer
     )
 {
-    for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCIDs.Next;
+    for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCids.Next;
             Entry != NULL;
             Entry = Entry->Next) {
         QUIC_CID_HASH_ENTRY* SourceCid =
@@ -1030,8 +1036,8 @@ QuicConnGetDestCidFromSeq(
     _In_ BOOLEAN RemoveFromList
     )
 {
-    for (QUIC_LIST_ENTRY* Entry = Connection->DestCIDs.Flink;
-            Entry != &Connection->DestCIDs;
+    for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+            Entry != &Connection->DestCids;
             Entry = Entry->Flink) {
         QUIC_CID_QUIC_LIST_ENTRY* DestCid =
             QUIC_CONTAINING_RECORD(

--- a/core/crypto.c
+++ b/core/crypto.c
@@ -112,26 +112,26 @@ QuicCryptoInitialize(
     RecvBufferInitialized = TRUE;
 
     if (QuicConnIsServer(Connection)) {
-        QUIC_DBG_ASSERT(Connection->SourceCIDs.Next != NULL);
-        QUIC_CID_HASH_ENTRY* SourceCID =
+        QUIC_DBG_ASSERT(Connection->SourceCids.Next != NULL);
+        QUIC_CID_HASH_ENTRY* SourceCid =
             QUIC_CONTAINING_RECORD(
-                Connection->SourceCIDs.Next,
+                Connection->SourceCids.Next,
                 QUIC_CID_HASH_ENTRY,
                 Link);
 
-        HandshakeCid = SourceCID->CID.Data;
-        HandshakeCidLength = SourceCID->CID.Length;
+        HandshakeCid = SourceCid->CID.Data;
+        HandshakeCidLength = SourceCid->CID.Length;
 
     } else {
-        QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCIDs));
-        QUIC_CID_QUIC_LIST_ENTRY* DestCID =
+        QUIC_DBG_ASSERT(!QuicListIsEmpty(&Connection->DestCids));
+        QUIC_CID_QUIC_LIST_ENTRY* DestCid =
             QUIC_CONTAINING_RECORD(
-                Connection->DestCIDs.Flink,
+                Connection->DestCids.Flink,
                 QUIC_CID_QUIC_LIST_ENTRY,
                 Link);
 
-        HandshakeCid = DestCID->CID.Data;
-        HandshakeCidLength = DestCID->CID.Length;
+        HandshakeCid = DestCid->CID.Data;
+        HandshakeCidLength = DestCid->CID.Length;
     }
 
     Status =

--- a/core/inline.c
+++ b/core/inline.c
@@ -327,8 +327,8 @@ uint16_t
 QuicPacketEncodeLongHeaderV1(
     _In_ uint32_t Version, // Allows for version negotiation forcing
     _In_ QUIC_LONG_HEADER_TYPE_V1 PacketType,
-    _In_ const QUIC_CID* const DestCID,
-    _In_ const QUIC_CID* const SourceCID,
+    _In_ const QUIC_CID* const DestCid,
+    _In_ const QUIC_CID* const SourceCid,
     _In_ uint16_t TokenLength,
     _In_reads_opt_(TokenLength)
         const uint8_t* const Token,
@@ -344,7 +344,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != 0)
 uint16_t
 QuicPacketEncodeShortHeaderV1(
-    _In_ const QUIC_CID* const DestCID,
+    _In_ const QUIC_CID* const DestCid,
     _In_ uint64_t PacketNumber,
     _In_ uint8_t PacketNumberLength,
     _In_ BOOLEAN SpinBit,
@@ -359,12 +359,12 @@ _Success_(return != 0)
 uint16_t
 QuicPacketEncodeRetryV1(
     _In_ uint32_t Version,
-    _In_reads_(DestCIDLength) const uint8_t* const DestCID,
-    _In_ uint8_t DestCIDLength,
-    _In_reads_(SourceCIDLength) const uint8_t* const SourceCID,
-    _In_ uint8_t SourceCIDLength,
-    _In_reads_(OrigDestCIDLength) const uint8_t* const OrigDestCID,
-    _In_ uint8_t OrigDestCIDLength,
+    _In_reads_(DestCidLength) const uint8_t* const DestCid,
+    _In_ uint8_t DestCidLength,
+    _In_reads_(SourceCidLength) const uint8_t* const SourceCid,
+    _In_ uint8_t SourceCidLength,
+    _In_reads_(OrigDestCidLength) const uint8_t* const OrigDestCid,
+    _In_ uint8_t OrigDestCidLength,
     _In_ uint16_t TokenLength,
     _In_reads_(TokenLength)
         uint8_t* Token,

--- a/core/lookup.h
+++ b/core/lookup.h
@@ -108,7 +108,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicLookupAddSourceConnectionID(
     _In_ QUIC_LOOKUP* Lookup,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCID,
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid,
     _Out_opt_ QUIC_CONNECTION** Collision
     );
 
@@ -119,7 +119,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicLookupRemoveSourceConnectionID(
     _In_ QUIC_LOOKUP* Lookup,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCID
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid
     );
 
 //

--- a/core/packet.h
+++ b/core/packet.h
@@ -47,17 +47,17 @@ typedef struct QUIC_HEADER_INVARIANT {
             uint8_t VARIANT : 7;
             uint8_t IsLongHeader : 1;
             uint32_t Version;
-            uint8_t DestCIDLength;
-            uint8_t DestCID[0];
-            //uint8_t SourceCIDLength;
-            //uint8_t SourceCID[SourceCIDLength];
+            uint8_t DestCidLength;
+            uint8_t DestCid[0];
+            //uint8_t SourceCidLength;
+            //uint8_t SourceCid[SourceCidLength];
 
         } LONG_HDR;
 
         struct {
             uint8_t VARIANT : 7;
             uint8_t IsLongHeader : 1;
-            uint8_t DestCID[0];
+            uint8_t DestCid[0];
 
         } SHORT_HDR;
     };
@@ -88,10 +88,10 @@ typedef struct QUIC_VERSION_NEGOTIATION_PACKET {
     uint8_t Unused : 7;
     uint8_t IsLongHeader : 1;
     uint32_t Version;
-    uint8_t DestCIDLength;
-    uint8_t DestCID[0];
-    //uint8_t SourceCIDLength;
-    //uint8_t SourceCID[SourceCIDLength];
+    uint8_t DestCidLength;
+    uint8_t DestCid[0];
+    //uint8_t SourceCidLength;
+    //uint8_t SourceCid[SourceCidLength];
     //uint32_t SupportedVersions[0];
 
 } QUIC_VERSION_NEGOTIATION_PACKET;
@@ -130,10 +130,10 @@ typedef struct QUIC_LONG_HEADER_V1 {
     uint8_t FixedBit        : 1;    // Must be 1.
     uint8_t IsLongHeader    : 1;
     uint32_t Version;
-    uint8_t DestCIDLength;
-    uint8_t DestCID[0];
-    //uint8_t SourceCIDLength;
-    //uint8_t SourceCID[SourceCIDLength];
+    uint8_t DestCidLength;
+    uint8_t DestCid[0];
+    //uint8_t SourceCidLength;
+    //uint8_t SourceCid[SourceCidLength];
     //  QUIC_VAR_INT TokenLength;       {Initial}
     //  uint8_t Token[0];               {Initial}
     //QUIC_VAR_INT Length;
@@ -165,12 +165,12 @@ typedef struct QUIC_RETRY_V1 {
     uint8_t FixedBit        : 1;    // Must be 1.
     uint8_t IsLongHeader    : 1;
     uint32_t Version;
-    uint8_t DestCIDLength;
-    uint8_t DestCID[0];
-    //uint8_t SourceCIDLength;
-    //uint8_t SourceCID[SourceCIDLength];
-    //uint8_t OrigDestCIDLength;
-    //uint8_t OrigDestCID[OrigDestCIDLength];
+    uint8_t DestCidLength;
+    uint8_t DestCid[0];
+    //uint8_t SourceCidLength;
+    //uint8_t SourceCid[SourceCidLength];
+    //uint8_t OrigDestCidLength;
+    //uint8_t OrigDestCid[OrigDestCidLength];
     //uint8_t Token[*];
 
 } QUIC_RETRY_V1;
@@ -196,7 +196,7 @@ typedef struct QUIC_SHORT_HEADER_V1 {
     uint8_t SpinBit         : 1;
     uint8_t FixedBit        : 1;    // Must be 1.
     uint8_t IsLongHeader    : 1;
-    uint8_t DestCID[0];             // Length depends on connection.
+    uint8_t DestCid[0];             // Length depends on connection.
     //uint8_t PacketNumber[PnLength];
     //uint8_t Payload[0];
 
@@ -205,8 +205,8 @@ typedef struct QUIC_SHORT_HEADER_V1 {
 //
 // Helper to calculate the length of the full short header, in bytes.
 //
-#define SHORT_HEADER_PACKET_NUMBER_V1(Header, DestCIDLen) \
-    ((Header)->ConnectionID + DestCIDLen)
+#define SHORT_HEADER_PACKET_NUMBER_V1(Header, DestCidLen) \
+    ((Header)->ConnectionID + DestCidLen)
 //
 // The minimum short header, in bytes.
 //
@@ -368,8 +368,8 @@ uint16_t
 QuicPacketEncodeLongHeaderV1(
     _In_ uint32_t Version, // Allows for version negotiation forcing
     _In_ QUIC_LONG_HEADER_TYPE_V1 PacketType,
-    _In_ const QUIC_CID* const DestCID,
-    _In_ const QUIC_CID* const SourceCID,
+    _In_ const QUIC_CID* const DestCid,
+    _In_ const QUIC_CID* const SourceCid,
     _In_ uint16_t TokenLength,
     _In_reads_opt_(TokenLength)
         const uint8_t* const Token,
@@ -383,9 +383,9 @@ QuicPacketEncodeLongHeaderV1(
 {
     uint16_t RequiredBufferLength =
         sizeof(QUIC_LONG_HEADER_V1) +
-        DestCID->Length +
+        DestCid->Length +
         sizeof(uint8_t) +
-        SourceCID->Length +
+        SourceCid->Length +
         sizeof(uint16_t) + // We always encode 2 bytes for the length.
         sizeof(uint32_t);  // We always encode 4 bytes for the packet number.
     if (PacketType == QUIC_INITIAL) {
@@ -403,18 +403,18 @@ QuicPacketEncodeLongHeaderV1(
     Header->Reserved        = 0;
     Header->PnLength        = sizeof(uint32_t) - 1;
     Header->Version         = Version;
-    Header->DestCIDLength   = DestCID->Length;
+    Header->DestCidLength   = DestCid->Length;
 
-    uint8_t *HeaderBuffer = Header->DestCID;
-    if (DestCID->Length != 0) {
-        memcpy(HeaderBuffer, DestCID->Data, DestCID->Length);
-        HeaderBuffer += DestCID->Length;
+    uint8_t *HeaderBuffer = Header->DestCid;
+    if (DestCid->Length != 0) {
+        memcpy(HeaderBuffer, DestCid->Data, DestCid->Length);
+        HeaderBuffer += DestCid->Length;
     }
-    *HeaderBuffer = SourceCID->Length;
+    *HeaderBuffer = SourceCid->Length;
     HeaderBuffer++;
-    if (SourceCID->Length != 0) {
-        memcpy(HeaderBuffer, SourceCID->Data, SourceCID->Length);
-        HeaderBuffer += SourceCID->Length;
+    if (SourceCid->Length != 0) {
+        memcpy(HeaderBuffer, SourceCid->Data, SourceCid->Length);
+        HeaderBuffer += SourceCid->Length;
     }
     if (PacketType == QUIC_INITIAL) {
         HeaderBuffer = QuicVarIntEncode(TokenLength, HeaderBuffer);
@@ -446,12 +446,12 @@ _Success_(return != 0)
 uint16_t
 QuicPacketEncodeRetryV1(
     _In_ uint32_t Version,
-    _In_reads_(DestCIDLength) const uint8_t* const DestCID,
-    _In_ uint8_t DestCIDLength,
-    _In_reads_(SourceCIDLength) const uint8_t* const SourceCID,
-    _In_ uint8_t SourceCIDLength,
-    _In_reads_(OrigDestCIDLength) const uint8_t* const OrigDestCID,
-    _In_ uint8_t OrigDestCIDLength,
+    _In_reads_(DestCidLength) const uint8_t* const DestCid,
+    _In_ uint8_t DestCidLength,
+    _In_reads_(SourceCidLength) const uint8_t* const SourceCid,
+    _In_ uint8_t SourceCidLength,
+    _In_reads_(OrigDestCidLength) const uint8_t* const OrigDestCid,
+    _In_ uint8_t OrigDestCidLength,
     _In_ uint16_t TokenLength,
     _In_reads_(TokenLength)
         uint8_t* Token,
@@ -462,9 +462,9 @@ QuicPacketEncodeRetryV1(
 {
     uint16_t RequiredBufferLength =
         MIN_RETRY_HEADER_LENGTH_V1 +
-        DestCIDLength +
-        SourceCIDLength +
-        OrigDestCIDLength +
+        DestCidLength +
+        SourceCidLength +
+        OrigDestCidLength +
         TokenLength;
     if (BufferLength < RequiredBufferLength) {
         return 0;
@@ -477,24 +477,24 @@ QuicPacketEncodeRetryV1(
     Header->Type            = QUIC_RETRY;
     Header->UNUSED          = 0;
     Header->Version         = Version;
-    Header->DestCIDLength   = DestCIDLength;
+    Header->DestCidLength   = DestCidLength;
 
-    uint8_t *HeaderBuffer = Header->DestCID;
-    if (DestCIDLength != 0) {
-        memcpy(HeaderBuffer, DestCID, DestCIDLength);
-        HeaderBuffer += DestCIDLength;
+    uint8_t *HeaderBuffer = Header->DestCid;
+    if (DestCidLength != 0) {
+        memcpy(HeaderBuffer, DestCid, DestCidLength);
+        HeaderBuffer += DestCidLength;
     }
-    *HeaderBuffer = SourceCIDLength;
+    *HeaderBuffer = SourceCidLength;
     HeaderBuffer++;
-    if (SourceCIDLength != 0) {
-        memcpy(HeaderBuffer, SourceCID, SourceCIDLength);
-        HeaderBuffer += SourceCIDLength;
+    if (SourceCidLength != 0) {
+        memcpy(HeaderBuffer, SourceCid, SourceCidLength);
+        HeaderBuffer += SourceCidLength;
     }
-    *HeaderBuffer = OrigDestCIDLength;
+    *HeaderBuffer = OrigDestCidLength;
     HeaderBuffer++;
-    if (OrigDestCIDLength != 0) {
-        memcpy(HeaderBuffer, OrigDestCID, OrigDestCIDLength);
-        HeaderBuffer += OrigDestCIDLength;
+    if (OrigDestCidLength != 0) {
+        memcpy(HeaderBuffer, OrigDestCid, OrigDestCidLength);
+        HeaderBuffer += OrigDestCidLength;
     }
     if (TokenLength != 0) {
         memcpy(HeaderBuffer, Token, TokenLength);
@@ -512,7 +512,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != 0)
 uint16_t
 QuicPacketEncodeShortHeaderV1(
-    _In_ const QUIC_CID* const DestCID,
+    _In_ const QUIC_CID* const DestCid,
     _In_ uint64_t PacketNumber,
     _In_ uint8_t PacketNumberLength,
     _In_ BOOLEAN SpinBit,
@@ -526,7 +526,7 @@ QuicPacketEncodeShortHeaderV1(
 
     uint16_t RequiredBufferLength =
         sizeof(QUIC_SHORT_HEADER_V1) +
-        DestCID->Length +
+        DestCid->Length +
         PacketNumberLength;
     if (BufferLength < RequiredBufferLength) {
         return 0;
@@ -541,10 +541,10 @@ QuicPacketEncodeShortHeaderV1(
     Header->KeyPhase        = KeyPhase;
     Header->PnLength        = PacketNumberLength - 1;
 
-    uint8_t *HeaderBuffer = Header->DestCID;
-    if (DestCID->Length != 0) {
-        memcpy(HeaderBuffer, DestCID->Data, DestCID->Length);
-        HeaderBuffer += DestCID->Length;
+    uint8_t *HeaderBuffer = Header->DestCid;
+    if (DestCid->Length != 0) {
+        memcpy(HeaderBuffer, DestCid->Data, DestCid->Length);
+        HeaderBuffer += DestCid->Length;
     }
 
     QuicPktNumEncode(PacketNumber, PacketNumberLength, HeaderBuffer);

--- a/core/packet_builder.c
+++ b/core/packet_builder.c
@@ -53,14 +53,14 @@ QuicPacketBuilderInitialize(
         Connection->State.EncryptionEnabled ?
             QUIC_ENCRYPTION_OVERHEAD : 0;
 
-    if (Connection->SourceCIDs.Next == NULL) {
+    if (Connection->SourceCids.Next == NULL) {
         QuicTraceLogConnWarning(NoSrcCidAvailable, Connection, "No src CID to send with.");
         return FALSE;
     }
 
-    Builder->SourceCID =
+    Builder->SourceCid =
         QUIC_CONTAINING_RECORD(
-            Connection->SourceCIDs.Next,
+            Connection->SourceCids.Next,
             QUIC_CID_HASH_ENTRY,
             Link);
 
@@ -296,7 +296,7 @@ QuicPacketBuilderPrepare(
                         Connection->Stats.QuicVersion,
                         (QUIC_LONG_HEADER_TYPE_V1)NewPacketType,
                         &Builder->Path->DestCid->CID,
-                        &Builder->SourceCID->CID,
+                        &Builder->SourceCid->CID,
                         Connection->Send.InitialTokenLength,
                         Connection->Send.InitialToken,
                         (uint32_t)Builder->Metadata->PacketNumber,

--- a/core/packet_builder.h
+++ b/core/packet_builder.h
@@ -23,7 +23,7 @@ typedef struct QUIC_PACKET_BUILDER {
     //
     // The source connection ID.
     //
-    QUIC_CID_HASH_ENTRY* SourceCID;
+    QUIC_CID_HASH_ENTRY* SourceCid;
 
     //
     // Represents a set of UDP datagrams.

--- a/core/path.c
+++ b/core/path.c
@@ -36,6 +36,27 @@ QuicPathInitialize(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicPathRemove(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint8_t Index
+    )
+{
+    QUIC_DBG_ASSERT(Index < Connection->PathsCount);
+    const QUIC_PATH* Path = &Connection->Paths[Index];
+    QuicTraceLogConnInfo(PathRemoved, Connection, "Path[%u] Removed", Path->ID);
+
+    if (Index + 1 < Connection->PathsCount) {
+        QuicMoveMemory(
+            Connection->Paths + Index,
+            Connection->Paths + Index + 1,
+            (Connection->PathsCount - Index - 1) * sizeof(QUIC_PATH));
+    }
+
+    Connection->PathsCount--;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
 QuicPathSetAllowance(
     _In_ QUIC_CONNECTION* Connection,
     _In_ QUIC_PATH* Path,

--- a/core/path.h
+++ b/core/path.h
@@ -124,6 +124,13 @@ QuicPathInitialize(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicPathRemove(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint8_t Index
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
 QuicPathSetAllowance(
     _In_ QUIC_CONNECTION* Connection,
     _In_ QUIC_PATH* Path,

--- a/core/send.c
+++ b/core/send.c
@@ -590,7 +590,7 @@ QuicSendWriteFrames(
 
             BOOLEAN HasMoreCidsToSend = FALSE;
             BOOLEAN MaxFrameLimitHit = FALSE;
-            for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCIDs.Next;
+            for (QUIC_SINGLE_LIST_ENTRY* Entry = Connection->SourceCids.Next;
                     Entry != NULL;
                     Entry = Entry->Next) {
                 QUIC_CID_HASH_ENTRY* SourceCid =
@@ -648,8 +648,8 @@ QuicSendWriteFrames(
 
             BOOLEAN HasMoreCidsToSend = FALSE;
             BOOLEAN MaxFrameLimitHit = FALSE;
-            for (QUIC_LIST_ENTRY* Entry = Connection->DestCIDs.Flink;
-                    Entry != &Connection->DestCIDs;
+            for (QUIC_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+                    Entry != &Connection->DestCids;
                     Entry = Entry->Flink) {
                 QUIC_CID_QUIC_LIST_ENTRY* DestCid =
                     QUIC_CONTAINING_RECORD(

--- a/test/lib/DrillDescriptor.cpp
+++ b/test/lib/DrillDescriptor.cpp
@@ -53,10 +53,10 @@ DrillPacketDescriptor::write(
     //
     RequiredSize += 1; // For the bit fields.
     RequiredSize += sizeof(this->Version);
-    RequiredSize += 1; // For the size of DestCID.
-    RequiredSize += this->DestCID.size();
-    RequiredSize += 1; // For the size of SourceCID.
-    RequiredSize += this->SourceCID.size();
+    RequiredSize += 1; // For the size of DestCid.
+    RequiredSize += this->DestCid.size();
+    RequiredSize += 1; // For the size of SourceCid.
+    RequiredSize += this->SourceCid.size();
 
     QUIC_FRE_ASSERTMSG(
         RequiredSize <= UINT16_MAX,
@@ -84,22 +84,22 @@ DrillPacketDescriptor::write(
     //
     // Copy Destination CID.
     //
-    if (DestCIDLen != nullptr) {
-        PacketBuffer.push_back(*DestCIDLen);
+    if (DestCidLen != nullptr) {
+        PacketBuffer.push_back(*DestCidLen);
     } else {
-        PacketBuffer.push_back((uint8_t) DestCID.size());
+        PacketBuffer.push_back((uint8_t) DestCid.size());
     }
-    PacketBuffer.insert(PacketBuffer.end(), DestCID.begin(), DestCID.end());
+    PacketBuffer.insert(PacketBuffer.end(), DestCid.begin(), DestCid.end());
 
     //
     // Copy Source CID.
     //
-    if (SourceCIDLen != nullptr) {
-        PacketBuffer.push_back((uint8_t) *SourceCIDLen);
+    if (SourceCidLen != nullptr) {
+        PacketBuffer.push_back((uint8_t) *SourceCidLen);
     } else {
-        PacketBuffer.push_back((uint8_t) SourceCID.size());
+        PacketBuffer.push_back((uint8_t) SourceCid.size());
     }
-    PacketBuffer.insert(PacketBuffer.end(), SourceCID.begin(), SourceCID.end());
+    PacketBuffer.insert(PacketBuffer.end(), SourceCid.begin(), SourceCid.end());
 
     //
     // TODO: Do type-specific stuff here.

--- a/test/lib/DrillDescriptor.h
+++ b/test/lib/DrillDescriptor.h
@@ -69,16 +69,16 @@ struct DrillPacketDescriptor {
     uint32_t Version;
 
     //
-    // Optional destination CID length. If not set, will use length of DestCID.
+    // Optional destination CID length. If not set, will use length of DestCid.
     //
-    uint8_t* DestCIDLen;
-    DrillBuffer DestCID;
+    uint8_t* DestCidLen;
+    DrillBuffer DestCid;
 
     //
-    // Optional source CID length. If not set, will use length of SourceCID.
+    // Optional source CID length. If not set, will use length of SourceCid.
     //
-    uint8_t* SourceCIDLen;
-    DrillBuffer SourceCID;
+    uint8_t* SourceCidLen;
+    DrillBuffer SourceCid;
 
     //
     // Write this descriptor to a byte array to send on the wire.

--- a/tools/attack/attack.cpp
+++ b/tools/attack/attack.cpp
@@ -132,14 +132,14 @@ RunAttackRandom(
                 Header->FixedBit = 1;
                 Header->Reserved = 0;
                 Header->Version = QUIC_VERSION_LATEST;
-                Header->DestCIDLength = 8;
+                Header->DestCidLength = 8;
                 ConnectionId++;
-                QuicCopyMemory(Header->DestCID, &ConnectionId, sizeof(ConnectionId));
-                Header->DestCID[8] = 8;
-                Header->DestCID[17] = 0;
+                QuicCopyMemory(Header->DestCid, &ConnectionId, sizeof(ConnectionId));
+                Header->DestCid[8] = 8;
+                Header->DestCid[17] = 0;
                 QuicVarIntEncode(
                     Length - (MIN_LONG_HEADER_LENGTH_V1 + 19),
-                    Header->DestCID + 18);
+                    Header->DestCid + 18);
             }
 
             ++PacketCount;

--- a/tools/etw/main.c
+++ b/tools/etw/main.c
@@ -516,7 +516,7 @@ void ProcessCommandArgs(int argc, char** argv)
     if (Cmd.FormatCSV) {
         switch (Cmd.Command) {
         case COMMAND_CONN_LIST:
-            printf("ID,State,Age(us),Active(us),Queued(us),Idle(us),TX,RX,LocalIp,RemoteIp,SourceCID,DestinationCID\n");
+            printf("ID,State,Age(us),Active(us),Queued(us),Idle(us),TX,RX,LocalIp,RemoteIp,SourceCid,DestinationCID\n");
             break;
         case COMMAND_CONN_TPUT:
             printf("ms,TxMbps,RxMbps,RttMs,CongEvents,InFlight,Cwnd,TxBufBytes,FlowAvailStrm,FlowAvailConn,SsThresh,CubicK,CubicWindowMax,StrmSndWnd\n");


### PR DESCRIPTION
This PR does two things:
1. Renames Source/DestCID to Source/DestCid.
2. Adds support for receiving update "Retire Prior To" fields in NEW_CONNECTION_ID frames and retires the CIDs accordingly. (All these changes in connection.*)

No new tests are added yet, as we don't have a way to send this yet. That will come in a follow up PR.