### PR TITLE
Move Handshake Start Event

### DIFF
--- a/core/connection.c
+++ b/core/connection.c
@@ -1353,9 +1353,6 @@ QuicConnStart(
     QUIC_PATH* Path = &Connection->Paths[0];
     QUIC_TEL_ASSERT(Path->Binding == NULL);
 
-    Connection->Stats.Timing.Start = QuicTimeUs64();
-    QuicTraceEvent(ConnHandshakeStart, Connection);
-
     if (!Connection->State.RemoteAddressSet) {
 
         QUIC_DBG_ASSERT(ServerName != NULL);
@@ -1476,8 +1473,6 @@ QuicConnStart(
     if (QUIC_FAILED(Status)) {
         goto Exit;
     }
-
-    Connection->State.Started = TRUE;
 
 Exit:
 
@@ -1740,6 +1735,10 @@ QuicConnHandshakeConfigure(
                 Connection->Streams.Types[STREAM_ID_FLAG_IS_SERVER | STREAM_ID_FLAG_IS_UNI_DIR].MaxTotalStreamCount;
         }
     }
+
+    Connection->State.Started = TRUE;
+    Connection->Stats.Timing.Start = QuicTimeUs64();
+    QuicTraceEvent(ConnHandshakeStart, Connection);
 
     Status =
         QuicCryptoInitializeTls(

--- a/core/crypto.c
+++ b/core/crypto.c
@@ -245,8 +245,6 @@ QuicCryptoInitializeTls(
         goto Error;
     }
 
-    Connection->State.Started = TRUE;
-
     if (!IsServer) {
         QuicCryptoProcessData(Crypto, TRUE);
     }

--- a/core/listener.c
+++ b/core/listener.c
@@ -422,9 +422,6 @@ QuicListenerAcceptConnection(
         }
     }
 
-    Connection->Stats.Timing.Start = QuicTimeUs64();
-    QuicTraceEvent(ConnHandshakeStart, Connection);
-
     if (Status != QUIC_STATUS_PENDING) {
         Status = QuicConnHandshakeConfigure(Connection, SecConfig);
         if (QUIC_FAILED(Status)) {


### PR DESCRIPTION
This moves the handshake start (ETW) event to right before we initialize TLS. This means we no longer include waiting for the server to give us a certificate or doing DNS on the client as part of this phase. It essentially purely tracks doing the TLS and network parts.