### PR TITLE
Path Challenge can be limited by Path Allowance

### DIFF
--- a/core/send.c
+++ b/core/send.c
@@ -796,7 +796,7 @@ QuicSendPathChallenges(
 
         QUIC_PATH* Path = &Connection->Paths[i];
         if (!Connection->Paths[i].SendChallenge ||
-            Path->Allowance < QUIC_MIN_SEND_ALLOWANCE) {
+            Connection->Paths[i].Allowance < QUIC_MIN_SEND_ALLOWANCE) {
             continue;
         }
 


### PR DESCRIPTION
While running the interop tool I hit a debug assert when trying to frame a path challenge. There wasn't enough room in the packet, and that was because the Path's allowance wasn't enough to fit the frame. This PR updates the code to check the limit before hand, but it is also more resilient to any other unforeseen issues as well (by cleaning up the builder).