### PR TITLE
Minor typo; Properly null out the binding in the error case.

### DIFF
--- a/platform/datapath_linux.c
+++ b/platform/datapath_linux.c
@@ -1489,7 +1489,7 @@ Exit:
             QuicRundownRelease(&Datapath->BindingsRundown);
             QuicRundownUninitialize(&Binding->Rundown);
             QUIC_FREE(Binding);
-            Binding == NULL;
+            Binding = NULL;
         }
     }
 


### PR DESCRIPTION
Change `Binding == NULL;` to `Binding = NULL; `

I wonder why the compiler didn't warn about this.