### PR TITLE
Fix Listener Rundown Synchronization Isssues

### DIFF
--- a/core/frame.h
+++ b/core/frame.h
@@ -76,7 +76,8 @@
 //
 #define QUIC_ERROR_CRYPTO_ERROR(TlsAlertCode)   ((QUIC_VAR_INT)(0x100 | (TlsAlertCode)))
 
-#define QUIC_ERROR_CRYPTO_HANDSHAKE_FAILURE     QUIC_ERROR_CRYPTO_ERROR(40) // TLS error code for 'handshake_failure'
+#define QUIC_ERROR_CRYPTO_HANDSHAKE_FAILURE         QUIC_ERROR_CRYPTO_ERROR(40)  // TLS error code for 'handshake_failure'
+#define QUIC_ERROR_CRYPTO_NO_APPLICATION_PROTOCOL   QUIC_ERROR_CRYPTO_ERROR(120) // TLS error code for 'no_application_protocol'
 
 //
 // Different types of QUIC frames

--- a/core/listener.h
+++ b/core/listener.h
@@ -82,7 +82,8 @@ QUIC_CONNECTION_ACCEPT_RESULT
 QuicListenerAcceptConnection(
     _In_ QUIC_LISTENER* Listener,
     _In_ QUIC_CONNECTION* Connection,
-    _In_ const QUIC_NEW_CONNECTION_INFO* Info
+    _In_ const QUIC_NEW_CONNECTION_INFO* Info,
+    _Out_ QUIC_SEC_CONFIG** SecConfig
     );
 
 //


### PR DESCRIPTION
Fixes some issues where `Listener` was being used after the rundown was released, which caused use-after-free issues. This PR also returns the correct TLS error code (no_application_protocol) when we can't find a listener that matches the requested ip/port/ALPN combination.