### PR TITLE
Fix Path Allowance (Amplification Protection) Logic

### DIFF
--- a/core/path.c
+++ b/core/path.c
@@ -66,7 +66,7 @@ QuicPathSetAllowance(
     BOOLEAN WasBlocked = Path->Allowance < QUIC_MIN_SEND_ALLOWANCE;
     Path->Allowance = NewAllowance;
 
-    if (Path->IsPeerValidated &&
+    if (!Path->IsPeerValidated &&
         (Path->Allowance < QUIC_MIN_SEND_ALLOWANCE) != WasBlocked) {
         if (WasBlocked) {
             QuicConnRemoveOutFlowBlockedReason(


### PR DESCRIPTION
Lars reported a connection failure with our interop server. Turns out amplification protection was kicking in but not getting cleared out properly. This PR fixes a simple logic bug (missing a `!`).