### PR TITLE
Fix failing QuicDrill Tests on Linux.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,15 +84,16 @@ steps:
   inputs:
     script: '$(testCmd)'
 
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results'
-  inputs:
-    testResultsFormat: 'JUnit'
-    testResultsFiles: '**/*test-results.xml'
-
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifacts'
   inputs:
     PathtoPublish: 'artifacts'
     ArtifactName: '$(platform)-Artifacts'
     publishLocation: 'Container'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/*test-results.xml'
+    failTaskOnFailedTests: true

--- a/build.ps1
+++ b/build.ps1
@@ -128,7 +128,7 @@ function CMake-Generate {
     } else {
         $Arguments += " 'Linux Makefiles'"
     }
-    switch ($Config) {
+    switch ($Tls) {
         "schannel" { $Arguments += " -DQUIC_TLS=schannel" }
         "openssl"  { $Arguments += " -DQUIC_TLS=openssl" }
         "stub"     { $Arguments += " -DQUIC_TLS=stub" }

--- a/test/lib/QuicDrill.cpp
+++ b/test/lib/QuicDrill.cpp
@@ -194,10 +194,11 @@ struct DrillSender {
         // Copy test packet into SendBuffer.
         memcpy(SendBuffer->Buffer, PacketBuffer->data(), DatagramLength);
 
-        QuicDataPathBindingSendTo(
-            Binding,
-            &ServerAddress,
-            SendContext);
+        Status =
+            QuicDataPathBindingSendTo(
+                Binding,
+                &ServerAddress,
+                SendContext);
 
         return Status;
     }
@@ -309,7 +310,9 @@ QuicDrillInitialPacketFailureTest(
         // N.B. Could fail if the server has other packets sent to it accidentally.
         //
         if (DroppedPacketsAfter - DroppedPacketsBefore != 1) {
-            TEST_FAILURE("DroppedPacketsAfter - DroppedPacketsBefore not equal to 1");
+            TEST_FAILURE(
+                "DroppedPacketsAfter - DroppedPacketsBefore (%d) not equal to 1",
+                DroppedPacketsAfter - DroppedPacketsBefore);
             return false;
         }
     }


### PR DESCRIPTION
Apparently the issue was not returning the `Status` from `QuicDataPathBindingSendTo` in `DrillSender::Send`

Add support to test.ps1 for debugging with GDB.
Fail Azure Pipelines when test failures occur.
Fix bug in build.ps1 where it wasn't parsing -Tls options correctly.

Addresses #50 