### PR TITLE
Increase spinquic Watchdog Wiggle Room

### DIFF
--- a/tools/spin/spinquic.cpp
+++ b/tools/spin/spinquic.cpp
@@ -70,7 +70,7 @@ public:
 // The amount of extra time (in milliseconds) to give the watchdog before
 // actually firing.
 //
-#define WATCHDOG_WIGGLE_ROOM 1000
+#define WATCHDOG_WIGGLE_ROOM 5000
 
 class SpinQuicWatchdog {
     QUIC_THREAD WatchdogThread;


### PR DESCRIPTION
The 1 second wiggle room still had the watchdog fire and the clean up code path seemed to still be running.