### PR TITLE
Onboard and Fix Event Validation Tests

### DIFF
--- a/test/bin/quic_gtest.cpp
+++ b/test/bin/quic_gtest.cpp
@@ -176,6 +176,16 @@ TEST_P(WithBool, ValidateStream) {
     QuicTestValidateStream(GetParam());
 }
 
+TEST(ParameterValidation, ValidateConnectionEvents) {
+    TestLogger Logger("QuicTestValidateConnectionEvents");
+    QuicTestValidateConnectionEvents();
+}
+
+TEST(ParameterValidation, ValidateStreamEvents) {
+    TestLogger Logger("QuicTestValidateStreamEvents");
+    QuicTestValidateStreamEvents();
+}
+
 TEST(Basic, CreateListener) {
     TestLogger Logger("QuicTestCreateListener");
     QuicTestCreateListener();


### PR DESCRIPTION
These tests were missing from the gtest runner. This PR adds them and fixes a bug they uncovered.