### PR TITLE
Fix Draft-25 Interop

### DIFF
--- a/core/crypto.c
+++ b/core/crypto.c
@@ -964,6 +964,11 @@ QuicCryptoProcessDataFrame(
 
     } else {
 
+        if (KeyType == QUIC_PACKET_KEY_1_RTT_OLD ||
+            KeyType == QUIC_PACKET_KEY_1_RTT_NEW) {
+            KeyType = QUIC_PACKET_KEY_1_RTT; // Treat them all as the same
+        }
+
         if (KeyType != Crypto->TlsState.ReadKey) {
             if (QuicRecvBufferAlreadyReadData(
                     &Crypto->RecvBuffer,

--- a/tools/interop/interop.cpp
+++ b/tools/interop/interop.cpp
@@ -59,6 +59,7 @@ const QuicPublicEndpoint PublicEndpoints[] = {
     { "ats",            "quic.ogre.com" },
     { "f5",             "f5quic.com" },
     { "gquic",          "quic.rocks" },
+    { "haskell",        "mew.org" },
     { "lsquic",         "http3-test.litespeedtech.com" },
     { "mvfst",          "fb.mvfst.net" },
     { "msquic",         "quic.westus.cloudapp.azure.com" },
@@ -749,6 +750,7 @@ RunInteropTests()
     } else {
         PrintTestResults((uint32_t)EndpointIndex);
     }
+    printf("\n");
 }
 
 int


### PR DESCRIPTION
A few things here:

- Fixed a product code bug related to checking key type for NST after KeyUpdate.
- Added a new interop server to the list.
- Added a new line to the end of the console output.

Latest run results:
```
      TARGET  VHDCRZSQUMB    VERSION   ALPN
 ============================================
     aioquic  V----------
   applequic  -----------
         ats  V----------
          f5  V----------
       gquic  VH-C---Q---  0xFF000019  hq-25
     haskell  V----------
      lsquic  VH-CR-SQUMB  0xFF000019  hq-25
       mvfst  VH-C---Q---  0xFF000019  hq-25
      msquic  V----------
 msquic-west  V----------
 msquic-east  V----------
      ngtcp2  VH-CR-SQUM-  0xFF000019  hq-25
    ngx_quic  V----------
     Pandora  -----------
    picoquic  VHDCR-SQUMB  0xFF000019  hq-25
       quant  VHDCRZSQU-B  0xFF000019  hq-25
       quinn  V----------
     quic-go  -----------
      quiche  -----------
     quicker  -----------
 quicly-quic  V----------
  quicly-h20  V----------
```