### PR TITLE
Add Asserts that Server Doesn't call ConnectionStart

### DIFF
--- a/core/api.c
+++ b/core/api.c
@@ -302,6 +302,7 @@ MsQuicConnectionStart(
     }
 
     QUIC_CONN_VERIFY(Connection, !Connection->State.HandleClosed);
+    QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
     Oper = QuicOperationAlloc(Connection->Worker, QUIC_OPER_TYPE_API_CALL);
     if (Oper == NULL) {
         Status = QUIC_STATUS_OUT_OF_MEMORY;

--- a/core/connection.c
+++ b/core/connection.c
@@ -1435,6 +1435,7 @@ QuicConnStart(
 {
     QUIC_STATUS Status;
     QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
     QUIC_TEL_ASSERT(Path->Binding == NULL);
 
     if (!Connection->State.RemoteAddressSet) {


### PR DESCRIPTION
Somehow it looks like spinquic got into a state where QuicConnStart was being called on a server connection. This adds a few more asserts to try to catch this earlier, since it should be impossible.