### PR TITLE
Ignore all Old Crypto Data

### DIFF
--- a/core/crypto.c
+++ b/core/crypto.c
@@ -969,18 +969,9 @@ QuicCryptoProcessDataFrame(
             KeyType = QUIC_PACKET_KEY_1_RTT; // Treat them all as the same
         }
 
-        if (KeyType != Crypto->TlsState.ReadKey) {
-            if (QuicRecvBufferAlreadyReadData(
-                    &Crypto->RecvBuffer,
-                    Crypto->RecvEncryptLevelStartOffset + Frame->Offset,
-                    (uint16_t)Frame->Length)) {
-                Status = QUIC_STATUS_SUCCESS;
-            } else {
-                QuicTraceEvent(ConnError,
-                    Connection, "Tried crypto with incorrect key.");
-                QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
-                Status = QUIC_STATUS_INVALID_STATE;
-            }
+        QUIC_DBG_ASSERT(KeyType <= Crypto->TlsState.ReadKey);
+        if (KeyType < Crypto->TlsState.ReadKey) {
+            Status = QUIC_STATUS_SUCCESS; // Old, likely retransmitted data.
             goto Error;
         }
 


### PR DESCRIPTION
This PR updates the crypto code to just ignore all data received with any previous keys. The previous logic tried to determine if there was any overlap with existing data that was incorrect, but it's not possible to check this because we don't have the previous base offset. Either way, we would just ignore the data.