### PR TITLE
Retransmit 0-RTT on Retry

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1595,7 +1595,6 @@ QuicConnRestart(
         Path->GotFirstRttSample = FALSE;
         Path->RttVariance = 0;
         Path->SmoothedRtt = MS_TO_US(Connection->Session->Settings.InitialRttMs);
-        //Path->SmoothedRtt = MS_TO_US(QUIC_INITIAL_RTT);
     }
 
     for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); ++i) {
@@ -1604,8 +1603,8 @@ QuicConnRestart(
     }
 
     QuicCongestionControlReset(&Connection->CongestionControl);
-    QuicLossDetectionReset(&Connection->LossDetection);
     QuicSendReset(&Connection->Send);
+    QuicLossDetectionReset(&Connection->LossDetection);
     QuicCryptoReset(&Connection->Crypto, CompleteReset);
 }
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -51,6 +51,13 @@ Abstract:
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicLossDetectionRetransmitFrames(
+    _In_ QUIC_LOSS_DETECTION* LossDetection,
+    _In_ QUIC_SENT_PACKET_METADATA* Packet
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
 QuicLossDetectionInitializeInternalState(
     _In_ QUIC_LOSS_DETECTION* LossDetection
     )
@@ -125,6 +132,7 @@ QuicLossDetectionReset(
     while (LossDetection->SentPackets != NULL) {
         QUIC_SENT_PACKET_METADATA* Packet = LossDetection->SentPackets;
         LossDetection->SentPackets = LossDetection->SentPackets->Next;
+        QuicLossDetectionRetransmitFrames(LossDetection, Packet);
         QuicSentPacketPoolReturnPacketMetadata(&Connection->Worker->SentPacketPool, Packet);
     }
     LossDetection->SentPacketsTail = &LossDetection->SentPackets;
@@ -132,6 +140,7 @@ QuicLossDetectionReset(
     while (LossDetection->LostPackets != NULL) {
         QUIC_SENT_PACKET_METADATA* Packet = LossDetection->LostPackets;
         LossDetection->LostPackets = LossDetection->LostPackets->Next;
+        QuicLossDetectionRetransmitFrames(LossDetection, Packet);
         QuicSentPacketPoolReturnPacketMetadata(&Connection->Worker->SentPacketPool, Packet);
     }
     LossDetection->LostPacketsTail = &LossDetection->LostPackets;


### PR DESCRIPTION
Updates the loss detection code to mark outstanding data for retransmit on Retry (and Version Negotiation) so that 0-RTT is immediately retransmitted.

Fixes #99.