### PR TITLE
Don't Prematurely Discard TLS State on Server

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1227,21 +1227,16 @@ QuicCryptoProcessTlsCompletion(
         QUIC_TEL_ASSERT(!Connection->State.Connected);
 
         QuicTraceEvent(ConnHandshakeComplete, Connection);
+        InterlockedDecrement(&Connection->Paths[0].Binding->HandshakeConnections);
+        InterlockedExchangeAdd64(
+            (int64_t*)&MsQuicLib.CurrentHandshakeMemoryUsage,
+            -1 * (int64_t)QUIC_CONN_HANDSHAKE_MEMORY_USAGE);
 
         //
         // We should have the 1-RTT keys by connection complete time.
         //
         QUIC_TEL_ASSERT(Crypto->TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT] != NULL);
         QUIC_TEL_ASSERT(Crypto->TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL);
-
-        //
-        // Only mark the handshake as complete on success.
-        //
-        Connection->State.Connected = TRUE;
-        InterlockedDecrement(&Connection->Paths[0].Binding->HandshakeConnections);
-        InterlockedExchangeAdd64(
-            (int64_t*)&MsQuicLib.CurrentHandshakeMemoryUsage,
-            -1 * (int64_t)QUIC_CONN_HANDSHAKE_MEMORY_USAGE);
 
         if (QuicConnIsServer(Connection)) {
             //
@@ -1251,6 +1246,13 @@ QuicCryptoProcessTlsCompletion(
             QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_HANDSHAKE_DONE);
             QuicCryptoHandshakeConfirmed(&Connection->Crypto);
         }
+
+        //
+        // Only set the connected flag after we do the confirmation code path
+        // above so that TLS state isn't prematurely destroyed (before the
+        // CONNECTED event is indicated to the app).
+        //
+        Connection->State.Connected = TRUE;
 
         (void)QuicConnGenerateNewSourceCid(Connection, FALSE);
 


### PR DESCRIPTION
This PR fixes #97.

The fix here is to rearrange the code so that the connected flag is set a bit later, so that logic to decide to discard TLS state doesn't evaluate to TRUE until after the CONNECTED event is indicated to the app.