### PR TITLE
Increase Callback Error Time

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -240,7 +240,7 @@ QUIC_STATIC_ASSERT(IS_POWER_OF_TWO(QUIC_MAX_RANGE_DECODE_ACKS), L"Must be power 
 // long running app callbacks.
 //
 #define QUIC_MAX_CALLBACK_TIME_WARNING          MS_TO_US(10)
-#define QUIC_MAX_CALLBACK_TIME_ERROR            MS_TO_US(200)
+#define QUIC_MAX_CALLBACK_TIME_ERROR            MS_TO_US(1000)
 
 //
 // The number of milliseconds that must elapse before a connection is


### PR DESCRIPTION
Fixes #103 by increasing the timeout used for asserting that the app took too long in a callback from 200 ms to 1 second.