### PR TITLE
Allow passing in X509* and to openssl for TLS configuration

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -80,6 +80,7 @@ typedef enum QUIC_SEC_CONFIG_FLAGS {
     QUIC_SEC_CONFIG_FLAG_CERTIFICATE_CONTEXT    = 0x00000004,
     QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE       = 0x00000008,
     QUIC_SEC_CONFIG_FLAG_ENABLE_OCSP            = 0x00000010,
+    QUIC_SEC_CONFIG_FLAG_CERTIFICATE_X509       = 0x00000020,
     QUIC_SEC_CONFIG_FLAG_CERTIFICATE_NULL       = 0xF0000000    // Can't be used with anything else.
 } QUIC_SEC_CONFIG_FLAGS;
 
@@ -159,10 +160,10 @@ typedef struct QUIC_CERTIFICATE_FILE {
     char *CertificateFile;
 } QUIC_CERTIFICATE_FILE;
 
-typedef struct QUIC_CERTIFICATE_HANDLE {
-    void *CertificateFileHandle;
-    void *PrivateKeyFileHandle;
-} QUIC_CERTIFICATE_HANDLE;
+typedef struct QUIC_CERTIFICATE_X509 {
+    void *CertificateHandle;
+    void *PrivateKeyHandle;
+} QUIC_CERTIFICATE_X509;
 
 //
 // A single contiguous buffer.

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -698,7 +698,7 @@ QuicTlsServerSecConfigCreate(
     QUIC_SEC_CONFIG* SecurityConfig = NULL;
     uint32_t SSLOpts = 0;
     QUIC_CERTIFICATE_FILE* CertFile;
-    QUIC_CERTIFICATE_HANDLE* CertStruct;
+    QUIC_CERTIFICATE_X509* CertStruct;
     X509* CertHandle;
     EVP_PKEY* PrivateKeyHandle;
 
@@ -820,14 +820,12 @@ QuicTlsServerSecConfigCreate(
             goto Exit;
         }
     }
-    else
+    else // QUIC_SEC_CONFIG_FLAG_CERTIFICATE_CONTEXT 
     {
-        // QUIC_SEC_CONFIG_FLAG_CERTIFICATE_CONTEXT
-
         CertStruct = Certificate;
+        CertHandle = CertStruct->CertificateHandle;
+        PrivateKeyHandle = CertStruct->PrivateKeyHandle;
 
-        CertHandle = CertStruct->CertificateFileHandle;
-        PrivateKeyHandle = CertStruct->PrivateKeyFileHandle;
         Ret = SSL_CTX_use_certificate(SecurityConfig->SSLCtx, CertHandle);
         if (Ret != 1) {
             QuicTraceLogError("[ tls] SSL_CTX_use_certificate failed, error: %ld", ERR_get_error());


### PR DESCRIPTION
Still a draft PR because I don't have the entire E2E working yet.

This PR adds the ability to configure openssl with an X509* and EVP_PKEY. Typically in .NET, we work with the managed type X509Certificate2, which can be created from different sources on unix systems (files, etc.). When calling into msquic, we'd like to be able to take information from the X509Certificate2 and use that to create the msquic SecConfig. 

In .NET, there is similar code which does this as well.
https://github.com/dotnet/runtime/blob/529c1c557784cedf21d2ad227cc143a95a02a17b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs#L593-L619
https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/Common/src/System/Net/Security/Unix/SafeFreeSslCredentials.cs#L57-L83

I started trying this change out and ran into issues calling SSL_CTX_use_certificate where openssl constantly seg faulted. My guess is somehow I'm providing an invalid pointer or I need to do some sort of ref counting around it in managed code.
