### PR TITLE
Added `disable_coredump=0` environment variable

### DIFF
--- a/.azure/scripts/run-executable.ps1
+++ b/.azure/scripts/run-executable.ps1
@@ -142,7 +142,7 @@ function Start-Executable {
             }
         } else {
             $pinfo.FileName = "bash"
-            $pinfo.Arguments = "-c `"ulimit -c unlimited && $($Path) $($Arguments) && echo Done`""
+            $pinfo.Arguments = "-c `"ulimit -c unlimited && ASAN_OPTIONS=disable_coredump=0 $($Path) $($Arguments) && echo Done`""
             $pinfo.WorkingDirectory = $LogDir
         }
     }


### PR DESCRIPTION
This environment variable tells ASAN to use `madvise` to indicate to the kernel not to include reserved-but-not-commited memory in core dumps.