### PR TITLE
Always Validate Retry Token

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1019,7 +1019,8 @@ QuicBindingValidateRetryToken(
 }
 
 //
-// Returns TRUE we should respond to the connection attempt with a Retry packet.
+// Returns TRUE if we should respond to the connection attempt with a Retry
+// packet.
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN


### PR DESCRIPTION
Fixes #80.

Updates the server side retry token logic to always validate the token if present. This is required because the client validates the server eventually sends the correct transport parameter in return; and we only do that if we validate the token.