### PR TITLE
Enable Full Log Collection for miTLS Tests

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -51,6 +51,7 @@ stages:
       platform: windows
       arch: x64
       tls: mitls
+      logProfile: Full.Light
       extraArgs: -Filter -*Unreachable/0
 
 # OpenSSL tests are broken because they can't load on a different

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -6,6 +6,7 @@ parameters:
   config: 'Debug'
   arch: ''
   tls: ''
+  logProfile: 'Basic.Light'
   extraArgs: ''
 
 jobs:
@@ -37,7 +38,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/test.ps1
-      arguments: -LogProfile Basic.Light -ConvertLogs -GenerateXmlResults -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraArgs }}
+      arguments: -LogProfile ${{ parameters.logProfile }} -ConvertLogs -GenerateXmlResults -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraArgs }}
 
   - template: ./upload-test-artifacts.yml
     parameters:


### PR DESCRIPTION
We're seeing test failures that need more logs to debug.