### PR TITLE
Enable abort_on_error for ASAN;

### DIFF
--- a/.azure/scripts/run-executable.ps1
+++ b/.azure/scripts/run-executable.ps1
@@ -145,7 +145,7 @@ function Start-Executable {
             }
         } else {
             $pinfo.FileName = "bash"
-            $pinfo.Arguments = "-c `"ulimit -c unlimited && ASAN_OPTIONS=disable_coredump=0 $($Path) $($Arguments) && echo Done`""
+            $pinfo.Arguments = "-c `"ulimit -c unlimited && ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 $($Path) $($Arguments) && echo Done`""
             $pinfo.WorkingDirectory = $LogDir
         }
     }


### PR DESCRIPTION
Abort on error ensures that ASAN calls abort(), which is signals SIGABRT, which, when uncaught, creates a core dump.