### PR TITLE
Stop Framing When Out of Room

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -677,6 +677,9 @@ QuicSendWriteFrames(
             if (!HasMoreCidsToSend) {
                 Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_NEW_CONNECTION_ID;
             }
+            if (MaxFrameLimitHit || RanOutOfRoom) {
+                return TRUE;
+            }
         }
 
         if ((Send->SendFlags & QUIC_CONN_SEND_FLAG_RETIRE_CONNECTION_ID)) {
@@ -724,6 +727,9 @@ QuicSendWriteFrames(
             }
             if (!HasMoreCidsToSend) {
                 Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_RETIRE_CONNECTION_ID;
+            }
+            if (MaxFrameLimitHit || RanOutOfRoom) {
+                return TRUE;
             }
         }
     }

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -8,7 +8,7 @@
 //
 // The maximum number of frames we will write to a single packet.
 //
-#define QUIC_MAX_FRAMES_PER_PACKET 8
+#define QUIC_MAX_FRAMES_PER_PACKET 12
 
 typedef struct QUIC_STREAM QUIC_STREAM;
 


### PR DESCRIPTION
Fixes a stack buffer overrun when framing NEW_CONNECTION_ID and RETIRE_CONNECTION_ID frames. Also increases the max frame count limit to allow for a more common scenario of replacing all existing frames with new ones.