### PR TITLE
New Wire Format for QUIC Transport Parameters

### DIFF
--- a/src/core/unittest/CMakeLists.txt
+++ b/src/core/unittest/CMakeLists.txt
@@ -8,10 +8,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 set(
     SOURCES
-    FrameTest.cpp
+    main.cpp
     PacketNumberTest.cpp
     RangeTest.cpp
-    main.cpp
+    TransportParamTest.cpp
+    VarIntTest.cpp
 )
 
 add_executable(msquiccoretest ${SOURCES})

--- a/src/core/unittest/TransportParamTest.cpp
+++ b/src/core/unittest/TransportParamTest.cpp
@@ -1,0 +1,98 @@
+/*++
+
+    Copyright (c) Microsoft Corporation.
+    Licensed under the MIT License.
+
+Abstract:
+
+    Unit test for the QUIC transport parameter encoding and decoding logic.
+
+--*/
+
+#include "main.h"
+
+#ifdef QUIC_LOGS_WPP
+#include "transportparamtest.tmh"
+#endif
+
+static QUIC_CONNECTION JunkConnection;
+
+void CompareTransportParams(
+    _In_ const QUIC_TRANSPORT_PARAMETERS* A,
+    _In_ const QUIC_TRANSPORT_PARAMETERS* B,
+    _In_ bool IsServer = false
+    )
+{
+#define COMPARE_TP_FIELD(TpName, Field) \
+    if (A->Flags & QUIC_TP_FLAG_##TpName) { TEST_EQUAL(A->Field, B->Field); }
+
+    TEST_EQUAL(A->Flags, B->Flags);
+    COMPARE_TP_FIELD(INITIAL_MAX_DATA, InitialMaxData);
+    COMPARE_TP_FIELD(INITIAL_MAX_STRM_DATA_BIDI_LOCAL, InitialMaxStreamDataBidiLocal);
+    COMPARE_TP_FIELD(INITIAL_MAX_STRM_DATA_BIDI_REMOTE, InitialMaxStreamDataBidiRemote);
+    COMPARE_TP_FIELD(INITIAL_MAX_STRM_DATA_UNI, InitialMaxStreamDataUni);
+    COMPARE_TP_FIELD(INITIAL_MAX_STRMS_BIDI, InitialMaxBidiStreams);
+    COMPARE_TP_FIELD(INITIAL_MAX_STRMS_UNI, InitialMaxUniStreams);
+    COMPARE_TP_FIELD(MAX_PACKET_SIZE, MaxPacketSize);
+    COMPARE_TP_FIELD(ACK_DELAY_EXPONENT, AckDelayExponent);
+    COMPARE_TP_FIELD(IDLE_TIMEOUT, IdleTimeout);
+    COMPARE_TP_FIELD(MAX_ACK_DELAY, MaxAckDelay);
+    COMPARE_TP_FIELD(ACTIVE_CONNECTION_ID_LIMIT, ActiveConnectionIdLimit);
+    if (IsServer) { // TODO
+        //COMPARE_TP_FIELD(StatelessResetToken);
+        //COMPARE_TP_FIELD(AckPreferredAddressDelayExponent);
+        //COMPARE_TP_FIELD(OriginalConnectionID);
+        //COMPARE_TP_FIELD(OriginalConnectionIDLength);
+    }
+}
+
+void EncodeDecodeAndCompare(
+    _In_ const QUIC_TRANSPORT_PARAMETERS* Original,
+    _In_ bool IsServer = false
+    )
+{
+    uint32_t BufferLength;
+    auto Buffer =
+        QuicCryptoTlsEncodeTransportParameters(
+            &JunkConnection, Original, &BufferLength);
+    TEST_NOT_EQUAL(nullptr, Buffer);
+
+    TEST_TRUE(UINT16_MAX >= (BufferLength - QuicTlsTPHeaderSize));
+
+    auto TPBuffer = Buffer + QuicTlsTPHeaderSize;
+    uint16_t TPBufferLength = (uint16_t)(BufferLength - QuicTlsTPHeaderSize);
+
+    QUIC_TRANSPORT_PARAMETERS Decoded;
+    BOOLEAN DecodedSuccessfully =
+        QuicCryptoTlsDecodeTransportParameters(
+            &JunkConnection, TPBuffer, TPBufferLength, &Decoded);
+
+    QUIC_FREE(Buffer);
+
+    TEST_TRUE(DecodedSuccessfully);
+
+    CompareTransportParams(Original, &Decoded, IsServer);
+}
+
+TEST(TransportParamTest, EmptyClient)
+{
+    QUIC_TRANSPORT_PARAMETERS Original;
+    QuicZeroMemory(&Original, sizeof(Original));
+    EncodeDecodeAndCompare(&Original);
+}
+
+TEST(TransportParamTest, EmptyServer)
+{
+    QUIC_TRANSPORT_PARAMETERS Original;
+    QuicZeroMemory(&Original, sizeof(Original));
+    EncodeDecodeAndCompare(&Original, true);
+}
+
+TEST(TransportParamTest, Preset1)
+{
+    QUIC_TRANSPORT_PARAMETERS Original;
+    QuicZeroMemory(&Original, sizeof(Original));
+    Original.Flags |= QUIC_TP_FLAG_IDLE_TIMEOUT;
+    Original.IdleTimeout = 100000;
+    EncodeDecodeAndCompare(&Original);
+}

--- a/src/core/unittest/VarIntTest.cpp
+++ b/src/core/unittest/VarIntTest.cpp
@@ -5,14 +5,14 @@
 
 Abstract:
 
-    Unit test for the framing logic.
+    Unit test for the variable length integer encoding and decoding logic.
 
 --*/
 
 #include "main.h"
 
 #ifdef QUIC_LOGS_WPP
-#include "frametest.tmh"
+#include "varinttest.tmh"
 #endif
 
 uint64_t Encode(uint64_t Value)
@@ -30,7 +30,7 @@ uint64_t Decode(uint64_t Encoded)
     return Decoded;
 }
 
-TEST(FrameTest, WellKnownEncode)
+TEST(VarIntTest, WellKnownEncode)
 {
     TEST_EQUAL(Encode(0), 0);
     TEST_EQUAL(Encode(0x3F), 0x3F);
@@ -42,7 +42,7 @@ TEST(FrameTest, WellKnownEncode)
     TEST_EQUAL(Encode(0x3FFFFFFFFFFFFFFF), 0xFFFFFFFFFFFFFFFF);
 }
 
-TEST(FrameTest, WellKnownDecode)
+TEST(VarIntTest, WellKnownDecode)
 {
     TEST_EQUAL(Decode(0), 0);
     TEST_EQUAL(Decode(0x3F), 0x3F);
@@ -54,7 +54,7 @@ TEST(FrameTest, WellKnownDecode)
     TEST_EQUAL(Decode(0xFFFFFFFFFFFFFFFF), 0x3FFFFFFFFFFFFFFFULL);
 }
 
-TEST(FrameTest, RandomEncodeDecode)
+TEST(VarIntTest, RandomEncodeDecode)
 {
     for (uint32_t i = 0; i < 1000; i++) {
 


### PR DESCRIPTION
The new wire format for transport parameters, defined from quicwg/base-drafts#3169 that is part of the new draft (or at least will be).