### PR TITLE
Update Version/ALPN for New Drafts

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1261,7 +1261,7 @@ QuicBindingDeliverPackets(
         // Only Initial (version specific) packets are processed from here on.
         //
         switch (Packet->Invariant->LONG_HDR.Version) {
-        case QUIC_VERSION_DRAFT_25:
+        case QUIC_VERSION_DRAFT_27:
         case QUIC_VERSION_MS_1:
             if (Packet->LH->Type != QUIC_INITIAL) {
                 QuicPacketLogDrop(Binding, Packet, "Non-initial packet not matched with a connection");

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1490,7 +1490,7 @@ QuicConnOnQuicVersionSet(
     QuicTraceEvent(ConnVersionSet, Connection, Connection->Stats.QuicVersion);
 
     switch (Connection->Stats.QuicVersion) {
-    case QUIC_VERSION_DRAFT_25:
+    case QUIC_VERSION_DRAFT_27:
     case QUIC_VERSION_MS_1:
     default:
         Connection->State.HeaderProtectionEnabled = TRUE;

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -20,7 +20,7 @@ Abstract:
 // The list is in priority order (highest to lowest).
 //
 const uint32_t QuicSupportedVersionList[] = {
-    QUIC_VERSION_DRAFT_25,
+    QUIC_VERSION_DRAFT_27,
     QUIC_VERSION_MS_1
 };
 
@@ -554,7 +554,7 @@ QuicPacketLogHeader(
             break;
         }
 
-        case QUIC_VERSION_DRAFT_25:
+        case QUIC_VERSION_DRAFT_27:
         case QUIC_VERSION_MS_1: {
             const QUIC_LONG_HEADER_V1 * const LongHdr =
                 (const QUIC_LONG_HEADER_V1 * const)Packet;
@@ -643,7 +643,7 @@ QuicPacketLogHeader(
         const uint8_t* DestCid = Invariant->SHORT_HDR.DestCid;
 
         switch (Version) {
-        case QUIC_VERSION_DRAFT_25:
+        case QUIC_VERSION_DRAFT_27:
         case QUIC_VERSION_MS_1: {
             const QUIC_SHORT_HEADER_V1 * const Header =
                 (const QUIC_SHORT_HEADER_V1 * const)Packet;

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -233,7 +233,7 @@ QuicPacketIsHandshake(
     }
 
     switch (Packet->LONG_HDR.Version) {
-        case QUIC_VERSION_DRAFT_25:
+        case QUIC_VERSION_DRAFT_27:
         case QUIC_VERSION_MS_1:
             return ((QUIC_LONG_HEADER_V1*)Packet)->Type != QUIC_0_RTT_PROTECTED;
         default:

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -282,7 +282,7 @@ QuicPacketBuilderPrepare(
             Builder->PacketNumberLength = 4; // TODO - Determine correct length based on BDP.
 
             switch (Connection->Stats.QuicVersion) {
-            case QUIC_VERSION_DRAFT_25:
+            case QUIC_VERSION_DRAFT_27:
             case QUIC_VERSION_MS_1:
                 Builder->HeaderLength =
                     QuicPacketEncodeShortHeaderV1(
@@ -304,7 +304,7 @@ QuicPacketBuilderPrepare(
         } else { // Long Header
 
             switch (Connection->Stats.QuicVersion) {
-            case QUIC_VERSION_DRAFT_25:
+            case QUIC_VERSION_DRAFT_27:
             case QUIC_VERSION_MS_1:
             default:
                 Builder->HeaderLength =
@@ -622,7 +622,7 @@ QuicPacketBuilderFinalize(
 
     if (Builder->PacketType != SEND_PACKET_SHORT_HEADER_TYPE) {
         switch (Connection->Stats.QuicVersion) {
-        case QUIC_VERSION_DRAFT_25:
+        case QUIC_VERSION_DRAFT_27:
         case QUIC_VERSION_MS_1:
         default:
             QuicVarIntEncode2Bytes(

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -26,7 +26,7 @@ Environment:
 #include <stdio.h>
 #include <stdlib.h>
 
-#define ALPN_HTTP_OVER_QUIC     "hq-25"
+#define ALPN_HTTP_OVER_QUIC     "hq-27"
 
 //
 // Converts the QUIC Status Code to a string for console output.

--- a/src/inc/quic_versions.h
+++ b/src/inc/quic_versions.h
@@ -17,7 +17,7 @@ Abstract:
 #define QUIC_VERSION_VER_NEG    0x00000000      // Version for 'Version Negotiation'
 #define QUIC_VERSION_1          0x01000000      // First official version
 #define QUIC_VERSION_MS_1       0x0000cdab      // First Microsoft version (currently same as latest draft)
-#define QUIC_VERSION_DRAFT_25   0x190000ff      // IETF draft 25
+#define QUIC_VERSION_DRAFT_27   0x190000ff      // IETF draft 27
 
 //
 // The QUIC version numbers, in host byte order.
@@ -25,7 +25,7 @@ Abstract:
 #define QUIC_VERSION_VER_NEG_H  0x00000000      // Version for 'Version Negotiation'
 #define QUIC_VERSION_1_H        0x00000001      // First official version
 #define QUIC_VERSION_1_MS_H     0xabcd0000      // First Microsoft version (-1412628480 in decimal)
-#define QUIC_VERSION_DRAFT_25_H 0xff000019      // IETF draft 25
+#define QUIC_VERSION_DRAFT_27_H 0xff000019      // IETF draft 27
 
 //
 // Represents a reserved version value; used to force version negotation.
@@ -36,8 +36,8 @@ Abstract:
 //
 // The latest QUIC version number.
 //
-#define QUIC_VERSION_LATEST     QUIC_VERSION_DRAFT_25
-#define QUIC_VERSION_LATEST_H   QUIC_VERSION_DRAFT_25_H
+#define QUIC_VERSION_LATEST     QUIC_VERSION_DRAFT_27
+#define QUIC_VERSION_LATEST_H   QUIC_VERSION_DRAFT_27_H
 
 inline
 BOOLEAN
@@ -47,7 +47,7 @@ QuicIsVersionSupported(
 {
     switch (Version) {
     case QUIC_VERSION_VER_NEG:
-    case QUIC_VERSION_DRAFT_25:
+    case QUIC_VERSION_DRAFT_27:
     case QUIC_VERSION_MS_1:
         return TRUE;
     default:

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -20,7 +20,10 @@ uint16_t Port = 443;
 const char* ServerName = "localhost";
 const char* ServerIp = nullptr;
 QUIC_ADDR ServerAddress = {0};
-std::vector<const char*> ALPNs({ "h3-24", "h3-25", "hq-24", "hq-25", "smb" });
+std::vector<const char*> ALPNs(
+    { "h3-25", "h3-26", "h3-27",
+      "hq-25", "hq-26", "hq-27",
+      "smb" });
 
 QUIC_API_V1* MsQuic;
 HQUIC Registration;


### PR DESCRIPTION
In anticipation of the WG releasing draft-27 (ignoring the just released -26 because of some issues) this PR updates the version and ALPN strings accordingly.