### PR TITLE
Fix CID ETW Events

### DIFF
--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -2860,19 +2860,19 @@
             />
         <string
             id="Etw.ConnSourceCidAdd"
-            value="[conn][%1] New Source CID: %3"
+            value="[conn][%1] New Source CID: %4"
             />
         <string
             id="Etw.ConnDestCidAdd"
-            value="[conn][%1] New Destination CID: %3"
+            value="[conn][%1] New Destination CID: %4"
             />
         <string
             id="Etw.ConnSourceCidRemove"
-            value="[conn][%1] Removed Source CID: %3"
+            value="[conn][%1] Removed Source CID: %4"
             />
         <string
             id="Etw.ConnDestCidRemove"
-            value="[conn][%1] Removed Destination CID: %3"
+            value="[conn][%1] Removed Destination CID: %4"
             />
         <string
             id="Etw.ConnAssignWorker"

--- a/src/tools/etwlib/QuicEvents.h
+++ b/src/tools/etwlib/QuicEvents.h
@@ -242,6 +242,7 @@ struct QuicConnEventPayload {
             uint32_t WindowLastMax;
         } Cubic;
         struct {
+            uint64_t SequenceNumber;
             uint8_t CidLength;
             uint8_t Cid[1];
         } SourceCidAdd, SourceCidRemove;


### PR DESCRIPTION
Missed a few changes from a previous ETW manifest update. The wrong value (the length) is getting dumped when converted to text.