### PR TITLE
Retry Force CID Update on Failure in Test Code

### DIFF
--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -188,13 +188,30 @@ TestConnection::ForceKeyUpdate()
 QUIC_STATUS
 TestConnection::ForceCidUpdate()
 {
-    return
-        MsQuic->SetParam(
-            QuicConnection,
-            QUIC_PARAM_LEVEL_CONNECTION,
-            QUIC_PARAM_CONN_FORCE_CID_UPDATE,
-            0,
-            nullptr);
+    QUIC_STATUS Status;
+    uint32_t Try = 0;
+
+    do {
+        //
+        // Forcing a CID update is only allowed when the handshake is confirmed.
+        // So, even if the caller waits for connection complete, it's possible
+        // the call can fail with QUIC_STATUS_INVALID_STATE. To get around this
+        // we allow for a couple retries (with some sleeps).
+        //
+        if (Try != 0) {
+            QuicSleep(100);
+        }
+        Status =
+            MsQuic->SetParam(
+                QuicConnection,
+                QUIC_PARAM_LEVEL_CONNECTION,
+                QUIC_PARAM_CONN_FORCE_CID_UPDATE,
+                0,
+                nullptr);
+
+    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 3);
+
+    return Status;
 }
 
 QUIC_STATUS


### PR DESCRIPTION
Fixes #181.

Adds some retry logic to the test code that forces the CID update to allow for race conditions between setting the parameter and the handshake being confirmed.