### PR TITLE
Re-enable Visual Studio to run tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ if(QUIC_BUILD_TEST)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         option(gtest_force_shared_crt "Use shared (DLL) run-time lib even when Google Test is built as static lib." ON)
     endif()
+    enable_testing()
     add_subdirectory(submodules/googletest)
 
     add_subdirectory(src/core/unittest)


### PR DESCRIPTION
During refactoring of the CMakeLists.txt files, the ability for the CMake-generated Visual Studio project to automatically run tests was lost.
This change adds that functionality back.