### PR TITLE
Test Fixes for Key Update

### DIFF
--- a/src/test/lib/QuicTest.cpp
+++ b/src/test/lib/QuicTest.cpp
@@ -650,7 +650,9 @@ PingStreamShutdown(
 #endif
 
     if (ConnState->StreamsComplete > 0 && ConnState->StreamsComplete % 2 == 0 && ConnState->Stats->ServerKeyUpdate) {
-        ConnState->Connection->ForceKeyUpdate();
+        if (QUIC_FAILED(ConnState->Connection->ForceKeyUpdate())) {
+            TEST_FAILURE("Server ForceKeyUpdate failed.");
+        }
     }
 
     ConnState->OnStreamComplete();
@@ -1545,11 +1547,11 @@ QuicTestKeyUpdate(
                     QuicSleep(100);
 
                     if (ClientKeyUpdate) {
-                        Client.ForceKeyUpdate();
+                        TEST_QUIC_SUCCEEDED(Client.ForceKeyUpdate());
                     }
 
                     if (ServerKeyUpdate) {
-                        Server->ForceKeyUpdate();
+                        TEST_QUIC_SUCCEEDED(Server->ForceKeyUpdate());
                     }
 
                     //

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -176,13 +176,30 @@ TestConnection::WaitForPeerClose()
 QUIC_STATUS
 TestConnection::ForceKeyUpdate()
 {
-    return
-        MsQuic->SetParam(
-            QuicConnection,
-            QUIC_PARAM_LEVEL_CONNECTION,
-            QUIC_PARAM_CONN_FORCE_KEY_UPDATE,
-            0,
-            nullptr);
+    QUIC_STATUS Status;
+    uint32_t Try = 0;
+
+    do {
+        //
+        // Forcing a key update is only allowed when the handshake is confirmed.
+        // So, even if the caller waits for connection complete, it's possible
+        // the call can fail with QUIC_STATUS_INVALID_STATE. To get around this
+        // we allow for a couple retries (with some sleeps).
+        //
+        if (Try != 0) {
+            QuicSleep(100);
+        }
+        Status =
+            MsQuic->SetParam(
+                QuicConnection,
+                QUIC_PARAM_LEVEL_CONNECTION,
+                QUIC_PARAM_CONN_FORCE_KEY_UPDATE,
+                0,
+                nullptr);
+
+    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 3);
+
+    return Status;
 }
 
 QUIC_STATUS


### PR DESCRIPTION
The test code wasn't validating the return status when forcing a key update. Also, this PR adds some retry logic when forcing the key update to work around possible race conditions related to handshake confirmed (similar to forcing CID update).