### PR TITLE
Create VPack for Windows

### DIFF
--- a/.azure/scripts/prepare-package.ps1
+++ b/.azure/scripts/prepare-package.ps1
@@ -19,7 +19,7 @@ $RootDir = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $ArtifactsDir = Join-Path $RootDir "artifacts"
 
 # Output directory for all package files.
-$PackageDir = Join-Path $ArtifactsDir "package/all"
+$PackageDir = Join-Path $ArtifactsDir "package"
 
 function Force-Copy($Source, $Destination) {
     New-Item -Path $Destination -ItemType Directory -Force | Out-Null

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -42,7 +42,6 @@ jobs:
       versionAs: parts
       sourceDirectory: $(Build.ArtifactStagingDirectory)
       description: msquic.$(Build.SourceBranchName)
-      multiArchitecture: true
       pushPkgName: msquic
       owner: quicdev@microsoft.com
       majorVer: 1


### PR DESCRIPTION
Updates the Azure Pipeline packaging stage to generate a VPack that can be consumed by the Windows OS build.

I have verified this by running through the mirror repo's build and updating my local OS enlistment to consume the VPack:
```
g:\os\src>dir ..\osdep\OSS\msquic
 Volume in drive G is SSD2
 Volume Serial Number is 5E53-7F8B

 Directory of g:\os\osdep\OSS\msquic

02/27/2020  01:37 PM    <DIR>          .
02/27/2020  01:37 PM    <DIR>          ..
02/27/2020  01:37 PM    <DIR>          bin
02/27/2020  01:37 PM    <DIR>          lib
02/27/2020  01:37 PM            29,523 msquic.h
02/27/2020  01:37 PM             8,363 MsQuic.wprp
02/27/2020  01:37 PM           120,004 MsQuicEtw.man
02/27/2020  01:37 PM             4,073 msquicp.h
02/27/2020  01:37 PM             6,359 msquic_winkernel.h
02/27/2020  01:37 PM             7,805 msquic_winuser.h
02/27/2020  01:37 PM    <DIR>          pdb
               6 File(s)        176,127 bytes
```