### PR TITLE
Fix Filtering Logic in Test Script

### DIFF
--- a/.azure/scripts/run-gtest.ps1
+++ b/.azure/scripts/run-gtest.ps1
@@ -405,8 +405,12 @@ $TestCases = GetTestCases
 
 # Apply any filtering.
 if ($Filter -ne "") {
+    $isNegative = $false
     foreach ($f in $Filter.Split(":")) {
         if ($f.StartsWith("-")) {
+            $isNegative = $true
+        }
+        if ($isNegative) {
             $f = $f.Substring(1)
             $TestCases = ($TestCases | Where-Object { !($_ -Like $f) }) -as [String[]]
         } else {


### PR DESCRIPTION
The PowerShell script wasn't correctly applying the negative filter. All filters after the `-` are negative; not just the one prefixed with the `-`.