### PR TITLE
Completely Ignore Ideal Processor Changed Events

### DIFF
--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -386,7 +386,7 @@ QuicTestValidateStreamEvents1(
     TEST_TRUE(Session.IsValid());
 
     { // Connections scope
-    ConnValidator Client, Server(false);
+    ConnValidator Client, Server;
 
     MsQuic->SetContext(Listener, &Server);
 
@@ -491,7 +491,7 @@ QuicTestValidateStreamEvents2(
     TEST_TRUE(Session.IsValid());
 
     { // Connections scope
-    ConnValidator Client, Server(false);
+    ConnValidator Client, Server;
 
     MsQuic->SetContext(Listener, &Server);
 


### PR DESCRIPTION
Updates EventTest to ignore ideal-processor-changed events. Since they can come at any time, it's impossible to have the test validate them. So we'll ignore them altogether.