### PR TITLE
Fix Disable Encryption Getting Set

### DIFF
--- a/src/core/library.h
+++ b/src/core/library.h
@@ -58,12 +58,6 @@ typedef struct QUIC_LIBRARY {
     //
     BOOLEAN Loaded : 1;
 
-    //
-    // Indicates encryption is enabled or disabled for new connections.
-    // Defaults to FALSE.
-    //
-    BOOLEAN EncryptionDisabled : 1;
-
 #ifdef QuicVerifierEnabled
     //
     // The app or driver verifier is globally enabled.
@@ -72,9 +66,15 @@ typedef struct QUIC_LIBRARY {
 #endif
 
     //
+    // Indicates encryption is enabled or disabled for new connections.
+    // Defaults to FALSE.
+    //
+    BOOLEAN EncryptionDisabled;
+
+    //
     // Index for the current stateless retry token key.
     //
-    BOOLEAN CurrentStatelessRetryKey : 1;
+    BOOLEAN CurrentStatelessRetryKey;
 
     //
     // Configurable (app & registry) settings.

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -444,6 +444,7 @@ QuicRegistrationParamSet(
         }
 
         MsQuicLib.EncryptionDisabled = *(uint8_t*)Buffer == FALSE;
+        QuicTraceLogWarning("[ lib] Updated encryption disabled = %hu", MsQuicLib.EncryptionDisabled);
 
         Status = QUIC_STATUS_SUCCESS;
         break;


### PR DESCRIPTION
After debugging the KeyUpdate test failures, I found that somehow encryption was disabled, and that the EncryptionDisabled flag was set on the library object. From code inspection, I found that this was part of a bitfield (along with CurrentStatelessRetryKey) that could be set from multiple parallel threads. This PR fixes this up by removing these variables from the bitfield so they can be set in parallel, with their own synchronization.