### PR TITLE
Track Unregistered Server Connections

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -60,7 +60,7 @@ MsQuicConnectionOpen(
 #pragma prefast(suppress: __WARNING_25024, "Pointer cast already validated.")
     Session = (QUIC_SESSION*)SessionHandle;
 
-    Status = QuicConnInitialize(NULL, &Connection);
+    Status = QuicConnInitialize(Session, NULL, &Connection);
     if (QUIC_FAILED(Status)) {
         goto Error;
     }
@@ -68,7 +68,6 @@ MsQuicConnectionOpen(
     Connection->ClientCallbackHandler = Handler;
     Connection->ClientContext = Context;
 
-    QuicSessionRegisterConnection(Session, Connection);
     QuicRegistrationQueueNewConnection(Session->Registration, Connection);
 
     *NewConnection = (HQUIC)Connection;

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1075,7 +1075,11 @@ QuicBindingCreateConnection(
     QUIC_CONNECTION* Connection = NULL;
 
     QUIC_CONNECTION* NewConnection;
-    QUIC_STATUS Status = QuicConnInitialize(Datagram, &NewConnection);
+    QUIC_STATUS Status =
+        QuicConnInitialize(
+            MsQuicLib.UnregisteredSession,
+            Datagram,
+            &NewConnection);
     if (QUIC_FAILED(Status)) {
         QuicConnRelease(NewConnection, QUIC_CONN_REF_HANDLE_OWNER);
         QuicPacketLogDropWithValue(Binding, QuicDataPathRecvDatagramToRecvPacket(Datagram),

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -782,6 +782,7 @@ QuicConnRemoveOutFlowBlockedReason(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QuicConnInitialize(
+    _In_ QUIC_SESSION* Session,
     _In_opt_ const QUIC_RECV_DATAGRAM* const Datagram,
     _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem))
         QUIC_CONNECTION** Connection

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -154,6 +154,11 @@ typedef struct QUIC_LIBRARY {
     QUIC_LIST_ENTRY Bindings;
 
     //
+    // Contains all (server) connections currently not in an app's registration.
+    //
+    QUIC_SESSION* UnregisteredSession;
+
+    //
     // Set of workers that manage processing client Initial packets on the
     // server side.
     //

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -374,7 +374,7 @@ QuicListenerClaimConnection(
 Exit:
 
     if (Status != QUIC_STATUS_PENDING && QUIC_FAILED(Status)) {
-        QuicSessionUnregisterConnection(Connection->Session, Connection);
+        QuicSessionUnregisterConnection(Connection);
     }
 
     return Status;

--- a/src/core/session.h
+++ b/src/core/session.h
@@ -131,6 +131,22 @@ typedef struct QUIC_SESSION {
 #endif // #ifdef QUIC_SILO
 
 //
+// Initializes an empty session object.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+__drv_allocatesMem(Mem)
+_Must_inspect_result_
+_Success_(return != NULL)
+QUIC_SESSION*
+QuicSessionAlloc(
+    _In_opt_ QUIC_REGISTRATION* Registration,
+    _In_opt_ void* Context,
+    _In_ uint8_t AlpnLength,
+    _In_reads_opt_(AlpnLength)
+        const uint8_t* Alpn
+    );
+
+//
 // Tracing rundown for the session.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -165,7 +181,6 @@ QuicSessionRegisterConnection(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicSessionUnregisterConnection(
-    _In_ QUIC_SESSION* Session,
     _Inout_ QUIC_CONNECTION* Connection
     );
 


### PR DESCRIPTION
Fixes #116.

This PR tracks currently unregistered server connections in a global "unregistered" session so that these connections can be cleaned up properly on library shutdown.