### PR TITLE
Use Private Agent for Internal Testing

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -59,13 +59,9 @@ stages:
   dependsOn:
   - build_windows
   jobs:
-  - template: ./templates/run-bvt.yml
+  - template: ./templates/run-bvt-int.yml
     parameters:
-      image: windows-latest
-      platform: windows
       arch: x64
-      tls: schannel
-      extraArgs: -Filter "ParameterValidation.*:-*Events"
 
 #
 # Package

--- a/.azure/scripts/prepare-test-machine.ps1
+++ b/.azure/scripts/prepare-test-machine.ps1
@@ -48,6 +48,14 @@ $ScriptsDir = Join-Path $RootDir ".azure" "scripts"
 $ArtifactsDir = Join-Path $RootDir "artifacts"
 
 if ($IsWindows) {
+    # Disable SChannel TLS 1.3 (client and server).
+    $TlsServerKeyPath = "HKLM\System\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server"
+    reg.exe add $TlsServerKeyPath /v DisabledByDefault /t REG_DWORD /d 1 /f | Out-Null
+    reg.exe add $TlsServerKeyPath /v Enabled /t REG_DWORD /d 0 /f | Out-Null
+    $TlsClientKeyPath = "HKLM\System\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
+    reg.exe add $TlsClientKeyPath /v DisabledByDefault /t REG_DWORD /d 1 /f | Out-Null
+    reg.exe add $TlsClientKeyPath /v Enabled /t REG_DWORD /d 0 /f | Out-Null
+
     # Run procdump installation script.
     & (Join-Path $ScriptsDir "install-procdump.ps1")
 

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -4,6 +4,8 @@ jobs:
 - job: Package
   displayName: Package for Windows OS
   pool: Package ES Lab A
+  variables:
+    runCodesignValidationInjection: false
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: Download Build Artifacts
@@ -37,6 +39,7 @@ jobs:
       parallel: true
 
   - task: PkgESVPack@10
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     inputs:
       vPackCmd: push
       versionAs: parts

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -14,6 +14,8 @@ jobs:
   displayName: BVT ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }}
   pool:
     vmImage: ${{ parameters.image }}
+  variables:
+    runCodesignValidationInjection: false
   steps:
   - checkout: self
     persistCredentials: true


### PR DESCRIPTION
Updates the internal CI to use our private agent pool to run schannel tests on custom Windows builds.