### PR TITLE
Increase Test Timeout to 15 Minutes

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -35,7 +35,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 10
+    timeoutInMinutes: 15
     continueOnError: true
     inputs:
       pwsh: true


### PR DESCRIPTION
Converting logs on failure takes a long time.