### PR TITLE
Call QuicConnOnShutdownComplete in MsQuicSessionClose

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1207,6 +1207,7 @@ QuicConnOnShutdownComplete(
         //
 
         QuicConnCloseHandle(Connection);
+        QuicConnUninitialize(Connection);
         QuicConnRelease(Connection, QUIC_CONN_REF_HANDLE_OWNER);
 
     } else {
@@ -1220,11 +1221,6 @@ QuicConnOnShutdownComplete(
         (void)QuicConnIndicateEvent(Connection, &Event);
 
         Connection->ClientCallbackHandler = NULL;
-    }
-
-#pragma prefast(suppress:6001, "SAL doesn't understand ref counts")
-    if (Connection->Paths[0].Binding != NULL) {
-        QuicBindingRemoveConnection(Connection->Paths[0].Binding, Connection);
     }
 }
 

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -281,7 +281,7 @@ MsQuicSessionClose(
             QUIC_CONNECTION* Connection =
                 QUIC_CONTAINING_RECORD(Entry, QUIC_CONNECTION, SessionLink);
             Entry = Entry->Flink;
-            QuicConnCloseHandle(Connection);
+            QuicConnOnShutdownComplete(Connection);
         }
     }
 


### PR DESCRIPTION
Updates MsQuicSessionClose to call QuicConnOnShutdownComplete instead of QuicConnCloseHandle (which is called by QuicConnOnShutdownComplete already) because calling QuicConnCloseHandle directly leads to a use after free.