### PR TITLE
Add Version and Release Helper Scripts

### DIFF
--- a/scripts/create-release.ps1
+++ b/scripts/create-release.ps1
@@ -1,0 +1,51 @@
+<#
+
+.SYNOPSIS
+This script automates creating a new release branch from the latest master.
+
+.PARAMETER Type
+    Specifies the type of release (Major or Minor) and updates the current
+    version accordingly.
+
+.EXAMPLE
+    create-release.ps1 -Type Major
+
+#>
+
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Major", "Minor")]
+    [string]$Type
+)
+
+Set-StrictMode -Version 'Latest'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Relevant file paths used by this script.
+$RootDir = Split-Path $PSScriptRoot -Parent
+$MsQuicVerFilePath = Join-Path $RootDir "src" "inc" "msquic.ver"
+$UpdateVersionScript = Join-Path $RootDir "scripts" "update-version.ps1"
+
+# Make sure we're on the latest master.
+git checkout master
+git pull
+
+# Get the current major and minor version numbers from msquic.ver.
+$Version = (Select-String -Path $MsQuicVerFilePath "VER_FILEVERSION *(.*),.*,0$" -AllMatches).Matches[0].Groups[1].Value.Replace(",", ".")
+
+# Create a new release branch with the current version number.
+git checkout -b "release/$Version"
+git push --set-upstream origin "release/$Version"
+Write-Host "New release branch created: release/$Versio"
+
+# Go back to master and update the version number.
+git checkout master
+Invoke-Expression ($UpdateVersionScript + " -Part " + $Type)
+
+# Create a new branch, commit the changes, push the branch and open the browser to create the PR.
+git checkout -b "new-version-after-release-$Version"
+git commit -am "Increment Version for $Type Release: $Version"
+git push --set-upstream origin "new-version-after-release-$Version"
+Start-Process https://github.com/microsoft/msquic/pull/new/new-version-after-release-$Version
+
+Write-Host "Please continue the Pull Request process in the browser."

--- a/scripts/update-version.ps1
+++ b/scripts/update-version.ps1
@@ -1,0 +1,53 @@
+<#
+
+.SYNOPSIS
+This script automates updating all the necessary files for incrementing the
+current version number.
+
+.PARAMETER Part
+    Specifies the part of the version number to increment:
+    Major, Minor, or Patch
+
+.EXAMPLE
+    update-version.ps1 -Part Major
+
+#>
+
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Major", "Minor", "Patch")]
+    [string]$Part
+)
+
+Set-StrictMode -Version 'Latest'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Relevant file paths used by this script.
+$RootDir = Split-Path $PSScriptRoot -Parent
+$MsQuicVerFilePath = Join-Path $RootDir "src" "inc" "msquic.ver"
+$CreatePackageFilePath = Join-Path $RootDir ".azure" "templates" "create-package.yml"
+
+# Get the current version number from the msquic.ver file.
+$OriginalVersion = (Select-String -Path $MsQuicVerFilePath "VER_FILEVERSION *(.*),0$" -AllMatches).Matches[0].Groups[1].Value
+$OriginalVersion2 = $OriginalVersion.Replace(",", ".")
+$Version = $OriginalVersion.Split(",")
+Write-Host "Current version: $Version"
+
+# Increment the version number according to the input arg.
+switch ($Part) {
+    "Major"   { $Version[0] = [int]$Version[0] + 1; $Version[1] = 0; $Version[2] = 0 }
+    "Minor"   { $Version[1] = [int]$Version[1] + 1; $Version[2] = 0  }
+    "Patch"   { $Version[2] = [int]$Version[2] + 1 }
+}
+Write-Host "    New version: $Version"
+
+# Write the new version to the files.
+(Get-Content $MsQuicVerFilePath) `
+    -replace "($OriginalVersion)", "$($Version[0]),$($Version[1]),$($Version[2])" `
+    -replace "($OriginalVersion2)", "$($Version[0]).$($Version[1]).$($Version[2])" |`
+    Out-File $MsQuicVerFilePath
+(Get-Content $CreatePackageFilePath) `
+    -replace "majorVer: (.*)", "majorVer: $($Version[0])" `
+    -replace "minorVer: (.*)", "minorVer: $($Version[1])" `
+    -replace "patchVer: (.*)", "patchVer: $($Version[2])" |`
+    Out-File $CreatePackageFilePath


### PR DESCRIPTION
This PR adds two new scripts:

- **update-version.ps1** - updates all the version number in all files in the repository
- **create-release.ps1** - creates a new release branch from master (with the current major/minor version number) and updates the master version number accordingly.