### PR TITLE
Use MinRtt instead of SmoothedRtt for RX buffer tuning

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -529,7 +529,7 @@ QuicStreamOnBytesDelivered(
             Stream->Connection->Session->Settings.ConnFlowControlWindow) {
 
             uint32_t TimeThreshold = (uint32_t)
-                ((Stream->RecvWindowBytesDelivered * Stream->Connection->Paths[0].SmoothedRtt) / RecvBufferDrainThreshold);
+                ((Stream->RecvWindowBytesDelivered * Stream->Connection->Paths[0].MinRtt) / RecvBufferDrainThreshold);
             if (QuicTimeDiff32(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
 
                 //
@@ -552,9 +552,9 @@ QuicStreamOnBytesDelivered(
                 //
 
                 QuicTraceLogStreamVerbose(IncreaseRxBuffer, Stream,
-                    "Increasing max RX buffer size to %u (SRtt=%u; TimeNow=%u; LastUpdate=%u)",
+                    "Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)",
                     Stream->RecvBuffer.VirtualBufferLength * 2,
-                    Stream->Connection->Paths[0].SmoothedRtt,
+                    Stream->Connection->Paths[0].MinRtt,
                     TimeNow,
                     Stream->RecvWindowLastUpdate);
 


### PR DESCRIPTION
Any difference between MinRtt and SmoothedRtt ought to be considered bufferbloat.
Growing the flow control window in response to buffer bloat is a pathological
positive feedback loop. Using MinRtt mitigates this problem as long as the
bottleneck buffer wasn't bloated before the connection started taking RTT
samples.