### PR TITLE
Try to Improve AZP Failure Debuggability

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -35,7 +35,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 15
+    timeoutInMinutes: 20
     continueOnError: true
     inputs:
       pwsh: true

--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -6,7 +6,7 @@
       <Buffers Value="20"/>
     </SystemCollector>
     <EventCollector Id="EC_LowVolume" Name="LowVolume">
-      <BufferSize Value="64"/>
+      <BufferSize Value="32"/>
       <Buffers Value="32"/>
     </EventCollector>
     <EventCollector Id="EC_HighVolume" Name="High Volume">


### PR DESCRIPTION
We're seeing Azure Pipelines throw the following error when uploading our logs/dump files:
```
Error: ENOSPC: no space left on device, write
    at Error (native)
    at Object.fs.writeSync (fs.js:796:20)
    at copyFileSync (d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\node_modules\shelljs\src\cp.js:34:8)
    at d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\node_modules\shelljs\src\cp.js:198:5
    at Array.forEach (native)
    at Object._cp (d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\node_modules\shelljs\src\cp.js:157:11)
    at Object.cp (d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\node_modules\shelljs\src\common.js:186:23)
    at Object.cp (d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\node_modules\azure-pipelines-task-lib\task.js:681:15)
    at matchedFiles.forEach.err (d:\a\_tasks\CopyFiles_5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c\2.164.0\copyfiles.js:98:24)
    at Array.forEach (native)
```
This PR tries to fix this by reducing the log buffer sizes. It also increases the log timeout as I've seen that hit too.