### PR TITLE
Consolidate CID checks in QuicPacketValidateInvariant

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -913,22 +913,6 @@ QuicBindingPreprocessDatagram(
         return FALSE;
     }
 
-    if (Binding->Exclusive) {
-        if (Packet->DestCidLen != 0) {
-            QuicPacketLogDrop(Binding, Packet, "Non-zero length CID on exclusive binding");
-            return FALSE;
-        }
-    } else {
-        if (Packet->DestCidLen == 0) {
-            QuicPacketLogDrop(Binding, Packet, "Zero length CID on non-exclusive binding");
-            return FALSE;
-
-        } else if (Packet->DestCidLen < QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH) {
-            QuicPacketLogDrop(Binding, Packet, "Less than min length CID on non-exclusive binding");
-            return FALSE;
-        }
-    }
-
     if (Packet->Invariant->IsLongHeader) {
         //
         // Validate we support this long header packet version.


### PR DESCRIPTION
Moves the CID checks in QuicBindingPreprocessDatagram (where they are currently
happening only for the first packet in a datagram) into QuicPacketValidateInvariant
(which is called for every packet in a datagram).