### PR TITLE
Remove two unused variables

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1287,8 +1287,6 @@ QuicBindingReceive(
     QUIC_RECV_DATAGRAM** SubChainTail = &SubChain;
     QUIC_RECV_DATAGRAM** SubChainDataTail = &SubChain;
     uint32_t SubChainLength = 0;
-    char* CurrentDestCid = NULL;
-    uint32_t CurrentDestCidLen = 0;
 
     //
     // Breaks the chain of datagrams into subchains by destination CID and


### PR DESCRIPTION
They were accidentally added in commit 79ae115d088e469c.