### PR TITLE
Fix Endless CID Exchange Bug

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -952,6 +952,7 @@ QuicConnReplaceRetiredCids(
 
         Path->DestCid = NewDestCid;
         Path->DestCid->CID.UsedLocally = TRUE;
+        Path->InitiatedCidUpdate = TRUE;
     }
 
     return TRUE;


### PR DESCRIPTION
Fixes an issue found by the HTTP team where performance was tanking because we were endlessly switching through CIDs. The problem seems to be because we didn't treat replacing a in-use-CID as a locally initiated CID change. So, when the peer updated in response, we just immediately updated again! And that would go on endlessly. The fix was simply to set the flag when we make the replacement.