### PR TITLE
Get/Set Global Parameters

### DIFF
--- a/docs/api/GetParam.md
+++ b/docs/api/GetParam.md
@@ -10,7 +10,9 @@ typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 (QUIC_API * QUIC_GET_PARAM_FN)(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _Inout_ _Pre_defensive_ uint32_t* BufferLength,
@@ -23,7 +25,7 @@ QUIC_STATUS
 
 `Handle`
 
-The valid handle to any API object. This includes handles to registration, session, listener, connection and stream objects.
+The valid handle to any API object. This includes handles to registration, session, listener, connection and stream objects. For `Level` equal to `QUIC_PARAM_LEVEL_GLOBAL`, this parameter must be `NULL`.
 
 `Level`
 

--- a/docs/api/SetParam.md
+++ b/docs/api/SetParam.md
@@ -10,7 +10,9 @@ typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 (QUIC_API * QUIC_SET_PARAM_FN)(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _In_ uint32_t BufferLength,
@@ -23,7 +25,7 @@ QUIC_STATUS
 
 `Handle`
 
-The valid handle to any API object. This includes handles to registration, session, listener, connection and stream objects.
+The valid handle to any API object. This includes handles to registration, session, listener, connection and stream objects. For `Level` equal to `QUIC_PARAM_LEVEL_GLOBAL`, this parameter must be `NULL`.
 
 `Level`
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -931,7 +931,9 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QUIC_API
 MsQuicSetParam(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _In_ uint32_t BufferLength,
@@ -941,7 +943,7 @@ MsQuicSetParam(
 {
     QUIC_PASSIVE_CODE();
 
-    if (Handle == NULL) {
+    if ((Handle == NULL) ^ (Level == QUIC_PARAM_LEVEL_GLOBAL)) {
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
@@ -950,6 +952,14 @@ MsQuicSetParam(
         Handle);
 
     QUIC_STATUS Status;
+
+    if (Level == QUIC_PARAM_LEVEL_GLOBAL) {
+        //
+        // Global parameters are processed inline.
+        //
+        Status = QuicLibrarySetGlobalParam(Param, BufferLength, Buffer);
+        goto Error;
+    }
 
     if (Handle->Type == QUIC_HANDLE_TYPE_REGISTRATION ||
         Handle->Type == QUIC_HANDLE_TYPE_SESSION ||
@@ -1024,7 +1034,9 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QUIC_API
 MsQuicGetParam(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _Inout_ _Pre_defensive_ uint32_t* BufferLength,
@@ -1034,7 +1046,8 @@ MsQuicGetParam(
 {
     QUIC_PASSIVE_CODE();
 
-    if (Handle == NULL || BufferLength == NULL) {
+    if (((Handle == NULL) ^ (Level == QUIC_PARAM_LEVEL_GLOBAL)) ||
+        BufferLength == NULL) {
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
@@ -1043,6 +1056,14 @@ MsQuicGetParam(
     QuicTraceEvent(ApiEnter,
         QUIC_TRACE_API_GET_PARAM,
         Handle);
+
+    if (Level == QUIC_PARAM_LEVEL_GLOBAL) {
+        //
+        // Global parameters are processed inline.
+        //
+        Status = QuicLibraryGetGlobalParam(Param, BufferLength, Buffer);
+        goto Error;
+    }
 
     if (Handle->Type == QUIC_HANDLE_TYPE_REGISTRATION ||
         Handle->Type == QUIC_HANDLE_TYPE_SESSION ||

--- a/src/core/api.h
+++ b/src/core/api.h
@@ -214,7 +214,9 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QUIC_API
 MsQuicSetParam(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _In_ uint32_t BufferLength,
@@ -226,7 +228,9 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QUIC_API
 MsQuicGetParam(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _Inout_ _Pre_defensive_ uint32_t* BufferLength,

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -418,6 +418,132 @@ MsQuicSetCallbackHandler(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
+QuicLibrarySetGlobalParam(
+    _In_ uint32_t Param,
+    _In_ uint32_t BufferLength,
+    _In_reads_bytes_(BufferLength)
+        const void* Buffer
+    )
+{
+    QUIC_STATUS Status;
+
+    switch (Param) {
+    case QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT:
+
+        if (BufferLength != sizeof(MsQuicLib.Settings.RetryMemoryLimit)) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        MsQuicLib.Settings.RetryMemoryLimit = *(uint16_t*)Buffer;
+        MsQuicLib.Settings.AppSet.RetryMemoryLimit = TRUE;
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
+    case QUIC_PARAM_GLOBAL_ENCRYPTION:
+
+        if (BufferLength != sizeof(uint8_t)) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        MsQuicLib.EncryptionDisabled = *(uint8_t*)Buffer == FALSE;
+        QuicTraceLogWarning("[ lib] Updated encryption disabled = %hu", MsQuicLib.EncryptionDisabled);
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
+    default:
+        Status = QUIC_STATUS_INVALID_PARAMETER;
+        break;
+    }
+
+    return Status;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicLibraryGetGlobalParam(
+    _In_ uint32_t Param,
+    _Inout_ uint32_t* BufferLength,
+    _Out_writes_bytes_opt_(*BufferLength)
+        void* Buffer
+    )
+{
+    QUIC_STATUS Status;
+
+    switch (Param) {
+    case QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT:
+
+        if (*BufferLength < sizeof(MsQuicLib.Settings.RetryMemoryLimit)) {
+            *BufferLength = sizeof(MsQuicLib.Settings.RetryMemoryLimit);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *BufferLength = sizeof(MsQuicLib.Settings.RetryMemoryLimit);
+        *(uint16_t*)Buffer = MsQuicLib.Settings.RetryMemoryLimit;
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
+    case QUIC_PARAM_GLOBAL_SUPPORTED_VERSIONS:
+
+        if (*BufferLength < sizeof(QuicSupportedVersionList)) {
+            *BufferLength = sizeof(QuicSupportedVersionList);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *BufferLength = sizeof(QuicSupportedVersionList);
+        QuicCopyMemory(
+            Buffer,
+            QuicSupportedVersionList,
+            sizeof(QuicSupportedVersionList));
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
+    case QUIC_PARAM_GLOBAL_ENCRYPTION:
+
+        if (*BufferLength < sizeof(uint8_t)) {
+            *BufferLength = sizeof(uint8_t);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *BufferLength = sizeof(uint8_t);
+        *(uint8_t*)Buffer = !MsQuicLib.EncryptionDisabled;
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
+    default:
+        Status = QUIC_STATUS_INVALID_PARAMETER;
+        break;
+    }
+
+    return Status;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
 QuicLibrarySetParam(
     _In_ HQUIC Handle,
     _In_ QUIC_PARAM_LEVEL Level,

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -241,6 +241,24 @@ QuicPartitionIdGetIndex(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
+QuicLibrarySetGlobalParam(
+    _In_ uint32_t Param,
+    _In_ uint32_t BufferLength,
+    _In_reads_bytes_(BufferLength)
+        const void* Buffer
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicLibraryGetGlobalParam(
+    _In_ uint32_t Param,
+    _Inout_ uint32_t* BufferLength,
+    _Out_writes_bytes_opt_(*BufferLength)
+        void* Buffer
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
 QuicLibrarySetParam(
     _In_ HQUIC Handle,
     _In_ QUIC_PARAM_LEVEL Level,

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -349,19 +349,6 @@ QuicRegistrationParamSet(
     QUIC_STATUS Status;
 
     switch (Param) {
-    case QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT:
-
-        if (BufferLength != sizeof(MsQuicLib.Settings.RetryMemoryLimit)) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
-
-        MsQuicLib.Settings.RetryMemoryLimit = *(uint16_t*)Buffer;
-        MsQuicLib.Settings.AppSet.RetryMemoryLimit = TRUE;
-
-        Status = QUIC_STATUS_SUCCESS;
-        break;
-
     case QUIC_PARAM_REGISTRATION_CID_PREFIX:
 
         if (BufferLength == 0) {
@@ -396,19 +383,6 @@ QuicRegistrationParamSet(
         Status = QUIC_STATUS_SUCCESS;
         break;
 
-    case QUIC_PARAM_REGISTRATION_ENCRYPTION:
-
-        if (BufferLength != sizeof(uint8_t)) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
-
-        MsQuicLib.EncryptionDisabled = *(uint8_t*)Buffer == FALSE;
-        QuicTraceLogWarning("[ lib] Updated encryption disabled = %hu", MsQuicLib.EncryptionDisabled);
-
-        Status = QUIC_STATUS_SUCCESS;
-        break;
-
     default:
         Status = QUIC_STATUS_INVALID_PARAMETER;
         break;
@@ -430,25 +404,6 @@ QuicRegistrationParamGet(
     QUIC_STATUS Status;
 
     switch (Param) {
-    case QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT:
-
-        if (*BufferLength < sizeof(MsQuicLib.Settings.RetryMemoryLimit)) {
-            *BufferLength = sizeof(MsQuicLib.Settings.RetryMemoryLimit);
-            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
-            break;
-        }
-
-        if (Buffer == NULL) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
-
-        *BufferLength = sizeof(MsQuicLib.Settings.RetryMemoryLimit);
-        *(uint16_t*)Buffer = MsQuicLib.Settings.RetryMemoryLimit;
-
-        Status = QUIC_STATUS_SUCCESS;
-        break;
-
     case QUIC_PARAM_REGISTRATION_CID_PREFIX:
 
         if (*BufferLength < Registration->CidPrefixLength) {
@@ -469,25 +424,6 @@ QuicRegistrationParamGet(
         } else {
             *BufferLength = 0;
         }
-
-        Status = QUIC_STATUS_SUCCESS;
-        break;
-
-    case QUIC_PARAM_REGISTRATION_ENCRYPTION:
-
-        if (*BufferLength < sizeof(uint8_t)) {
-            *BufferLength = sizeof(uint8_t);
-            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
-            break;
-        }
-
-        if (Buffer == NULL) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
-
-        *BufferLength = sizeof(uint8_t);
-        *(uint8_t*)Buffer = !MsQuicLib.EncryptionDisabled;
 
         Status = QUIC_STATUS_SUCCESS;
         break;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -292,19 +292,25 @@ void
 //
 
 typedef enum QUIC_PARAM_LEVEL {
-    QUIC_PARAM_LEVEL_REGISTRATION       = 0,
-    QUIC_PARAM_LEVEL_SESSION            = 1,
-    QUIC_PARAM_LEVEL_LISTENER           = 2,
-    QUIC_PARAM_LEVEL_CONNECTION         = 3,
-    QUIC_PARAM_LEVEL_TLS                = 4,
-    QUIC_PARAM_LEVEL_STREAM             = 5
+    QUIC_PARAM_LEVEL_GLOBAL,
+    QUIC_PARAM_LEVEL_REGISTRATION,
+    QUIC_PARAM_LEVEL_SESSION,
+    QUIC_PARAM_LEVEL_LISTENER,
+    QUIC_PARAM_LEVEL_CONNECTION,
+    QUIC_PARAM_LEVEL_TLS,
+    QUIC_PARAM_LEVEL_STREAM
 } QUIC_PARAM_LEVEL;
+
+//
+// Parameters for QUIC_PARAM_LEVEL_GLOBAL.
+//
+#define QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT          0   // uint16_t
+#define QUIC_PARAM_GLOBAL_SUPPORTED_VERSIONS            1   // uint32_t[] - network byte order
 
 //
 // Parameters for QUIC_PARAM_LEVEL_REGISTRATION.
 //
-#define QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT    0   // uint16_t
-#define QUIC_PARAM_REGISTRATION_CID_PREFIX              1   // uint8_t[]
+#define QUIC_PARAM_REGISTRATION_CID_PREFIX              0   // uint8_t[]
 
 //
 // Parameters for QUIC_PARAM_LEVEL_SESSION.
@@ -377,7 +383,9 @@ typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 (QUIC_API * QUIC_SET_PARAM_FN)(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _In_ uint32_t BufferLength,
@@ -389,7 +397,9 @@ typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 (QUIC_API * QUIC_GET_PARAM_FN)(
-    _In_ _Pre_defensive_ HQUIC Handle,
+    _When_(Level == QUIC_PARAM_LEVEL_GLOBAL, _Reserved_)
+    _When_(Level != QUIC_PARAM_LEVEL_GLOBAL, _In_ _Pre_defensive_)
+        HQUIC Handle,
     _In_ _Pre_defensive_ QUIC_PARAM_LEVEL Level,
     _In_ uint32_t Param,
     _Inout_ _Pre_defensive_ uint32_t* BufferLength,

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -132,16 +132,15 @@ inline
 QUIC_STATUS
 QuicForceRetry(
     _In_ const QUIC_API_TABLE* MsQuic,
-    _In_ HQUIC Handle,
     _In_ BOOLEAN Enabled
     )
 {
     uint16_t value = Enabled ? 0 : 65;
     return
         MsQuic->SetParam(
-            Handle,
-            QUIC_PARAM_LEVEL_REGISTRATION,
-            QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT,
+            NULL,
+            QUIC_PARAM_LEVEL_GLOBAL,
+            QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT,
             sizeof(value),
             &value);
 }

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -27,9 +27,9 @@ extern "C" {
 #define QUIC_CERTIFICATE_FLAG_DISABLE_CERT_VALIDATION   0x80000000
 
 //
-// The different private parameters for QUIC_PARAM_LEVEL_REGISTRATION.
+// The different private parameters for QUIC_PARAM_LEVEL_GLOBAL.
 //
-#define QUIC_PARAM_REGISTRATION_ENCRYPTION              0x80000001  // uint8_t (BOOLEAN)
+#define QUIC_PARAM_GLOBAL_ENCRYPTION                    0x80000001  // uint8_t (BOOLEAN)
 
 //
 // The different private parameters for QUIC_PARAM_LEVEL_SESSION.

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -223,9 +223,9 @@ QuicDrillInitialPacketFailureTest(
 
     Status =
         MsQuic->SetParam(
-            Registration,
-            QUIC_PARAM_LEVEL_REGISTRATION,
-            QUIC_PARAM_REGISTRATION_ENCRYPTION,
+            nullptr,
+            QUIC_PARAM_LEVEL_GLOBAL,
+            QUIC_PARAM_GLOBAL_ENCRYPTION,
             sizeof(Disabled),
             &Disabled);
     if (QUIC_FAILED(Status)) {
@@ -316,9 +316,9 @@ QuicDrillInitialPacketFailureTest(
 Failure:
     Status =
         MsQuic->SetParam(
-            Registration,
-            QUIC_PARAM_LEVEL_REGISTRATION,
-            QUIC_PARAM_REGISTRATION_ENCRYPTION,
+            nullptr,
+            QUIC_PARAM_LEVEL_GLOBAL,
+            QUIC_PARAM_GLOBAL_ENCRYPTION,
             sizeof(Enabled),
             &Enabled);
     if (QUIC_FAILED(Status)) {

--- a/src/test/lib/QuicTest.cpp
+++ b/src/test/lib/QuicTest.cpp
@@ -34,9 +34,9 @@ void QuicTestInitialize()
     uint8_t Disabled = FALSE;
     if (QUIC_FAILED(
         MsQuic->SetParam(
-            MsQuic->Registration,
-            QUIC_PARAM_LEVEL_REGISTRATION,
-            QUIC_PARAM_REGISTRATION_ENCRYPTION,
+            nullptr,
+            QUIC_PARAM_LEVEL_GLOBAL,
+            QUIC_PARAM_GLOBAL_ENCRYPTION,
             sizeof(Disabled),
             &Disabled))) {
         QuicTraceLogError("[test] Disabling encryption failed");
@@ -343,9 +343,9 @@ struct StatelessRetryHelper
             uint16_t value = 0;
             TEST_QUIC_SUCCEEDED(
                 MsQuic->SetParam(
-                    Registration,
-                    QUIC_PARAM_LEVEL_REGISTRATION,
-                    QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT,
+                    nullptr,
+                    QUIC_PARAM_LEVEL_GLOBAL,
+                    QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT,
                     sizeof(value),
                     &value));
         }
@@ -355,9 +355,9 @@ struct StatelessRetryHelper
             uint16_t value = 65;
             TEST_QUIC_SUCCEEDED(
                 MsQuic->SetParam(
-                    Registration,
-                    QUIC_PARAM_LEVEL_REGISTRATION,
-                    QUIC_PARAM_REGISTRATION_RETRY_MEMORY_PERCENT,
+                    nullptr,
+                    QUIC_PARAM_LEVEL_GLOBAL,
+                    QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT,
                     sizeof(value),
                     &value));
         }

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -64,11 +64,7 @@ main(
     TryGetValue(argc, argv, "port", &LocalPort);
     TryGetValue(argc, argv, "retry", &Retry);
     if (Retry) {
-        EXIT_ON_FAILURE(
-            QuicForceRetry(
-                MsQuic,
-                Registration,
-                true));
+        EXIT_ON_FAILURE(QuicForceRetry(MsQuic, true));
         printf("Enabling forced RETRY on server.\n");
     }
 

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -185,12 +185,12 @@ ParseCommonCommands(
         uint8_t value = FALSE;
         if (QUIC_FAILED(
             MsQuic->SetParam(
-                Registration,
-                QUIC_PARAM_LEVEL_REGISTRATION,
-                QUIC_PARAM_REGISTRATION_ENCRYPTION,
+                nullptr,
+                QUIC_PARAM_LEVEL_GLOBAL,
+                QUIC_PARAM_GLOBAL_ENCRYPTION,
                 sizeof(value),
                 &value))) {
-            printf("MsQuic->SetParam (REGISTRATION_ENCRYPTION) failed!\n");
+            printf("MsQuic->SetParam (GLOBAL_ENCRYPTION) failed!\n");
         }
     }
 }


### PR DESCRIPTION
This PR refactors some of the parameters that were marked as registration specific (but not in actuality) into global parameters. It also adds a new global parameter to query the supported QUIC versions.