### PR TITLE
Add Migration Enabled Setting

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1790,12 +1790,15 @@ QuicConnHandshakeConfigure(
             QUIC_TP_FLAG_INITIAL_MAX_STRM_DATA_UNI |
             QUIC_TP_FLAG_MAX_PACKET_SIZE |
             QUIC_TP_FLAG_MAX_ACK_DELAY |
-            /* QUIC_TP_FLAG_DISABLE_ACTIVE_MIGRATION | TODO - Add config option to re-enable if behind 4-tuple LB */
             QUIC_TP_FLAG_ACTIVE_CONNECTION_ID_LIMIT;
 
         if (Connection->IdleTimeoutMs != 0) {
             LocalTP.Flags |= QUIC_TP_FLAG_IDLE_TIMEOUT;
             LocalTP.IdleTimeout = Connection->IdleTimeoutMs;
+        }
+
+        if (!Connection->Session->Settings.MigrationEnabled) {
+            LocalTP.Flags |= QUIC_TP_FLAG_DISABLE_ACTIVE_MIGRATION;
         }
 
         LocalTP.MaxAckDelay =

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -374,7 +374,12 @@ QUIC_STATIC_ASSERT(
 // The lifetime of a QUIC stateless retry token encryption key.
 // This is also the interval that generates new keys.
 //
-#define QUIC_STATELESS_RETRY_KEY_LIFETIME_MS 30000
+#define QUIC_STATELESS_RETRY_KEY_LIFETIME_MS    30000
+
+//
+// The default value for migration being enabled or not.
+//
+#define QUIC_DEFAULT_MIGRATION_ENABLED          TRUE
 
 /*************************************************************
                   PERSISTENT SETTINGS
@@ -389,6 +394,7 @@ QUIC_STATIC_ASSERT(
 #define QUIC_SETTING_MAX_OPERATIONS_PER_DRAIN   "MaxOperationsPerDrain"
 
 #define QUIC_SETTING_SEND_PACING_DEFAULT        "SendPacingDefault"
+#define QUIC_SETTING_MIGRATION_ENABLED          "MigrationEnabled"
 
 #define QUIC_SETTING_INITIAL_WINDOW_PACKETS     "InitialWindowPackets"
 #define QUIC_SETTING_SEND_IDLE_TIMEOUT_MS       "SendIdleTimeoutMs"

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -774,6 +774,24 @@ QuicSessionParamGet(
         Status = QUIC_STATUS_SUCCESS;
         break;
 
+    case QUIC_PARAM_SESSION_MIGRATION_ENABLED:
+        if (*BufferLength < sizeof(Session->Settings.MigrationEnabled)) {
+            *BufferLength = sizeof(Session->Settings.MigrationEnabled);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *BufferLength = sizeof(Session->Settings.MigrationEnabled);
+        *(BOOLEAN*)Buffer = Session->Settings.MigrationEnabled;
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
     default:
         Status = QUIC_STATUS_INVALID_PARAMETER;
         break;
@@ -931,6 +949,23 @@ QuicSessionParamSet(
         QuicTraceLogInfo("[sess][%p] Updated max bytes per key to %llu bytes",
             Session,
             Session->Settings.MaxBytesPerKey);
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+    }
+
+    case QUIC_PARAM_SESSION_MIGRATION_ENABLED: {
+        if (BufferLength != sizeof(Session->Settings.MigrationEnabled)) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        Session->Settings.AppSet.MigrationEnabled = TRUE;
+        Session->Settings.MigrationEnabled = *(BOOLEAN*)Buffer;
+
+        QuicTraceLogInfo("[sess][%p] Updated migration enabled to %hhu",
+            Session,
+            Session->Settings.MigrationEnabled);
 
         Status = QUIC_STATUS_SUCCESS;
         break;

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -24,6 +24,9 @@ QuicSettingsSetDefault(
     if (!Settings->AppSet.PacingDefault) {
         Settings->PacingDefault = QUIC_DEFAULT_SEND_PACING;
     }
+    if (!Settings->AppSet.MigrationEnabled) {
+        Settings->MigrationEnabled = QUIC_DEFAULT_MIGRATION_ENABLED;
+    }
     if (!Settings->AppSet.MaxPartitionCount) {
         Settings->MaxPartitionCount = QUIC_MAX_PARTITION_COUNT;
     }
@@ -98,6 +101,9 @@ QuicSettingsCopy(
 {
     if (!Settings->AppSet.PacingDefault) {
         Settings->PacingDefault = ParentSettings->PacingDefault;
+    }
+    if (!Settings->AppSet.MigrationEnabled) {
+        Settings->MigrationEnabled = ParentSettings->MigrationEnabled;
     }
     if (!Settings->AppSet.MaxPartitionCount) {
         Settings->MaxPartitionCount = ParentSettings->MaxPartitionCount;
@@ -183,6 +189,17 @@ QuicSettingsLoad(
             (uint8_t*)&Value,
             &ValueLen);
         Settings->PacingDefault = !!Value;
+    }
+
+    if (!Settings->AppSet.MigrationEnabled) {
+        Value = QUIC_DEFAULT_MIGRATION_ENABLED;
+        ValueLen = sizeof(Value);
+        QuicStorageReadValue(
+            Storage,
+            QUIC_SETTING_MIGRATION_ENABLED,
+            (uint8_t*)&Value,
+            &ValueLen);
+        Settings->MigrationEnabled = !!Value;
     }
 
     if (!Settings->AppSet.MaxPartitionCount) {
@@ -414,9 +431,10 @@ QuicSettingsDump(
     _In_ const QUIC_SETTINGS* Settings
     )
 {
-    QuicTraceLogVerbose("[sett] PacingDefault          = %hu", (uint16_t)Settings->PacingDefault);
-    QuicTraceLogVerbose("[sett] MaxPartitionCount      = %hu", (uint16_t)Settings->MaxPartitionCount);
-    QuicTraceLogVerbose("[sett] MaxOperationsPerDrain  = %hu", (uint16_t)Settings->MaxOperationsPerDrain);
+    QuicTraceLogVerbose("[sett] PacingDefault          = %hhu", Settings->PacingDefault);
+    QuicTraceLogVerbose("[sett] MigrationEnabled       = %hhu", Settings->MigrationEnabled);
+    QuicTraceLogVerbose("[sett] MaxPartitionCount      = %hhu", Settings->MaxPartitionCount);
+    QuicTraceLogVerbose("[sett] MaxOperationsPerDrain  = %hhu", Settings->MaxOperationsPerDrain);
     QuicTraceLogVerbose("[sett] RetryMemoryLimit       = %hu", Settings->RetryMemoryLimit);
     QuicTraceLogVerbose("[sett] MaxStatelessOperations = %u", Settings->MaxStatelessOperations);
     QuicTraceLogVerbose("[sett] MaxWorkerQueueDelayUs  = %u", Settings->MaxWorkerQueueDelayUs);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -8,6 +8,7 @@
 typedef struct QUIC_SETTINGS {
 
     BOOLEAN PacingDefault;
+    BOOLEAN MigrationEnabled;
     uint8_t MaxPartitionCount;
     uint8_t MaxOperationsPerDrain;
     uint16_t RetryMemoryLimit;
@@ -32,6 +33,7 @@ typedef struct QUIC_SETTINGS {
 
     struct {
         BOOLEAN PacingDefault : 1;
+        BOOLEAN MigrationEnabled : 1;
         BOOLEAN MaxPartitionCount : 1;
         BOOLEAN MaxOperationsPerDrain : 1;
         BOOLEAN RetryMemoryLimit : 1;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -321,6 +321,7 @@ typedef enum QUIC_PARAM_LEVEL {
 #define QUIC_PARAM_SESSION_IDLE_TIMEOUT                 3   // uint64_t - milliseconds
 #define QUIC_PARAM_SESSION_DISCONNECT_TIMEOUT           4   // uint32_t - milliseconds
 #define QUIC_PARAM_SESSION_MAX_BYTES_PER_KEY            5   // uint64_t - bytes
+#define QUIC_PARAM_SESSION_MIGRATION_ENABLED            6   // uint8_t (BOOLEAN)
 
 //
 // Parameters for QUIC_PARAM_LEVEL_LISTENER.


### PR DESCRIPTION
This adds a new setting that can be used to configure migration support on the server side. This is necessary when a server is set up in an environment where it cannot support migration (4-tuple load balancing of multiple back end servers). As with most all settings, it can be set via the registry on Windows or dynamically for the listener's session.

Fixes #282