### PR TITLE
Remove stale TODO comment about CC send idle

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -14,9 +14,6 @@ Abstract:
 
 Future work:
 
-    -The congestion window (and the cubic curve epoch) should
-     be reset when the sender is idle for a while.
-
     -Early slowstart exit via HyStart or similar.
 
 --*/


### PR DESCRIPTION
This old TODO comment fooled me for a while. Send idle has already been
implemented; see QUIC_CONGESTION_CONTROL::SendIdleTimeoutMs.