### PR TITLE
Include ETW RC in User Mode DLL

### DIFF
--- a/src/bin/winuser/msquic.rc
+++ b/src/bin/winuser/msquic.rc
@@ -21,3 +21,5 @@
 #include "msquic.ver"
 
 #endif // QUIC_WINDOWS_INTERNAL
+
+#include "MsQuicEtw.rc"


### PR DESCRIPTION
We weren't correctly embedding the ETW RC file in the user mode binary. We were only doing it for kernel mode.