### PR TITLE
Add Helpers to PowerShell Scripts

### DIFF
--- a/.azure/scripts/run-executable.ps1
+++ b/.azure/scripts/run-executable.ps1
@@ -77,7 +77,12 @@ function Log($msg) {
 
 # Make sure the executable is present.
 if (!(Test-Path $Path)) {
-    Write-Error "[$(Get-Date)] $($Path) does not exist!"
+    Write-Error "$($Path) does not exist!"
+}
+
+# Make sure procdump is installed on Windows.
+if ($IsWindows -and !(Test-Path ($RootDir + "\bld\tools\procdump64.exe"))) {
+    Write-Error "Procdump not installed!`n `nRun the following to install it:`n `n    $(Join-Path $RootDir ".azure" "scripts" "install-procdump.ps1")`n"
 }
 
 # Root directory of the project.

--- a/.azure/scripts/run-gtest.ps1
+++ b/.azure/scripts/run-gtest.ps1
@@ -105,7 +105,12 @@ function Log($msg) {
 
 # Make sure the test executable is present.
 if (!(Test-Path $Path)) {
-    Write-Error "[$(Get-Date)] $($Path) does not exist!"
+    Write-Error "$($Path) does not exist!"
+}
+
+# Make sure procdump is installed on Windows.
+if ($IsWindows -and !(Test-Path ($RootDir + "\bld\tools\procdump64.exe"))) {
+    Write-Error "Procdump not installed!`n `nRun the following to install it:`n `n    $(Join-Path $RootDir ".azure" "scripts" "install-procdump.ps1")`n"
 }
 
 # Root directory of the project.

--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -69,15 +69,20 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $RunExecutable = Join-Path $RootDir ".azure/scripts/run-executable.ps1"
 
 # Path to the quicinterop exectuable.
-$SpinQuic = $null
+$QuicInterop = $null
 if ($IsWindows) {
-    $SpinQuic = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\quicinterop.exe"
+    $QuicInterop = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\quicinterop.exe"
 } else {
-    $SpinQuic = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/quicinterop"
+    $QuicInterop = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/quicinterop"
+}
+
+# Make sure the build is present.
+if (!(Test-Path $QuicInterop)) {
+    Write-Error "Build does not exist!`n `nRun the following to generate it:`n `n    $(Join-Path $RootDir "scripts" "build.ps1") -Config $Config -Arch $Arch -Tls $Tls`n"
 }
 
 # Build up all the arguments to pass to the Powershell script.
-$Arguments = "-Path $($SpinQuic) -ShowOutput"
+$Arguments = "-Path $($QuicInterop) -ShowOutput"
 if ($KeepOutputOnSuccess) {
     $Arguments += " -KeepOutputOnSuccess"
 }

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -21,6 +21,8 @@ param (
     [string]$Configuration
 )
 
+#Requires -RunAsAdministrator
+
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -82,6 +82,11 @@ if ($IsWindows) {
     $SpinQuic = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/spinquic"
 }
 
+# Make sure the build is present.
+if (!(Test-Path $SpinQuic)) {
+    Write-Error "Build does not exist!`n `nRun the following to generate it:`n `n    $(Join-Path $RootDir "scripts" "build.ps1") -Config $Config -Arch $Arch -Tls $Tls`n"
+}
+
 # Build up all the arguments to pass to the Powershell script.
 $Arguments = "-Path $($SpinQuic) -Arguments 'both -timeout:$($Timeout)' -ShowOutput"
 if ($KeepOutputOnSuccess) {

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -151,6 +151,11 @@ if ($IsWindows) {
     $MsQuicPlatTest = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/msquicplatformtest"
 }
 
+# Make sure the build is present.
+if (!(Test-Path $MsQuicTest)) {
+    Write-Error "Build does not exist!`n `nRun the following to generate it:`n `n    $(Join-Path $RootDir "scripts" "build.ps1") -Config $Config -Arch $Arch -Tls $Tls`n"
+}
+
 # Build up all the arguments to pass to the Powershell script.
 $TestArguments =  "-ExecutionMode $($ExecutionMode) -IsolationMode $($IsolationMode)"
 


### PR DESCRIPTION
Per Chris' request, I added some helpers for what to do when a particular file is missing. Some examples:

```
PS E:\msquic> .\scripts\prepare-machine.ps1 -Configuration Build
.\scripts\prepare-machine.ps1: The script 'prepare-machine.ps1' cannot be run because it contains a "#requires" statement for running as Administrator. The current PowerShell session is not running as Administrator. Start PowerShell by using the Run as Administrator option, and then try running the script again.

PS E:\msquic> .\scripts\test.ps1 -Filter *ValidateApi* -ListTestCases -Config Release
Write-Error: E:\msquic\artifacts\windows\x64_Release_schannel\msquictest.exe does not exist!

Run the following to build it:

    E:\msquic\scripts\build.ps1 -Config Release -Arch x64 -Tls schannel

PS E:\msquic> .\scripts\test.ps1 -Filter *ValidateApi* -ListTestCases
Write-Error: Procdump not installed!

Run the following to install it:

    E:\msquic\.azure\scripts\install-procdump.ps1

```