### PR TITLE
Increase BVT Timeout to 40 minutes

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -35,7 +35,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 30
+    timeoutInMinutes: 40
     continueOnError: true
     inputs:
       pwsh: true


### PR DESCRIPTION
I've seen the miTLS tests timing out at the 30 minute mark and almost being complete. We've added more and more tests over the last few weeks and each test takes a min of ~1 sec (for logging start/stop). 1,500 tests (which is what we're at about) equals ~25 minutes min. Many of our tests aren't instant, so that 5 minute time window isn't enough.