### PR TITLE
Remove quicetwlib Static Lib from VPack

### DIFF
--- a/.azure/scripts/prepare-package.ps1
+++ b/.azure/scripts/prepare-package.ps1
@@ -43,7 +43,6 @@ foreach ($Config in $Configs) {
     foreach ($Arch in $Archs) {
         $InputDir = Join-Path $ArtifactsDir "windows/$($Arch.Item1)_$($Config.Item1)_schannel"
         Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "msquicetw.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/user")
         Force-Copy (Join-Path $InputDir "msquic.dll") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
         Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
         Force-Copy (Join-Path $InputDir "msquictest.exe") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")


### PR DESCRIPTION
It's unnecessary. It's not used in Windows and won't ever be now.