### PR TITLE
Use Git Attributes File to Normal Line Endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Use Windows line endings for all files.
-* text eol=crlf
+# Standardize line endings for all text files.
+* text eol=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Windows line endings for all files.
+* text eol=crlf


### PR DESCRIPTION
Been having merge issues because of different tools & OS being used to make changes. This should force everything to use Windows line endings.