### PR TITLE
Move ETW Initialization Back into the Platform

### DIFF
--- a/src/bin/winuser/dllmain.c
+++ b/src/bin/winuser/dllmain.c
@@ -36,20 +36,14 @@ DllMain(
 
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls(Instance);
-
-        EventRegisterMicrosoft_Quic_ETW();
-        TraceLoggingRegister(clog_hTrace);
-        EventSetInformation(Microsoft_Quic_ETWHandle, EventProviderBinaryTrackInfo, NULL, 0);
-
         QuicPlatformSystemLoad();
+        EventSetInformation(Microsoft_Quic_ETWHandle, EventProviderBinaryTrackInfo, NULL, 0);
         MsQuicLibraryLoad();
         break;
 
     case DLL_PROCESS_DETACH:
         MsQuicLibraryUnload();
         QuicPlatformSystemUnload();
-        EventUnregisterMicrosoft_Quic_ETW();
-        TraceLoggingUnregister(clog_hTrace);
         break;
     }
 

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -34,6 +34,9 @@ QuicPlatformSystemLoad(
     void
     )
 {
+    EventRegisterMicrosoft_Quic_ETW();
+    TraceLoggingRegister(clog_hTrace);
+
     (void)QueryPerformanceFrequency((LARGE_INTEGER*)&QuicPlatformPerfFreq);
     QuicPlatform.Heap = NULL;
 
@@ -47,6 +50,8 @@ QuicPlatformSystemUnload(
     )
 {
     QuicTraceLogInfo(FN_platform_winuser0c22020f4491112ca1f62af9913bb8bd, "[ dll] Unloaded");
+    EventUnregisterMicrosoft_Quic_ETW();
+    TraceLoggingUnregister(clog_hTrace);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)


### PR DESCRIPTION
I want the shared platform code to still initialize the platform, so that I get events for all the users. The `EventSetInformation` call stays in the DLL specific code though, so only it injects the info.