### PR TITLE
Fix Race Condition Crash

### DIFF
--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -649,8 +649,6 @@ QuicLookupFindConnectionByRemoteHash(
         return NULL; // Nothing registered yet.
     }
 
-    QUIC_DBG_ASSERT(Lookup->MaximizePartitioning);
-
     uint32_t Hash = QuicPacketHash(RemoteAddress, RemoteCidLength, RemoteCid);
 
     QuicDispatchRwLockAcquireShared(&Lookup->RwLock);

--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -645,6 +645,10 @@ QuicLookupFindConnectionByRemoteHash(
         const uint8_t* const RemoteCid
     )
 {
+    if (!Lookup->MaximizePartitioning) {
+        return NULL; // Nothing registered yet.
+    }
+
     QUIC_DBG_ASSERT(Lookup->MaximizePartitioning);
 
     uint32_t Hash = QuicPacketHash(RemoteAddress, RemoteCidLength, RemoteCid);


### PR DESCRIPTION
This PR fixes a crash/assert found via a spinquic run on AZP. A received packet was received before a listener completed it's registration with a newly created binding. This resulted in the lookup being called to find a matching connection before it was fully initialized. This change modifies the assert to just check and return instead.