### PR TITLE
Per-Platform TLS Defaults in PowerShell Scripts

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -58,7 +58,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
-    [string]$Tls = "schannel",
+    [string]$Tls = $null,
 
     [Parameter(Mandatory = $false)]
     [switch]$DisableLogs = $false,
@@ -84,6 +84,15 @@ param (
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Default TLS based on current platform.
+if ($null -eq $Tls) {
+    if ($IsWindows) {
+        $Tls = "schannel"
+    } else {
+        $Tls = "openssl"
+    }
+}
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent

--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -40,7 +40,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
-    [string]$Tls = "schannel",
+    [string]$Tls = $null,
 
     [Parameter(Mandatory = $false)]
     [switch]$KeepOutputOnSuccess = $false,
@@ -61,6 +61,15 @@ param (
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Default TLS based on current platform.
+if ($null -eq $Tls) {
+    if ($IsWindows) {
+        $Tls = "schannel"
+    } else {
+        $Tls = "openssl"
+    }
+}
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -43,7 +43,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
-    [string]$Tls = "schannel",
+    [string]$Tls = $null,
 
     [Parameter(Mandatory = $false)]
     [Int32]$Timeout = 60000,
@@ -67,6 +67,15 @@ param (
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Default TLS based on current platform.
+if ($null -eq $Tls) {
+    if ($IsWindows) {
+        $Tls = "schannel"
+    } else {
+        $Tls = "openssl"
+    }
+}
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -83,7 +83,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
-    [string]$Tls = "schannel",
+    [string]$Tls = $null,
 
     [Parameter(Mandatory = $false)]
     [string]$Filter = "",
@@ -130,6 +130,15 @@ param (
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Default TLS based on current platform.
+if ($null -eq $Tls) {
+    if ($IsWindows) {
+        $Tls = "schannel"
+    } else {
+        $Tls = "openssl"
+    }
+}
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent


### PR DESCRIPTION
Fixes #348. Makes Linux default to OpenSSL for the PowerShell scripts.