### PR TITLE
Default-Initialize Status in GetParam, SetParam, and StreamStart functions

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -473,7 +473,7 @@ MsQuicStreamStart(
     _In_ QUIC_STREAM_START_FLAGS Flags
     )
 {
-    QUIC_STATUS Status;
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     QUIC_STREAM* Stream;
     QUIC_CONNECTION* Connection;
 
@@ -947,7 +947,7 @@ MsQuicSetParam(
         QUIC_TRACE_API_SET_PARAM,
         Handle);
 
-    QUIC_STATUS Status;
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
 
     if (Level == QUIC_PARAM_LEVEL_GLOBAL) {
         //
@@ -1047,7 +1047,7 @@ MsQuicGetParam(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    QUIC_STATUS Status;
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
 
     QuicTraceEvent(ApiEnter,
         QUIC_TRACE_API_GET_PARAM,


### PR DESCRIPTION
Facebook's Infer Static Analysis tool noticed that there are possible paths through the three of these functions where Status does not get initialized, and will return whatever's uninitialized stack data. 

Note:  Infer was only run on the Linux codebase as Infer doesn't really support Windows code at this time. 