### PR TITLE
Remove QuicRangeValidate Debug Function

### DIFF
--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -146,8 +146,6 @@ QuicAckTrackerAckPacket(
         PtkConnPre(Connection),
         PacketNumber);
 
-    QuicRangeValidate(&Tracker->PacketNumbersToAck);
-
     BOOLEAN NewLargestPacketNumber =
         PacketNumber == QuicRangeGetMax(&Tracker->PacketNumbersToAck);
     if (NewLargestPacketNumber) {

--- a/src/core/range.c
+++ b/src/core/range.c
@@ -535,27 +535,3 @@ QuicRangeGetMaxSafe(
         return FALSE;
     }
 }
-
-#if DEBUG
-
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-QuicRangeValidate(
-    _In_ QUIC_RANGE* Range
-    )
-{
-    for (uint32_t i = 0; i < QuicRangeSize(Range); i++) {
-        QUIC_SUBRANGE* Sub = QuicRangeGet(Range, i);
-        //
-        // In the current testing, our usage doesn't go into the full 64-bit
-        // range. So we assume any values greater than 32-bits are likely bugs
-        // from some kind of encoding or runaway thread issue. As test coverage
-        // expands these asserts will be relaxed and/or removed.
-        //
-        uint64_t High = QuicRangeGetHigh(Sub);
-        QUIC_DBG_ASSERT(Sub->Low <= 0xFFFFFFFFllu);
-        QUIC_DBG_ASSERT(High <= 0xFFFFFFFFllu);
-    }
-}
-
-#endif

--- a/src/core/range.h
+++ b/src/core/range.h
@@ -367,24 +367,3 @@ QuicRangeGetMaxSafe(
     _In_ QUIC_RANGE* Range,
     _Out_ uint64_t* Value
     );
-
-//
-// Use for debugging purposes.
-//
-
-#if DEBUG
-
-//
-// Some simple heuristics to try to make sure the range is valid.
-//
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-QuicRangeValidate(
-    _In_ QUIC_RANGE* Range
-    );
-
-#else
-
-#define QuicRangeValidate(range) UNREFERENCED_PARAMETER(range)
-
-#endif


### PR DESCRIPTION
A recent run of spinquic hit one of the asserts in QuicRangeValidate. Now that we run for an extended amount of time, it's possible to eventually generate enough packets to hit these asserts. Therefore the asserts are no longer necessary.