### PR TITLE
Queue Ping Probe on No Retransmissions Available

### DIFF
--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -182,10 +182,11 @@ QuicCryptoWriteFrames(
     );
 
 //
-// Called when a crypto frame is inferred to be lost.
+// Called when a crypto frame is inferred to be lost. Returns TRUE if data is
+// queued to be sent.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicCryptoOnLoss(
     _In_ QUIC_CRYPTO* Crypto,
     _In_ QUIC_SENT_FRAME_METADATA* FrameMetadata

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -185,7 +185,7 @@ QuicSendValidate(
 #endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-void
+BOOLEAN
 QuicSendSetSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ uint32_t SendFlags
@@ -245,6 +245,8 @@ QuicSendSetSendFlag(
     }
 
     QuicSendValidate(Send);
+
+    return CanSetFlag;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -301,7 +303,7 @@ QuicSendUpdateAckState(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicSendSetStreamSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ QUIC_STREAM* Stream,
@@ -313,7 +315,7 @@ QuicSendSetStreamSendFlag(
         //
         // Ignore all frames if the connection is closed.
         //
-        return;
+        return FALSE;
     }
 
     //
@@ -358,6 +360,8 @@ QuicSendSetStreamSendFlag(
         }
         Stream->SendFlags |= SendFlags;
     }
+
+    return SendFlags != 0;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/send.h
+++ b/src/core/send.h
@@ -337,10 +337,10 @@ QuicSendProcessDelayedAckTimer(
 
 //
 // Indicates the connection has a given QUIC_CONN_SEND_FLAG_* that is ready
-// to be sent.
+// to be sent. Returns TRUE if the flag is (or already was) queued.
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
-void
+BOOLEAN
 QuicSendSetSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ uint32_t SendFlag
@@ -367,10 +367,10 @@ QuicSendUpdateAckState(
 
 //
 // Indicates the stream has a given QUIC_STREAM_SEND_FLAG_* that is ready
-// to be sent.
+// to be sent. Returns TRUE if the flag is (or already was) queued.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicSendSetStreamSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ QUIC_STREAM* Stream,

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -714,10 +714,11 @@ QuicStreamSendWrite(
     );
 
 //
-// Called when a stream frame is inferred to be lost.
+// Called when a stream frame is inferred to be lost. Returns TRUE if data is
+// queued to be sent.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicStreamOnLoss(
     _In_ QUIC_STREAM* Stream,
     _In_ QUIC_SENT_FRAME_METADATA* FrameMetadata


### PR DESCRIPTION
There are cases where calling retransmit on an outstanding packet doesn't actually result in any new data being queued up. In those scenarios, we want to make sure to still queue up a PING frame for our loss detection probes. This PR updates those code paths to appropriate return back the state indicating if data is actually going to be sent out in response to the packet being "retransmitted".