### PR TITLE
Fix Binding Build Warning from Static Analysis

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -770,6 +770,7 @@ QuicBindingProcessStatelessOperation(
         }
 
         uint8_t NewDestCid[MSQUIC_CID_MAX_LENGTH];
+        QUIC_DBG_ASSERT(sizeof(NewDestCid) >= MsQuicLib.CidTotalLength);
         QuicRandom(sizeof(NewDestCid), NewDestCid);
 
         QUIC_RETRY_TOKEN_CONTENTS Token = { 0 };


### PR DESCRIPTION
Fixing a kernel mode build warning in binding.c from static analysis.
```
##[warning]src\core\binding.c(782,0): Warning C6385: Reading invalid data from 'NewDestCid':  the readable size is '13' bytes, but '14' bytes may be read.
```
Just adds a debug assert (which has the analysis assume) for the warning.