### PR TITLE
delete error QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE flags

### DIFF
--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -302,9 +302,6 @@ QuicTlsServerSecConfigCreate(
         // Using NULL certificate.
         //
         goto Format;
-    } else if (Flags & QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE) {
-        Status = QUIC_STATUS_INVALID_PARAMETER;
-        goto Error;
     } else if (Flags & QUIC_SEC_CONFIG_FLAG_CERTIFICATE_CONTEXT) {
         if (Certificate == NULL) {
             Status = QUIC_STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
it's a bug in ubuntu18.04.  when i run "./quicsample -server -cert_file:cert -key_file:key " it will always fail to run and return "Failed to load certificate from file! " 

the reason is as follows:
in funcation GetSecConfigForFile, the default paramter is "QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE",  
![image](https://user-images.githubusercontent.com/800879/81362792-46b71b00-9114-11ea-960f-e78489499937.png)
but tls_stub.c: QuicTlsServerSecConfigCreate , if the flags is "Flags & QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE", it will goto error.
![image](https://user-images.githubusercontent.com/800879/81363435-e75a0a80-9115-11ea-918e-48cc6f405569.png)

i think the if condition of  "Flags & QUIC_SEC_CONFIG_FLAG_CERTIFICATE_FILE" is unneccary. 
