### PR TITLE
Support NoProcDump Mode for Windows Test Script

### DIFF
--- a/.azure/scripts/run-gtest.ps1
+++ b/.azure/scripts/run-gtest.ps1
@@ -93,7 +93,10 @@ param (
     [switch]$CompressOutput = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$NoProgress = $false
+    [switch]$NoProgress = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoProcDump = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -216,6 +219,9 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
             } else {
                 $pinfo.Arguments = "-g -G $($Path) $($Arguments)"
             }
+        } elseif ($NoProcDump) {
+            $pinfo.FileName = $Path
+            $pinfo.Arguments = $Arguments
         } else {
             $pinfo.FileName = $RootDir + "\bld\tools\procdump64.exe"
             $pinfo.Arguments = "-ma -e -b -l -accepteula -x $($OutputDir) $($Path) $($Arguments)"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -125,7 +125,10 @@ param (
     [switch]$CompressOutput = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$NoProgress = $false
+    [switch]$NoProgress = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoProcDump = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -200,6 +203,9 @@ if ($CompressOutput) {
 }
 if ($NoProgress) {
     $TestArguments += " -NoProgress"
+}
+if ($NoProcDump) {
+    $TestArguments += " -NoProcDump"
 }
 
 # Run the script.


### PR DESCRIPTION
This PR adds support to the test script to disable procdump usage. I made this initially to test the assumption that procdump was the reason that Windows tests run so slow (compared to Linux); and it definitely did confirm it. I'm not sure why, but it seems from start to finish, no matter how long the exe that is run takes, procdump launch of a process takes almost a second.