### PR TITLE
Fix Bug in fread Call in Interop Server

### DIFF
--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -222,8 +222,8 @@ HttpRequest::SendData()
             size_t BytesRead =
                 fread(
                     Buffer.RawBuffer + Buffer.QuicBuffer.Length,
-                    BytesAvail,
                     1,
+                    BytesAvail,
                     File);
             Buffer.QuicBuffer.Length += (uint32_t)BytesRead;
             if (BytesAvail != BytesRead) {


### PR DESCRIPTION
Fixes a bug in the interop server code that was incorrectly calling `fread`. It had the `size` and `count` parameters swapped, which resulted in the `BytesRead` always being `1`.

Fixes #388 
Fixes #179