### PR TITLE
Add Random Loss to SpinQuic

### DIFF
--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -30,12 +30,12 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run SpinQuic
-    timeoutInMinutes: 10
+    timeoutInMinutes: 12
     continueOnError: true
     inputs:
       pwsh: true
       filePath: scripts/spin.ps1
-      arguments: -GenerateXmlResults -Timeout 300000 -LogProfile SpinQuic.Light -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -GenerateXmlResults -Timeout 600000 -LogProfile SpinQuic.Light -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 
   - template: ./upload-test-artifacts.yml
     parameters:

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -266,7 +266,6 @@ QuicStreamClose(
 {
     if (!Stream->Flags.ShutdownComplete) {
 
-        QUIC_CONN_VERIFY(Stream->Connection, !Stream->Flags.Started);
         if (Stream->Flags.Started) {
             //
             // TODO - If the stream hasn't been aborted already, then this is a

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -128,7 +128,6 @@ QuicStreamSendShutdown(
             goto Exit;
         }
 
-        QUIC_CONN_VERIFY(Stream->Connection, ApiSendRequests == NULL);
         while (ApiSendRequests != NULL) {
             //
             // These sends were queued by the app after queueing a graceful

--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -6,7 +6,7 @@
       <Buffers Value="20"/>
     </SystemCollector>
     <EventCollector Id="EC_LowVolume" Name="LowVolume">
-      <BufferSize Value="32"/>
+      <BufferSize Value="16"/>
       <Buffers Value="32"/>
     </EventCollector>
     <EventCollector Id="EC_HighVolume" Name="High Volume">

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -375,7 +375,7 @@ void Spin(LockableVector<HQUIC>& Connections, bool IsServer)
         }
 
         switch (GetRandom(SpinQuicAPICallCount)) {
-        case SpinQuicAPICallCreateConnection :
+        case SpinQuicAPICallCreateConnection:
             if (!IsServer) {
                 auto ctx = new SpinQuicConnection();
                 if (ctx == nullptr) continue;
@@ -615,19 +615,19 @@ QUIC_THREAD_CALLBACK(ClientSpin, Context)
     QUIC_THREAD_RETURN(0);
 }
 
-static BOOLEAN QUIC_API DatapathHookReceiveCallback(struct QUIC_RECV_DATAGRAM* /* Datagram */)
+BOOLEAN QUIC_API DatapathHookReceiveCallback(struct QUIC_RECV_DATAGRAM* /* Datagram */)
 {
     uint8_t RandomValue;
     QuicRandom(sizeof(RandomValue), &RandomValue);
     return (RandomValue % 100) < Settings.LossPercent;
 }
 
-static BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */)
+BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */)
 {
     return FALSE; // Don't drop
 }
 
-static QUIC_TEST_DATAPATH_HOOKS DataPathHooks = {
+QUIC_TEST_DATAPATH_HOOKS DataPathHooks = {
     DatapathHookReceiveCallback, DatapathHookSendCallback
 };
 
@@ -637,12 +637,12 @@ void PrintHelpText(void)
           "\n" \
           "  -alpn:<alpn>         default: 'spin'\n" \
           "  -dstport:<port>      default: 9999\n" \
+          "  -loss:<percent>      default: 1\n" \
           "  -max_ops:<count>     default: UINT64_MAX\n"
           "  -seed:<seed>         default: 6\n" \
           "  -sessions:<count>    default: 4\n" \
           "  -target:<ip>         default: '127.0.0.1'\n" \
           "  -timeout:<count_ms>  default: 60000\n" \
-          "  -loss:<percent>      default: 1\n" \
           );
     exit(1);
 }


### PR DESCRIPTION
Now that we support injecting hooks into the data path, let's make use of it in spinquic to add some random loss.

Also increases runtime to 10 min.