### PR TITLE
Get SpinQuic Running Clean

### DIFF
--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -234,6 +234,7 @@ QuicAckTrackerAckFrameEncode(
     Tracker->LargestPacketNumberAcknowledged =
         Builder->Metadata->Frames[Builder->Metadata->FrameCount].ACK.LargestAckedPacketNumber =
         QuicRangeGetMax(&Tracker->PacketNumbersToAck);
+    Builder->Metadata->Flags.HasAckFrame = TRUE;
     (void)QuicPacketBuilderAddFrame(Builder, QUIC_FRAME_ACK, FALSE);
 
     return TRUE;

--- a/src/core/ack_tracker.h
+++ b/src/core/ack_tracker.h
@@ -36,6 +36,12 @@ typedef struct QUIC_ACK_TRACKER {
     //
     uint16_t AckElicitingPacketsToAcknowledge;
 
+    //
+    // Indicates an ACK frame has already been written for all the currently
+    // queued packet numbers.
+    //
+    BOOLEAN AlreadyWrittenAckFrame;
+
 } QUIC_ACK_TRACKER;
 
 //
@@ -109,7 +115,7 @@ QuicAckTrackerOnAckFrameAcked(
 
 //
 // Helper function that indicates if any (even non-ACK eliciting) packets are
-// queued up to be acknowledged.
+// queued up to be acknowledged in a new ACK frame.
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
 inline
@@ -118,5 +124,7 @@ QuicAckTrackerHasPacketsToAck(
     _In_ const QUIC_ACK_TRACKER* Tracker
     )
 {
-    return QuicRangeSize(&Tracker->PacketNumbersToAck) != 0;
+    return
+        !Tracker->AlreadyWrittenAckFrame &&
+        QuicRangeSize(&Tracker->PacketNumbersToAck) != 0;
 }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1701,6 +1701,9 @@ QuicConnStart(
     QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
 
     if (Connection->State.ClosedLocally || Connection->State.Started) {
+        if (ServerName != NULL) {
+            QUIC_FREE(ServerName);
+        }
         return QUIC_STATUS_INVALID_STATE;
     }
 

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -291,6 +291,7 @@ QuicCryptoReset(
     _In_ BOOLEAN ResetTls
     )
 {
+    QUIC_DBG_ASSERT(!QuicConnIsServer(QuicCryptoGetConnection(Crypto)));
     QUIC_TEL_ASSERT(!Crypto->TlsDataPending);
     QUIC_TEL_ASSERT(!Crypto->TlsCallPending);
     QUIC_TEL_ASSERT(Crypto->RecvTotalConsumed == 0);

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -509,7 +509,6 @@ QuicCryptoWriteOneFrame(
         QuicCryptoFrameEncode(&Frame, Offset, BufferLength, Buffer));
 
     PacketMetadata->Flags.IsAckEliciting = TRUE;
-    PacketMetadata->Flags.HasCrypto = TRUE;
     PacketMetadata->Frames[PacketMetadata->FrameCount].Type = QUIC_FRAME_CRYPTO;
     PacketMetadata->Frames[PacketMetadata->FrameCount].CRYPTO.Offset = CryptoOffset;
     PacketMetadata->Frames[PacketMetadata->FrameCount].CRYPTO.Length = (uint16_t)Frame.Length;

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -384,14 +384,16 @@ QuicCryptoDiscardKeys(
         KeyType == QUIC_PACKET_KEY_INITIAL ?
             Crypto->TlsState.BufferOffsetHandshake :
             Crypto->TlsState.BufferOffset1Rtt;
-    QUIC_DBG_ASSERT(BufferOffset != 0);
-    QUIC_DBG_ASSERT(Crypto->MaxSentLength >= BufferOffset);
-    if (Crypto->NextSendOffset < BufferOffset) {
-        Crypto->NextSendOffset = BufferOffset;
-    }
-    if (Crypto->UnAckedOffset < BufferOffset) {
-        Crypto->UnAckedOffset = BufferOffset;
-        QuicRangeSetMin(&Crypto->SparseAckRanges, Crypto->UnAckedOffset);
+    //QUIC_DBG_ASSERT(BufferOffset != 0); // TODO - Get OpenSSL working properly so this can be enabled.
+    if (BufferOffset != 0) {
+        QUIC_DBG_ASSERT(Crypto->MaxSentLength >= BufferOffset);
+        if (Crypto->NextSendOffset < BufferOffset) {
+            Crypto->NextSendOffset = BufferOffset;
+        }
+        if (Crypto->UnAckedOffset < BufferOffset) {
+            Crypto->UnAckedOffset = BufferOffset;
+            QuicRangeSetMin(&Crypto->SparseAckRanges, Crypto->UnAckedOffset);
+        }
     }
 
     if (HasAckElicitingPacketsToAcknowledge) {

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -384,16 +384,14 @@ QuicCryptoDiscardKeys(
         KeyType == QUIC_PACKET_KEY_INITIAL ?
             Crypto->TlsState.BufferOffsetHandshake :
             Crypto->TlsState.BufferOffset1Rtt;
-    //QUIC_DBG_ASSERT(BufferOffset != 0); // TODO - Get OpenSSL working properly so this can be enabled.
-    if (BufferOffset != 0) {
-        QUIC_DBG_ASSERT(Crypto->MaxSentLength >= BufferOffset);
-        if (Crypto->NextSendOffset < BufferOffset) {
-            Crypto->NextSendOffset = BufferOffset;
-        }
-        if (Crypto->UnAckedOffset < BufferOffset) {
-            Crypto->UnAckedOffset = BufferOffset;
-            QuicRangeSetMin(&Crypto->SparseAckRanges, Crypto->UnAckedOffset);
-        }
+    QUIC_DBG_ASSERT(BufferOffset != 0);
+    QUIC_DBG_ASSERT(Crypto->MaxSentLength >= BufferOffset);
+    if (Crypto->NextSendOffset < BufferOffset) {
+        Crypto->NextSendOffset = BufferOffset;
+    }
+    if (Crypto->UnAckedOffset < BufferOffset) {
+        Crypto->UnAckedOffset = BufferOffset;
+        QuicRangeSetMin(&Crypto->SparseAckRanges, Crypto->UnAckedOffset);
     }
 
     if (HasAckElicitingPacketsToAcknowledge) {

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1164,6 +1164,7 @@ QuicLossDetectionProcessAckBlocks(
             while (*LostPacketsStart && (*LostPacketsStart)->PacketNumber < AckBlock->Low) {
                 LostPacketsStart = &((*LostPacketsStart)->Next);
             }
+
             QUIC_SENT_PACKET_METADATA** End = LostPacketsStart;
             while (*End && (*End)->PacketNumber <= QuicRangeGetHigh(AckBlock)) {
                 QuicTraceLogVerbose(
@@ -1179,6 +1180,7 @@ QuicLossDetectionProcessAckBlocks(
                 //
                 End = &((*End)->Next);
             }
+
             if (LostPacketsStart != End) {
                 *AckedPacketsTail = *LostPacketsStart;
                 AckedPacketsTail = End;
@@ -1187,10 +1189,9 @@ QuicLossDetectionProcessAckBlocks(
                 if (End == LossDetection->LostPacketsTail) {
                     LossDetection->LostPacketsTail = LostPacketsStart;
                 }
-                QUIC_DBG_ASSERT(LossDetection->LostPackets != NULL || LossDetection->LostPacketsTail == &LossDetection->LostPackets);
-            }
 
-            QuicLossValidate(LossDetection);
+                QuicLossValidate(LossDetection);
+            }
         }
 
         //
@@ -1200,6 +1201,7 @@ QuicLossDetectionProcessAckBlocks(
             while (*SentPacketsStart && (*SentPacketsStart)->PacketNumber < AckBlock->Low) {
                 SentPacketsStart = &((*SentPacketsStart)->Next);
             }
+
             QUIC_SENT_PACKET_METADATA** End = SentPacketsStart;
             while (*End && (*End)->PacketNumber <= QuicRangeGetHigh(AckBlock)) {
 
@@ -1222,10 +1224,9 @@ QuicLossDetectionProcessAckBlocks(
                 if (End == LossDetection->SentPacketsTail) {
                     LossDetection->SentPacketsTail = SentPacketsStart;
                 }
-                QUIC_DBG_ASSERT(LossDetection->SentPackets != NULL || LossDetection->SentPacketsTail == &LossDetection->SentPackets);
-            }
 
-            QuicLossValidate(LossDetection);
+                QuicLossValidate(LossDetection);
+            }
         }
 
         if (LargestAckedPacket != NULL &&

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -88,7 +88,9 @@ QuicLossValidate(
         Tail = &((*Tail)->Next);
     }
     QUIC_DBG_ASSERT(Tail == LossDetection->SentPacketsTail);
-    QUIC_DBG_ASSERT(LossDetection->PacketsInFlight == AckElicitingPackets);
+    if (ValidatePacketCounts) {
+        QUIC_DBG_ASSERT(LossDetection->PacketsInFlight == AckElicitingPackets);
+    }
 
     Tail = &LossDetection->LostPackets;
     while (*Tail) {

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -279,8 +279,12 @@ QuicPacketBuilderPrepare(
         Builder->Metadata->PacketNumber = Connection->Send.NextPacketNumber++;
         Builder->Metadata->Flags.KeyType = NewPacketKeyType;
         Builder->Metadata->Flags.IsAckEliciting = FALSE;
-        Builder->Metadata->Flags.HasCrypto = FALSE;
         Builder->Metadata->Flags.IsPMTUD = IsPathMtuDiscovery;
+        Builder->Metadata->Flags.HasAckFrame = FALSE;
+        Builder->Metadata->Flags.SuspectedLost = FALSE;
+#if DEBUG
+        Builder->Metadata->Flags.Freed = FALSE;
+#endif
 
         Builder->PacketStart = Builder->DatagramLength;
         Builder->HeaderLength = 0;

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -280,7 +280,6 @@ QuicPacketBuilderPrepare(
         Builder->Metadata->Flags.KeyType = NewPacketKeyType;
         Builder->Metadata->Flags.IsAckEliciting = FALSE;
         Builder->Metadata->Flags.IsPMTUD = IsPathMtuDiscovery;
-        Builder->Metadata->Flags.HasAckFrame = FALSE;
         Builder->Metadata->Flags.SuspectedLost = FALSE;
 #if DEBUG
         Builder->Metadata->Flags.Freed = FALSE;

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -434,8 +434,7 @@ QuicSendWriteFrames(
     // specific frames.
     //
 
-    if (!Builder->Metadata->Flags.HasAckFrame &&
-        Builder->PacketType != QUIC_0_RTT_PROTECTED &&
+    if (Builder->PacketType != QUIC_0_RTT_PROTECTED &&
         QuicAckTrackerHasPacketsToAck(&Packets->AckTracker)) {
         if (!QuicAckTrackerAckFrameEncode(&Packets->AckTracker, Builder)) {
             RanOutOfRoom = TRUE;

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -434,7 +434,8 @@ QuicSendWriteFrames(
     // specific frames.
     //
 
-    if (Builder->PacketType != QUIC_0_RTT_PROTECTED &&
+    if (!Builder->Metadata->Flags.HasAckFrame &&
+        Builder->PacketType != QUIC_0_RTT_PROTECTED &&
         QuicAckTrackerHasPacketsToAck(&Packets->AckTracker)) {
         if (!QuicAckTrackerAckFrameEncode(&Packets->AckTracker, Builder)) {
             RanOutOfRoom = TRUE;

--- a/src/core/sent_packet_metadata.c
+++ b/src/core/sent_packet_metadata.c
@@ -54,9 +54,12 @@ QuicSentPacketPoolGetPacketMetadata(
     _In_ uint8_t FrameCount
     )
 {
-    return
-        (QUIC_SENT_PACKET_METADATA*)
+    QUIC_SENT_PACKET_METADATA* Metadata =
         QuicPoolAlloc(Pool->Pools + FrameCount - 1);
+#if DEBUG
+    Metadata->Flags.Freed = FALSE;
+#endif
+    return Metadata;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -69,6 +72,10 @@ QuicSentPacketPoolReturnPacketMetadata(
     _Analysis_assume_(
         Metadata->FrameCount > 0 &&
         Metadata->FrameCount <= QUIC_MAX_FRAMES_PER_PACKET);
+
+#if DEBUG
+    Metadata->Flags.Freed = TRUE;
+#endif
 
     for (uint8_t i = 0; i < Metadata->FrameCount; i++) {
         switch (Metadata->Frames[i].Type)

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -76,9 +76,9 @@ typedef struct QUIC_SEND_PACKET_FLAGS {
 
     uint8_t KeyType                 : 2;
     BOOLEAN IsAckEliciting          : 1;
-    BOOLEAN HasCrypto               : 1;
     BOOLEAN IsPMTUD                 : 1;
     BOOLEAN KeyPhase                : 1;
+    BOOLEAN HasAckFrame             : 1;
     BOOLEAN SuspectedLost           : 1;
 #if DEBUG
     BOOLEAN Freed                   : 1;

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -78,7 +78,6 @@ typedef struct QUIC_SEND_PACKET_FLAGS {
     BOOLEAN IsAckEliciting          : 1;
     BOOLEAN IsPMTUD                 : 1;
     BOOLEAN KeyPhase                : 1;
-    BOOLEAN HasAckFrame             : 1;
     BOOLEAN SuspectedLost           : 1;
 #if DEBUG
     BOOLEAN Freed                   : 1;

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -80,7 +80,9 @@ typedef struct QUIC_SEND_PACKET_FLAGS {
     BOOLEAN IsPMTUD                 : 1;
     BOOLEAN KeyPhase                : 1;
     BOOLEAN SuspectedLost           : 1;
-    BOOLEAN RESERVED                : 1;
+#if DEBUG
+    BOOLEAN Freed                   : 1;
+#endif
 
 } QUIC_SEND_PACKET_FLAGS;
 

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -662,7 +662,7 @@ QuicSessionServerCacheSetStateInternal(
     _In_ QUIC_SESSION* Session,
     _In_ uint16_t ServerNameLength,
     _In_reads_(ServerNameLength)
-    const char* ServerName,
+        const char* ServerName,
     _In_ uint32_t QuicVersion,
     _In_ const QUIC_TRANSPORT_PARAMETERS* Parameters,
     _In_opt_ QUIC_SEC_CONFIG* SecConfig
@@ -683,6 +683,9 @@ QuicSessionServerCacheSetStateInternal(
         Cache->QuicVersion = QuicVersion;
         Cache->TransportParameters = *Parameters;
         if (SecConfig != NULL) {
+            if (Cache->SecConfig != NULL) {
+                QuicTlsSecConfigRelease(Cache->SecConfig);
+            }
             Cache->SecConfig = QuicTlsSecConfigAddRef(SecConfig);
         }
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1519,6 +1519,27 @@ QuicTlsProcessData(
 
 Exit:
 
+    if (!(TlsContext->ResultFlags & QUIC_TLS_RESULT_ERROR)) {
+        if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
+            State->BufferOffsetHandshake == 0) {
+            State->BufferOffsetHandshake = State->BufferTotalLength;
+            QuicTraceLogConnInfo(
+                OpenSslHandshakeDataStart,
+                TlsContext->Connection,
+                "Writing Handshake data starts at %u",
+                State->BufferOffsetHandshake);
+        }
+        if (State->WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL &&
+            State->BufferOffset1Rtt == 0) {
+            State->BufferOffset1Rtt = State->BufferTotalLength;
+            QuicTraceLogConnInfo(
+                OpenSsl1RttDataStart,
+                TlsContext->Connection,
+                "Writing 1-RTT data starts at %u",
+                State->BufferOffset1Rtt);
+        }
+    }
+
     return TlsContext->ResultFlags;
 }
 

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -53,8 +53,8 @@ const uint16_t MinMessageLengths[] = {
     0,                              // QUIC_TLS_MESSAGE_INVALID
     0,                              // QUIC_TLS_MESSAGE_CLIENT_INITIAL (Dynamic)
     7 + 1,                          // QUIC_TLS_MESSAGE_CLIENT_HANDSHAKE
-    7 + 1,                          // QUIC_TLS_MESSAGE_SERVER_INITIAL
-    7 + 4,                          // QUIC_TLS_MESSAGE_SERVER_HANDSHAKE
+    7 + 1 + 32,                     // QUIC_TLS_MESSAGE_SERVER_INITIAL
+    7 + 4 + 32,                     // QUIC_TLS_MESSAGE_SERVER_HANDSHAKE
     7 + 1                           // QUIC_TLS_MESSAGE_TICKET
 };
 
@@ -162,8 +162,10 @@ typedef struct QUIC_FAKE_TLS_MESSAGE {
         struct {
             uint8_t Success : 1;
             uint8_t EarlyDataAccepted : 1;
+            uint8_t HandshakeSecret[32];
         } SERVER_INITIAL;
         struct {
+            uint8_t OneRttSecret[32];
             uint16_t CertificateLength;
             uint16_t ExtListLength;
             uint8_t Certificate[0];
@@ -178,6 +180,10 @@ typedef struct QUIC_FAKE_TLS_MESSAGE {
 } QUIC_FAKE_TLS_MESSAGE;
 
 #pragma pack(pop)
+
+typedef struct QUIC_KEY {
+    uint64_t Secret;
+} QUIC_KEY;
 
 typedef struct QUIC_TLS_SESSION {
 
@@ -232,18 +238,25 @@ GetTlsIdentifier(
 __drv_allocatesMem(Mem)
 QUIC_PACKET_KEY*
 QuicStubAllocKey(
-    _In_ QUIC_PACKET_KEY_TYPE Type
+    _In_ QUIC_PACKET_KEY_TYPE Type,
+    _In_reads_(QUIC_AEAD_AES_256_GCM_SIZE)
+        const uint8_t* Secret
     )
 {
     size_t PacketKeySize =
         sizeof(QUIC_PACKET_KEY) +
         (Type == QUIC_PACKET_KEY_1_RTT ? sizeof(QUIC_SECRET) : 0);
     QUIC_PACKET_KEY *Key = QUIC_ALLOC_NONPAGED(PacketKeySize);
-    QUIC_DBG_ASSERT(Key != NULL);
+    QUIC_FRE_ASSERT(Key != NULL);
     QuicZeroMemory(Key, PacketKeySize);
     Key->Type = Type;
-    Key->PacketKey = (QUIC_KEY*)0x1;
+    QuicKeyCreate(QUIC_AEAD_AES_256_GCM, Secret, &Key->PacketKey);
     Key->HeaderKey = (QUIC_HP_KEY*)0x1;
+    if (Type == QUIC_PACKET_KEY_1_RTT) {
+        Key->TrafficSecret[0].Hash = QUIC_HASH_SHA256;
+        Key->TrafficSecret[0].Aead = QUIC_AEAD_AES_256_GCM;
+        QuicCopyMemory(Key->TrafficSecret[0].Secret, Secret, QUIC_AEAD_AES_256_GCM_SIZE);
+    }
     return Key;
 }
 
@@ -583,7 +596,7 @@ QuicTlsReset(
         TlsContext->Connection,
         "Resetting TLS state");
 
-    QUIC_DBG_ASSERT(TlsContext->IsServer == FALSE);
+    QUIC_FRE_ASSERT(TlsContext->IsServer == FALSE);
     TlsContext->LastMessageType = QUIC_TLS_MESSAGE_INVALID;
 }
 
@@ -608,7 +621,7 @@ QuicTlsServerProcess(
 {
     uint16_t DrainLength = 0;
 
-    QUIC_DBG_ASSERT(State->BufferLength < State->BufferAllocLength);
+    QUIC_FRE_ASSERT(State->BufferLength < State->BufferAllocLength);
     __assume(State->BufferLength < State->BufferAllocLength);
 
     const QUIC_FAKE_TLS_MESSAGE* ClientMessage =
@@ -670,7 +683,7 @@ QuicTlsServerProcess(
         }
 
         const QUIC_SEC_CONFIG* SecurityConfig = TlsContext->SecConfig;
-        QUIC_DBG_ASSERT(SecurityConfig != NULL);
+        QUIC_FRE_ASSERT(SecurityConfig != NULL);
 
         if (MaxServerMessageLength < MinMessageLengths[QUIC_TLS_MESSAGE_SERVER_INITIAL]) {
             *ResultFlags |= QUIC_TLS_RESULT_ERROR;
@@ -694,11 +707,15 @@ QuicTlsServerProcess(
             break;
         }
 
+        uint8_t HandshakeSecret[QUIC_AEAD_AES_256_GCM_SIZE];
+        QuicRandom(sizeof(HandshakeSecret), HandshakeSecret);
+
         uint16_t MessageLength = MinMessageLengths[QUIC_TLS_MESSAGE_SERVER_INITIAL];
         TlsWriteUint24(ServerMessage->Length, MessageLength - 4);
         ServerMessage->Type = QUIC_TLS_MESSAGE_SERVER_INITIAL;
         ServerMessage->SERVER_INITIAL.EarlyDataAccepted =
             State->EarlyDataState == QUIC_TLS_EARLY_DATA_ACCEPTED;
+        memcpy(ServerMessage->SERVER_INITIAL.HandshakeSecret, HandshakeSecret, QUIC_AEAD_AES_256_GCM_SIZE);
 
         State->BufferLength = MessageLength;
         State->BufferTotalLength = MessageLength;
@@ -716,16 +733,21 @@ QuicTlsServerProcess(
 
         if (State->EarlyDataState == QUIC_TLS_EARLY_DATA_ACCEPTED) {
             *ResultFlags |= QUIC_TLS_RESULT_EARLY_DATA_ACCEPT;
-            State->ReadKeys[QUIC_PACKET_KEY_0_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_0_RTT);
+            uint8_t Secret[QUIC_AEAD_AES_256_GCM_SIZE];
+            QuicZeroMemory(Secret, sizeof(Secret));
+            State->ReadKeys[QUIC_PACKET_KEY_0_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_0_RTT, Secret);
         }
 
         *ResultFlags |= QUIC_TLS_RESULT_READ_KEY_UPDATED;
         State->ReadKey = QUIC_PACKET_KEY_HANDSHAKE;
-        State->ReadKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE);
+        State->ReadKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE, HandshakeSecret);
 
         *ResultFlags |= QUIC_TLS_RESULT_WRITE_KEY_UPDATED;
         State->WriteKey = QUIC_PACKET_KEY_HANDSHAKE;
-        State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE);
+        State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE, HandshakeSecret);
+
+        uint8_t OneRttSecret[QUIC_AEAD_AES_256_GCM_SIZE];
+        QuicRandom(sizeof(OneRttSecret), OneRttSecret);
 
         MessageLength =
             MinMessageLengths[QUIC_TLS_MESSAGE_SERVER_HANDSHAKE] +
@@ -734,12 +756,13 @@ QuicTlsServerProcess(
             4 + (uint16_t)TlsContext->LocalTPLength;
         TlsWriteUint24(ServerMessage->Length, MessageLength - 4);
         ServerMessage->Type = QUIC_TLS_MESSAGE_SERVER_HANDSHAKE;
+        memcpy(ServerMessage->SERVER_HANDSHAKE.OneRttSecret, OneRttSecret, QUIC_AEAD_AES_256_GCM_SIZE);
         ServerMessage->SERVER_HANDSHAKE.CertificateLength = SecurityConfig->FormatLength;
         memcpy(ServerMessage->SERVER_HANDSHAKE.Certificate, SecurityConfig->FormatBuffer, SecurityConfig->FormatLength);
 
         ExtListLength = 0;
 
-        QUIC_DBG_ASSERT(State->NegotiatedAlpn != NULL);
+        QUIC_FRE_ASSERT(State->NegotiatedAlpn != NULL);
 
         QUIC_TLS_ALPN_EXT* ALPN =
             (QUIC_TLS_ALPN_EXT*)
@@ -769,7 +792,7 @@ QuicTlsServerProcess(
 
         *ResultFlags |= QUIC_TLS_RESULT_WRITE_KEY_UPDATED;
         State->WriteKey = QUIC_PACKET_KEY_1_RTT;
-        State->WriteKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT);
+        State->WriteKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT, OneRttSecret);
 
         DrainLength = (uint16_t)TlsReadUint24(ClientMessage->Length) + 4;
 
@@ -816,7 +839,7 @@ QuicTlsServerProcess(
 
             *ResultFlags |= QUIC_TLS_RESULT_READ_KEY_UPDATED;
             State->ReadKey = QUIC_PACKET_KEY_1_RTT;
-            State->ReadKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT);
+            State->ReadKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT, State->WriteKeys[QUIC_PACKET_KEY_1_RTT]->TrafficSecret[0].Secret);
 
             TlsContext->LastMessageType = QUIC_TLS_MESSAGE_TICKET;
 
@@ -863,7 +886,7 @@ QuicTlsClientProcess(
 {
     uint16_t DrainLength = 0;
 
-    QUIC_DBG_ASSERT(State->BufferLength < State->BufferAllocLength);
+    QUIC_FRE_ASSERT(State->BufferLength < State->BufferAllocLength);
     __assume(State->BufferLength < State->BufferAllocLength);
 
     const QUIC_FAKE_TLS_MESSAGE* ServerMessage =
@@ -937,7 +960,9 @@ QuicTlsClientProcess(
 
         if (TlsContext->EarlyDataAttempted) {
             State->WriteKey = QUIC_PACKET_KEY_0_RTT;
-            State->WriteKeys[QUIC_PACKET_KEY_0_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_0_RTT);
+            uint8_t Secret[QUIC_AEAD_AES_256_GCM_SIZE];
+            QuicZeroMemory(Secret, sizeof(Secret));
+            State->WriteKeys[QUIC_PACKET_KEY_0_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_0_RTT, Secret);
         }
 
         TlsContext->LastMessageType = QUIC_TLS_MESSAGE_CLIENT_INITIAL;
@@ -964,11 +989,11 @@ QuicTlsClientProcess(
 
             *ResultFlags |= QUIC_TLS_RESULT_READ_KEY_UPDATED;
             State->ReadKey = QUIC_PACKET_KEY_HANDSHAKE;
-            State->ReadKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE);
+            State->ReadKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE, ServerMessage->SERVER_INITIAL.HandshakeSecret);
 
             *ResultFlags |= QUIC_TLS_RESULT_WRITE_KEY_UPDATED;
             State->WriteKey = QUIC_PACKET_KEY_HANDSHAKE;
-            State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE);
+            State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] = QuicStubAllocKey(QUIC_PACKET_KEY_HANDSHAKE, ServerMessage->SERVER_INITIAL.HandshakeSecret);
 
         } else if (ServerMessage->Type == QUIC_TLS_MESSAGE_SERVER_HANDSHAKE) {
 
@@ -1078,11 +1103,11 @@ QuicTlsClientProcess(
 
             *ResultFlags |= QUIC_TLS_RESULT_READ_KEY_UPDATED;
             State->ReadKey = QUIC_PACKET_KEY_1_RTT;
-            State->ReadKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT);
+            State->ReadKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT, ServerMessage->SERVER_HANDSHAKE.OneRttSecret);
 
             *ResultFlags |= QUIC_TLS_RESULT_WRITE_KEY_UPDATED;
             State->WriteKey = QUIC_PACKET_KEY_1_RTT;
-            State->WriteKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT);
+            State->WriteKeys[QUIC_PACKET_KEY_1_RTT] = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT, ServerMessage->SERVER_HANDSHAKE.OneRttSecret);
 
             TlsContext->LastMessageType = QUIC_TLS_MESSAGE_CLIENT_HANDSHAKE;
 
@@ -1294,8 +1319,6 @@ QuicTlsParamGet(
 // Crypto / Key Functionality
 //
 
-const uint64_t MAGIC_NO_ENCRYPTION_VALUE = 0xF0F1F2F3F4F5F6F7;
-
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _When_(ReadKey != NULL, _At_(*ReadKey, __drv_allocatesMem(Mem)))
 _When_(WriteKey != NULL, _At_(*WriteKey, __drv_allocatesMem(Mem)))
@@ -1312,14 +1335,21 @@ QuicPacketKeyCreateInitial(
     )
 {
     UNREFERENCED_PARAMETER(IsServer);
-    UNREFERENCED_PARAMETER(Salt);
-    UNREFERENCED_PARAMETER(CIDLength);
-    UNREFERENCED_PARAMETER(CID);
+
+    uint8_t Secret[QUIC_AEAD_AES_256_GCM_SIZE];
+    QuicZeroMemory(Secret, sizeof(Secret));
+    for (uint8_t i = 0; i < QUIC_VERSION_SALT_LENGTH; ++i) {
+        Secret[i % QUIC_AEAD_AES_256_GCM_SIZE] += Salt[i];
+    }
+    for (uint8_t i = 0; i < CIDLength; ++i) {
+        Secret[(i + QUIC_VERSION_SALT_LENGTH) % QUIC_AEAD_AES_256_GCM_SIZE] += CID[i];
+    }
+
     if (ReadKey != NULL) {
-        *ReadKey = QuicStubAllocKey(QUIC_PACKET_KEY_INITIAL);
+        *ReadKey = QuicStubAllocKey(QUIC_PACKET_KEY_INITIAL, Secret);
     }
     if (WriteKey != NULL) {
-        *WriteKey = QuicStubAllocKey(QUIC_PACKET_KEY_INITIAL);
+        *WriteKey = QuicStubAllocKey(QUIC_PACKET_KEY_INITIAL, Secret);
     }
     return QUIC_STATUS_SUCCESS;
 }
@@ -1337,7 +1367,9 @@ QuicPacketKeyDerive(
     UNREFERENCED_PARAMETER(Secret);
     UNREFERENCED_PARAMETER(SecretName);
     UNREFERENCED_PARAMETER(CreateHpKey);
-    *NewKey = QuicStubAllocKey(KeyType);
+    uint8_t NullSecret[QUIC_AEAD_AES_256_GCM_SIZE];
+    QuicZeroMemory(NullSecret, sizeof(NullSecret));
+    *NewKey = QuicStubAllocKey(KeyType, NullSecret);
     return QUIC_STATUS_SUCCESS;
 }
 
@@ -1348,6 +1380,7 @@ QuicPacketKeyFree(
     )
 {
     if (Key != NULL) {
+        QuicKeyFree(Key->PacketKey);
         QUIC_FREE(Key);
     }
 }
@@ -1363,7 +1396,8 @@ QuicPacketKeyUpdate(
     if (OldKey == NULL || OldKey->Type != QUIC_PACKET_KEY_1_RTT) {
         return QUIC_STATUS_INVALID_STATE;
     }
-    *NewKey = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT);
+    OldKey->TrafficSecret[0].Secret[0]++;
+    *NewKey = QuicStubAllocKey(QUIC_PACKET_KEY_1_RTT, OldKey->TrafficSecret[0].Secret);
     return QUIC_STATUS_SUCCESS;
 }
 
@@ -1378,9 +1412,13 @@ QuicKeyCreate(
     _Out_ QUIC_KEY** NewKey
     )
 {
-    UNREFERENCED_PARAMETER(AeadType);
-    UNREFERENCED_PARAMETER(RawKey);
-    *NewKey = (QUIC_KEY*)0x1;
+    QUIC_KEY *Key = QUIC_ALLOC_NONPAGED(sizeof(QUIC_KEY));
+    QUIC_FRE_ASSERT(Key != NULL);
+    Key->Secret = AeadType;
+    for (uint16_t i = 0; i < QuicKeyLength(AeadType); ++i) {
+        ((uint8_t*)&Key->Secret)[i % 8] += RawKey[i];
+    }
+    *NewKey = Key;
     return QUIC_STATUS_SUCCESS;
 }
 
@@ -1390,7 +1428,9 @@ QuicKeyFree(
     _In_opt_ QUIC_KEY* Key
     )
 {
-    UNREFERENCED_PARAMETER(Key);
+    if (Key != NULL) {
+        QUIC_FREE(Key);
+    }
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -1413,8 +1453,7 @@ QuicEncrypt(
     UNREFERENCED_PARAMETER(AuthDataLength);
     UNREFERENCED_PARAMETER(AuthData);
     uint16_t PlainTextLength = BufferLength - QUIC_ENCRYPTION_OVERHEAD;
-    *(uint64_t*)(Buffer + PlainTextLength) = MAGIC_NO_ENCRYPTION_VALUE;
-    *(uint64_t*)(Buffer + PlainTextLength + sizeof(uint64_t)) = MAGIC_NO_ENCRYPTION_VALUE;
+    *(uint64_t*)(Buffer + PlainTextLength) = Key->Secret;
     return QUIC_STATUS_SUCCESS;
 }
 
@@ -1437,7 +1476,7 @@ QuicDecrypt(
     UNREFERENCED_PARAMETER(AuthDataLength);
     UNREFERENCED_PARAMETER(AuthData);
     uint16_t PlainTextLength = BufferLength - QUIC_ENCRYPTION_OVERHEAD;
-    if (*(uint64_t*)(Buffer + PlainTextLength) != MAGIC_NO_ENCRYPTION_VALUE) {
+    if (*(uint64_t*)(Buffer + PlainTextLength) != Key->Secret) {
         return QUIC_STATUS_INVALID_PARAMETER;
     } else {
         return QUIC_STATUS_SUCCESS;

--- a/src/tools/dbg/packet.cpp
+++ b/src/tools/dbg/packet.cpp
@@ -36,11 +36,7 @@ EXT_COMMAND(
         Packet.PacketLength());
 
     if (Flags.IsAckEliciting) {
-        Dml("Retransmittable\n"
-            "\t                     ");
-    }
-    if (Flags.HasCrypto) {
-        Dml("Crypto Frames\n"
+        Dml("Ack Eliciting\n"
             "\t                     ");
     }
     if (Flags.IsPMTUD) {

--- a/src/tools/dbg/quictypes.h
+++ b/src/tools/dbg/quictypes.h
@@ -816,7 +816,6 @@ typedef struct QUIC_SEND_PACKET_FLAGS {
     UINT8 KeyType                   : 2;
     BOOLEAN IsAckEliciting          : 1;
     BOOLEAN IsPMTUD                 : 1;
-    BOOLEAN HasAckFrame             : 1;
     BOOLEAN SuspectedLost           : 1;
 
     PCSTR KeyTypeStr() {

--- a/src/tools/dbg/quictypes.h
+++ b/src/tools/dbg/quictypes.h
@@ -815,8 +815,9 @@ typedef struct QUIC_SEND_PACKET_FLAGS {
 
     UINT8 KeyType                   : 2;
     BOOLEAN IsAckEliciting          : 1;
-    BOOLEAN HasCrypto               : 1;
     BOOLEAN IsPMTUD                 : 1;
+    BOOLEAN HasAckFrame             : 1;
+    BOOLEAN SuspectedLost           : 1;
 
     PCSTR KeyTypeStr() {
         switch (KeyType) {

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -792,26 +792,6 @@ main(int argc, char **argv)
 
     MsQuic->RegistrationClose(Registration);
 
-    if (Settings.LossPercent != 0) {
-        QUIC_TEST_DATAPATH_HOOKS* Value = nullptr;
-        uint32_t TryCount = 0;
-        while (TryCount++ < 10) {
-            if (QUIC_SUCCEEDED(
-                MsQuic->SetParam(
-                    nullptr,
-                    QUIC_PARAM_LEVEL_GLOBAL,
-                    QUIC_PARAM_GLOBAL_TEST_DATAPATH_HOOKS,
-                    sizeof(Value),
-                    &Value))) {
-                break;
-            }
-            QuicSleep(500); // Let the current datapath queue drain.
-        }
-        if (TryCount == 10) {
-            printf("Failed to disable test datapath hook!\n");
-        }
-    }
-
     MsQuicClose(MsQuic);
 
     return 0;

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -805,11 +805,10 @@ main(int argc, char **argv)
                     &Value))) {
                 break;
             }
-            QuicSleep(100); // Let the current datapath queue drain.
+            QuicSleep(500); // Let the current datapath queue drain.
         }
         if (TryCount == 10) {
             printf("Failed to disable test datapath hook!\n");
-            QUIC_FRE_ASSERTMSG(FALSE, "Failed to disable test datapath hook!");
         }
     }
 


### PR DESCRIPTION
Fixes bugs/issues found by spinquic with now that we have random loss and address sanitizer enabled. 

- Add some debug validation to loss detection.

- Fixes a loss detection bug where a packet in the sent packet's list was getting freed, but the tail of the list was not being properly updated.

- Fixes a few leaks found by address sanitizer.

- Certain loss patterns led to the ack tracker framing ACKs over and over.

- Spinquic doesn't really need to clean up datapath hooks.

- Update Linux address sanitizer to dump objects for better debugging.

- Update Crypto to clean up any recovery state when discarding keys.

- Updated stub TLS to use randomly generated secrets for connection encryption, to prevent cross-connection packet contamination (which doesn't exist with a real TLS solution).

- Fixes OpenSSL to correctly set buffer offsets when new write keys are available.

Fixes #163.