### PR TITLE
Disable Logs in Azure Pipelines Runs

### DIFF
--- a/.azure/templates/run-bvt-int.yml
+++ b/.azure/templates/run-bvt-int.yml
@@ -3,7 +3,7 @@
 parameters:
   config: 'Debug'
   arch: ''
-  logProfile: 'Full.Light'
+  logProfile: 'None'
   extraArgs: ''
 
 jobs:

--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -35,7 +35,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/spin.ps1
-      arguments: -GenerateXmlResults -Timeout 600000 -LogProfile SpinQuic.Light -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -GenerateXmlResults -Timeout 600000 -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 
   - template: ./upload-test-artifacts.yml
     parameters:


### PR DESCRIPTION
The logs are overrunning and causing problems. Disabling them in a few places (spinquic & internal test runs) for now.