### PR TITLE
Don't Accept Retry after ACK

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3498,6 +3498,11 @@ QuicConnRecvFrames(
                 return FALSE;
             }
 
+            if (!QuicConnIsServer(Connection) &&
+                !Connection->State.GotFirstServerResponse) {
+                Connection->State.GotFirstServerResponse = TRUE;
+            }
+
             Packet->HasNonProbingFrame = TRUE;
             break;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3498,11 +3498,6 @@ QuicConnRecvFrames(
                 return FALSE;
             }
 
-            if (!QuicConnIsServer(Connection) &&
-                !Connection->State.GotFirstServerResponse) {
-                Connection->State.GotFirstServerResponse = TRUE;
-            }
-
             Packet->HasNonProbingFrame = TRUE;
             break;
         }
@@ -3530,10 +3525,6 @@ QuicConnRecvFrames(
                     &Frame);
             if (QUIC_SUCCEEDED(Status)) {
                 AckPacketImmediately = TRUE;
-                if (!QuicConnIsServer(Connection) &&
-                    !Connection->State.GotFirstServerResponse) {
-                    Connection->State.GotFirstServerResponse = TRUE;
-                }
             } else if (Status == QUIC_STATUS_OUT_OF_MEMORY) {
                 return FALSE;
             } else {
@@ -4129,6 +4120,11 @@ QuicConnRecvFrames(
     }
 
 Done:
+
+    if (!QuicConnIsServer(Connection) &&
+        !Connection->State.GotFirstServerResponse) {
+        Connection->State.GotFirstServerResponse = TRUE;
+    }
 
     if (UpdatedFlowControl) {
         QuicConnLogOutFlowStats(Connection);


### PR DESCRIPTION
During some spinquic runs, it seems we were getting into a state where a RETRY packet is received after a packet with an ACK frame that had already acknowledged the previously sent CRYPTO data. This caused the Crypto code to get into a state where it thinks everything was sent already (and drained from the buffer) but we still need to send.

The fix here is to reject the RETRY packet if we've already received any packet from the server.