### PR TITLE
Fix race condition in Ping tests

### DIFF
--- a/src/test/lib/TestStream.cpp
+++ b/src/test/lib/TestStream.cpp
@@ -146,6 +146,12 @@ TestStream::StartPing(
                 TEST_FAILURE("MsQuic->StreamSend failed, 0x%x.", Status);
                 return false;
             }
+            if (resultingBytesLeft == 0) {
+                // On the finish packet if it succeeds, the instance
+                // we are executing in will be deleted. Return
+                // so we don't execute the while on a deleted instance.
+                return true;
+            }
         }
 
     } else {


### PR DESCRIPTION
In StartPing, when the QUIC_SEND_FLAG_FIN flag is set and there are no bytes left, if the SteamSend completes successfully, we are racing against stream callback, which deletes the instance we are currently executing. When the loop continues, BytesToSend is read again, which is the use after free. Explicitly exiting the loop upon no data left removes the race

Closes #395