### PR TITLE
Improve Output when CDB.exe is Missing

### DIFF
--- a/.azure/scripts/run-executable.ps1
+++ b/.azure/scripts/run-executable.ps1
@@ -173,16 +173,15 @@ function Start-Executable {
 # Uses CDB.exe to print the crashing callstack in the dump file.
 function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
-    $Output = cdb.exe -z $File -c "kn;q" | Join-String -Separator "`n"
-    Write-Host "=================================================================================="
-    Write-Host " $(Split-Path $DumpFile -Leaf)"
-    Write-Host "=================================================================================="
     try {
+        $Output = cdb.exe -z $File -c "kn;q" | Join-String -Separator "`n"
         $Output = ($Output | Select-String -Pattern " # Child-SP(?s).*quit:").Matches[0].Groups[0].Value
+        Write-Host "=================================================================================="
+        Write-Host " $(Split-Path $DumpFile -Leaf)"
+        Write-Host "=================================================================================="
         $Output -replace "quit:", "=================================================================================="
     } catch {
-        Log "Failed to extract callstack"
-        $Output
+        # Silently fail
     }
 }
 

--- a/.azure/scripts/run-gtest.ps1
+++ b/.azure/scripts/run-gtest.ps1
@@ -310,16 +310,15 @@ function Start-AllTestCases {
 # Uses CDB.exe to print the crashing callstack in the dump file.
 function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
-    $Output = cdb.exe -z $File -c "kn;q" | Join-String -Separator "`n"
-    Write-Host "=================================================================================="
-    Write-Host " $(Split-Path $DumpFile -Leaf)"
-    Write-Host "=================================================================================="
     try {
+        $Output = cdb.exe -z $File -c "kn;q" | Join-String -Separator "`n"
         $Output = ($Output | Select-String -Pattern " # Child-SP(?s).*quit:").Matches[0].Groups[0].Value
+        Write-Host "=================================================================================="
+        Write-Host " $(Split-Path $DumpFile -Leaf)"
+        Write-Host "=================================================================================="
         $Output -replace "quit:", "=================================================================================="
     } catch {
-        Log "Failed to extract callstack"
-        $Output
+        # Silently fail
     }
 }
 


### PR DESCRIPTION
Apparently CDB.exe isn't installed on the public Azure Pipelines images by default, though I just opened an Issue to hopefully get it added (https://github.com/actions/virtual-environments/issues/942). Until then, let's not crash or complain.