### PR TITLE
Don't Use App Closed until 1-RTT Keys

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1425,9 +1425,9 @@ QuicConnTryClose(
     if (!ClosedRemotely) {
 
         if ((Flags & QUIC_CLOSE_APPLICATION) &&
-            Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT] == NULL) {
+            Connection->Crypto.TlsState.WriteKey < QUIC_PACKET_KEY_1_RTT) {
             //
-            // Application close can only happen if we have 1-RTT keys.
+            // Application close can only happen if we are using 1-RTT keys.
             // Otherwise we have to send "user_canceled" TLS error code as a
             // connection close. Overwrite all application provided parameters.
             //

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -227,17 +227,10 @@ QuicSendSetSendFlag(
     if (IsCloseFrame) {
 
         //
-        // Remove all flags for things we aren't allowed to send once the
-        // connection has been closed.
+        // Remove all flags for things we aren't allowed to send once the connection
+        // has been closed.
         //
         Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_CONN_CLOSED_MASK;
-        if (Connection->Crypto.TlsState.WriteKey < QUIC_PACKET_KEY_1_RTT) {
-            //
-            // No need to continue to exchange CRYPTO frames during the
-            // handshake if the connection has been closed.
-            //
-            Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_CRYPTO;
-        }
 
         //
         // Remove any queued up streams.

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -227,10 +227,17 @@ QuicSendSetSendFlag(
     if (IsCloseFrame) {
 
         //
-        // Remove all flags for things we aren't allowed to send once the connection
-        // has been closed.
+        // Remove all flags for things we aren't allowed to send once the
+        // connection has been closed.
         //
         Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_CONN_CLOSED_MASK;
+        if (Connection->Crypto.TlsState.WriteKey < QUIC_PACKET_KEY_1_RTT) {
+            //
+            // No need to continue to exchange CRYPTO frames during the
+            // handshake if the connection has been closed.
+            //
+            Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_CRYPTO;
+        }
 
         //
         // Remove any queued up streams.


### PR DESCRIPTION
Spinquic was occassionally hitting an assert in send.c that indicated nothing was being framed. This ended up because we had queued an app close while we were still writing handshake packets. This caused things to get stuck/confused. The proper fix is to not queue app close until we are on 1-RTT keys. Instead, just use the transport closed which can be used at any level.