### PR TITLE
Only Change Partitions for New Paths

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -4320,7 +4320,7 @@ QuicConnRecvDatagramBatch(
             QuicConnRecvPostProcessing(Connection, &Path, Packet);
             RecvState->ResetIdleTimeout |= Packet->CompletelyValid;
 
-            if (Path->IsActive && Packet->CompletelyValid &&
+            if (Path->IsActive && !Path->IsPeerValidated && Packet->CompletelyValid &&
                 (Datagrams[i]->PartitionIndex % MsQuicLib.PartitionCount) != RecvState->PartitionIndex) {
                 RecvState->PartitionIndex = Datagrams[i]->PartitionIndex % MsQuicLib.PartitionCount;
                 RecvState->UpdatePartitionId = TRUE;


### PR DESCRIPTION
In the kernel mode loopback scenario, the receive callback is delivered inline from the send thread. If the receiver then updates their worker thread (and therefor the thread they send next from) based on that thread, it creates an endless loop of updating partitions.

The fix here is to only update the partition if the path is new (i.e. not yet validated yet). I validated this with Hermes.