### PR TITLE
Allow a Single Partition Update per Path

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -4320,10 +4320,11 @@ QuicConnRecvDatagramBatch(
             QuicConnRecvPostProcessing(Connection, &Path, Packet);
             RecvState->ResetIdleTimeout |= Packet->CompletelyValid;
 
-            if (Path->IsActive && !Path->IsPeerValidated && Packet->CompletelyValid &&
+            if (Path->IsActive && !Path->PartitionUpdated && Packet->CompletelyValid &&
                 (Datagrams[i]->PartitionIndex % MsQuicLib.PartitionCount) != RecvState->PartitionIndex) {
                 RecvState->PartitionIndex = Datagrams[i]->PartitionIndex % MsQuicLib.PartitionCount;
                 RecvState->UpdatePartitionId = TRUE;
+                Path->PartitionUpdated = TRUE;
             }
 
             if (Packet->IsShortHeader && Packet->NewLargestPacketNumber) {

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -58,6 +58,11 @@ typedef struct QUIC_PATH {
     BOOLEAN SendResponse : 1;
 
     //
+    // Indicates the partition has updated for this path.
+    //
+    uint8_t PartitionUpdated : 1;
+
+    //
     // The currently calculated path MTU.
     //
     uint16_t Mtu;


### PR DESCRIPTION
A slight modification to my previous PR. Instead of using the IsPeerValid flag, we add a new flag just for partition update. This allows for the initial client path update scenario (since it's path starts as valid).