### PR TITLE
Add flags and queue check to QuicDatagramValidate

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -667,7 +667,7 @@ inline
 _Ret_notnull_
 QUIC_CONNECTION*
 QuicDatagramGetConnection(
-    _In_ QUIC_DATAGRAM* Datagram
+    _In_ const QUIC_DATAGRAM* const Datagram
     )
 {
     return QUIC_CONTAINING_RECORD(Datagram, QUIC_CONNECTION, Datagram);

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -32,8 +32,10 @@ QuicDatagramValidate(
     )
 {
     QUIC_CONNECTION* Connection = QuicDatagramGetConnection(Datagram);
-    // If Datagram flag is set, SendQueue must not be null,
-    // Otherwise SendQueue must be null
+    //
+    // If a datagram is to be sent down the connection, the datagram must have
+    // items in its queue. Otherwise, sending will have an error case.
+    //
     if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
         QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
     } else {

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -31,6 +31,15 @@ QuicDatagramValidate(
     _In_ const QUIC_DATAGRAM* Datagram
     )
 {
+    QUIC_CONNECTION* Connection = QuicDatagramGetConnection(Datagram);
+    // If Datagram flag is set, SendQueue must not be null,
+    // Otherwise SendQueue must be null
+    if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
+        QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
+    } else {
+        QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
+    }
+
     if (!Datagram->SendEnabled) {
         QUIC_DBG_ASSERT(Datagram->MaxSendLength == 0);
     } else {

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -36,10 +36,12 @@ QuicDatagramValidate(
     // If a datagram is to be sent down the connection, the datagram must have
     // items in its queue. Otherwise, sending will have an error case.
     //
-    if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
-        QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
-    } else if (Connection->State.PeerTransportParameterValid) {
-        QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
+    if (!QuicConnIsClosed(Connection)) {
+        if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
+            QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
+        } else if (Connection->State.PeerTransportParameterValid) {
+            QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
+        }
     }
 
     if (!Datagram->SendEnabled) {
@@ -423,7 +425,7 @@ QuicDatagramSendFlush(
         QUIC_DBG_ASSERT(!(SendRequest->Flags & QUIC_SEND_FLAG_BUFFERED));
         QUIC_TEL_ASSERT(Datagram->SendEnabled);
 
-        if (SendRequest->TotalLength > (uint64_t)Datagram->MaxSendLength) {
+        if (SendRequest->TotalLength > (uint64_t)Datagram->MaxSendLength || QuicConnIsClosed(Connection)) {
             QuicDatagramCancelSend(Connection, SendRequest);
             continue;
         }

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -36,12 +36,13 @@ QuicDatagramValidate(
     // If a datagram is to be sent down the connection, the datagram must have
     // items in its queue. Otherwise, sending will have an error case.
     //
-    if (!QuicConnIsClosed(Connection)) {
-        if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
-            QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
-        } else if (Connection->State.PeerTransportParameterValid) {
-            QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
-        }
+    if (QuicConnIsClosed(Connection)) {
+        QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
+        QUIC_DBG_ASSERT((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) == 0);
+    } else if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
+        QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
+    } else if (Connection->State.PeerTransportParameterValid) {
+        QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
     }
 
     if (!Datagram->SendEnabled) {

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -38,7 +38,7 @@ QuicDatagramValidate(
     //
     if ((Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_DATAGRAM) != 0) {
         QUIC_DBG_ASSERT(Datagram->SendQueue != NULL);
-    } else {
+    } else if (Connection->State.PeerTransportParameterValid) {
         QUIC_DBG_ASSERT(Datagram->SendQueue == NULL);
     }
 

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -275,7 +275,7 @@ QuicSendGetConnection(
 
 QUIC_CONNECTION*
 QuicDatagramGetConnection(
-    _In_ QUIC_DATAGRAM* Datagram
+    _In_ const QUIC_DATAGRAM* const Datagram
     );
 
 uint8_t


### PR DESCRIPTION
Assert that if SendFlags for Datagram is set, that the send queue is not null. Otherwise the opposite

Should help with debugging #425