### PR TITLE
Disable String Pooling for Kernel Mode

### DIFF
--- a/src/bin/winkernel/msquic.kernel.vcxproj
+++ b/src/bin/winkernel/msquic.kernel.vcxproj
@@ -91,6 +91,7 @@
       <AdditionalIncludeDirectories>..\..\inc;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>false</StringPooling>
       <AdditionalOptions>/Gw /kernel /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/src/core/core.kernel.vcxproj
+++ b/src/core/core.kernel.vcxproj
@@ -144,6 +144,7 @@
       <AdditionalIncludeDirectories>..\inc;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>false</StringPooling>
       <AdditionalOptions>/Gw /kernel /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>

--- a/src/platform/platform.kernel.vcxproj
+++ b/src/platform/platform.kernel.vcxproj
@@ -85,6 +85,7 @@
       <AdditionalIncludeDirectories>..\inc;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>false</StringPooling>
       <AdditionalOptions>/Gw /kernel /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>

--- a/src/test/bin/winkernel/msquictest.kernel.vcxproj
+++ b/src/test/bin/winkernel/msquictest.kernel.vcxproj
@@ -92,6 +92,7 @@
       <AdditionalIncludeDirectories>..\..;..\..\..\inc;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>false</StringPooling>
       <AdditionalOptions>/Gw /kernel /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/src/test/lib/testlib.kernel.vcxproj
+++ b/src/test/lib/testlib.kernel.vcxproj
@@ -89,6 +89,7 @@
       <AdditionalIncludeDirectories>..\;..\..\inc;..\..\..\submodules\wil\include;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>false</StringPooling>
       <AdditionalOptions>/Gw /kernel /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>


### PR DESCRIPTION
Apparently string pooling was causing some strings to be put in the `PAGE` section of the driver, which caused a runtime error on Xbox. From binary inspection, this change seemed to move the string to the `.data` section:
```
0:000> uf msquic!QuicPlatformInitialize;!dh msquic
msquic!QuicPlatformInitialize [E:\msquic\src\platform\platform_winkernel.c @ 115]:
  ...
  120 00000001`4004a0b1 488d151071ffff  lea     rdx,[msquic!`string'+0x128 (00000001`400411c8)]  <==== HERE
  120 00000001`4004a0b8 4533c0          xor     r8d,r8d
  120 00000001`4004a0bb 488d0de698ffff  lea     rcx,[msquic!QuicPlatform+0x8 (00000001`400439a8)]
  120 00000001`4004a0c2 ff15b0cfffff    call    qword ptr [msquic!_imp_BCryptOpenAlgorithmProvider (00000001`40047078)]
...
SECTION HEADER #3
   .data name
    29F0 virtual size
   41000 virtual address               <==== is in HERE
    1400 size of raw data
   40200 file pointer to raw data
       0 file pointer to relocation table
       0 file pointer to line numbers
       0 number of relocations
       0 number of line numbers
C8000040 flags
         Initialized Data
         Not Paged
         (no align specified)
         Read Write
```