### PR TITLE
Reset Datagram SendFlag when writing last datagram and out of buffer

### DIFF
--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -469,6 +469,7 @@ QuicDatagramWriteFrame(
 {
     QUIC_CONNECTION* Connection = QuicDatagramGetConnection(Datagram);
     QUIC_DBG_ASSERT(Datagram->SendEnabled);
+    BOOLEAN ExitValue = FALSE;
 
     QuicDatagramValidate(Datagram);
 
@@ -478,7 +479,8 @@ QuicDatagramWriteFrame(
         if (Builder->Metadata->Flags.KeyType == QUIC_PACKET_KEY_0_RTT &&
             !(SendRequest->Flags & QUIC_SEND_FLAG_ALLOW_0_RTT)) {
             QUIC_DBG_ASSERT(FALSE);
-            return FALSE; // This datagram isn't allowed in 0-RTT.
+            ExitValue = FALSE;
+            goto Exit; // This datagram isn't allowed in 0-RTT.
         }
 
         QUIC_DBG_ASSERT(SendRequest->TotalLength <= Datagram->MaxSendLength);
@@ -505,7 +507,8 @@ QuicDatagramWriteFrame(
                 Builder->Datagram->Length < Datagram->MaxSendLength ||
                 Builder->Metadata->FrameCount != 0 ||
                 Builder->PacketStart != 0);
-            return TRUE;
+            ExitValue = TRUE;
+            goto Exit;
         }
 
         if (Datagram->PrioritySendQueueTail == &SendRequest->Next) {
@@ -524,13 +527,21 @@ QuicDatagramWriteFrame(
             SendRequest,
             &Builder->Metadata->Frames[Builder->Metadata->FrameCount].DATAGRAM.ClientContext);
         if (++Builder->Metadata->FrameCount == QUIC_MAX_FRAMES_PER_PACKET) {
-            return TRUE;
+            if (Datagram->SendQueue == NULL) {
+                Connection->Send.SendFlags &= ~QUIC_CONN_SEND_FLAG_DATAGRAM;
+            }
+            ExitValue = TRUE;
+            goto Exit;
         }
     }
 
     Connection->Send.SendFlags &= ~QUIC_CONN_SEND_FLAG_DATAGRAM;
+    ExitValue = FALSE;
 
-    return FALSE;
+Exit:
+    QuicDatagramValidate(Datagram);
+
+    return ExitValue;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)


### PR DESCRIPTION
If flag isn't reset, we get in an invalid state where we are told to write a datagram, but have none to write.

Also adds validation to ensure when leaving QuicDatagramWriteFrame the datagram is valid.

Closes #425