### PR TITLE
Tests Wait Longer with Random Loss

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -147,6 +147,9 @@ QuicTestConnect(
                 if (!Client.WaitForZeroRttTicket()) {
                     return;
                 }
+                //
+                // TODO - Don't wait for client/server shutdown when using random loss.
+                //
                 Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
                 if (!Client.WaitForShutdownComplete()) {
                     return;
@@ -279,6 +282,8 @@ QuicTestConnect(
             if (RandomLossPercentage == 0) {
                 TEST_TRUE(Server->GetPeerClosed());
                 TEST_EQUAL(Server->GetPeerCloseErrorCode(), QUIC_TEST_NO_ERROR);
+            } else {
+                Server->Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
             }
         }
     }

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -260,13 +260,20 @@ QuicTestConnect(
                     TEST_EQUAL(100, Client.GetLocalBidiStreamCount());
                 }
 
-                Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
-                if (!Client.WaitForShutdownComplete()) {
-                    return;
-                }
+                if (RandomLossPercentage == 0) {
+                    //
+                    // Don't worry about graceful shutdown if we have random
+                    // loss. It will likely just result in the maximum wait
+                    // timeout, causing the test to run longer.
+                    //
+                    Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+                    if (!Client.WaitForShutdownComplete()) {
+                        return;
+                    }
 
-                TEST_FALSE(Client.GetPeerClosed());
-                TEST_FALSE(Client.GetTransportClosed());
+                    TEST_FALSE(Client.GetPeerClosed());
+                    TEST_FALSE(Client.GetTransportClosed());
+                }
             }
 
             if (RandomLossPercentage == 0) {

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -94,7 +94,6 @@ QuicTestConnect(
     MsQuicSession Session;
     TEST_TRUE(Session.IsValid());
     TEST_QUIC_SUCCEEDED(Session.SetPeerBidiStreamCount(4));
-    TEST_QUIC_SUCCEEDED(Session.SetIdleTimeout(10000));
     MsQuicSession Session2("MsQuicTest2", "MsQuicTest");
     TEST_TRUE(Session2.IsValid());
     TEST_QUIC_SUCCEEDED(Session2.SetPeerBidiStreamCount(4));
@@ -103,6 +102,16 @@ QuicTestConnect(
     StatelessRetryHelper RetryHelper(ServerStatelessRetry);
     PrivateTransportHelper TpHelper(MultiPacketClientInitial);
     RandomLossHelper LossHelper(RandomLossPercentage);
+
+    if (RandomLossPercentage != 0) {
+        TEST_QUIC_SUCCEEDED(Session.SetIdleTimeout(30000));
+        TEST_QUIC_SUCCEEDED(Session.SetDisconnectTimeout(30000));
+        TEST_QUIC_SUCCEEDED(Session2.SetIdleTimeout(30000));
+        TEST_QUIC_SUCCEEDED(Session2.SetDisconnectTimeout(30000));
+    } else {
+        TEST_QUIC_SUCCEEDED(Session.SetIdleTimeout(10000));
+        TEST_QUIC_SUCCEEDED(Session2.SetIdleTimeout(10000));
+    }
 
     {
         TestListener Listener(

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -147,13 +147,8 @@ QuicTestConnect(
                 if (!Client.WaitForZeroRttTicket()) {
                     return;
                 }
-                //
-                // TODO - Don't wait for client/server shutdown when using random loss.
-                //
-                Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
-                if (!Client.WaitForShutdownComplete()) {
-                    return;
-                }
+                Session.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
+                Session2.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
             }
         }
 

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -135,14 +135,15 @@ TestConnection::WaitForConnectionComplete()
 bool
 TestConnection::WaitForZeroRttTicket()
 {
+    const uint32_t MaxTryCount = 1 + GetWaitTimeout() / 100;
     uint32_t TryCount = 0;
-    while (TryCount++ < 20) {
+    while (TryCount++ < MaxTryCount) {
         if (HasNewZeroRttTicket()) {
             break;
         }
         QuicSleep(100);
     }
-    if (TryCount == 20) {
+    if (TryCount == MaxTryCount) {
         TEST_FAILURE("WaitForZeroRttTicket failed.");
         return false;
     }

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -182,6 +182,12 @@ struct MsQuicSession {
     void SetAutoCleanup() {
         CloseAllConnectionsOnDelete = true;
     }
+    void Shutdown(
+        _In_ QUIC_CONNECTION_SHUTDOWN_FLAGS Flags,
+        _In_ QUIC_UINT62 ErrorCode
+        ) {
+        MsQuic->SessionShutdown(Handle, Flags, ErrorCode);
+    }
     QUIC_STATUS
     SetTlsTicketKey(
         _In_reads_bytes_(44)

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -233,7 +233,7 @@ struct MsQuicSession {
     }
     QUIC_STATUS
     SetDisconnectTimeout(
-        uint64_t value  // milliseconds
+        uint32_t value  // milliseconds
         ) {
         return
             MsQuic->SetParam(

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -232,6 +232,18 @@ struct MsQuicSession {
                 &value);
     }
     QUIC_STATUS
+    SetDisconnectTimeout(
+        uint64_t value  // milliseconds
+        ) {
+        return
+            MsQuic->SetParam(
+                Handle,
+                QUIC_PARAM_LEVEL_SESSION,
+                QUIC_PARAM_SESSION_DISCONNECT_TIMEOUT,
+                sizeof(value),
+                &value);
+    }
+    QUIC_STATUS
     SetMaxBytesPerKey(
         uint64_t value
         ) {


### PR DESCRIPTION
When using random loss in the tests (especially with high loss rates like 10%) we should wait a lot longer than normal before considering the test case failed. This updates the rest of the places that seemed to be causing occasional timeout failures.

Fixes #440 