### PR TITLE
Remove flags that can't be sent during congestion control without allowance

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1012,7 +1012,8 @@ QuicSendFlush(
             // While we are CC blocked, very few things are still allowed to
             // be sent. If those are queued then we can still send.
             //
-            if (!(SendFlags & QUIC_CONN_SEND_FLAGS_BYPASS_CC)) {
+            SendFlags &= QUIC_CONN_SEND_FLAGS_BYPASS_CC;
+            if (!SendFlags) {
                 if (QuicCongestionControlCanSend(&Connection->CongestionControl)) {
                     //
                     // The current pacing chunk is finished. We need to schedule a


### PR DESCRIPTION
Without removing these flags, the framing logic thinks it has data that can be sent, even though congestion control told us that we could not send certain types of frames, causing empty frames to be generated.