### PR TITLE
Fix Send Flags used for Packet Building

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -444,6 +444,13 @@ QuicPacketBuilderGetPacketTypeAndKeyForControlFrames(
         return TRUE;
     }
 
+    QuicTraceLogConnWarning(
+        GetPacketTypeFailure,
+        Builder->Connection,
+        "Failed to get packet type for control frames, 0x%x",
+        SendFlags);
+    QUIC_DBG_ASSERT(FALSE); // This shouldn't have been called then!
+
     return FALSE;
 }
 
@@ -457,22 +464,17 @@ QuicPacketBuilderPrepareForControlFrames(
     )
 {
     QUIC_DBG_ASSERT(!(SendFlags & QUIC_CONN_SEND_FLAG_PMTUD));
-
     QUIC_PACKET_KEY_TYPE PacketKeyType;
-    if (!QuicPacketBuilderGetPacketTypeAndKeyForControlFrames(
+    return
+        QuicPacketBuilderGetPacketTypeAndKeyForControlFrames(
             Builder,
             SendFlags,
-            &PacketKeyType)) {
-        QuicTraceLogConnWarning(
-            GetPacketTypeFailure,
-            Builder->Connection,
-            "Failed to get packet type for control frames, 0x%x",
-            SendFlags);
-        QUIC_DBG_ASSERT(FALSE); // This shouldn't have been called then!
-        return FALSE;
-    }
-
-    return QuicPacketBuilderPrepare(Builder, PacketKeyType, IsTailLossProbe, FALSE);
+            &PacketKeyType) &&
+        QuicPacketBuilderPrepare(
+            Builder,
+            PacketKeyType,
+            IsTailLossProbe,
+            FALSE);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1056,7 +1056,7 @@ QuicSendFlush(
             if (!QuicPacketBuilderPrepareForControlFrames(
                     &Builder,
                     Send->TailLossProbeNeeded,
-                    Send->SendFlags & ~QUIC_CONN_SEND_FLAG_PMTUD)) {
+                    SendFlags & ~QUIC_CONN_SEND_FLAG_PMTUD)) {
                 break;
             }
             WrotePacketFrames = QuicSendWriteFrames(Send, &Builder);


### PR DESCRIPTION
A follow up to #443 this fixes a bug where the wrong `SendFlags` variable was being used when deciding what type of packet to build next. Also makes a slight refactor of the packet builder code. Moves the assert to the first point of failure, and then cleans up the previous code.