### PR TITLE
Separate datapath shutdown from datapath cleanup

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -280,9 +280,7 @@ MsQuicLibraryUninitialize(
     // Ensure all datapath workers are shut down, so new connections won't be 
     // created while we shut down worker threads.
     //
-    if (MsQuicLib.Datapath != NULL) {
-        QuicDataPathShutdownWorkers(MsQuicLib.Datapath);
-    }
+    QuicDataPathShutdown(MsQuicLib.Datapath);
 
     //
     // The library's worker pool for processing half-opened connections

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -277,6 +277,14 @@ MsQuicLibraryUninitialize(
     }
 
     //
+    // Ensure all datapath workers are shut down, so new connections won't be 
+    // created while we shut down worker threads.
+    //
+    if (MsQuicLib.Datapath != NULL) {
+        QuicDataPathShutdownWorkers(MsQuicLib.Datapath);
+    }
+
+    //
     // The library's worker pool for processing half-opened connections
     // needs to be cleaned up first, as it's the last thing that can be
     // holding on to connection objects.

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -252,13 +252,13 @@ QuicDataPathInitialize(
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicDataPathShutdownWorkers(
+QuicDataPathShutdown(
     _In_ QUIC_DATAPATH* Datapath
     );
 
 //
 // Closes a QUIC Datapath library handle.
-// It is expected that QuicDataPathShutdownWorkers is called before this
+// It is expected that QuicDataPathShutdown is called before this
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -248,7 +248,17 @@ QuicDataPathInitialize(
     );
 
 //
+// Shuts down all workers in a QUIC Datapath handle.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicDataPathShutdownWorkers(
+    _In_ QUIC_DATAPATH* Datapath
+    );
+
+//
 // Closes a QUIC Datapath library handle.
+// It is expected that QuicDataPathShutdownWorkers is called before this
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -101,6 +101,12 @@ void
     );
 
 typedef
+void
+(*QUIC_DATAPATH_SHUTDOWN_WORKERS)(
+    _In_ QUIC_DATAPATH* Datapath
+    );
+
+typedef
 BOOLEAN
 (*QUIC_DATAPATH_IS_PADDING_PREFERRED)(
     _In_ QUIC_DATAPATH* Datapath
@@ -245,6 +251,7 @@ typedef struct QUIC_PLATFORM_DISPATCH {
     QUIC_RANDOM Random;
 
     QUIC_DATAPATH_INITIALIZE DatapathInitialize;
+    QUIC_DATAPATH_SHUTDOWN_WORKERS DatapathShutdownWorkers;
     QUIC_DATAPATH_UNINITIALIZE DatapathUninitialize;
     QUIC_DATAPATH_RECVCONTEXT_TO_RECVBUFFER DatapathRecvContextToRecvPacket;
     QUIC_DATAPATH_RECVBUFFER_TO_RECVCONTEXT DatapathRecvPacketToRecvContext;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -548,14 +548,10 @@ Exit:
 }
 
 void
-QuicDataPathShutdownWorkers(
+QuicDataPathShutdown(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     PlatDispatch->DatapathShutdownWorkers(Datapath);
 #else
@@ -571,10 +567,6 @@ QuicDataPathUninitialize(
     _Inout_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     PlatDispatch->DatapathUninitialize(Datapath);
 #else

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -946,14 +946,10 @@ Exit:
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicDataPathShutdownWorkers(
+QuicDataPathShutdown(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
     WskReleaseProviderNPI(&Datapath->WskRegistration);
     WskDeregister(&Datapath->WskRegistration);
 
@@ -965,10 +961,6 @@ QuicDataPathUninitialize(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
     for (uint32_t i = 0; i < Datapath->ProcCount; i++) {
         QuicPoolUninitialize(&Datapath->ProcContexts[i].SendContextPool);
         QuicPoolUninitialize(&Datapath->ProcContexts[i].SendBufferPool);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -946,7 +946,7 @@ Exit:
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicDataPathUninitialize(
+QuicDataPathShutdownWorkers(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
@@ -956,6 +956,19 @@ QuicDataPathUninitialize(
 
     WskReleaseProviderNPI(&Datapath->WskRegistration);
     WskDeregister(&Datapath->WskRegistration);
+
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicDataPathUninitialize(
+    _In_ QUIC_DATAPATH* Datapath
+    )
+{
+    if (Datapath == NULL) {
+        return;
+    }
+
     for (uint32_t i = 0; i < Datapath->ProcCount; i++) {
         QuicPoolUninitialize(&Datapath->ProcContexts[i].SendContextPool);
         QuicPoolUninitialize(&Datapath->ProcContexts[i].SendBufferPool);
@@ -963,6 +976,7 @@ QuicDataPathUninitialize(
         QuicPoolUninitialize(&Datapath->ProcContexts[i].RecvDatagramPool);
         QuicPoolUninitialize(&Datapath->ProcContexts[i].UroRecvDatagramPool);
     }
+
     QUIC_FREE(Datapath);
 }
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -770,14 +770,10 @@ Exit:
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicDataPathShutdownWorkers(
+QuicDataPathShutdown(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
     //
     // Disable processing on the completion threads and kick the IOCPs to make
     // sure the threads knows they are disabled.
@@ -803,10 +799,6 @@ QuicDataPathUninitialize(
     _In_ QUIC_DATAPATH* Datapath
     )
 {
-    if (Datapath == NULL) {
-        return;
-    }
-
     //
     // Wait for all outstanding binding to clean up.
     //

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -62,6 +62,7 @@ struct QuicAddr
                 &SockAddr))) {
             GTEST_FATAL_FAILURE_("Failed to resolve IP address.");
         }
+        QuicDataPathShutdown(Datapath);
         QuicDataPathUninitialize(Datapath);
     }
 };
@@ -229,6 +230,7 @@ TEST_F(DataPathTest, Initialize)
             &datapath));
     ASSERT_NE(datapath, nullptr);
 
+    QuicDataPathShutdown(datapath);
     QuicDataPathUninitialize(
         datapath);
 }
@@ -285,6 +287,7 @@ TEST_F(DataPathTest, Bind)
 
     QuicDataPathBindingDelete(binding);
 
+    QuicDataPathShutdown(datapath);
     QuicDataPathUninitialize(
         datapath);
 }
@@ -332,6 +335,7 @@ TEST_F(DataPathTest, Rebind)
     QuicDataPathBindingDelete(binding1);
     QuicDataPathBindingDelete(binding2);
 
+    QuicDataPathShutdown(datapath);
     QuicDataPathUninitialize(
         datapath);
 }
@@ -409,6 +413,7 @@ TEST_P(DataPathTest, Data)
     QuicDataPathBindingDelete(client);
     QuicDataPathBindingDelete(server);
 
+    QuicDataPathShutdown(datapath);
     QuicDataPathUninitialize(
         datapath);
 
@@ -519,6 +524,7 @@ TEST_P(DataPathTest, DataRebind)
     QuicDataPathBindingDelete(client);
     QuicDataPathBindingDelete(server);
 
+    QuicDataPathShutdown(datapath);
     QuicDataPathUninitialize(
         datapath);
 

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -116,6 +116,7 @@ struct DrillSender {
         }
 
         if (Datapath != nullptr) {
+            QuicDataPathShutdown(Datapath);
             QuicDataPathUninitialize(Datapath);
         }
     }

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -381,6 +381,7 @@ Error:
     }
 
     if (Datapath != nullptr) {
+        QuicDataPathShutdown(Datapath);
         QuicDataPathUninitialize(Datapath);
     }
 }

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -151,6 +151,7 @@ main(int argc, char **argv)
             printf("Failed to resolve IP address of '%s'.\n", ServerName);
             exit(1);
         }
+        QuicDataPathShutdown(Datapath);
         QuicDataPathUninitialize(Datapath);
     } else {
         if (!QuicAddrFromString(ServerIp, Port, &ServerAddress)) {


### PR DESCRIPTION
If the datapath threads are still running, they can receive data, that can race when we are trying to clean up worker threads. By cleaning up the datapath threads before the worker threads, we avoid this race