### PR TITLE
Remove use of internal APIs from sample application

### DIFF
--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -417,7 +417,11 @@ GetValue(
 {
     const size_t nameLen = strlen(name);
     for (int i = 1; i < argc; i++) {
+#ifdef _WIN32
         if (_strnicmp(argv[i] + 1, name, nameLen) == 0) {
+#else
+        if (strncasecmp(argv[i] + 1, name, nameLen) == 0) {
+#endif
             return argv[i] + 1 + nameLen + 1;
         }
     }

--- a/src/tools/sample/CMakeLists.txt
+++ b/src/tools/sample/CMakeLists.txt
@@ -10,7 +10,7 @@ target_compile_options(quicsample PRIVATE
      $<$<CXX_COMPILER_ID:MSVC>:
         ${MSVC_WARNING_FLAGS}>)
 
-target_link_libraries(quicsample msquic platform)
+target_link_libraries(quicsample msquic)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(quicsample


### PR DESCRIPTION
The sample application should show how things can be done with the public API, without needing access to the platform project. Will make it much easier to learn how the API works.