### PR TITLE
New External Contribution Rules

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,15 +18,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 One of the easiest ways to contribute is to participate in discussion on GitHub issues.
 
-If you find a non-security related bug, you can help us by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new). The best bug reports provide a detailed description of the issue and step-by-step instructions for predictably reproducing the issue. Even better, you can submit a Pull Request with a fix.
+If you find a non-security related bug, you can help us by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose). The best bug reports provide a detailed description of the issue and step-by-step instructions for predictably reproducing the issue. Even better, you can submit a Pull Request with a fix.
 
 If you find a security issue, please **do not open a GitHub Issue**, and instead follow [these instructions](SECURITY.md).
 
 ## New Features
 
-You can request a new feature by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new).
+You can request a new feature by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose).
 
-If you would like to implement a new feature, please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new) and communicate your proposal so that the community can review and provide feedback. Getting early feedback will help ensure your implementation work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
+If you would like to implement a new feature, please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose) and communicate your proposal so that the community can review and provide feedback. Getting early feedback will help ensure your implementation work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
 
 ## Contributor License Agreement
 
@@ -42,7 +42,7 @@ We accept fixes and features! Here are some resources to help you get started on
 
 ### Process and Restrictions
 
-For all but the absolute simplest changes we request that you please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
+For all but the absolute simplest changes we request that you please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
 
 If you would like to contribute, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. You might also read these two blogs posts on contributing code: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik. All code submissions will be rigorously reviewed and tested by the team, and only those that meet an extremely high bar for both quality and design/roadmap appropriateness will be merged into the source.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 One of the easiest ways to contribute is to participate in discussion on GitHub issues.
 
-If you find a non-security related bug, you can help us by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose). The best bug reports provide a detailed description of the issue and step-by-step instructions for predictably reproducing the issue. Even better, you can submit a Pull Request with a fix.
+If you find a non-security related bug, you can help us by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose). The best bug reports provide a detailed description of the issue and step-by-step instructions for reliably reproducing the issue. Even better, you can submit a Pull Request with a fix.
 
 If you find a security issue, please **do not open a GitHub Issue**, and instead follow [these instructions](SECURITY.md).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to MsQuic
 
-We would love for you to contribute to MsQuic and help make it even better than it is today! As a contributor, here are the guidelines we would like you to follow.
+We'd love your help with MsQuic! Here are our contribution guidelines.
 
 - [Code of Conduct](#code-of-conduct)
 - [Bugs](#bugs)
@@ -10,7 +10,7 @@ We would love for you to contribute to MsQuic and help make it even better than 
   - [Process](#process)
   - [Tests](#tests)
 
-> **Important** - Since much of MsQuic is directly included in the Windows kernel, we have to take certain precautions to protect from any bug being introduced (accidental or otherwise). We are still working on bringing up the necessary tests and CI systems for these purposes. Until they are completely onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
+> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
 
 ## Code of Conduct
 
@@ -44,13 +44,13 @@ We accept fixes and features! Here are some resources to help you get started on
 
 ### Process
 
-For all but the absolute simplest changes we request that you please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
+For all but the absolute simplest changes, first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
 
-If you would like to contribute, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. You might also read these two blogs posts on contributing code: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik. All code submissions will be rigorously reviewed and tested by the team, and only those that meet an extremely high bar for both quality and design/roadmap appropriateness will be merged into the source.
+If you would like to contribute, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. You might also read these two blogs posts on contributing code: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik. All code submissions will be rigorously reviewed and tested by the team, and only those that meet the bar for both quality and design/roadmap appropriateness will be merged into the source.
 
 ### Tests
 
-We have a significant number of existing tests to prevent any regressions and ensure expected functionality. For all new Pull Requests the following rules apply:
+We have tests to prevent regressions and validate functionality. For all new Pull Requests the following rules apply:
 
 - Existing tests should continue to pass.
 - Tests need to be provided for every bug/feature that is completed.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We'd love your help with MsQuic! Here are our contribution guidelines.
   - [Process](#process)
   - [Tests](#tests)
 
-> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
+> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and we are working to complete it by the end of 2020.
 
 ## Code of Conduct
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to MsQuic
+
+We would love for you to contribute to MsQuic and help make it even better than it is today! As a contributor, here are the guidelines we would like you to follow.
+
+- [Code of Conduct](#code-of-conduct)
+- [Bugs](#bugs)
+- [New Features](#new-features)
+- [Contributor License Agreement](#contributor-license-agreement)
+- [Contributing Code](#contributing-code)
+  - [Process and Restrictions](#process-and-restrictions)
+  - [Tests](#tests)
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with additional questions or comments.
+
+## Bugs
+
+One of the easiest ways to contribute is to participate in discussion on GitHub issues.
+
+If you find a non-security related bug, you can help us by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new). The best bug reports provide a detailed description of the issue and step-by-step instructions for predictably reproducing the issue. Even better, you can submit a Pull Request with a fix.
+
+If you find a security issue, please **do not open a GitHub Issue**, and instead follow [these instructions](SECURITY.md).
+
+## New Features
+
+You can request a new feature by [submitting a GitHub Issue](https://github.com/microsoft/msquic/issues/new).
+
+If you would like to implement a new feature, please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new) and communicate your proposal so that the community can review and provide feedback. Getting early feedback will help ensure your implementation work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
+
+## Contributor License Agreement
+
+You will need to complete a Contributor License Agreement (CLA) for any code submissions. Briefly, this agreement testifies that you are granting us permission to use the submitted change according to the terms of the project's license, and that the work being submitted is under appropriate copyright. You only need to do this once. For more information see https://cla.opensource.microsoft.com/.
+
+## Contributing Code
+
+We accept fixes and features! Here are some resources to help you get started on how to contribute code or new content.
+
+* Look at the [documentation](../docs/) to get started on building the source code on your own.
+* ["Help wanted" issues](https://github.com/microsoft/msquic/labels/help%20wanted) - these issues are up for grabs. Comment on an issue if you want to create a fix.
+* ["Good first issue" issues](https://github.com/microsoft/msquic/labels/good%20first%20issue) - we think these are a good for newcomers.
+
+### Process and Restrictions
+
+For all but the absolute simplest changes we request that you please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
+
+If you would like to contribute, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. You might also read these two blogs posts on contributing code: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik. All code submissions will be rigorously reviewed and tested by the team, and only those that meet an extremely high bar for both quality and design/roadmap appropriateness will be merged into the source.
+
+> **Important** - Since much of this code is directly included in the latest Windows kernel, we have to take certain precautions to protect from any bug being introduced (accidental or otherwise). We are still working on bringing up the necessary tests and CI systems for these purposes. Until they are completely onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
+
+### Tests
+
+We have a significant number of existing tests to prevent any regressions and ensure expected functionality. For all new Pull Requests the following rules apply:
+
+- Existing tests should continue to pass.
+- Tests need to be provided for every bug/feature that is completed.
+- Tests only need to be present for issues that need to be verified by QA (for example, not tasks)
+- If there is a scenario that is far too hard to test there does not need to be a test for it.
+  - "Too hard" is determined by the team as a whole, and should be considered extremely rare.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We would love for you to contribute to MsQuic and help make it even better than 
 - [New Features](#new-features)
 - [Contributor License Agreement](#contributor-license-agreement)
 - [Contributing Code](#contributing-code)
-  - [Process and Restrictions](#process-and-restrictions)
+  - [Process](#process)
   - [Tests](#tests)
 
 > **Important** - Since much of MsQuic is directly included in the Windows kernel, we have to take certain precautions to protect from any bug being introduced (accidental or otherwise). We are still working on bringing up the necessary tests and CI systems for these purposes. Until they are completely onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,8 @@ We would love for you to contribute to MsQuic and help make it even better than 
   - [Process and Restrictions](#process-and-restrictions)
   - [Tests](#tests)
 
+> **Important** - Since much of MsQuic is directly included in the Windows kernel, we have to take certain precautions to protect from any bug being introduced (accidental or otherwise). We are still working on bringing up the necessary tests and CI systems for these purposes. Until they are completely onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
+
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with additional questions or comments.
@@ -40,13 +42,11 @@ We accept fixes and features! Here are some resources to help you get started on
 * ["Help wanted" issues](https://github.com/microsoft/msquic/labels/help%20wanted) - these issues are up for grabs. Comment on an issue if you want to create a fix.
 * ["Good first issue" issues](https://github.com/microsoft/msquic/labels/good%20first%20issue) - we think these are a good for newcomers.
 
-### Process and Restrictions
+### Process
 
 For all but the absolute simplest changes we request that you please first [submit a GitHub Issue](https://github.com/microsoft/msquic/issues/new/choose) so that the community can review and provide feedback. Getting early feedback will help ensure your work is accepted by the community. This will also allow us to better coordinate our efforts and minimize duplicated effort.
 
 If you would like to contribute, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. You might also read these two blogs posts on contributing code: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik. All code submissions will be rigorously reviewed and tested by the team, and only those that meet an extremely high bar for both quality and design/roadmap appropriateness will be merged into the source.
-
-> **Important** - Since much of this code is directly included in the latest Windows kernel, we have to take certain precautions to protect from any bug being introduced (accidental or otherwise). We are still working on bringing up the necessary tests and CI systems for these purposes. Until they are completely onboarded, any external contributions to the [core](../src/core) or kernel mode files in the [platform](../src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -69,19 +69,4 @@ For testing or experimentation purposes, MsQuic may be built with other configur
 
 # Contributing
 
-> For the time being, **external code contributions will not be accepted**. We are still
-working on setting up internal repository sycnhronization, continuous integration,
-and generally ironing out our processes.
-
-Most contributions require you to agree to a Contributor License Agreement (CLA)
-declaring that you have the right to, and actually do, grant us the rights to use
-your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you
-need to provide a CLA and decorate the PR appropriately (e.g., status check, comment).
-Simply follow the instructions provided by the bot. You will only need to do this
-once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For information on contributing, please see our guidlines in [CONTRIBUTING.md](./.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ For testing or experimentation purposes, MsQuic may be built with other configur
 
 For information on contributing, please see our [contribution guidlines](./.github/CONTRIBUTING.md).
 
-> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](./src/core) or kernel mode files in the [platform](./src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.
+> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](./src/core) or kernel mode files in the [platform](./src/platform) will not be accepted. This is only a **temporary restriction** and we are working to complete it by the end of 2020.

--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ For testing or experimentation purposes, MsQuic may be built with other configur
 
 # Contributing
 
-For information on contributing, please see our guidlines in [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
+For information on contributing, please see our [contribution guidlines](./.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ For testing or experimentation purposes, MsQuic may be built with other configur
 # Contributing
 
 For information on contributing, please see our [contribution guidlines](./.github/CONTRIBUTING.md).
+
+> **Important** - We are still bringing up important regression tests for the core code. Until they are onboarded, any external contributions to the [core](./src/core) or kernel mode files in the [platform](./src/platform) will not be accepted. This is only a **temporary restriction** and will hopefully be removed in the coming months.


### PR DESCRIPTION
We're now opening up some of the repo to external contribution! We're allowing all but the core and Windows kernel mode code. This adds new documentation on the guidelines for external contributions.