### PR TITLE
Fix Newly Found Leaks

### DIFF
--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -64,7 +64,7 @@ TEST(SpinFrame, SpinFrame1000000)
             TEST_QUIC_SUCCEEDED(QuicRandom(BufferLength, Buffer));
         }
 
-        do { 
+        do {
             TEST_QUIC_SUCCEEDED(QuicRandom(sizeof(FrameType), &FrameType));
         } while (!QUIC_FRAME_IS_KNOWN(FrameType));
 
@@ -214,6 +214,8 @@ TEST(SpinFrame, SpinFrame1000000)
                 break;
         }
     }
+
+    QuicRangeUninitialize(&AckBlocks);
 
     RecordProperty("SuccessfulDecodes", SuccessfulDecodes);
     RecordProperty("FailedDecodes", FailedDecodes);

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -101,6 +101,7 @@ protected:
     struct TlsContext
     {
         QUIC_TLS* Ptr;
+        QUIC_SEC_CONFIG* ClientConfig;
         QUIC_EVENT ProcessCompleteEvent;
 
         QUIC_TLS_PROCESS_STATE State;
@@ -111,6 +112,7 @@ protected:
 
         TlsContext() :
             Ptr(nullptr),
+            ClientConfig(nullptr),
             Connected(false) {
             QuicEventInitialize(&ProcessCompleteEvent, FALSE, FALSE);
             QuicZeroMemory(&State, sizeof(State));
@@ -120,6 +122,9 @@ protected:
 
         ~TlsContext() {
             QuicTlsUninitialize(Ptr);
+            if (ClientConfig != nullptr) {
+                QuicTlsSecConfigRelease(ClientConfig);
+            }
             QuicEventUninitialize(ProcessCompleteEvent);
             QUIC_FREE(State.Buffer);
             for (uint8_t i = 0; i < QUIC_PACKET_KEY_COUNT; ++i) {
@@ -159,7 +164,7 @@ protected:
 
         void InitializeClient(
             TlsSession& Session,
-            QUIC_SEC_CONFIG* ClientConfig,
+            QUIC_SEC_CONFIG* SecConfig,
             bool MultipleAlpns = false,
             uint16_t TPLen = 64
             )
@@ -167,7 +172,7 @@ protected:
             QUIC_TLS_CONFIG Config = {0};
             Config.IsServer = FALSE;
             Config.TlsSession = Session.Ptr;
-            Config.SecConfig = ClientConfig;
+            Config.SecConfig = SecConfig;
             Config.AlpnBuffer = MultipleAlpns ? MultiAlpn : Alpn;
             Config.AlpnBufferLength = MultipleAlpns ? sizeof(MultiAlpn) : sizeof(Alpn);
             Config.LocalTPBuffer =
@@ -190,7 +195,6 @@ protected:
             bool MultipleAlpns = false
             )
         {
-            QUIC_SEC_CONFIG* ClientConfig;
             QuicTlsClientSecConfigCreate(
                 CertValidationIgnoreFlags, &ClientConfig);
             InitializeClient(Session, ClientConfig, MultipleAlpns);

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -138,6 +138,10 @@ void QuicTestValidateSession()
             nullptr,
             &Session));
 
+    MsQuic->SessionClose(
+        Session);
+    Session = nullptr;
+
     //
     // Can't call SessionClose with invalid values as MsQuic asserts
     // (on purpose).


### PR DESCRIPTION
Azure Pipelines address sanitizer runs recently started complaining about more memory leaks. Looks like they've always been there and were just now being reported.