### PR TITLE
Add support for building in UWP mode

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -96,11 +96,9 @@ stages:
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
-      platform: windows-uwp
+      platform: UWP
       arch: x64
       tls: schannel
-      extraBuildArgs: -Uwp
-      extraName: uwp
 
 - stage: build_linux
   displayName: Build Linux

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -96,7 +96,7 @@ stages:
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
-      platform: windows
+      platform: windows-uwp
       arch: x64
       tls: schannel
       extraBuildArgs: -Uwp

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -99,7 +99,7 @@ stages:
       platform: windows
       arch: x64
       tls: schannel
-      extraBuildArgs: uwp
+      extraBuildArgs: -Uwp
       extraName: uwp
 
 - stage: build_linux

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -100,6 +100,7 @@ stages:
       arch: x64
       tls: schannel
       extraBuildArgs: uwp
+      extraName: uwp
 
 - stage: build_linux
   displayName: Build Linux

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -93,6 +93,12 @@ stages:
       platform: windows
       arch: x64
       tls: mitls
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64_uwp
+      tls: schannel
 
 - stage: build_linux
   displayName: Build Linux

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -96,7 +96,7 @@ stages:
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
-      platform: UWP
+      platform: uwp
       arch: x64
       tls: schannel
 

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -97,8 +97,9 @@ stages:
     parameters:
       image: windows-latest
       platform: windows
-      arch: x64_uwp
+      arch: x64
       tls: schannel
+      extraBuildArgs: uwp
 
 - stage: build_linux
   displayName: Build Linux

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -6,11 +6,10 @@ parameters:
   arch: ''
   tls: ''
   extraBuildArgs: ''
-  extraName: ''
 
 jobs:
-- job: build_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}
-  displayName: Build ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }} ${{ parameters.extraName }}
+- job: build_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}
+  displayName: Build ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }}
   pool:
     vmImage: ${{ parameters.image }}
   steps:
@@ -29,13 +28,13 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraBuildArgs }}
+      arguments: -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -Platform ${{ parameters.platform }} ${{ parameters.extraBuildArgs }}
 
   - task: PowerShell@2
     displayName: Build Source Code (Release)
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Config Release -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraBuildArgs }}
+      arguments: -Config Release -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -Platform ${{ parameters.platform }} ${{ parameters.extraBuildArgs }}
 
   - template: ./upload-artifacts.yml

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -6,10 +6,11 @@ parameters:
   arch: ''
   tls: ''
   extraBuildArgs: ''
+  extraName: ''
 
 jobs:
-- job: build_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}
-  displayName: Build ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }}
+- job: build_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}
+  displayName: Build ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }} ${{ parameters.extraName }}
   pool:
     vmImage: ${{ parameters.image }}
   steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(QUIC_BUILD_TEST "Builds the test code" ON)
 option(QUIC_ENABLE_LOGGING "Enables logging" ON)
 option(QUIC_SANITIZE_ADDRESS "Enables address sanitizer" OFF)
 option(QUIC_STATIC_LINK_CRT "Statically links the C runtime" ON)
+option(QUIC_UWP_BUILD "Build for UWP" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
@@ -87,6 +88,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
     # Custom build flags.
     set(QUIC_COMMON_FLAGS "-DWIN32_LEAN_AND_MEAN -DSECURITY_WIN32 /MP")
+
+    if(QUIC_UWP_BUILD)
+        set(QUIC_COMMON_FLAGS "${QUIC_COMMON_FLAGS} -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -DQUIC_UWP_BUILD")
+    endif()
+
     if(QUIC_ENABLE_LOGGING)
         message(STATUS "Configuring for manifested ETW events and logging")
         set(QUIC_COMMON_FLAGS "${QUIC_COMMON_FLAGS} -DQUIC_EVENTS_MANIFEST_ETW -DQUIC_LOGS_MANIFEST_ETW")

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -56,7 +56,7 @@ param (
     [string]$Config = "Debug",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("x86", "x64", "arm", "arm64", "x86_uwp", "x64_uwp", "arm_uwp", "arm64_uwp")]
+    [ValidateSet("x86", "x64", "arm", "arm64")]
     [string]$Arch = "x64",
 
     [Parameter(Mandatory = $false)]

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -9,7 +9,7 @@ This script provides helpers for building msquic.
 .PARAMETER Arch
     The CPU architecture to build for.
 
-.PARAMETER Uwp
+.PARAMETER UWP
     Set to build for UWP platform
 
 .PARAMETER Tls
@@ -60,7 +60,7 @@ param (
     [string]$Arch = "x64",
 
     [Parameter(Mandatory = $false)]
-    [switch]$Uwp = $false,
+    [switch]$UWP = $false,
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
@@ -103,7 +103,7 @@ if ("" -eq $Tls) {
     }
 }
 
-if (!$IsWindows -And $Uwp) {
+if (!$IsWindows -And $UWP) {
     Write-Error "[$(Get-Date)] Cannot build UWP on non windows platforms"
     exit
 }
@@ -124,7 +124,7 @@ if ($IsWindows) {
     $ArtifactsDir = Join-Path $BaseArtifactsDir "linux"
     $BuildDir = Join-Path $BaseBuildDir "linux"
 }
-if ($Uwp) {
+if ($UWP) {
     $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_uwp_$($Config)_$($Tls)"
     $BuildDir = Join-Path $BuildDir "$($Arch)_uwp_$($Tls)"
 } else {
@@ -197,7 +197,7 @@ function CMake-Generate {
     if ($PGO) {
         $Arguments += " -DQUIC_PGO=on"
     }
-    if ($Uwp) {
+    if ($UWP) {
         Write-Host "UWP Build"
         $Arguments += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10 -DQUIC_UWP_BUILD=on -DQUIC_STATIC_LINK_CRT=Off"
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -118,19 +118,21 @@ $SrcDir = Join-Path $RootDir "src"
 $ArtifactsDir = $null
 $BuildDir = $null
 if ($IsWindows) {
-    $ArtifactsDir = Join-Path $BaseArtifactsDir "windows"
-    $BuildDir = Join-Path $BaseBuildDir "windows"
+    if ($IsUwp) {
+        $ArtifactsDir = Join-Path $BaseArtifactsDir "windows-uwp"
+        $BuildDir = Join-Path $BaseBuildDir "windows-uwp"
+    } else {
+        $ArtifactsDir = Join-Path $BaseArtifactsDir "windows"
+        $BuildDir = Join-Path $BaseBuildDir "windows"
+    }
 } else {
     $ArtifactsDir = Join-Path $BaseArtifactsDir "linux"
     $BuildDir = Join-Path $BaseBuildDir "linux"
 }
-if ($UWP) {
-    $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_uwp_$($Config)_$($Tls)"
-    $BuildDir = Join-Path $BuildDir "$($Arch)_uwp_$($Tls)"
-} else {
-    $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_$($Config)_$($Tls)"
-    $BuildDir = Join-Path $BuildDir "$($Arch)_$($Tls)"
-}
+
+$ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_$($Config)_$($Tls)"
+$BuildDir = Join-Path $BuildDir "$($Arch)_$($Tls)"
+
 
 if ($Clean) {
     # Delete old build/config directories.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -133,7 +133,6 @@ if ($IsWindows) {
 $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_$($Config)_$($Tls)"
 $BuildDir = Join-Path $BuildDir "$($Arch)_$($Tls)"
 
-
 if ($Clean) {
     # Delete old build/config directories.
     if (Test-Path $ArtifactsDir) { Remove-Item $ArtifactsDir -Recurse -Force | Out-Null }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -60,7 +60,7 @@ param (
     [string]$Arch = "x64",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("UWP", "windows", "linux")] # For future expansion
+    [ValidateSet("uwp", "windows", "linux")] # For future expansion
     [switch]$Platform = $null,
 
     [Parameter(Mandatory = $false)]
@@ -104,8 +104,8 @@ if ("" -eq $Tls) {
     }
 }
 
-if (!$IsWindows -And $Platform -eq "UWP") {
-    Write-Error "[$(Get-Date)] Cannot build UWP on non windows platforms"
+if (!$IsWindows -And $Platform -eq "uwp") {
+    Write-Error "[$(Get-Date)] Cannot build uwp on non windows platforms"
     exit
 }
 
@@ -119,7 +119,7 @@ $SrcDir = Join-Path $RootDir "src"
 $ArtifactsDir = $null
 $BuildDir = $null
 if ($IsWindows) {
-    if ($Platform -eq "UWP") {
+    if ($Platform -eq "uwp") {
         $ArtifactsDir = Join-Path $BaseArtifactsDir "uwp"
         $BuildDir = Join-Path $BaseBuildDir "uwp"
     } else {
@@ -199,7 +199,7 @@ function CMake-Generate {
     if ($PGO) {
         $Arguments += " -DQUIC_PGO=on"
     }
-    if ($Platform -eq "UWP") {
+    if ($Platform -eq "uwp") {
         $Arguments += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10 -DQUIC_UWP_BUILD=on -DQUIC_STATIC_LINK_CRT=Off"
 
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -60,6 +60,7 @@ param (
     [string]$Arch = "x64",
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet("UWP", "windows", "linux")] # For future expansion
     [switch]$Platform = $null,
 
     [Parameter(Mandatory = $false)]

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -61,7 +61,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("uwp", "windows", "linux")] # For future expansion
-    [switch]$Platform = $null,
+    [switch]$Platform = "",
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -61,7 +61,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("uwp", "windows", "linux")] # For future expansion
-    [switch]$Platform = "",
+    [string]$Platform = "",
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
@@ -104,6 +104,14 @@ if ("" -eq $Tls) {
     }
 }
 
+if ("" -eq $Platform) {
+    if ($IsWindows) {
+        $Platform = "windows"
+    } else {
+        $Platform = "linux"
+    }
+}
+
 if (!$IsWindows -And $Platform -eq "uwp") {
     Write-Error "[$(Get-Date)] Cannot build uwp on non windows platforms"
     exit
@@ -116,20 +124,9 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $BaseArtifactsDir = Join-Path $RootDir "artifacts"
 $BaseBuildDir = Join-Path $RootDir "build"
 $SrcDir = Join-Path $RootDir "src"
-$ArtifactsDir = $null
-$BuildDir = $null
-if ($IsWindows) {
-    if ($Platform -eq "uwp") {
-        $ArtifactsDir = Join-Path $BaseArtifactsDir "uwp"
-        $BuildDir = Join-Path $BaseBuildDir "uwp"
-    } else {
-        $ArtifactsDir = Join-Path $BaseArtifactsDir "windows"
-        $BuildDir = Join-Path $BaseBuildDir "windows"
-    }
-} else {
-    $ArtifactsDir = Join-Path $BaseArtifactsDir "linux"
-    $BuildDir = Join-Path $BaseBuildDir "linux"
-}
+
+$ArtifactsDir = Join-Path $BaseArtifactsDir $Platform
+$BuildDir = Join-Path $BaseBuildDir $Platform
 
 $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_$($Config)_$($Tls)"
 $BuildDir = Join-Path $BuildDir "$($Arch)_$($Tls)"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -9,8 +9,8 @@ This script provides helpers for building msquic.
 .PARAMETER Arch
     The CPU architecture to build for.
 
-.PARAMETER UWP
-    Set to build for UWP platform
+.PARAMETER Platform
+    Specify which platform to build for
 
 .PARAMETER Tls
     The TLS library to use.
@@ -60,7 +60,7 @@ param (
     [string]$Arch = "x64",
 
     [Parameter(Mandatory = $false)]
-    [switch]$UWP = $false,
+    [switch]$Platform = $null,
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl", "stub", "mitls")]
@@ -103,7 +103,7 @@ if ("" -eq $Tls) {
     }
 }
 
-if (!$IsWindows -And $UWP) {
+if (!$IsWindows -And $Platform -eq "UWP") {
     Write-Error "[$(Get-Date)] Cannot build UWP on non windows platforms"
     exit
 }
@@ -118,9 +118,9 @@ $SrcDir = Join-Path $RootDir "src"
 $ArtifactsDir = $null
 $BuildDir = $null
 if ($IsWindows) {
-    if ($IsUwp) {
-        $ArtifactsDir = Join-Path $BaseArtifactsDir "windows-uwp"
-        $BuildDir = Join-Path $BaseBuildDir "windows-uwp"
+    if ($Platform -eq "UWP") {
+        $ArtifactsDir = Join-Path $BaseArtifactsDir "uwp"
+        $BuildDir = Join-Path $BaseBuildDir "uwp"
     } else {
         $ArtifactsDir = Join-Path $BaseArtifactsDir "windows"
         $BuildDir = Join-Path $BaseBuildDir "windows"
@@ -198,8 +198,7 @@ function CMake-Generate {
     if ($PGO) {
         $Arguments += " -DQUIC_PGO=on"
     }
-    if ($UWP) {
-        Write-Host "UWP Build"
+    if ($Platform -eq "UWP") {
         $Arguments += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10 -DQUIC_UWP_BUILD=on -DQUIC_STATIC_LINK_CRT=Off"
 
     }

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(msquic PRIVATE core platform)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(msquic PUBLIC
         ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)
+    if(QUIC_UWP_BUILD)
+        target_link_libraries(msquic PUBLIC OneCoreUAP)
+    endif()
     SET_TARGET_PROPERTIES(msquic
         PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/winuser/msquic.def\"")
 else()

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -862,6 +862,8 @@ QuicRandom(
 // Network Compartment ID interfaces
 //
 
+#ifndef QUIC_UWP_BUILD
+
 #define QUIC_COMPARTMENT_ID NET_IF_COMPARTMENT_ID
 
 #define QUIC_UNSPECIFIED_COMPARTMENT_ID NET_IF_COMPARTMENT_ID_UNSPECIFIED
@@ -870,6 +872,8 @@ QuicRandom(
 #define QuicCompartmentIdGetCurrent() GetCurrentThreadCompartmentId()
 #define QuicCompartmentIdSetCurrent(CompartmentId) \
     HRESULT_FROM_WIN32(SetCurrentThreadCompartmentId(CompartmentId))
+
+#endif
 
 //
 // Test Interface for loading a self-signed certificate.

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -31,6 +31,11 @@ Environment:
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 
+#ifdef QUIC_UWP_BUILD
+#undef WINAPI_FAMILY
+#define WINAPI_FAMILY WINAPI_FAMILY_DESKTOP_APP
+#endif
+
 #pragma warning(push) // Don't care about OACR warnings in publics
 #pragma warning(disable:26036)
 #pragma warning(disable:28252)
@@ -700,7 +705,7 @@ QuicTimeAtOrBefore32(
 // essentially what SetThreadDescription does, but that is not available in
 // older versions of Windows.
 //
-#if !defined(QUIC_WINDOWS_INTERNAL)
+#if !defined(QUIC_WINDOWS_INTERNAL) && !defined(QUIC_UWP_BUILD)
 #define ThreadNameInformation ((THREADINFOCLASS)38)
 
 typedef struct _THREAD_NAME_INFORMATION {
@@ -776,6 +781,9 @@ QuicThreadCreate(
             ARRAYSIZE(WideName) - 1,
             Config->Name,
             _TRUNCATE);
+#if defined(QUIC_UWP_BUILD)
+        SetThreadDescription(*Thread, WideName);
+#else
         THREAD_NAME_INFORMATION ThreadNameInfo;
         RtlInitUnicodeString(&ThreadNameInfo.ThreadName, WideName);
         NtSetInformationThread(
@@ -783,6 +791,7 @@ QuicThreadCreate(
             ThreadNameInformation,
             &ThreadNameInfo,
             sizeof(ThreadNameInfo));
+#endif
     }
     return QUIC_STATUS_SUCCESS;
 }

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -718,7 +718,9 @@ QuicDataPathInitialize(
             Status = HRESULT_FROM_WIN32(LastError);
             goto Error;
         }
-
+#ifdef QUIC_UWP_BUILD
+        SetThreadDescription(Datapath->ProcContexts[i].CompletionThread, L"quic_datapath");
+#else
         THREAD_NAME_INFORMATION ThreadNameInfo;
         RtlInitUnicodeString(&ThreadNameInfo.ThreadName, L"quic_datapath");
         NTSTATUS NtStatus =
@@ -734,6 +736,7 @@ QuicDataPathInitialize(
                 NtStatus,
                 "NtSetInformationThread(name)");
         }
+#endif
 
         // TODO - Set thread priority higher to better match kernel at dispatch?
     }

--- a/src/tools/attack/CMakeLists.txt
+++ b/src/tools/attack/CMakeLists.txt
@@ -17,4 +17,7 @@ target_link_libraries(quicattack core platform)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(quicattack
         ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)
+    if(QUIC_UWP_BUILD)
+        target_link_libraries(quicattack OneCoreUAP)
+    endif()
 endif()

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -221,7 +221,7 @@ ParseServerCommand(
 {
     PingConfig.ServerMode = true;
 
-    const char* localAddress;
+    const char* localAddress = nullptr;
     TryGetValue(argc, argv, "listen", &localAddress);
     if (!ConvertArgToAddress(localAddress, 0, &PingConfig.LocalIpAddr)) {
         printf("Failed to decode IP address: '%s'!\nMust be *, a IPv4 or a IPv6 address.\n", localAddress);


### PR DESCRIPTION
Flags needed to be added to the build. Right now we have to force override a compiler defined macro in the platform header file. Looking to see if there is a way to do this only through the command line.

Running tests is possible, but requires installing the msix file, so not extremely feasable. I'll look into this more as well. I did add a build however so we can be sure this at leasts continues to build.

Closes #436 