### PR TITLE
Increase Azure Pipelines Timeout for BVTs

### DIFF
--- a/.azure/templates/run-bvt-int.yml
+++ b/.azure/templates/run-bvt-int.yml
@@ -30,7 +30,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 20
+    timeoutInMinutes: 25
     continueOnError: true
     inputs:
       pwsh: true

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -35,7 +35,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 20
+    timeoutInMinutes: 25
     continueOnError: true
     inputs:
       pwsh: true


### PR DESCRIPTION
I've noticed AZP timing out right after the tests complete. Let's give it just a bit more time to run.