### PR TITLE
Move datapath shutdown to occur before connection cleanup

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -276,6 +276,9 @@ MsQuicLibraryUninitialize(
         MsQuicLib.UnregisteredSession = NULL;
     }
 
+    QuicDataPathUninitialize(MsQuicLib.Datapath);
+    MsQuicLib.Datapath = NULL;
+
     //
     // The library's worker pool for processing half-opened connections
     // needs to be cleaned up first, as it's the last thing that can be
@@ -311,9 +314,6 @@ MsQuicLibraryUninitialize(
         MsQuicLib.StatelessRetryKeys[i] = NULL;
     }
     QuicLockUninitialize(&MsQuicLib.StatelessRetryKeysLock);
-
-    QuicDataPathUninitialize(MsQuicLib.Datapath);
-    MsQuicLib.Datapath = NULL;
 
     QuicTraceEvent(
         LibraryUninitialized,


### PR DESCRIPTION
Make it so the datapath can't accept any new data and cause a race with shutdown cleanup.

Replacement for #448 as this might be a simpler fix. Don't want to loose all work in 448 in case it was on the right track.