### PR TITLE
Build QNS interop image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+*
+!CMakeLists.txt
+!run_endpoint.sh
+!src
+!submodules/openssl
+submodules/openssl/pyca-cryptography
+submodules/openssl/boringssl
+**/*.o
+**/*.a
+**/*.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM 	martenseemann/quic-network-simulator-endpoint as source
+RUN 	apt-get update -y \
+	&& apt-get install -y \
+		build-essential \
+		cmake \
+	&& apt-get clean
+COPY 	. /src
+
+FROM	source as build
+WORKDIR /src/Debug
+RUN	cmake -DQUIC_ENABLE_LOGGING=OFF -DQUIC_BUILD_TEST=OFF ..
+RUN     cmake --build .
+RUN 	openssl ecparam -out server.eckey -noout -name prime256v1 -genkey
+RUN	openssl pkcs8 -topk8 -inform pem -in server.eckey -nocrypt \
+		-out server.key
+RUN	openssl req -batch -new -key server.key -days 9365 -nodes -x509 \
+		-subj "/" -addext "subjectAltName = DNS:server" -out server.crt
+
+FROM 	martenseemann/quic-network-simulator-endpoint
+RUN 	apt-get update -y \
+	&& apt-get install -y \
+		libatomic1 \
+	&& apt-get clean
+COPY 	--from=build /src/Debug/bin/Release /bin
+COPY 	--from=build /src/Debug/bin/Release/*.so /lib/x86_64-linux-gnu
+COPY 	--from=source /src/run_endpoint.sh /run_endpoint.sh
+COPY 	--from=build /src/Debug/server.* /
+RUN 	chmod +x /run_endpoint.sh
+ENTRYPOINT [ "/run_endpoint.sh" ]

--- a/run_endpoint.sh
+++ b/run_endpoint.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/env bash
+
+# Set up the routing needed for the simulation
+/setup.sh
+
+if [ -n "$TESTCASE" ]; then
+    case "$TESTCASE" in
+    # TODO: add supported test cases here
+    "versionnegotiation"|"handshake"|"transfer"|"retry"|"resumption"|\
+    "multiconnect"|"zerortt"|"chacha20")
+        ;;
+    *)
+        exit 127
+        ;;
+    esac
+fi
+
+# The following variables are available for use:
+# - ROLE contains the role of this execution context, client or server
+# - SERVER_PARAMS contains user-supplied command line parameters
+# - CLIENT_PARAMS contains user-supplied command line parameters
+
+if [ "$ROLE" == "client" ]; then
+    # Wait for the simulator to start up.
+    /wait-for-it.sh sim:57832 -s -t 30
+    cd /downloads || exit
+
+    # TODO: add client support
+    # I am not sure if the msquic codebase has an h09 client?
+    exit 127
+
+elif [ "$ROLE" == "server" ]; then
+    case "$TESTCASE" in
+    "retry")
+        SERVER_PARAMS="-retry:1 $SERVER_PARAMS"
+        ;;
+    *)
+        ;;
+    esac
+
+    quicinteropserver ${SERVER_PARAMS} -root:/www -listen:* -port:443 \
+        -file:/server.crt -key:/server.key 2>&1
+fi


### PR DESCRIPTION
This builds a docker image for the quic-network-simulator (https://github.com/marten-seemann/quic-network-simulator/).

What's missing is a `run_endpoint.sh` script that configures the client and server binary for the various QNS tests. Since I'm not super-familiar with the options these things take, I'll let @nibanks or someone else add that script...

First step for #462.