### PR TITLE
Workaround for LTTng Duplicate Tracepoint

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -105,7 +105,6 @@ stages:
       platform: linux
       arch: x64
       tls: openssl
-      extraBuildArgs: -DisableLogs
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
@@ -113,7 +112,7 @@ stages:
       platform: linux
       arch: x64
       tls: stub
-      extraBuildArgs: -DisableLogs -SanitizeAddress
+      extraBuildArgs: -SanitizeAddress
 
 #
 # Build Verification Tests

--- a/src/bin/linux/exports.txt
+++ b/src/bin/linux/exports.txt
@@ -1,5 +1,5 @@
 msquic
 {
-  global: MsQuicOpen; MsQuicClose;
+  global: MsQuicOpen; MsQuicClose; __tracepoint_provider_MsQuic;
   local: *;
 };

--- a/src/bin/linux/init.c
+++ b/src/bin/linux/init.c
@@ -9,7 +9,9 @@ Abstract:
 
 --*/
 
+#define TRACEPOINT_CREATE_PROBES
 #include "quic_platform.h"
+#include "quic_trace.h"
 
 void
 MsQuicLibraryLoad(

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -14,7 +14,6 @@ Environment:
 --*/
 
 #define _GNU_SOURCE
-#define TRACEPOINT_CREATE_PROBES
 #define TRACEPOINT_DEFINE
 #include "platform_internal.h"
 #include "quic_platform.h"

--- a/src/platform/unittest/CMakeLists.txt
+++ b/src/platform/unittest/CMakeLists.txt
@@ -31,6 +31,6 @@ elseif(QUIC_TLS STREQUAL "mitls")
     target_link_libraries(msquicplatformtest kremlib evercrypt mitls quiccrypto ncrypt crypt32)
 endif()
 
-target_link_libraries(msquicplatformtest platform gtest)
+target_link_libraries(msquicplatformtest msquic platform gtest)
 
 add_test(msquicplatformtest msquicplatformtest)

--- a/src/tools/attack/CMakeLists.txt
+++ b/src/tools/attack/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/core)
 
 add_executable(quicattack ${SOURCES})
 
-target_link_libraries(quicattack core platform)
+target_link_libraries(quicattack msquic core platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(quicattack


### PR DESCRIPTION
Fixes #460. Only defines the LTTng tracepoint once, in the library init and explicitly exports it to share with the tools/tests.