### PR TITLE
Supress deprecation warning for ExInitializeWorkItem in kernel mode

### DIFF
--- a/src/platform/storage_winkernel.c
+++ b/src/platform/storage_winkernel.c
@@ -216,11 +216,14 @@ QuicStorageOpen(
     QuicLockInitialize(&Storage->Lock);
     Storage->Callback = Callback;
     Storage->CallbackContext = CallbackContext;
-    
+
+#pragma warning(push)
+#pragma warning(disable: 4996)
     ExInitializeWorkItem(
         &Storage->WorkItem,
         QuicStorageRegKeyChangeCallback,
         Storage);
+#pragma warning(pop)
 
     Status =
         ZwOpenKey(


### PR DESCRIPTION
Newest WDK has ExInitializeWorkItem deprecated

Closes #464 