### PR TITLE
Build DLL only for UWP

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -99,6 +99,7 @@ stages:
       platform: uwp
       arch: x64
       tls: schannel
+      extraBuildArgs: -DisableTools -DisableTest
 
 - stage: build_linux
   displayName: Build Linux


### PR DESCRIPTION
We don't use the test or tools. Let's not add build them right now, to reduce the AZP load.