### PR TITLE
Add folder support to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 message(STATUS "Source Dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "Host System name: ${CMAKE_HOST_SYSTEM_NAME}")
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
@@ -85,6 +87,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_custom_target(MsQuicEtw
         DEPENDS ${QUIC_BUILD_DIR}/inc/MsQuicEtw.h
         DEPENDS ${QUIC_BUILD_DIR}/inc/MsQuicEtw.rc)
+
+    set_property(TARGET MsQuicEtw PROPERTY FOLDER "libraries")
 
     # Custom build flags.
     set(QUIC_COMMON_FLAGS "-DWIN32_LEAN_AND_MEAN -DSECURITY_WIN32 /MP")
@@ -231,6 +235,9 @@ if(QUIC_BUILD_TEST)
     endif()
     enable_testing()
     add_subdirectory(submodules/googletest)
+
+    set_property(TARGET gtest PROPERTY FOLDER "tests")
+    set_property(TARGET gtest_main PROPERTY FOLDER "tests")
 
     add_subdirectory(src/core/unittest)
     add_subdirectory(src/platform/unittest)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS}")
 
 add_library(msquic SHARED ${SOURCES})
+
+set_property(TARGET msquic PROPERTY FOLDER "libraries")
+
 target_compile_options(msquic PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         ${CLANG_GCC_WARNING_FLAGS}>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -43,6 +43,9 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS}")
 
 add_library(core STATIC ${SOURCES})
+
+set_property(TARGET core PROPERTY FOLDER "libraries")
+
 target_compile_options(core PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         ${CLANG_GCC_WARNING_FLAGS}>

--- a/src/core/unittest/CMakeLists.txt
+++ b/src/core/unittest/CMakeLists.txt
@@ -18,6 +18,8 @@ set(SOURCES
 
 add_executable(msquiccoretest ${SOURCES})
 
+set_property(TARGET msquiccoretest PROPERTY FOLDER "tests")
+
 target_link_libraries(msquiccoretest msquic core platform gtest)
 
 add_test(msquiccoretest msquiccoretest)

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS}")
 
 add_library(platform STATIC ${SOURCES})
+
+set_property(TARGET platform PROPERTY FOLDER "libraries")
+
 target_compile_options(platform PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         ${CLANG_GCC_WARNING_FLAGS}>

--- a/src/platform/unittest/CMakeLists.txt
+++ b/src/platform/unittest/CMakeLists.txt
@@ -16,6 +16,8 @@ set(SOURCES
 
 add_executable(msquicplatformtest ${SOURCES})
 
+set_property(TARGET msquicplatformtest PROPERTY FOLDER "tests")
+
 if(WIN32)
     target_link_libraries(msquicplatformtest ntdll ws2_32 bcrypt advapi32)
 endif()

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(msquictest quic_gtest.cpp)
 
+set_property(TARGET msquictest PROPERTY FOLDER "tests")
+
 target_link_libraries(msquictest msquic testlib platform gtest)
 
 add_test(msquictest msquictest)

--- a/src/test/lib/CMakeLists.txt
+++ b/src/test/lib/CMakeLists.txt
@@ -20,6 +20,9 @@ include_directories(${PROJECT_SOURCE_DIR}/src/test)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_library(testlib ${SOURCES})
+
+set_property(TARGET testlib PROPERTY FOLDER "tests")
+
 target_compile_options(testlib PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         ${CLANG_GCC_WARNING_FLAGS}>

--- a/src/tools/attack/CMakeLists.txt
+++ b/src/tools/attack/CMakeLists.txt
@@ -12,6 +12,8 @@ include_directories(${PROJECT_SOURCE_DIR}/src/core)
 
 add_executable(quicattack ${SOURCES})
 
+set_property(TARGET quicattack PROPERTY FOLDER "tools")
+
 target_link_libraries(quicattack msquic core platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/etw/CMakeLists.txt
+++ b/src/tools/etw/CMakeLists.txt
@@ -17,6 +17,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
 
 add_executable(quicetw ${SOURCES})
 
+set_property(TARGET quicetw PROPERTY FOLDER "tools")
+
 target_link_libraries(quicetw msquic platform)
 target_link_libraries(quicetw
     ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi tdh advapi32)

--- a/src/tools/etwlib/CMakeLists.txt
+++ b/src/tools/etwlib/CMakeLists.txt
@@ -6,3 +6,5 @@ set(SOURCES QuicEventCollection.cpp)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_library(msquicetw STATIC ${SOURCES})
+
+set_property(TARGET msquicetw PROPERTY FOLDER "tools")

--- a/src/tools/interop/CMakeLists.txt
+++ b/src/tools/interop/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicinterop interop.cpp)
 
+set_property(TARGET quicinterop PROPERTY FOLDER "tools")
+
 target_link_libraries(quicinterop msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/interopserver/CMakeLists.txt
+++ b/src/tools/interopserver/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicinteropserver ${SOURCES})
 
+set_property(TARGET quicinteropserver PROPERTY FOLDER "tools")
+
 target_link_libraries(quicinteropserver msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/ping/CMakeLists.txt
+++ b/src/tools/ping/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicping ${SOURCES})
 
+set_property(TARGET quicping PROPERTY FOLDER "tools")
+
 target_link_libraries(quicping msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/post/CMakeLists.txt
+++ b/src/tools/post/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicpost ${SOURCES})
 
+set_property(TARGET quicpost PROPERTY FOLDER "tools")
+
 target_link_libraries(quicpost msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/reach/CMakeLists.txt
+++ b/src/tools/reach/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicreach reach.cpp)
 
+set_property(TARGET quicreach PROPERTY FOLDER "tools")
+
 target_link_libraries(quicreach msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/sample/CMakeLists.txt
+++ b/src/tools/sample/CMakeLists.txt
@@ -12,6 +12,8 @@ target_compile_options(quicsample PRIVATE
 
 target_link_libraries(quicsample msquic platform)
 
+set_property(TARGET quicsample PROPERTY FOLDER "tools")
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(quicsample
         ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)

--- a/src/tools/siduck/CMakeLists.txt
+++ b/src/tools/siduck/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${QUIC_CXX_FLAGS}")
 
 add_executable(quicsiduck siduck.cpp)
 
+set_property(TARGET quicsiduck PROPERTY FOLDER "tools")
+
 target_link_libraries(quicsiduck msquic platform)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/tools/spin/CMakeLists.txt
+++ b/src/tools/spin/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(spinquic spinquic.cpp)
 
 target_link_libraries(spinquic msquic platform)
 
+set_property(TARGET spinquic PROPERTY FOLDER "tools")
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(spinquic
         ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)

--- a/src/tools/void/CMakeLists.txt
+++ b/src/tools/void/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(quicvoidserver server.cpp)
 
 target_link_libraries(quicvoidserver msquic platform)
 
+set_property(TARGET quicvoidserver PROPERTY FOLDER "tools")
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(quicvoidserver
         ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)


### PR DESCRIPTION
When the solution is opened in VS or another IDE that supports folders, the projects are grouped accordingly. This makes it much easier to find the specific project you're looking for