### PR TITLE
Add trace logging to datapath thread

### DIFF
--- a/src/inc/quic_trace_lttng.h
+++ b/src/inc/quic_trace_lttng.h
@@ -1132,12 +1132,6 @@ QUIC_TRACE_EVENT(DatapathErrorStatus,
         ctf_string(Msg, Msg))
 )
 QUIC_TRACE_LEVEL(DatapathErrorStatus, TRACE_ERR)
-QUIC_TRACE_EVENT(DatapathWorkerThread, 
-    TP_ARGS(const void*, UdpBinding),
-    TP_FIELDS(
-        ctf_integer_hex(uint64_t, UdpBinding, UdpBinding))
-)
-QUIC_TRACE_LEVEL(DatapathWorkerThread, TRACE_INFO)
 
 #endif /* _QUIC_TRACE_LTTNG_H */
 

--- a/src/inc/quic_trace_lttng.h
+++ b/src/inc/quic_trace_lttng.h
@@ -1133,7 +1133,7 @@ QUIC_TRACE_EVENT(DatapathErrorStatus,
 )
 QUIC_TRACE_LEVEL(DatapathErrorStatus, TRACE_ERR)
 QUIC_TRACE_EVENT(DatapathWorkerThread, 
-    TP_ARGS(const void* UdpBinding),
+    TP_ARGS(const void*, UdpBinding),
     TP_FIELDS(
         ctf_integer_hex(uint64_t, UdpBinding, UdpBinding))
 )

--- a/src/inc/quic_trace_lttng.h
+++ b/src/inc/quic_trace_lttng.h
@@ -1132,6 +1132,12 @@ QUIC_TRACE_EVENT(DatapathErrorStatus,
         ctf_string(Msg, Msg))
 )
 QUIC_TRACE_LEVEL(DatapathErrorStatus, TRACE_ERR)
+QUIC_TRACE_EVENT(DatapathWorkerThread, 
+    TP_ARGS(const void* UdpBinding),
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, UdpBinding, UdpBinding))
+)
+QUIC_TRACE_LEVEL(DatapathWorkerThread, TRACE_INFO)
 
 #endif /* _QUIC_TRACE_LTTNG_H */
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2179,8 +2179,8 @@ QuicDataPathWorkerThread(
     QUIC_DATAPATH_PROC_CONTEXT* ProcContext = (QUIC_DATAPATH_PROC_CONTEXT*)Context;
     QUIC_DBG_ASSERT(ProcContext != NULL && ProcContext->Datapath != NULL);
 
-    QuicTraceEvent(
-        DatapathWorkerStart,
+    QuicTraceLogInfo(
+        DatapathWorkerThread,
         "[ udp][%p] Worker start",
         ProcContext);
 
@@ -2214,8 +2214,8 @@ QuicDataPathWorkerThread(
         }
     }
 
-    QuicTraceEvent(
-        DatapathWorkerStop,
+    QuicTraceLogInfo(
+        DatapathWorkerThread,
         "[ udp][%p] Worker stop",
         ProcContext);
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2180,7 +2180,7 @@ QuicDataPathWorkerThread(
     QUIC_DBG_ASSERT(ProcContext != NULL && ProcContext->Datapath != NULL);
 
     QuicTraceLogInfo(
-        DatapathWorkerThread,
+        DatapathWorkerThreadStart,
         "[ udp][%p] Worker start",
         ProcContext);
 
@@ -2215,7 +2215,7 @@ QuicDataPathWorkerThread(
     }
 
     QuicTraceLogInfo(
-        DatapathWorkerThread,
+        DatapathWorkerThreadStop,
         "[ udp][%p] Worker stop",
         ProcContext);
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2181,7 +2181,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceEvent(
         DatapathWorkerStart,
-        "[dpwrkr][%p] Start",
+        "[ udp][%p] Worker start",
         ProcContext);
 
     const size_t EpollEventCtMax = 16; // TODO: Experiment.
@@ -2216,7 +2216,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceEvent(
         DatapathWorkerStop,
-        "[dpwrkr][%p] Stop",
+        "[ udp][%p] Worker stop",
         ProcContext);
 
     return NO_ERROR;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2179,6 +2179,11 @@ QuicDataPathWorkerThread(
     QUIC_DATAPATH_PROC_CONTEXT* ProcContext = (QUIC_DATAPATH_PROC_CONTEXT*)Context;
     QUIC_DBG_ASSERT(ProcContext != NULL && ProcContext->Datapath != NULL);
 
+    QuicTraceEvent(
+        DatapathWorkerStart,
+        "[dpwrkr][%p] Start",
+        ProcContext);
+
     const size_t EpollEventCtMax = 16; // TODO: Experiment.
     struct epoll_event EpollEvents[EpollEventCtMax];
 
@@ -2208,6 +2213,11 @@ QuicDataPathWorkerThread(
                 EpollEvents[i].events);
         }
     }
+
+    QuicTraceEvent(
+        DatapathWorkerStop,
+        "[dpwrkr][%p] Stop",
+        ProcContext);
 
     return NO_ERROR;
 }

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2680,7 +2680,7 @@ QuicDataPathWorkerThread(
     QUIC_DATAPATH_PROC_CONTEXT* ProcContext = (QUIC_DATAPATH_PROC_CONTEXT*)CompletionContext;
 
     QuicTraceLogInfo(
-        DatapathWorkerThread,
+        DatapathWorkerThreadStart,
         "[ udp][%p] Worker start",
         ProcContext);
 
@@ -2764,7 +2764,7 @@ QuicDataPathWorkerThread(
     }
 
     QuicTraceLogInfo(
-        DatapathWorkerThread,
+        DatapathWorkerThreadStop,
         "[ udp][%p] Worker stop",
         ProcContext);
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2681,7 +2681,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceEvent(
         DatapathWorkerStart,
-        "[dpwrkr][%p] Start",
+        "[ udp][%p] Worker start",
         ProcContext);
 
     QUIC_DBG_ASSERT(ProcContext != NULL);
@@ -2765,7 +2765,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceEvent(
         DatapathWorkerStop,
-        "[dpwrkr][%p] Stop",
+        "[ udp][%p] Worker stop",
         ProcContext);
 
     return NO_ERROR;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2679,6 +2679,11 @@ QuicDataPathWorkerThread(
 {
     QUIC_DATAPATH_PROC_CONTEXT* ProcContext = (QUIC_DATAPATH_PROC_CONTEXT*)CompletionContext;
 
+    QuicTraceEvent(
+        DatapathWorkerStart,
+        "[dpwrkr][%p] Start",
+        ProcContext);
+
     QUIC_DBG_ASSERT(ProcContext != NULL);
     QUIC_DBG_ASSERT(ProcContext->Datapath != NULL);
 
@@ -2757,6 +2762,11 @@ QuicDataPathWorkerThread(
                 IoResult);
         }
     }
+
+    QuicTraceEvent(
+        DatapathWorkerStop,
+        "[dpwrkr][%p] Stop",
+        ProcContext);
 
     return NO_ERROR;
 }

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2679,8 +2679,8 @@ QuicDataPathWorkerThread(
 {
     QUIC_DATAPATH_PROC_CONTEXT* ProcContext = (QUIC_DATAPATH_PROC_CONTEXT*)CompletionContext;
 
-    QuicTraceEvent(
-        DatapathWorkerStart,
+    QuicTraceLogInfo(
+        DatapathWorkerThread,
         "[ udp][%p] Worker start",
         ProcContext);
 
@@ -2763,8 +2763,8 @@ QuicDataPathWorkerThread(
         }
     }
 
-    QuicTraceEvent(
-        DatapathWorkerStop,
+    QuicTraceLogInfo(
+        DatapathWorkerThread,
         "[ udp][%p] Worker stop",
         ProcContext);
 


### PR DESCRIPTION
No notifications were occuring when a datapath thread was created or shutdown, which is very helpful to debug thread race conditions