### PR TITLE
Wait for all connections to be freed during registration close

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -117,6 +117,7 @@ QuicConnAlloc(
     QuicSendInitialize(&Connection->Send);
     QuicLossDetectionInitialize(&Connection->LossDetection);
     QuicDatagramInitialize(&Connection->Datagram);
+    QuicRundownAcquire(&Session->Registration->ConnectionRundown);
 
     QUIC_PATH* Path = &Connection->Paths[0];
     QuicPathInitialize(Connection, Path);
@@ -372,6 +373,7 @@ QuicConnFree(
         QuicLibraryReleaseBinding(Path->Binding);
         Path->Binding = NULL;
     }
+    QuicRundownRelease(&Connection->Registration->ConnectionRundown);
     QuicDispatchLockUninitialize(&Connection->ReceiveQueueLock);
     QuicOperationQueueUninitialize(&Connection->OperQ);
     QuicStreamSetUninitialize(&Connection->Streams);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -372,15 +372,15 @@ QuicConnFree(
         QuicLibraryReleaseBinding(Path->Binding);
         Path->Binding = NULL;
     }
-    if (Connection->Registration != NULL) {
-        QuicRundownRelease(&Connection->Registration->ConnectionRundown);
-    }
     QuicDispatchLockUninitialize(&Connection->ReceiveQueueLock);
     QuicOperationQueueUninitialize(&Connection->OperQ);
     QuicStreamSetUninitialize(&Connection->Streams);
     QuicSendBufferUninitialize(&Connection->SendBuffer);
     QuicDatagramUninitialize(&Connection->Datagram);
     QuicSessionUnregisterConnection(Connection);
+    if (Connection->Registration != NULL) {
+        QuicRundownRelease(&Connection->Registration->ConnectionRundown);
+    }
     Connection->State.Freed = TRUE;
     if (Connection->RemoteServerName != NULL) {
         QUIC_FREE(Connection->RemoteServerName);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -117,7 +117,6 @@ QuicConnAlloc(
     QuicSendInitialize(&Connection->Send);
     QuicLossDetectionInitialize(&Connection->LossDetection);
     QuicDatagramInitialize(&Connection->Datagram);
-    QuicRundownAcquire(&Session->Registration->ConnectionRundown);
 
     QUIC_PATH* Path = &Connection->Paths[0];
     QuicPathInitialize(Connection, Path);
@@ -373,7 +372,9 @@ QuicConnFree(
         QuicLibraryReleaseBinding(Path->Binding);
         Path->Binding = NULL;
     }
-    QuicRundownRelease(&Connection->Registration->ConnectionRundown);
+    if (Connection->Registration != NULL) {
+        QuicRundownRelease(&Connection->Registration->ConnectionRundown);
+    }
     QuicDispatchLockUninitialize(&Connection->ReceiveQueueLock);
     QuicOperationQueueUninitialize(&Connection->OperQ);
     QuicStreamSetUninitialize(&Connection->Streams);

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -68,6 +68,7 @@ MsQuicRegistrationOpen(
     QuicLockInitialize(&Registration->Lock);
     QuicListInitializeHead(&Registration->Sessions);
     QuicRundownInitialize(&Registration->SecConfigRundown);
+    QuicRundownInitialize(&Registration->ConnectionRundown);
     Registration->AppNameLength = (uint8_t)(AppNameLength + 1);
     if (AppNameLength != 0) {
         QuicCopyMemory(Registration->AppName, Config->AppName, AppNameLength + 1);
@@ -139,6 +140,7 @@ Error:
 
     if (Registration != NULL) {
         QuicRundownUninitialize(&Registration->SecConfigRundown);
+        QuicRundownUninitialize(&Registration->ConnectionRundown);
         QuicLockUninitialize(&Registration->Lock);
         QUIC_FREE(Registration);
     }
@@ -192,10 +194,13 @@ MsQuicRegistrationClose(
     QuicListEntryRemove(&Registration->Link);
     QuicLockRelease(&MsQuicLib.Lock);
 
+    QuicRundownReleaseAndWait(&Registration->ConnectionRundown);
+
     QuicWorkerPoolUninitialize(Registration->WorkerPool);
     QuicRundownReleaseAndWait(&Registration->SecConfigRundown);
 
     QuicRundownUninitialize(&Registration->SecConfigRundown);
+    QuicRundownUninitialize(&Registration->ConnectionRundown);
     QuicLockUninitialize(&Registration->Lock);
 
     if (Registration->CidPrefix != NULL) {

--- a/src/core/registration.h
+++ b/src/core/registration.h
@@ -67,6 +67,11 @@ typedef struct QUIC_REGISTRATION {
     QUIC_LIST_ENTRY Sessions;
 
     //
+    // Rundown for all connections
+    //
+    QUIC_RUNDOWN_REF ConnectionRundown;
+
+    //
     // Rundown for all outstanding security configs.
     //
     QUIC_RUNDOWN_REF SecConfigRundown;

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -548,6 +548,7 @@ QuicSessionRegisterConnection(
 
     if (Session->Registration != NULL) {
         Connection->Registration = Session->Registration;
+        QuicRundownAcquire(&Session->Registration->ConnectionRundown);
 #ifdef QuicVerifierEnabledByAddr
         Connection->State.IsVerifying = Session->Registration->IsVerifying;
 #endif


### PR DESCRIPTION
If the connection received data after the registration worker pools were free, we hit a crash. This is caused by a race between cleaning up a connection and the binding receiving data. If we wait for the connections to be fully clean before cleaning up the worker threads, the race is avoided.

Should fix #472 but needs to be tested