### PR TITLE
Adds Various Improvements to Interop Tool

### DIFF
--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -39,6 +39,9 @@ This script runs quicinterop locally.
 .PARAMETER Test
     A particular test case to run.
 
+.PARAMETER Serial
+    Runs the test cases serially.
+
 #>
 
 param (
@@ -80,7 +83,10 @@ param (
     [string]$Port = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$Test = ""
+    [string]$Test = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Serial = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -144,6 +150,9 @@ if ($Port -ne "") {
 }
 if ($Test -ne "") {
     $ExtraArgs += " -test:$Test"
+}
+if ($Serial) {
+    $ExtraArgs += " -serial"
 }
 
 if ($ExtraArgs -ne "") {

--- a/src/tools/interop/interop.h
+++ b/src/tools/interop/interop.h
@@ -35,3 +35,5 @@ inline QuicTestFeature operator|(QuicTestFeature a, QuicTestFeature b)
 {
     return static_cast<QuicTestFeature>(static_cast<int>(a) | static_cast<int>(b));
 }
+
+const QuicTestFeature QuicTestFeatureDataPath = StreamData | ZeroRtt;


### PR DESCRIPTION
Adds a few improvements to the interop client tool:

- Allows specifying the test case letters, such as `-test:VHDC` in addition to the numerical equivalents.
- Doesn't use `h3-*` ALPNs for datapath tests as they are incorrect and cause weird test results.
- Adds a `-serial` option to run all tests serially. This improves results when either the network conditions don't allow for the parallel test cases or the server itself is not very good with parallel requests.