### PR TITLE
Clean up worker pools before closing any leftover quic sessions

### DIFF
--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -35,7 +35,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/spin.ps1
-      arguments: -GenerateXmlResults -Timeout 100000 -RepeatCount 6 -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -GenerateXmlResults -Timeout 600000 -RepeatCount 6 -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 
   - template: ./upload-test-artifacts.yml
     parameters:

--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -35,7 +35,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/spin.ps1
-      arguments: -GenerateXmlResults -Timeout 600000 -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -GenerateXmlResults -Timeout 100000 -RepeatCount 6 -ConvertLogs -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 
   - template: ./upload-test-artifacts.yml
     parameters:

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -15,6 +15,9 @@ This script runs spinquic locally for a period of time.
 .PARAMETER Timeout
     The run time in milliseconds.
 
+.Parameter RepeatCount
+    The amount of times to repeat the full test
+
 .PARAMETER KeepOutputOnSuccess
     Don't discard console output or logs on success.
 
@@ -47,6 +50,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [Int32]$Timeout = 60000,
+
+    [Parameter(Mandatory = $false)]
+    [Int32]$RepeatCount = 1,
 
     [Parameter(Mandatory = $false)]
     [switch]$KeepOutputOnSuccess = $false,
@@ -97,7 +103,7 @@ if (!(Test-Path $SpinQuic)) {
 }
 
 # Build up all the arguments to pass to the Powershell script.
-$Arguments = "-Path $($SpinQuic) -Arguments 'both -timeout:$($Timeout)' -ShowOutput"
+$Arguments = "-Path $($SpinQuic) -Arguments 'both -timeout:$($Timeout) -repeat_count:$($RepeatCount)' -ShowOutput"
 if ($KeepOutputOnSuccess) {
     $Arguments += " -KeepOutputOnSuccess"
 }

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -268,14 +268,6 @@ MsQuicLibraryUninitialize(
         MsQuicLib.Storage = NULL;
     }
 
-    //
-    // Clean up all the leftover, unregistered server connections.
-    //
-    if (MsQuicLib.UnregisteredSession != NULL) {
-        MsQuicSessionClose((HQUIC)MsQuicLib.UnregisteredSession);
-        MsQuicLib.UnregisteredSession = NULL;
-    }
-
     QuicDataPathUninitialize(MsQuicLib.Datapath);
     MsQuicLib.Datapath = NULL;
 
@@ -287,6 +279,14 @@ MsQuicLibraryUninitialize(
     if (MsQuicLib.WorkerPool != NULL) {
         QuicWorkerPoolUninitialize(MsQuicLib.WorkerPool);
         MsQuicLib.WorkerPool = NULL;
+    }
+
+    //
+    // Clean up all the leftover, unregistered server connections.
+    //
+    if (MsQuicLib.UnregisteredSession != NULL) {
+        MsQuicSessionClose((HQUIC)MsQuicLib.UnregisteredSession);
+        MsQuicLib.UnregisteredSession = NULL;
     }
 
 #if DEBUG

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -268,6 +268,14 @@ MsQuicLibraryUninitialize(
         MsQuicLib.Storage = NULL;
     }
 
+    //
+    // Clean up all the leftover, unregistered server connections.
+    //
+    if (MsQuicLib.UnregisteredSession != NULL) {
+        MsQuicSessionClose((HQUIC)MsQuicLib.UnregisteredSession);
+        MsQuicLib.UnregisteredSession = NULL;
+    }
+
     QuicDataPathUninitialize(MsQuicLib.Datapath);
     MsQuicLib.Datapath = NULL;
 
@@ -279,14 +287,6 @@ MsQuicLibraryUninitialize(
     if (MsQuicLib.WorkerPool != NULL) {
         QuicWorkerPoolUninitialize(MsQuicLib.WorkerPool);
         MsQuicLib.WorkerPool = NULL;
-    }
-
-    //
-    // Clean up all the leftover, unregistered server connections.
-    //
-    if (MsQuicLib.UnregisteredSession != NULL) {
-        MsQuicSessionClose((HQUIC)MsQuicLib.UnregisteredSession);
-        MsQuicLib.UnregisteredSession = NULL;
     }
 
 #if DEBUG

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -329,7 +329,7 @@ MsQuicSessionClose(
         // immediately cleaned up. Use shutdown to ensure this all gets placed
         // on the worker queue.
         //
-        MsQuicSessionShutdown(Handle, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
+        MsQuicSessionShutdown(Handle, QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
     }
 
     QuicRundownReleaseAndWait(&Session->Rundown);

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -733,9 +733,8 @@ main(int argc, char **argv)
     TryGetValue(argc, argv, "seed", &RngSeed);
     srand(RngSeed);
 
-    SpinQuicWatchdog Watchdog((uint32_t)Settings.RunTimeMs + WATCHDOG_WIGGLE_ROOM);
-
     for (uint32_t i = 0; i < RepeatCount; i++) {
+         SpinQuicWatchdog Watchdog((uint32_t)Settings.RunTimeMs + WATCHDOG_WIGGLE_ROOM);
         
         for (size_t i = 0; i < BufferCount; ++i) {
             Buffers[i].Length = MaxBufferSizes[i]; // TODO - Randomize?


### PR DESCRIPTION
Without this, we race cleanup.

Should fix #482