### PR TITLE
Minor Script Improvements

### DIFF
--- a/.azure/scripts/run-executable.ps1
+++ b/.azure/scripts/run-executable.ps1
@@ -98,7 +98,7 @@ $FailXmlText = @"
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="1" disabled="0" errors="0" time="0" name="Executable">
   <testsuite name="ExeName" tests="1" failures="1" disabled="0" errors="0" timestamp="date" time="0" >
-    <testcase name="Run" status="run" result="completed" time="0" timestamp="date" classname="ExeName">
+    <testcase name="ExeName" status="run" result="completed" time="0" timestamp="date" classname="ExeName">
       <failure message="Application Crashed" type=""><![CDATA[Application Crashed]]></failure>
     </testcase>
   </testsuite>
@@ -110,7 +110,7 @@ $SuccessXmlText = @"
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="1" disabled="0" errors="0" time="0" name="Executable">
   <testsuite name="ExeName" tests="1" failures="1" disabled="0" errors="0" timestamp="date" time="0" >
-    <testcase name="Run" status="run" result="completed" time="0" timestamp="date" classname="ExeName" />
+    <testcase name="ExeName" status="run" result="completed" time="0" timestamp="date" classname="ExeName" />
   </testsuite>
 </testsuites>
 "@
@@ -175,7 +175,7 @@ function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
     try {
         if ($env:BUILD_BUILDNUMBER -ne $null) {
-            $env:PATH += ";c:\Program Files (x86)\Windows Kits\10\Debuggers\x64" 
+            $env:PATH += ";c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
         }
         $Output = cdb.exe -z $File -c "kn;q" | Join-String -Separator "`n"
         $Output = ($Output | Select-String -Pattern " # Child-SP(?s).*quit:").Matches[0].Groups[0].Value

--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -39,6 +39,9 @@ This script runs quicinterop locally.
 .PARAMETER Test
     A particular test case to run.
 
+.PARAMETER Version
+    The initial version to use for the connection.
+
 .PARAMETER Serial
     Runs the test cases serially.
 
@@ -84,6 +87,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [string]$Test = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Version = "",
 
     [Parameter(Mandatory = $false)]
     [switch]$Serial = $false
@@ -150,6 +156,9 @@ if ($Port -ne "") {
 }
 if ($Test -ne "") {
     $ExtraArgs += " -test:$Test"
+}
+if ($Version -ne "") {
+    $ExtraArgs += " -version:$Version"
 }
 if ($Serial) {
     $ExtraArgs += " -serial"


### PR DESCRIPTION
Updates the PowerShell scripts with minor improvements:

- Spinquic script passes version parameter.
- Run exe script puts name for test failures, instead of just "Run"