### PR TITLE
Change strncat to strcat in QuicPlatFreeSelfSignedCert to fix compiling on linux

### DIFF
--- a/src/platform/selfsign_openssl.c
+++ b/src/platform/selfsign_openssl.c
@@ -386,7 +386,7 @@ QuicPlatFreeSelfSignedCert(
 
     char RmCmd[32] = {0};
     strncpy(RmCmd, "rm -rf ", 7 + 1);
-    strncat(RmCmd, Params->TempDir, strlen(Params->TempDir) + 1);
+    strcat(RmCmd, Params->TempDir);
     if (system(RmCmd) == -1) {
         QuicTraceEvent(
             LibraryError,


### PR DESCRIPTION
After commit https://github.com/microsoft/msquic/commit/2bf91b3ff5b9b9668e7ae1f2f2588cbc8e228c9c when trying to compile on linux using the Release config with gcc 9.3.0 you get the following error:
```
In function ‘strncat’,
    inlined from ‘QuicPlatFreeSelfSignedCert’ at /home/tomxmm0/Documents/Dev/msquic/src/platform/selfsign_openssl.c:389:5:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: ‘__builtin___strncat_chk’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/tomxmm0/Documents/Dev/msquic/src/platform/selfsign_openssl.c: In function ‘QuicPlatFreeSelfSignedCert’:
/home/tomxmm0/Documents/Dev/msquic/src/platform/selfsign_openssl.c:389:37: note: length computed here
  389 |     strncat(RmCmd, Params->TempDir, strlen(Params->TempDir) + 1);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
This is caused because the unnecessary use of strncat. 