### PR TITLE
[Linux] Move from si_family in the union to sockaddr;

### DIFF
--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -687,7 +687,7 @@ QuicDataPathResolveAddress(
     //
     // Prepopulate hint with input family. It might be unspecified.
     //
-    Hints.ai_family = Address->si_family;
+    Hints.ai_family = Address->Ip.sa_family;
 
     //
     // Try numeric name first.
@@ -1192,7 +1192,7 @@ QuicSocketContextRecvComplete(
         if (CMsg->cmsg_level == IPPROTO_IPV6 &&
             CMsg->cmsg_type == IPV6_PKTINFO) {
             struct in6_pktinfo* PktInfo6 = (struct in6_pktinfo*) CMSG_DATA(CMsg);
-            LocalAddr->si_family = AF_INET6;
+            LocalAddr->Ip.sa_family = AF_INET6;
             LocalAddr->Ipv6.sin6_addr = PktInfo6->ipi6_addr;
             LocalAddr->Ipv6.sin6_port = SocketContext->Binding->LocalAddress.Ipv6.sin6_port;
             QuicConvertFromMappedV6(LocalAddr, LocalAddr);
@@ -1204,7 +1204,7 @@ QuicSocketContextRecvComplete(
 
         if (CMsg->cmsg_level == IPPROTO_IP && CMsg->cmsg_type == IP_PKTINFO) {
             struct in_pktinfo* PktInfo = (struct in_pktinfo*)CMSG_DATA(CMsg);
-            LocalAddr->si_family = AF_INET;
+            LocalAddr->Ip.sa_family = AF_INET;
             LocalAddr->Ipv4.sin_addr = PktInfo->ipi_addr;
             LocalAddr->Ipv4.sin_port = SocketContext->Binding->LocalAddress.Ipv6.sin6_port;
             LocalAddr->Ipv6.sin6_scope_id = PktInfo->ipi_ifindex;
@@ -1528,7 +1528,7 @@ QuicDataPathBindingCreate(
     if (LocalAddress) {
         QuicConvertToMappedV6(LocalAddress, &Binding->LocalAddress);
     } else {
-        Binding->LocalAddress.si_family = AF_INET6;
+        Binding->LocalAddress.Ip.sa_family = AF_INET6;
     }
     for (uint32_t i = 0; i < SocketCount; i++) {
         Binding->SocketContexts[i].Binding = Binding;
@@ -1915,7 +1915,7 @@ QuicDataPathBindingSend(
     ProcContext = &Binding->Datapath->ProcContexts[QuicProcCurrentNumber()];
 
     RemoteAddrLen =
-        (AF_INET == RemoteAddress->si_family) ?
+        (AF_INET == RemoteAddress->Ip.sa_family) ?
             sizeof(RemoteAddress->Ipv4) : sizeof(RemoteAddress->Ipv6);
 
     if (LocalAddress == NULL) {
@@ -2020,7 +2020,7 @@ QuicDataPathBindingSend(
 
         // TODO: Avoid allocating both.
 
-        if (LocalAddress->si_family == AF_INET) {
+        if (LocalAddress->Ip.sa_family == AF_INET) {
             Mhdr.msg_control = ControlBuffer;
             Mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
 

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -578,7 +578,7 @@ QuicConvertToMappedV6(
 
     QuicZeroMemory(OutAddr, sizeof(QUIC_ADDR));
 
-    if (InAddr->si_family == AF_INET) {
+    if (InAddr->Ip.sa_family == AF_INET) {
         OutAddr->Ipv6.sin6_family = AF_INET6;
         OutAddr->Ipv6.sin6_port = InAddr->Ipv4.sin_port;
         memset(&(OutAddr->Ipv6.sin6_addr.s6_addr[10]), 0xff, 2);
@@ -594,7 +594,7 @@ QuicConvertFromMappedV6(
     _Out_ QUIC_ADDR* OutAddr
     )
 {
-    QUIC_DBG_ASSERT(InAddr->si_family == AF_INET6);
+    QUIC_DBG_ASSERT(InAddr->Ip.sa_family == AF_INET6);
 
     if (IN6_IS_ADDR_V4MAPPED(&InAddr->Ipv6.sin6_addr)) {
         QUIC_ADDR TmpAddrS = {0};

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -25,7 +25,7 @@ struct QuicAddr
     QUIC_ADDR SockAddr;
 
     uint16_t Port() {
-        if (SockAddr.si_family == AF_INET) {
+        if (QuicAddrGetFamily(&SockAddr) == AF_INET) {
             return SockAddr.Ipv4.sin_port;
         } else {
             return SockAddr.Ipv6.sin6_port;
@@ -34,7 +34,7 @@ struct QuicAddr
 
     #undef SetPort
     void SetPort(uint16_t port) {
-        if (SockAddr.si_family == AF_INET) {
+        if (QuicAddrGetFamily(&SockAddr) == AF_INET) {
             SockAddr.Ipv4.sin_port = port;
         } else {
             SockAddr.Ipv6.sin6_port = port;

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -760,8 +760,9 @@ void QuicTestValidateStream(bool Connect)
                 //
                 TEST_QUIC_SUCCEEDED(
                     Client.Start(
-                        ServerLocalAddr.SockAddr.si_family,
-                        QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+                        QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+                        QUIC_LOCALHOST_FOR_AF(
+                            QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
                         QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
                 //

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -502,8 +502,9 @@ QuicTestServerDisconnect(
 
                 TEST_QUIC_SUCCEEDED(
                     Client->Start(
-                        ServerLocalAddr.SockAddr.si_family,
-                        QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+                        QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+                        QUIC_LOCALHOST_FOR_AF(
+                            QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
                         QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
 

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -279,8 +279,9 @@ QuicTestValidateConnectionEvents1(
     TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Client.Handle,
-            ServerLocalAddr.SockAddr.si_family,
-            QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+            QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+            QUIC_LOCALHOST_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
             QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
     TEST_TRUE(QuicEventWaitWithTimeout(Client.Complete, 2000));
@@ -340,8 +341,9 @@ QuicTestValidateConnectionEvents2(
     TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Client.Handle,
-            ServerLocalAddr.SockAddr.si_family,
-            QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+            QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+            QUIC_LOCALHOST_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
             QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
     TEST_TRUE(QuicEventWaitWithTimeout(Client.Complete, 2000));
@@ -478,8 +480,9 @@ QuicTestValidateStreamEvents1(
     TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Client.Handle,
-            ServerLocalAddr.SockAddr.si_family,
-            QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+            QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+            QUIC_LOCALHOST_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
             QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
     TEST_TRUE(QuicEventWaitWithTimeout(Client.Complete, 2000));
@@ -573,8 +576,9 @@ QuicTestValidateStreamEvents2(
     TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Client.Handle,
-            ServerLocalAddr.SockAddr.si_family,
-            QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+            QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+            QUIC_LOCALHOST_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
             QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
     TEST_TRUE(QuicEventWaitWithTimeout(Client.Complete, 2000));

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -324,7 +324,8 @@ QuicTestConnectAndIdle(
                 TEST_QUIC_SUCCEEDED(
                     Client.Start(
                         AF_UNSPEC,
-                        QUIC_LOCALHOST_FOR_AF(ServerLocalAddr.SockAddr.si_family),
+                        QUIC_LOCALHOST_FOR_AF(
+                            QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
                         QuicAddrGetPort(&ServerLocalAddr.SockAddr)));
 
                 if (!Client.WaitForConnectionComplete()) {

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -138,7 +138,7 @@ struct DrillSender {
             return Status;
         }
 
-        ServerAddress.si_family = Family;
+        QuicAddrSetFamily(&ServerAddress, Family);
 
         Status =
             QuicDataPathResolveAddress(

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -304,8 +304,8 @@ ParseClientCommand(
     uint16_t ip;
     if (TryGetValue(argc, argv, "ip", &ip)) {
         switch (ip) {
-        case 4: PingConfig.Client.RemoteIpAddr.si_family = AF_INET; break;
-        case 6: PingConfig.Client.RemoteIpAddr.si_family = AF_INET6; break;
+        case 4: QuicAddrSetFamily(&PingConfig.Client.RemoteIpAddr, AF_INET); break;
+        case 6: QuicAddrSetFamily(&PingConfig.Client.RemoteIpAddr, AF_INET6); break;
         }
     }
 


### PR DESCRIPTION
**There is no functionality change in this PR**

This way we don't rely on the internal sockaddr structure ordering. On
darwin for example, si_family is not the first member of sockaddr. There's no
guarantee this structure will stay the same, and the proper way to do
this is to just use a sockaddr as the first member, which is guaranteed
to be the first member of both sockaddr_in and sockaddr_in6.

Note: quicping doesn't build currently.

```
/home/max/msquic/src/tools/ping/QuicPing.cpp: In function ‘void ParseClientCommand(int, char**)’:
/home/max/msquic/src/tools/ping/QuicPing.cpp:307:48: error: ‘QUIC_ADDR’ {aka ‘union QUIC_ADDR’} has no member named ‘si_family’
         case 4: PingConfig.Client.RemoteIpAddr.si_family = AF_INET; break;
                                                ^~~~~~~~~
/home/max/msquic/src/tools/ping/QuicPing.cpp:308:48: error: ‘QUIC_ADDR’ {aka ‘union QUIC_ADDR’} has no member named ‘si_family’
         case 6: PingConfig.Client.RemoteIpAddr.si_family = AF_INET6; break;
```

The fix here would be for platform-independent access to network-AF info (`QuicPlatformGetAddrAf`?). Please advise :)

Edit: quicping builds now. :)