### PR TITLE
Use library to provide deployment key for GitHub

### DIFF
--- a/.azure/scripts/publish-performance-results.ps1
+++ b/.azure/scripts/publish-performance-results.ps1
@@ -1,3 +1,9 @@
+param (
+    [Parameter(DeploymentKey = $true)]
+    [string]$Path
+)
+
+
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent
 $RootDir = Split-Path $RootDir -Parent
@@ -14,6 +20,9 @@ Copy-Item -Path $ResultsPath -Destination $GitPath -Recurse -Force
 
 git config user.email "quicdev@microsoft.com"
 git config user.name "QUIC Dev Bot"
+
+git config --global credential.helper store
+Add-Content "$env:USERPROFILE\.git-credentials" "https://$($DeploymentKey):x-oauth-basic@github.com`n"
 
 git add .
 git status

--- a/.azure/scripts/publish-performance-results.ps1
+++ b/.azure/scripts/publish-performance-results.ps1
@@ -1,9 +1,3 @@
-param (
-    [Parameter(DeploymentKey = $true)]
-    [string]$Path
-)
-
-
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent
 $RootDir = Split-Path $RootDir -Parent
@@ -22,7 +16,7 @@ git config user.email "quicdev@microsoft.com"
 git config user.name "QUIC Dev Bot"
 
 git config --global credential.helper store
-Add-Content "$env:USERPROFILE\.git-credentials" "https://$($DeploymentKey):x-oauth-basic@github.com`n"
+Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:MAPPED_DEPLOYMENT_KEY):x-oauth-basic@github.com`n"
 
 git add .
 git status

--- a/.azure/templates/publish-performance.yml
+++ b/.azure/templates/publish-performance.yml
@@ -31,4 +31,5 @@ jobs:
     inputs:
       pwsh: true
       filePath: .azure/scripts/publish-performance-results.ps1
-      arguments: -DeploymentKey $(GitHubDeploymentKey)
+    env:
+      MAPPED_DEPLOYMENT_KEY: $(GitHubDeploymentKey)

--- a/.azure/templates/publish-performance.yml
+++ b/.azure/templates/publish-performance.yml
@@ -10,9 +10,9 @@ jobs:
   variables:
   - name: runCodesignValidationInjection
     value: false
+  - group: DeploymentKeys
   steps:
   - checkout: self
-    persistCredentials: true
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Build Artifacts
@@ -31,3 +31,4 @@ jobs:
     inputs:
       pwsh: true
       filePath: .azure/scripts/publish-performance-results.ps1
+      arguments: -DeploymentKey $(GitHubDeploymentKey)


### PR DESCRIPTION
Like the other secure token, these do not get decrypted during PRs, so its safe.