### PR TITLE
Skip component governance detection for perf results

### DIFF
--- a/.azure/templates/publish-performance.yml
+++ b/.azure/templates/publish-performance.yml
@@ -10,6 +10,8 @@ jobs:
   variables:
   - name: runCodesignValidationInjection
     value: false
+  - name: skipComponentGovernanceDetection
+    value: true
   - group: DeploymentKeys
   steps:
   - checkout: self

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -15,6 +15,8 @@ jobs:
   variables:
   - name: runCodesignValidationInjection
     value: false
+  - name: skipComponentGovernanceDetection
+    value: true
   steps:
   - checkout: self
 


### PR DESCRIPTION
It adds over 6 minutes to the build, and we don't publish anything we're not planning on directly pushing anyway