### PR TITLE
Fix builds on non glibc based linux platforms

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -48,10 +48,12 @@ target_compile_options(platform PRIVATE
      $<$<CXX_COMPILER_ID:MSVC>:
         ${MSVC_WARNING_FLAGS}>)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    add_dependencies(platform MsQuicEtw)
-else()
-    target_link_libraries(platform ${LTTNGUST_LIBRARIES})
+if(QUIC_ENABLE_LOGGING)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        add_dependencies(platform MsQuicEtw)
+    else()
+        target_link_libraries(platform ${LTTNGUST_LIBRARIES})
+    endif()
 endif()
 
 if(QUIC_TLS STREQUAL "openssl")

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2172,14 +2172,14 @@ QuicDataPathBindingGetLocalMtu(
 }
 
 #ifndef TEMP_FAILURE_RETRY
-#define TEMP_FAILURE_RETRY(expression)                                  \
-        ({                                                              \
-            long int FailureRetryResult = 0;                            \
-            do {                                                        \
-                FailureRetryResult = (long int)(expression);            \
-            } while ((FailureRetryResult == -1L) && (errno == EINTR));  \
-            FailureRetryResult;                                         \
-        })
+#define TEMP_FAILURE_RETRY(expression)                              \
+    ({                                                              \
+        long int FailureRetryResult = 0;                            \
+        do {                                                        \
+            FailureRetryResult = (long int)(expression);            \
+        } while ((FailureRetryResult == -1L) && (errno == EINTR));  \
+        FailureRetryResult;                                         \
+    })
 #endif
 
 void*

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2176,8 +2176,8 @@ QuicDataPathBindingGetLocalMtu(
         ({                                                              \
             long int FailureRetryResult = 0;                            \
             do {                                                        \
-                FailureRetryResult = (long int)(expression)             \
-            } while ((FalureRetryResult == -1L) && (errno == EINTR));   \
+                FailureRetryResult = (long int)(expression);            \
+            } while ((FailureRetryResult == -1L) && (errno == EINTR));  \
             FailureRetryResult;                                         \
         })
 #endif

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -2171,6 +2171,17 @@ QuicDataPathBindingGetLocalMtu(
 #endif
 }
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression)                                  \
+        ({                                                              \
+            long int FailureRetryResult = 0;                            \
+            do {                                                        \
+                FailureRetryResult = (long int)(expression)             \
+            } while ((FalureRetryResult == -1L) && (errno == EINTR));   \
+            FailureRetryResult;                                         \
+        })
+#endif
+
 void*
 QuicDataPathWorkerThread(
     _In_ void* Context

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -637,7 +637,7 @@ QuicThreadCreate(
         return errno;
     }
 
-#ifdef __GLIBC__  // TODO figure out 
+#ifdef __GLIBC__ 
     if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         QUIC_TEL_ASSERT(Config->IdealProcessor < 64);
         // There is no way to set an ideal processor in Linux, so just set affinity

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -640,7 +640,7 @@ QuicThreadCreate(
 #ifdef __GLIBC__  // TODO figure out 
     if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         QUIC_TEL_ASSERT(Config->IdealProcessor < 64);
-        // TODO - Set Linux equivalent of ideal processor.
+        // There is no way to set an ideal processor in Linux, so just set affinity
         if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
             cpu_set_t CpuSet;
             CPU_ZERO(&CpuSet);
@@ -681,7 +681,7 @@ QuicThreadCreate(
 #ifndef __GLIBC__
     if (Status == QUIC_STATUS_SUCCESS && Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         QUIC_TEL_ASSERT(Config->IdealProcessor < 64);
-        // TODO - Set Linux equivalent of ideal processor.
+        // There is no way to set an ideal processor in Linux, so just set affinity
         if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
             cpu_set_t CpuSet;
             CPU_ZERO(&CpuSet);

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -637,6 +637,7 @@ QuicThreadCreate(
         return errno;
     }
 
+#ifdef __GLIBC__  // TODO figure out 
     if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         QUIC_TEL_ASSERT(Config->IdealProcessor < 64);
         // TODO - Set Linux equivalent of ideal processor.
@@ -654,6 +655,7 @@ QuicThreadCreate(
             // TODO - Set Linux equivalent of NUMA affinity.
         }
     }
+#endif
 
     if (Config->Flags & QUIC_THREAD_FLAG_HIGH_PRIORITY) {
         struct sched_param Params;
@@ -675,6 +677,26 @@ QuicThreadCreate(
             Status,
             "pthread_create failed");
     }
+
+#ifndef __GLIBC__
+    if (Status == QUIC_STATUS_SUCCESS && Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
+        QUIC_TEL_ASSERT(Config->IdealProcessor < 64);
+        // TODO - Set Linux equivalent of ideal processor.
+        if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
+            cpu_set_t CpuSet;
+            CPU_ZERO(&CpuSet);
+            CPU_SET(Config->IdealProcessor, &CpuSet);
+            if (!pthread_setaffinity_np(*Thread, sizeof(CpuSet), &CpuSet)) {
+                QuicTraceEvent(
+                    LibraryError,
+                    "[ lib] ERROR, %s.",
+                    "pthread_setaffinity_np failed");
+            }
+        } else {
+            // TODO - Set Linux equivalent of NUMA affinity.
+        }
+    }
+#endif
 
     pthread_attr_destroy(&Attr);
 


### PR DESCRIPTION
TEMP_FAILURE_RETRY is a glibc extension, but the spec is very well defined, and easy to recreate manually. 

pthread attribute setting for affinity doesn't exist, so only use the attribute if glibc is defined, otherwise set the thread affinity after creating the thread.

The logging disable change in CMake is needed because I couldn't figure out how to install LTTng on Alpine. 

Fixes #477 