### PR TITLE
Update DockerFile to Install Noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM 	martenseemann/quic-network-simulator-endpoint as source
+ENV	DEBIAN_FRONTEND=noninteractive
 RUN 	apt-get update -y \
 	&& apt-get install -y \
 		build-essential \


### PR DESCRIPTION
When using docker to build I was hitting an interactive prompt. According to https://techoverflow.net/2019/05/18/how-to-fix-configuring-tzdata-interactive-input-when-building-docker-images/ I just disable that.