### PR TITLE
Allow Zero-Length Stream Sends with FIN Flag

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -889,7 +889,7 @@ MsQuicStreamSend(
         goto Exit;
     }
 
-    if (TotalLength == 0) {
+    if (TotalLength == 0 && !(Flags & QUIC_SEND_FLAG_FIN)) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Exit;
     }

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -479,7 +479,7 @@ QuicStreamSendFlush(
         ApiSendRequests = ApiSendRequests->Next;
         SendRequest->Next = NULL;
 
-        QUIC_DBG_ASSERT(SendRequest->TotalLength != 0);
+        QUIC_DBG_ASSERT(SendRequest->TotalLength != 0 || SendRequest->Flags & QUIC_SEND_FLAG_FIN);
         QUIC_DBG_ASSERT(!(SendRequest->Flags & QUIC_SEND_FLAG_BUFFERED));
 
         if (!Stream->Flags.SendEnabled) {

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -252,14 +252,16 @@ HttpRequest::SendData()
         Shutdown = true;
     }
 
+    QUIC_STATUS Status;
     if (QUIC_FAILED(
+        Status =
         MsQuic->StreamSend(
             QuicStream,
             &Buffer.QuicBuffer,
             1,
             Buffer.Flags,
             this))) {
-        printf("[%s] Send failed\n", GetRemoteAddr(MsQuic, QuicStream).Address);
+        printf("[%s] Send failed, 0x%x\n", GetRemoteAddr(MsQuic, QuicStream).Address, Status);
         Abort(HttpRequestSendFailed);
     }
 }


### PR DESCRIPTION
Fixes #522.

To make things simpler for the app, this updates the stream send API to allow for zero-length sends, so long as they also have the FIN flag set. Tested with the quicinterop server.