### PR TITLE
Force disable logging for CMake versions older then 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ option(QUIC_STATIC_LINK_CRT "Statically links the C runtime" ON)
 option(QUIC_UWP_BUILD "Build for UWP" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 
+#FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
 if (${CMAKE_VERSION } VERSION_LESS "3.6.0")
     set(QUIC_ENABLE_LOGGING OFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,9 @@ option(QUIC_STATIC_LINK_CRT "Statically links the C runtime" ON)
 option(QUIC_UWP_BUILD "Build for UWP" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 
-#FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
-if (${CMAKE_VERSION } VERSION_LESS "3.6.0")
+# FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
+if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
+    message(WARNING "Logging unsupported on this version of CMake. Please upgrade to 3.6 or later.")
     set(QUIC_ENABLE_LOGGING OFF)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,10 @@ option(QUIC_STATIC_LINK_CRT "Statically links the C runtime" ON)
 option(QUIC_UWP_BUILD "Build for UWP" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 
+if (${CMAKE_VERSION } VERSION_LESS "3.6.0")
+    set(QUIC_ENABLE_LOGGING OFF)
+endif()
+
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     set(QUIC_PLATFORM "windows")
 else()


### PR DESCRIPTION
FindLTTngUST doesn't exist before 3.6.

I don't want to completely remove support for Ubuntu 16.04, so this will make it so that a build will work, just that logging will not.

Closes #528 