### PR TITLE
Allow datapath hook failure happen in spinquic

### DIFF
--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -756,7 +756,8 @@ main(int argc, char **argv)
 
         if (Settings.LossPercent != 0) {
             QUIC_TEST_DATAPATH_HOOKS* Value = &DataPathHooks;
-            if (QUIC_FAILED(MsQuic->SetParam(
+            if (QUIC_FAILED(
+                MsQuic->SetParam(
                     nullptr,
                     QUIC_PARAM_LEVEL_GLOBAL,
                     QUIC_PARAM_GLOBAL_TEST_DATAPATH_HOOKS,

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -756,13 +756,14 @@ main(int argc, char **argv)
 
         if (Settings.LossPercent != 0) {
             QUIC_TEST_DATAPATH_HOOKS* Value = &DataPathHooks;
-            EXIT_ON_FAILURE(
-                MsQuic->SetParam(
+            if (QUIC_FAILED(MsQuic->SetParam(
                     nullptr,
                     QUIC_PARAM_LEVEL_GLOBAL,
                     QUIC_PARAM_GLOBAL_TEST_DATAPATH_HOOKS,
                     sizeof(Value),
-                    &Value));
+                    &Value))) {
+                printf("Setting Datapath hooks failed.\n");
+            }
         }
 
         const QUIC_REGISTRATION_CONFIG RegConfig = { "spinquic", QUIC_EXECUTION_PROFILE_LOW_LATENCY };


### PR DESCRIPTION
In release mode, datapath hooks can't be enabled. Because we want to support debug spinquic with release libmsquic, we want to allow the failure rather then conditional compile.

Closes #532