### PR TITLE
Improvements to the Perf Script

### DIFF
--- a/.azure/templates/run-performance-int.yml
+++ b/.azure/templates/run-performance-int.yml
@@ -4,7 +4,7 @@ parameters:
   config: 'Release'
   arch: 'x64'
   tls: ''
-  extraArgs: ''
+  extraArgs: '-Publish'
 
 jobs:
 - job: performance_windows_${{ parameters.arch }}_${{ parameters.tls }}

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -41,7 +41,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/performance.ps1
-      arguments: -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraArgs }}
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -6,6 +6,7 @@ parameters:
   config: 'Release'
   arch: 'x64'
   tls: ''
+  extraArgs: '-Publish'
 
 jobs:
 - job: performance_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -200,7 +200,7 @@ function Run-Loopback-Test() {
         $PercentDiff = 100 * (($MedianCurrentResult - $MedianLastResult) / $MedianLastResult)
         $PercentDiffStr = $PercentDiff.ToString("#.##")
         if ($PercentDiff -ge 0) {
-            $PercentDiff = "+$PercentDiff"
+            $PercentDiffStr = "+$PercentDiffStr"
         }
         Write-Host "Median: $MedianCurrentResult kbps ($PercentDiffStr%)"
         Write-Host "Master: $MedianLastResult kbps"


### PR DESCRIPTION
This adds a number of improvements to the perf script:

- New parameters for controlling behavior, generally to be used for local execution.
- Get perf output from the stream instead of the connection (since it's more accurate since it doesn't include the handshake).
- Pretty up the output.