### PR TITLE
Customizable Performance Pipeline

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -1,6 +1,6 @@
 #
 # Continuous Integration (CI)
-# This pipeline builds MsQuic with PGO instrumentation and runs the performance tests with it.
+# This pipeline builds and runs MsQuic performance tests.
 #
 
 trigger: none
@@ -35,6 +35,7 @@ stages:
       platform: windows
       arch: x86
       tls: schannel
+      config: Release
       ${{ if eq(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest -PGO
       ${{ if ne(parameters.mode, 'PGO') }}:
@@ -45,6 +46,7 @@ stages:
       platform: windows
       arch: x64
       tls: schannel
+      config: Release
       ${{ if eq(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest -PGO
       ${{ if ne(parameters.mode, 'PGO') }}:

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -27,6 +27,8 @@ stages:
 - stage: build_windows
   displayName: Build Windows
   dependsOn: []
+  variables:
+    runCodesignValidationInjection: false
   jobs:
   # Officially supported configurations.
   - template: ./templates/build-config-user.yml
@@ -57,7 +59,7 @@ stages:
 #
 
 - stage: performance
-  displayName: Performance Testing
+  displayName: Performance Testing (${{ parameters.mode }})
   dependsOn:
   - build_windows
   jobs:

--- a/.azure/azure-pipelines.pgo.yml
+++ b/.azure/azure-pipelines.pgo.yml
@@ -35,9 +35,9 @@ stages:
       platform: windows
       arch: x86
       tls: schannel
-      ${{ if eq(parameters.mode, PGO) }}:
+      ${{ if eq(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest -PGO
-      ${{ if ne(parameters.mode, PGO) }}:
+      ${{ if ne(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
@@ -45,9 +45,9 @@ stages:
       platform: windows
       arch: x64
       tls: schannel
-      ${{ if eq(parameters.mode, PGO) }}:
+      ${{ if eq(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest -PGO
-      ${{ if ne(parameters.mode, PGO) }}:
+      ${{ if ne(parameters.mode, 'PGO') }}:
         extraBuildArgs: -DisableTest
 
 #
@@ -62,15 +62,15 @@ stages:
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
-      ${{ if eq(parameters.mode, PGO) }}:
+      ${{ if eq(parameters.mode, 'PGO') }}:
         extraArgs: -PGO
-      ${{ if eq(parameters.mode, Record) }}:
+      ${{ if eq(parameters.mode, 'Record') }}:
         extraArgs: -Record
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
       arch: x86
-      ${{ if eq(parameters.mode, PGO) }}:
+      ${{ if eq(parameters.mode, 'PGO') }}:
         extraArgs: -PGO
-      ${{ if eq(parameters.mode, Record) }}:
+      ${{ if eq(parameters.mode, 'Record') }}:
         extraArgs: -Record

--- a/.azure/azure-pipelines.pgo.yml
+++ b/.azure/azure-pipelines.pgo.yml
@@ -8,11 +8,15 @@ pr: none
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
-variables:
-- name: BuildArgs
-  value: -PGO
-- name: PerfArgs
-  value: -PGO
+parameters:
+- name: mode
+  type: string
+  displayName: Mode
+  default: Normal
+  values:
+  - Normal
+  - PGO
+  - Record
 
 #
 # Builds
@@ -31,14 +35,20 @@ stages:
       platform: windows
       arch: x86
       tls: schannel
-      extraBuildArgs: -DisableTest ${{ variables.BuildArgs }}
+      ${{ if eq(parameters.mode, PGO) }}:
+        extraBuildArgs: -DisableTest -PGO
+      ${{ if ne(parameters.mode, PGO) }}:
+        extraBuildArgs: -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
       platform: windows
       arch: x64
       tls: schannel
-      extraBuildArgs: -DisableTest ${{ variables.BuildArgs }}
+      ${{ if eq(parameters.mode, PGO) }}:
+        extraBuildArgs: -DisableTest -PGO
+      ${{ if ne(parameters.mode, PGO) }}:
+        extraBuildArgs: -DisableTest
 
 #
 # Performance Tests
@@ -52,9 +62,15 @@ stages:
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
-      extraArgs: ${{ variables.PerfArgs }}
+      ${{ if eq(parameters.mode, PGO) }}:
+        extraArgs: -PGO
+      ${{ if eq(parameters.mode, Record) }}:
+        extraArgs: -Record
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
       arch: x86
-      extraArgs: ${{ variables.PerfArgs }}
+      ${{ if eq(parameters.mode, PGO) }}:
+        extraArgs: -PGO
+      ${{ if eq(parameters.mode, Record) }}:
+        extraArgs: -Record

--- a/.azure/azure-pipelines.pgo.yml
+++ b/.azure/azure-pipelines.pgo.yml
@@ -8,6 +8,12 @@ pr: none
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
+variables:
+- name: BuildArgs
+  value: -PGO
+- name: PerfArgs
+  value: -PGO
+
 #
 # Builds
 #
@@ -25,14 +31,14 @@ stages:
       platform: windows
       arch: x86
       tls: schannel
-      extraBuildArgs: -PGO -DisableTest
+      extraBuildArgs: -DisableTest ${{ variables.BuildArgs }}
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
       platform: windows
       arch: x64
       tls: schannel
-      extraBuildArgs: -PGO -DisableTest
+      extraBuildArgs: -DisableTest ${{ variables.BuildArgs }}
 
 #
 # Performance Tests
@@ -46,9 +52,9 @@ stages:
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
-      extraArgs: -PGO
+      extraArgs: ${{ variables.PerfArgs }}
   - template: ./templates/run-performance-int.yml
     parameters:
       tls: schannel
       arch: x86
-      extraArgs: -PGO
+      extraArgs: ${{ variables.PerfArgs }}

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -26,7 +26,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)
-    condition: contains(${{ parameters.config }}, 'Debug')
+    condition: contains('${{ parameters.config }}', 'Debug')
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
@@ -34,7 +34,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Build Source Code (Release)
-    condition: contains(${{ parameters.config }}, 'Release')
+    condition: contains('${{ parameters.config }}', 'Release')
     inputs:
       pwsh: true
       filePath: scripts/build.ps1

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -5,6 +5,7 @@ parameters:
   platform: ''
   arch: ''
   tls: ''
+  config: 'Debug,Release'
   extraBuildArgs: ''
 
 jobs:
@@ -25,6 +26,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)
+    condition: contains(${{ parameters.config }}, 'Debug')
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
@@ -32,6 +34,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Build Source Code (Release)
+    condition: contains(${{ parameters.config }}, 'Release')
     inputs:
       pwsh: true
       filePath: scripts/build.ps1

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -24,6 +24,9 @@ This script runs performance tests locally for a period of time.
 .PARAMETER PGO
     Uses pgomgr to merge the resulting .pgc files back to the .pgd.
 
+.PARAMETER Record
+    Records the run to collect performance information for analysis.
+
 #>
 
 param (
@@ -49,7 +52,10 @@ param (
     [switch]$Publish = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$PGO = $false
+    [switch]$PGO = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Record = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -61,6 +67,15 @@ if ("" -eq $Tls) {
         $Tls = "schannel"
     } else {
         $Tls = "openssl"
+    }
+}
+
+if (!$IsWindows) {
+    if ($PGO) {
+        Write-Error "'-PGO' is not supported on this platform!"
+    }
+    if ($Record) {
+        Write-Error "'-Record' is not supported on this platform!"
     }
 }
 
@@ -84,9 +99,47 @@ if ($IsWindows) {
     $QuicPing = "quicping"
 }
 
+# Base output path.
+$OutputDir = Join-Path $RootDir "artifacts/PerfDataResults/$Platform"
+
 # Make sure the build is present.
 if (!(Test-Path (Join-Path $Artifacts $QuicPing))) {
     Write-Error "Build does not exist!`n `nRun the following to generate it:`n `n    $(Join-Path $RootDir "scripts" "build.ps1") -Config $Config -Arch $Arch -Tls $Tls`n"
+}
+
+# WPA Profile for collecting stacks.
+$WpaStackWalkProfileXml = `
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<WindowsPerformanceRecorder Version="1.0" Author="MsQuic" Copyright="Microsoft Corporation" Company="Microsoft Corporation">
+  <Profiles>
+    <SystemCollector Id="SC_HighVolume" Realtime="false">
+      <BufferSize Value="1024"/>
+      <Buffers Value="20"/>
+    </SystemCollector>
+    <SystemProvider Id="SP_CPU">
+      <Keywords>
+        <Keyword Value="SampledProfile"/>
+      </Keywords>
+      <Stacks>
+        <Stack Value="SampledProfile"/>
+      </Stacks>
+    </SystemProvider>
+    <Profile Id="CPU.Light.File" Name="CPU" Description="CPU Stacks" LoggingMode="File" DetailLevel="Light">
+      <Collectors>
+        <SystemCollectorId Value="SC_HighVolume">
+          <SystemProviderId Value="SP_CPU" />
+        </SystemCollectorId>
+      </Collectors>
+    </Profile>
+  </Profiles>
+</WindowsPerformanceRecorder>
+"@
+$WpaStackWalkProfile = Join-Path $Artifacts "stackwalk.wprp"
+if ($PGO) {
+    if ($IsWindows) {
+        $WpaStackWalkProfileXml | Out-File $WpaStackWalkProfile
+    }
 }
 
 function Start-Background-Executable($File, $Arguments) {
@@ -168,16 +221,27 @@ function Merge-PGO-Counts($Path) {
 function Run-Loopback-Test() {
     Write-Host "Running Loopback Test"
 
-    # Run server in it's own directory.
-    $ServerDir = "$($Artifacts)_server"
-    if (!(Test-Path $ServerDir)) { New-Item -Path $ServerDir -ItemType Directory -Force | Out-Null }
-    Copy-Item "$Artifacts\*" $ServerDir
+    $ServerDir = $Artifacts
+    if ($PGO) {
+        # PGO needs the server and client executing out of separate directories.
+        $ServerDir = "$($Artifacts)_server"
+        New-Item -Path $ServerDir -ItemType Directory -Force | Out-Null
+        Copy-Item "$Artifacts\*" $ServerDir
+    }
 
+    if ($Record) {
+        # Start collecting performance information.
+        if ($IsWindows) {
+            wpr.exe -start $WpaStackWalkProfile
+        }
+    }
+
+    # Start the server.
     $proc = Start-Background-Executable -File (Join-Path $ServerDir $QuicPing) -Arguments "-listen:* -port:4433 -selfsign:1 -peer_uni:1"
     Start-Sleep 4
 
     $allRunsResults = @()
-
+    $serverOutput = $null
     try {
         1..$Runs | ForEach-Object {
             $clientOutput = Run-Foreground-Executable -File (Join-Path $Artifacts $QuicPing) -Arguments "-target:localhost -port:4433 -uni:1 -length:$Length"
@@ -191,16 +255,27 @@ function Run-Loopback-Test() {
             $clientOutput | Write-Debug
         }
 
+        # Stop the server.
         $serverOutput = Stop-Background-Executable -Process $proc
+
     } catch {
         Stop-Background-Executable -Process $proc | Write-Host
         throw
     }
+
+    if ($Record) {
+        # Stop the performance colletion.
+        if ($IsWindows) {
+            wpr.exe -stop
+        }
+    }
+
     if ($PGO) {
         # Merge server PGO counts.
         Merge-PGO-Counts $ServerDir
+        # Clean up server directory.
+        Remove-Item $ServerDir -Recurse -Force | Out-Null
     }
-    Remove-Item $ServerDir -Recurse -Force | Out-Null
 
     $MedianCurrentResult = Median-Test-Results -FullResults $allRunsResults
 
@@ -217,33 +292,32 @@ function Run-Loopback-Test() {
     } else {
         Write-Host "Median: $MedianCurrentResult kbps"
     }
+
     # Write server output so we can detect possible failures early.
     Write-Debug $serverOutput
 
     if ($Publish) {
         Write-Host "Copying results.json out for publishing."
-        $ToPublishResults = [TestPublishResult]::new()
-        $ToPublishResults.CommitHash = $CurrentCommitHash.Substring(0, 7)
-        $ToPublishResults.PlatformName = $Platform
-        $ToPublishResults.TestName = "loopback"
-        $ToPublishResults.IndividualRunResults = $allRunsResults
+        $Results = [TestPublishResult]::new()
+        $Results.CommitHash = $CurrentCommitHash.Substring(0, 7)
+        $Results.PlatformName = $Platform
+        $Results.TestName = "loopback"
+        $Results.IndividualRunResults = $allRunsResults
 
-        $ResultsFolderRoot = "$Platform/loopback"
-        $ResultsFileName = "/results.json"
+        $LoopbackOutputDir = Join-Path $OutputDir "loopback"
+        New-Item $LoopbackOutputDir -ItemType Directory -Force | Out-Null
 
-        $NewFilePath = Join-Path $RootDir "artifacts/PerfDataResults/$ResultsFolderRoot"
-        $NewFileLocation = Join-Path $NewFilePath $ResultsFileName
-        New-Item $NewFilePath -ItemType Directory -Force | Out-Null
-
-        $ToPublishResults | ConvertTo-Json | Out-File $NewFileLocation
+        $ResultFile = Join-Path $LoopbackOutputDir "results.json"
+        $Results | ConvertTo-Json | Out-File $ResultFile
     }
 }
 
+# Run through all the test scenarios.
 Run-Loopback-Test
 
 if ($PGO) {
     Write-Host "Copying msquic.pgd out for publishing."
-    $OutPath = Join-Path $RootDir "\artifacts\PerfDataResults\winuser\pgo_$($Arch)"
-    if (!(Test-Path $OutPath)) { New-Item -Path $OutPath -ItemType Directory -Force | Write-Debug }
-    Copy-Item "$Artifacts\msquic.pgd" $OutPath
+    $PgoOutputDir = Join-Path $OutputDir "pgo_$($Arch)"
+    New-Item -Path $PgoOutputDir -ItemType Directory -Force | Out-Null
+    Copy-Item "$Artifacts\msquic.pgd" $PgoOutputDir
 }

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -101,6 +101,7 @@ if ($IsWindows) {
 
 # Base output path.
 $OutputDir = Join-Path $RootDir "artifacts/PerfDataResults/$Platform"
+New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
 # Make sure the build is present.
 if (!(Test-Path (Join-Path $Artifacts $QuicPing))) {
@@ -323,7 +324,5 @@ Run-Loopback-Test
 
 if ($PGO) {
     Write-Host "Saving msquic.pgd out for publishing."
-    $PgoOutputDir = Join-Path $OutputDir "pgo_$($Arch)"
-    New-Item -Path $PgoOutputDir -ItemType Directory -Force | Out-Null
-    Copy-Item "$Artifacts\msquic.pgd" $PgoOutputDir
+    Copy-Item "$Artifacts\msquic.pgd" $OutputDir
 }


### PR DESCRIPTION
This adds support for a new customizable performance pipeline: https://dev.azure.com/ms/msquic/_build?definitionId=356&_a=summary

You can run it in one of three modes:

- **Normal** - Just builds and runs performance tests for Release.
- **PGO** - Enables PGO for build and collects PGO counts during tests.
- **Record** - Records performance traces (ETW stackwalks) for the tests.