### PR TITLE
Fixes Leaks on Send Path

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1138,6 +1138,13 @@ QuicSendFlush(
     } while (Builder.SendContext != NULL ||
         Builder.TotalCountDatagrams < QUIC_MAX_DATAGRAMS_PER_SEND);
 
+    if (Builder.SendContext != NULL) {
+        //
+        // Final send, if there is anything left over.
+        //
+        QuicPacketBuilderFinalize(&Builder, TRUE);
+    }
+
     QuicPacketBuilderCleanup(&Builder);
 
     QuicTraceLogConnVerbose(

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -124,6 +124,11 @@ QuicPacketTraceType(
             QUIC_TRACE_PACKET_ONE_RTT : (Metadata->Flags.KeyType + 1);
 }
 
+void
+QuicSentPacketMetadataReleaseFrames(
+    _In_ QUIC_SENT_PACKET_METADATA* Metadata
+    );
+
 //
 // Helper for allocating the maximum sent packet metadata on the stack.
 //


### PR DESCRIPTION
Fixes #156.

The current send metadata struct could leak stream references if it failed to send (generally only will happen in OOM scenarios). This makes sure all that is cleaned up at the end, no matter what.