### PR TITLE
Migration Tests and Fixes

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -922,6 +922,7 @@ QuicSendPathChallenges(
         }
 
         QuicPacketBuilderFinalize(&Builder, TRUE);
+        QuicPacketBuilderCleanup(&Builder);
     }
 }
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -118,6 +118,11 @@ QuicTestNatAddrRebind(
     );
 
 void
+QuicTestPathValidationTimeout(
+    _In_ int Family
+    );
+
+void
 QuicTestChangeMaxStreamID(
     _In_ int Family
     );
@@ -574,4 +579,8 @@ typedef struct {
     QUIC_CTL_CODE(43, METHOD_BUFFERED, FILE_WRITE_DATA)
     // int - Family
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 43
+#define IOCTL_QUIC_RUN_PATH_VALIDATION_TIMEOUT \
+    QUIC_CTL_CODE(44, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // int - Family
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 44

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -502,6 +502,15 @@ TEST_P(WithFamilyArgs, RebindAddr) {
         QuicTestNatAddrRebind(GetParam().Family);
     }
 }
+
+TEST_P(WithFamilyArgs, PathValidationTimeout) {
+    TestLoggerT<ParamType> Logger("QuicTestPathValidationTimeout", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_PATH_VALIDATION_TIMEOUT, GetParam().Family));
+    } else {
+        QuicTestPathValidationTimeout(GetParam().Family);
+    }
+}
 #endif
 
 TEST_P(WithFamilyArgs, ChangeMaxStreamIDs) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -541,6 +541,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     sizeof(INT32),
     sizeof(INT32),
     sizeof(INT32),
+    sizeof(INT32),
     sizeof(INT32)
 };
 
@@ -937,6 +938,13 @@ QuicTestCtlEvtIoDeviceControl(
         QUIC_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(
             QuicTestChangeMaxStreamID(
+                Params->Family));
+        break;
+
+    case IOCTL_QUIC_RUN_PATH_VALIDATION_TIMEOUT:
+        QUIC_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(
+            QuicTestPathValidationTimeout(
                 Params->Family));
         break;
 

--- a/src/test/lib/TestAbstractionLayer.h
+++ b/src/test/lib/TestAbstractionLayer.h
@@ -13,7 +13,7 @@ Abstract:
 #include <quic_datapath.h>
 #include <MsQuicTests.h>
 
-const uint32_t TestWaitTimeout = 1000;
+const uint32_t TestWaitTimeout = 2000;
 
 #define TEST_FAILURE(Format, ...) \
     LogTestFailure(__FILE__, __FUNCTION__, __LINE__, Format, ##__VA_ARGS__)


### PR DESCRIPTION
Adds a new test case for timing out path validation. Also fixes an issue in the product code where we weren't correctly probing on the new and active path when there is a migration.