### PR TITLE
Improve Loopback Perf Results

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -99,6 +99,14 @@ if ($IsWindows) {
     $QuicPing = "quicping"
 }
 
+# QuicPing arguments
+$ServerArgs = "-listen:* -port:4433 -selfsign:1 -peer_uni:1"
+$ClientArgs = "-target:localhost -port:4433 -uni:1 -length:$Length"
+if ($IsWindows) {
+    # Always use the same local address and core to provide more consistent results.
+    $ClientArgs += " -bind:127.0.0.1:4434 -ip:4 -core:0"
+}
+
 # Base output path.
 $OutputDir = Join-Path $RootDir "artifacts/PerfDataResults/$Platform"
 New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
@@ -249,14 +257,14 @@ function Run-Loopback-Test() {
     }
 
     # Start the server.
-    $proc = Start-Background-Executable -File (Join-Path $ServerDir $QuicPing) -Arguments "-listen:* -port:4433 -selfsign:1 -peer_uni:1"
+    $proc = Start-Background-Executable -File (Join-Path $ServerDir $QuicPing) -Arguments $ServerArgs
     Start-Sleep 4
 
     $allRunsResults = @()
     $serverOutput = $null
     try {
         1..$Runs | ForEach-Object {
-            $clientOutput = Run-Foreground-Executable -File (Join-Path $Artifacts $QuicPing) -Arguments "-target:localhost -port:4433 -core:0 -uni:1 -length:$Length"
+            $clientOutput = Run-Foreground-Executable -File (Join-Path $Artifacts $QuicPing) -Arguments $ClientArgs
             $parsedRunResult = Parse-Loopback-Results -Results $clientOutput
             $allRunsResults += $parsedRunResult
             if ($PGO) {

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -63,10 +63,9 @@ QuicFuzzerRecvMsg(
 #define MAX_URO_PAYLOAD_LENGTH              (UINT16_MAX - QUIC_UDP_HEADER_SIZE)
 
 //
-// 60K is the largest buffer most NICs can offload without any software
-// segmentation. Current generation NICs advertise (60K < limit <= 64K).
+// The maximum single buffer size for sending coalesced payloads.
 //
-#define QUIC_LARGE_SEND_BUFFER_SIZE         0xF000
+#define QUIC_LARGE_SEND_BUFFER_SIZE         0xFFFF
 
 //
 // The maximum number of UDP datagrams to preallocate for URO.

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -55,7 +55,7 @@ QuicFuzzerRecvMsg(
 //
 // The maximum number of UDP datagrams that can be sent with one call.
 //
-#define QUIC_MAX_BATCH_SEND                 1
+#define QUIC_MAX_BATCH_SEND                 7
 
 //
 // The maximum UDP receive coalescing payload.


### PR DESCRIPTION
- Uses a consistent UDP tuple for the tests, so RSS always puts things on the same NUMA node.
- Uses UDP send batching (up to 7) to improve throughput.