### PR TITLE
Fix WPR Profile XML

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -128,6 +128,9 @@ $WpaStackWalkProfileXml = `
     </SystemCollector>
     <SystemProvider Id="SP_CPU">
       <Keywords>
+        <Keyword Value="CpuConfig"/>
+        <Keyword Value="Loader"/>
+        <Keyword Value="ProcessThread"/>
         <Keyword Value="SampledProfile"/>
       </Keywords>
       <Stacks>


### PR DESCRIPTION
The WPR profile XML wasn't collecting everything necessary to view the full stacks in WPA. Now it does.