### PR TITLE
Allow QuicPing server to specify number of connections allowed before shutting down

### DIFF
--- a/src/tools/ping/Client.cpp
+++ b/src/tools/ping/Client.cpp
@@ -42,13 +42,13 @@ void QuicPingClientRun()
             return;
         }
 
-        auto Connections = new PingConnection*[PingConfig.Client.ConnectionCount];
-        for (uint32_t i = 0; i < PingConfig.Client.ConnectionCount; i++) {
+        auto Connections = new PingConnection*[PingConfig.ConnectionCount];
+        for (uint32_t i = 0; i < PingConfig.ConnectionCount; i++) {
             Connections[i] =
                 new PingConnection(
                     &Tracker,
                     Session.Handle,
-                    PingConfig.Client.ConnectionCount == 1);
+                    PingConfig.ConnectionCount == 1);
             if (!Connections[i]) {
                 printf("Failed to open a connection!\n");
                 return;
@@ -64,7 +64,7 @@ void QuicPingClientRun()
         //
         // Start connecting to the remote server.
         //
-        for (uint32_t i = 0; i < PingConfig.Client.ConnectionCount; i++) {
+        for (uint32_t i = 0; i < PingConfig.ConnectionCount; i++) {
             Connections[i]->Connect();
         }
 
@@ -77,7 +77,7 @@ void QuicPingClientRun()
         }
     }
 
-    if (PingConfig.Client.ConnectionCount > 1 &&
+    if (PingConfig.ConnectionCount > 1 &&
         (Tracker.BytesSent != 0 || Tracker.BytesReceived != 0)) {
         uint64_t ElapsedMicroseconds = Tracker.CompleteTime - Tracker.StartTime;
         if (Timeout) {

--- a/src/tools/ping/PingConnection.cpp
+++ b/src/tools/ping/PingConnection.cpp
@@ -47,8 +47,7 @@ PingConnection::PingConnection(
 
 PingConnection::PingConnection(
     _In_ PingTracker* Tracker,
-    _In_ HQUIC Connection,
-    _In_ int OverloadToken
+    _In_ HQUIC Connection
     ) :
     Tracker(Tracker), QuicConnection(Connection), DumpResumption(false),
     ConnectedSuccessfully(false), BytesSent(0), BytesReceived(0), DatagramLength(0),

--- a/src/tools/ping/PingConnection.cpp
+++ b/src/tools/ping/PingConnection.cpp
@@ -33,19 +33,6 @@ PingConnection::PingConnection(
 }
 
 PingConnection::PingConnection(
-    _In_ HQUIC Connection
-    ) :
-    Tracker(nullptr), QuicConnection(Connection), DumpResumption(false),
-    ConnectedSuccessfully(false), BytesSent(0), BytesReceived(0), DatagramLength(0),
-    DatagramsSent(0), DatagramsAcked(0), DatagramsLost(0), DatagramsCancelled(0),
-    DatagramsReceived(0), DatagramsJitterTotal(0), DatagramLastTime(0),
-    TimedOut(false) {
-
-    StartTime = QuicTimeUs64();
-    MsQuic->SetCallbackHandler(Connection, (void*)QuicCallbackHandler, this);
-}
-
-PingConnection::PingConnection(
     _In_ PingTracker* Tracker,
     _In_ HQUIC Connection
     ) :

--- a/src/tools/ping/PingConnection.cpp
+++ b/src/tools/ping/PingConnection.cpp
@@ -45,6 +45,21 @@ PingConnection::PingConnection(
     MsQuic->SetCallbackHandler(Connection, (void*)QuicCallbackHandler, this);
 }
 
+PingConnection::PingConnection(
+    _In_ PingTracker* Tracker,
+    _In_ HQUIC Connection,
+    _In_ int OverloadToken
+    ) :
+    Tracker(Tracker), QuicConnection(Connection), DumpResumption(false),
+    ConnectedSuccessfully(false), BytesSent(0), BytesReceived(0), DatagramLength(0),
+    DatagramsSent(0), DatagramsAcked(0), DatagramsLost(0), DatagramsCancelled(0),
+    DatagramsReceived(0), DatagramsJitterTotal(0), DatagramLastTime(0),
+    TimedOut(false) {
+
+    StartTime = QuicTimeUs64();
+    MsQuic->SetCallbackHandler(Connection, (void*)QuicCallbackHandler, this);
+}
+
 PingConnection::~PingConnection() {
     if (QuicConnection != nullptr) {
         MsQuic->ConnectionClose(QuicConnection);

--- a/src/tools/ping/PingConnection.h
+++ b/src/tools/ping/PingConnection.h
@@ -111,7 +111,7 @@ struct PingConnection {
     PingConnection(
         _In_ PingTracker* Tracker,
         _In_ HQUIC Session,
-        _In_ bool DumpResumption = false
+        _In_ bool DumpResumption
         );
 
     //
@@ -123,13 +123,10 @@ struct PingConnection {
 
     //
     // Constructor for incoming connection with tracker.
-    // Overload token is because otherwise this matches the first constructor
-    // which is for clients.
     //
     PingConnection(
         _In_ PingTracker* Tracker,
-        _In_ HQUIC Connection,
-        _In_ int OverloadToken
+        _In_ HQUIC Connection
         );
 
     //

--- a/src/tools/ping/PingConnection.h
+++ b/src/tools/ping/PingConnection.h
@@ -49,6 +49,17 @@ struct PingTracker {
     }
 
     void
+    WaitForever(
+        ) {
+        if (InterlockedDecrement(&RefCount) == 0) {
+            CompleteTime = QuicTimeUs64();
+            return;
+        } else {
+            QuicEventWaitForever(Done);
+        }
+    }
+
+    void
     AddItem() {
         InterlockedIncrement(&RefCount);
     }
@@ -108,6 +119,17 @@ struct PingConnection {
     //
     PingConnection(
         _In_ HQUIC Connection
+        );
+
+    //
+    // Constructor for incoming connection with tracker.
+    // Overload token is because otherwise this matches the first constructor
+    // which is for clients.
+    //
+    PingConnection(
+        _In_ PingTracker* Tracker,
+        _In_ HQUIC Connection,
+        _In_ int OverloadToken
         );
 
     //

--- a/src/tools/ping/PingConnection.h
+++ b/src/tools/ping/PingConnection.h
@@ -115,13 +115,6 @@ struct PingConnection {
         );
 
     //
-    // Constructor for incoming connection.
-    //
-    PingConnection(
-        _In_ HQUIC Connection
-        );
-
-    //
     // Constructor for incoming connection with tracker.
     //
     PingConnection(

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -354,6 +354,7 @@ main(
     int ErrorCode = -1;
     uint16_t execProfile = DEFAULT_EXECUTION_PROFILE;
     QUIC_REGISTRATION_CONFIG RegConfig = { "quicping", DEFAULT_EXECUTION_PROFILE };
+    uint32_t connections = 0;
 
     QuicPlatformSystemLoad();
     QuicPlatformInitialize();
@@ -381,7 +382,6 @@ main(
     // 0 to the server means infinite. For client, 0 will be coorced into
     // DEFAULT_CLIENT_CONNECTION_COUNT
     //
-    uint32_t connections = 0;
     TryGetValue(argc, argv, "connections", &connections);
     PingConfig.ConnectionCount = connections;
 

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -299,6 +299,10 @@ ParseClientCommand(
 {
     PingConfig.ServerMode = false;
 
+    if (PingConfig.ConnectionCount == 0) {
+        PingConfig.ConnectionCount = DEFAULT_CLIENT_CONNECTION_COUNT;
+    }
+
     TryGetValue(argc, argv, "target", &PingConfig.Client.Target);
 
     uint16_t ip;
@@ -331,10 +335,6 @@ ParseClientCommand(
     PingConfig.Client.Version = version;
 
     TryGetValue(argc, argv, "resume", &PingConfig.Client.ResumeToken);
-
-    uint32_t connections = DEFAULT_CLIENT_CONNECTION_COUNT;
-    TryGetValue(argc, argv, "connections", &connections);
-    PingConfig.Client.ConnectionCount = connections;
 
     uint32_t waitTimeout = DEFAULT_WAIT_TIMEOUT;
     TryGetValue(argc, argv, "wait", &waitTimeout);
@@ -376,6 +376,14 @@ main(
         MsQuicClose(MsQuic);
         goto Error;
     }
+
+    //
+    // 0 to the server means infinite. For client, 0 will be coorced into
+    // DEFAULT_CLIENT_CONNECTION_COUNT
+    //
+    uint32_t connections = 0;
+    TryGetValue(argc, argv, "connections", &connections);
+    PingConfig.ConnectionCount = connections;
 
     //
     // Parse input to see if we are a client or server

--- a/src/tools/ping/QuicPing.h
+++ b/src/tools/ping/QuicPing.h
@@ -133,13 +133,14 @@ typedef struct QUIC_PING_CONFIG {
     uint32_t IoSize;
     uint32_t IoCount;
 
+    uint32_t ConnectionCount;
+
     struct {
         bool UseExplicitRemoteAddr : 1;
         const char* Target;         // SNI
         QUIC_ADDR RemoteIpAddr;
         uint32_t Version;           // QUIC protocol version
         const char* ResumeToken;
-        uint32_t ConnectionCount;
         uint32_t WaitTimeout;       // Milliseconds
     } Client;
 

--- a/src/tools/ping/Server.cpp
+++ b/src/tools/ping/Server.cpp
@@ -11,7 +11,6 @@ Abstract:
 
 #include "QuicPing.h"
 
-
 struct PingServer {
 
     HQUIC QuicListener;

--- a/src/tools/ping/Server.cpp
+++ b/src/tools/ping/Server.cpp
@@ -50,7 +50,7 @@ struct PingServer {
         ) {
         switch (Event->Type) {
         case QUIC_LISTENER_EVENT_NEW_CONNECTION: {
-            auto Connection = new PingConnection(&Tracker, Event->NEW_CONNECTION.Connection, 42);
+            auto Connection = new PingConnection(&Tracker, Event->NEW_CONNECTION.Connection);
             if (Connection != NULL) {
                 Event->NEW_CONNECTION.SecurityConfig = SecurityConfig;
                 if (!Connection->Initialize(true)) {


### PR DESCRIPTION
By doing this, performance tests can be cleaner to run, as they can explicitly state how many connections are expected. Also adds parity with the client