### PR TITLE
Disable Send Buffering for Perf

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -107,7 +107,7 @@ if ($IsWindows) {
 
 # QuicPing arguments
 $ServerArgs = "-listen:* -port:4433 -selfsign:1 -peer_uni:1 -connections:$Runs"
-$ClientArgs = "-target:localhost -port:4433 -uni:1 -length:$Length"
+$ClientArgs = "-target:localhost -port:4433 -sendbuf:0 -uni:1 -length:$Length"
 if ($IsWindows) {
     # Always use the same local address and core to provide more consistent results.
     $ClientArgs += " -bind:127.0.0.1:4434 -ip:4 -core:0"


### PR DESCRIPTION
When looking at a trace for some of the latest perf runs I noticed some CPU from send buffering. Let's disable that in our automated tests to see how much benefit we get.

Results from latest perf run with these changes:

Stub (i.e. no crypto):
```
Median: 14931989 kbps (+64.34%)
Master: 9085911 kbps
```
Schannel:
```
Median: 5818387 kbps (+23.08%)
Master: 4727407 kbps
```
FYI, @maolson-msft & @pravb here is the cost of send buffering. It's a lot more than I expected.