### PR TITLE
Updates Initial RTT Usage to Latest Spec

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1128,7 +1128,7 @@ QuicConnGetDestCidFromSeq(
 // Adds a sample (in microsec) to the connection's RTT estimator.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
+void
 QuicConnUpdateRtt(
     _In_ QUIC_CONNECTION* Connection,
     _In_ QUIC_PATH* Path,

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -321,7 +321,7 @@ QuicLossDetectionUpdateTimer(
         TimeoutType = LOSS_TIMER_INITIAL;
         TimeFires =
             LossDetection->TimeOfLastPacketSent +
-            ((2 * Path->SmoothedRtt) << LossDetection->ProbeCount);
+            ((Path->SmoothedRtt + 4 * Path->RttVariance) << LossDetection->ProbeCount);
 
     } else {
         TimeoutType = LOSS_TIMER_PROBE;

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -34,6 +34,7 @@ QuicPathInitialize(
     } else {
         Path->SmoothedRtt = MS_TO_US(QUIC_INITIAL_RTT);
     }
+    Path->RttVariance = Path->SmoothedRtt / 2;
 
     QuicTraceLogConnInfo(
         PathInitialized,

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -25,7 +25,7 @@ typedef struct QUIC_PATH QUIC_PATH;
 // Until the first RTT sample is collected, this is the default estimate of the
 // RTT.
 //
-#define QUIC_INITIAL_RTT                        500 // millisec
+#define QUIC_INITIAL_RTT                        333 // millisec
 
 //
 // The minimum QUIC Packet Size (UDP payload size) for initial QUIC packets.


### PR DESCRIPTION
Updates the initial RTT value and usage to match the latest loss recovery spec. The PTO is still ~1 second after the first packet, so practically things are unchanged.

For the specific spec change, see https://github.com/quicwg/base-drafts/pull/3525/files