### PR TITLE
Fix azure build temp directory

### DIFF
--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -12,12 +12,12 @@ jobs:
     inputs:
       artifactName: drop
       itemPattern: drop/win*/*_schannel/**
-      downloadPath: $(Build.TempDirectory)
+      downloadPath: $(Agent.TempDirectory)
 
   - task: CopyFiles@2
     displayName: Move Build Artifacts
     inputs:
-      sourceFolder: $(Build.TempDirectory)/drop
+      sourceFolder: $(Agent.TempDirectory)/drop
       targetFolder: artifacts
 
   - task: PowerShell@2

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -14,7 +14,7 @@ steps:
     downloadPath: $(Agent.TempDirectory)
 
 - task: DownloadBuildArtifacts@0
-  displayName: Download�CLOG Artifacts
+  displayName: Download CLOG Artifacts
   inputs:
     artifactName: drop
     itemPattern: drop/clog/**

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -11,19 +11,19 @@ steps:
   inputs:
     artifactName: drop
     itemPattern: drop/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
-    downloadPath: $(Build.TempDirectory)
+    downloadPath: $(Agent.TempDirectory)
 
 - task: DownloadBuildArtifacts@0
-  displayName: Download CLOG Artifacts
+  displayName: Downloadï¿½CLOG Artifacts
   inputs:
     artifactName: drop
     itemPattern: drop/clog/**
-    downloadPath: $(Build.TempDirectory)
+    downloadPath: $(Agent.TempDirectory)
 
 - task: CopyFiles@2
   displayName: Move Build Artifacts
   inputs:
-    sourceFolder: $(Build.TempDirectory)/drop
+    sourceFolder: $(Agent.TempDirectory)/drop
     targetFolder: artifacts
 
 - task: PowerShell@2

--- a/.azure/templates/publish-performance.yml
+++ b/.azure/templates/publish-performance.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Download Build Artifacts
     inputs:
       artifactName: performance
-      downloadPath: $(Build.TempDirectory)
+      downloadPath: $(Agent.TempDirectory)
 
   - task: CopyFiles@2
     displayName: Move Build Artifacts


### PR DESCRIPTION
Build.TempDirectory is not a variable, and just gets used as the folder name. Agent.TempDirectory is unique per test