### PR TITLE
buildessential and not buildessentials

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -70,7 +70,7 @@ if ($IsWindows) {
             sudo apt-add-repository ppa:lttng/stable-2.10
             sudo apt-get update
             sudo apt-get install -y cmake
-            sudo apt-get install -y build-essentials
+            sudo apt-get install -y build-essential
             sudo apt-get install -y liblttng-ust-dev
             sudo apt-get install -y lttng-tools
         }


### PR DESCRIPTION
please verify this with a fresh WSL2 (I'm using Ubuntu18.04 LTS)