### PR TITLE
Fix up issues in the PS Performance script

### DIFF
--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -385,13 +385,11 @@ function Get-MedianTestResults($FullResults) {
 }
 
 function Get-TestResult($Results, $Matcher) {
-    try {
-        # Unused variable on purpose
-        $Results -match $Matcher | Out-Null
+    $Found = $Results -match $Matcher
+    if ($Found) {
         return $Matches[1]
-    } catch {
-        Write-Output "Error Processing Results:`n`n$Results"
-        throw
+    } else {
+        Write-Error "Error Processing Results:`n`n$Results"
     }
 }
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -352,7 +352,6 @@ function Remove-RemoteFile {
 function Invoke-LocalExe {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
     param ($Exe, $RunArgs, $Timeout)
-
     if (!$IsWindows) {
         $BasePath = Split-Path $Exe -Parent
         $env:LD_LIBRARY_PATH = $BasePath
@@ -361,7 +360,7 @@ function Invoke-LocalExe {
     $FullCommand = "$Exe $RunArgs"
     Write-Debug "Running Locally: $FullCommand"
 
-    $LocalJob = Invoke-Command -ScriptBlock { & $Exe ($RunArgs).Split(" ") } -AsJob
+    $LocalJob = Start-Job -ScriptBlock { & $Using:Exe ($Using:RunArgs).Split(" ") }
 
     # Wait 60 seconds for the job to finish
     Wait-Job -Job $LocalJob -Timeout $Timeout | Out-Null

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -351,7 +351,7 @@ function Remove-RemoteFile {
 
 function Invoke-LocalExe {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
-    param ($Exe, $RunArgs)
+    param ($Exe, $RunArgs, $Timeout)
 
     if (!$IsWindows) {
         $BasePath = Split-Path $Exe -Parent
@@ -364,7 +364,7 @@ function Invoke-LocalExe {
     $LocalJob = Invoke-Command -ScriptBlock { & $Exe ($RunArgs).Split(" ") } -AsJob
 
     # Wait 60 seconds for the job to finish
-    Wait-Job -Job $LocalJob -Timeout 60 | Out-Null
+    Wait-Job -Job $LocalJob -Timeout $Timeout | Out-Null
     Stop-Job -Job $LocalJob | Out-Null
 
     $RetVal = Receive-Job -Job $LocalJob

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -47,7 +47,7 @@ This script runs performance tests locally for a period of time.
 param (
     [Parameter(Mandatory = $false)]
     [ValidateSet("Debug", "Release")]
-    [string]$Config = "Debug",
+    [string]$Config = "Release",
 
     [Parameter(Mandatory = $false)]
     [string]$TestsFile = "",
@@ -56,16 +56,20 @@ param (
     [string]$Remote = "",
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet("x86", "x64", "arm", "arm64")]
     [string]$LocalArch = "x64",
 
     [Parameter(Mandatory = $false)]
-    [string]$LocalTls = "stub",
+    [ValidateSet("schannel", "openssl", "stub", "mitls")]
+    [string]$LocalTls = "",
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet("x86", "x64", "arm", "arm64")]
     [string]$RemoteArch = "x64",
 
     [Parameter(Mandatory = $false)]
-    [string]$RemoteTls = "stub",
+    [ValidateSet("schannel", "openssl", "stub", "mitls")]
+    [string]$RemoteTls = "",
 
     [Parameter(Mandatory = $false)]
     [string]$ComputerName = "quic-server",
@@ -88,7 +92,7 @@ param (
     [Parameter(Mandatory = $false)]
     [switch]$PGO = $false,
 
-    [number]$Timeout = 60
+    [int]$Timeout = 60
 )
 
 Set-StrictMode -Version 'Latest'
@@ -106,6 +110,22 @@ if ($IsWindows) {
 } else {
     $LocalPlatform = "linux"
 }
+
+# Set Tls
+if (($LocalTls -eq "") -and ($RemoteTls -eq "")) {
+    if ($IsWindows) {
+        $LocalTls = "schannel"
+        $RemoteTls = $LocalTls
+    } else {
+        $LocalTls = "openssl"
+        $RemoteTls = $LocalTls
+    }
+} elseif (($LocalTls -ne "") -xor ($RemoteTls -ne "")) {
+    Write-Error "Both TLS arguments must be set if a manual setting is done"
+}
+
+Write-Host $LocalTls
+Write-Host $RemoteTls
 
 if (!$IsWindows) {
     if ($PGO) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -124,9 +124,6 @@ if (($LocalTls -eq "") -and ($RemoteTls -eq "")) {
     Write-Error "Both TLS arguments must be set if a manual setting is done"
 }
 
-Write-Host $LocalTls
-Write-Host $RemoteTls
-
 if (!$IsWindows) {
     if ($PGO) {
         Write-Error "'-PGO' is not supported on this platform!"

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -39,6 +39,9 @@ This script runs performance tests locally for a period of time.
 .PARAMETER Record
     Records ETW traces
 
+.PARAMETER Timeout
+    Timeout in seconds for each individual client test invocation.
+
 #>
 
 param (
@@ -83,7 +86,9 @@ param (
     [switch]$Record = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$PGO = $false
+    [switch]$PGO = $false,
+
+    [number]$Timeout = 60
 )
 
 Set-StrictMode -Version 'Latest'
@@ -274,7 +279,7 @@ function Invoke-Test {
 
     try {
         1..$Test.Iterations | ForEach-Object {
-            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments
+            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout
             $LocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher
             $AllRunsResults += $LocalParsedResults
             if ($PGO) {


### PR DESCRIPTION
Timeout added to local run (configurable)
Local matcher now prints error on failure
Release mode as default
Automatically configure tls to match system if not set
Validate sets for tls and arch to enable tab completion