### PR TITLE
Static WSK Receive Callbacks

### DIFF
--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -228,10 +228,10 @@ QuicTraceStubVarArgs(
 #define QuicTraceLogInfoEnabled()    EventEnabledQuicLogInfo()
 #define QuicTraceLogVerboseEnabled() EventEnabledQuicLogVerbose()
 
-#if DEBUG
-#define QUIC_ETW_BUFFER_LENGTH 512
+#ifdef _KERNEL_MODE
+#define QUIC_ETW_BUFFER_LENGTH 64
 #else
-#define QUIC_ETW_BUFFER_LENGTH 256
+#define QUIC_ETW_BUFFER_LENGTH 128
 #endif
 
 #define LogEtw(EventName, Fmt, ...) \

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1383,6 +1383,12 @@ QuicDataPathBindingCreate(
         goto Error;
     }
 
+    //
+    // Must set output pointer first thing, as the receive path will try to
+    // use the output.
+    //
+    *NewBinding = Binding;
+
     RtlZeroMemory(Binding, sizeof(QUIC_DATAPATH_BINDING));
     Binding->Datapath = Datapath;
     Binding->ClientContext = RecvCallbackContext;
@@ -1677,12 +1683,6 @@ QuicDataPathBindingCreate(
             goto Error;
         }
     }
-
-    //
-    // Must set output pointer before starting receive path, as the receive path
-    // will try to use the output.
-    //
-    *NewBinding = Binding;
 
     //
     // If no specific local port was indicated, then the stack just

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -823,7 +823,11 @@ QuicDataPathInitialize(
     uint32_t DatapathLength;
     QUIC_DATAPATH* Datapath;
     BOOLEAN WskRegistered = FALSE;
-    WSK_EVENT_CALLBACK_CONTROL CallbackControl;
+    WSK_EVENT_CALLBACK_CONTROL CallbackControl =
+    {
+        &NPI_WSK_INTERFACE_ID,
+        WSK_EVENT_RECEIVE_FROM
+    };
 
     if (RecvCallback == NULL || UnreachableCallback == NULL || NewDataPath == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
@@ -921,8 +925,6 @@ QuicDataPathInitialize(
         goto Error;
     }
 
-    CallbackControl.NpiId = (PNPIID)&NPI_WSK_INTERFACE_ID;
-    CallbackControl.EventMask = WSK_EVENT_RECEIVE_FROM;
     Status =
         Datapath->WskProviderNpi.Dispatch->
         WskControlClient(

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -482,17 +482,10 @@ QuicDataPathIoCompletion(
     )
 {
     UNREFERENCED_PARAMETER(DeviceObject);
+    UNREFERENCED_PARAMETER(Irp);
 
-    if (Irp->PendingReturned) {
-        QUIC_EVENT* CompletionEvent = (QUIC_EVENT*)Context;
-        NT_ASSERT(CompletionEvent);
-
-        //
-        // Set the event to indicate we have completed the operation.
-        //
-#pragma prefast(suppress: 28182, "SAL doesn't understand this callback parameter")
-        QuicEventSet(*CompletionEvent);
-    }
+    QUIC_DBG_ASSERT(Context != NULL);
+    KeSetEvent((KEVENT*)Context, IO_NO_INCREMENT, FALSE);
 
     //
     // Always return STATUS_MORE_PROCESSING_REQUIRED to

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -549,10 +549,11 @@ public:
             Iter = &((*Iter)->Next);
         }
         *Iter = Hook;
-        if (Hooks == Hook) {
+        bool DoRegister = Hooks == Hook;
+        QuicDispatchLockRelease(&Lock);
+        if (DoRegister) {
             Register();
         }
-        QuicDispatchLockRelease(&Lock);
     }
 
     void RemoveHook(DatapathHook* Hook) {
@@ -562,10 +563,11 @@ public:
             Iter = &((*Iter)->Next);
         }
         *Iter = Hook->Next;
-        if (Hooks == nullptr) {
+        bool DoUnregister = Hooks == nullptr;
+        QuicDispatchLockRelease(&Lock);
+        if (DoUnregister) {
             Unregister();
         }
-        QuicDispatchLockRelease(&Lock);
     }
 };
 


### PR DESCRIPTION
When looking at the performance traces, we found that the receive callbacks were taking a significant amount of time in a spinlock and it came down to MsQuic not using static callbacks.