### PR TITLE
Switch msquic.h to use local header includes rather then system header includes

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -29,11 +29,11 @@ Supported Platforms:
 #pragma warning(disable:4214)  // nonstandard extension used: bit field types other than int
 
 #ifdef _KERNEL_MODE
-#include <msquic_winkernel.h>
+#include "msquic_winkernel.h"
 #elif _WIN32
-#include <msquic_winuser.h>
+#include "msquic_winuser.h"
 #elif __linux__
-#include <msquic_linux.h>
+#include "msquic_linux.h"
 #else
 #error "Unsupported Platform"
 #endif

--- a/src/inc/msquic_linux.h
+++ b/src/inc/msquic_linux.h
@@ -32,7 +32,7 @@ Environment:
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <quic_sal_stub.h>
+#include "quic_sal_stub.h"
 
 #ifdef __cplusplus
 extern "C++" {


### PR DESCRIPTION
I ran into a case where I just copied msquic.h and msquic_winuser.h into a basic c++ project, and the headers failed to compile because it wasn't looking in the local directory.