### PR TITLE
Fix Kernel Mode Tests on Debug

### DIFF
--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -228,10 +228,10 @@ QuicTraceStubVarArgs(
 #define QuicTraceLogInfoEnabled()    EventEnabledQuicLogInfo()
 #define QuicTraceLogVerboseEnabled() EventEnabledQuicLogVerbose()
 
-#if DEBUG
-#define QUIC_ETW_BUFFER_LENGTH 512
+#ifdef _KERNEL_MODE
+#define QUIC_ETW_BUFFER_LENGTH 64
 #else
-#define QUIC_ETW_BUFFER_LENGTH 256
+#define QUIC_ETW_BUFFER_LENGTH 128
 #endif
 
 #define LogEtw(EventName, Fmt, ...) \

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -549,10 +549,11 @@ public:
             Iter = &((*Iter)->Next);
         }
         *Iter = Hook;
-        if (Hooks == Hook) {
+        bool DoRegister = Hooks == Hook;
+        QuicDispatchLockRelease(&Lock);
+        if (DoRegister) {
             Register();
         }
-        QuicDispatchLockRelease(&Lock);
     }
 
     void RemoveHook(DatapathHook* Hook) {
@@ -562,10 +563,11 @@ public:
             Iter = &((*Iter)->Next);
         }
         *Iter = Hook->Next;
-        if (Hooks == nullptr) {
+        bool DoUnregister = Hooks == nullptr;
+        QuicDispatchLockRelease(&Lock);
+        if (DoUnregister) {
             Unregister();
         }
-        QuicDispatchLockRelease(&Lock);
     }
 };
 


### PR DESCRIPTION
Fixes for getting kernel mode tests running for debug builds. They now all run/pass locally. Next step is to get it automated.