### PR TITLE
Make perf results be placed into a path including configuration.

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -179,8 +179,7 @@ if ($Local) {
 
 Set-Session -Session $Session
 
-$OutputDir = Join-Path $RootDir "artifacts/PerfDataResults"
-New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+
 
 $RemotePlatform = Invoke-TestCommand -Session $Session -ScriptBlock {
     if ($IsWindows) {
@@ -189,6 +188,9 @@ $RemotePlatform = Invoke-TestCommand -Session $Session -ScriptBlock {
         return "linux"
     }
 }
+
+$OutputDir = Join-Path $RootDir "artifacts/PerfDataResults/$RemotePlatform/$($RemoteArch)_$($Config)_$($RemoteTls)"
+New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
 # Join path in script to ensure right platform separator
 $RemoteDirectory = Invoke-TestCommand -Session $Session -ScriptBlock {


### PR DESCRIPTION
Without this, during PGO runs the PGO data has the same name, and gets put into the same location on azure, overwriting the prior test