### PR TITLE
Remove QPC from Indicate Event Functions

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -696,26 +696,11 @@ QuicConnIndicateEvent(
                 Connection,
                 "Event silently discarded (no handler).");
         } else {
-            uint64_t StartTime = QuicTimeUs64();
             Status =
                 Connection->ClientCallbackHandler(
                     (HQUIC)Connection,
                     Connection->ClientContext,
                     Event);
-            uint64_t EndTime = QuicTimeUs64();
-            if (EndTime - StartTime > QUIC_MAX_CALLBACK_TIME_WARNING) {
-                QuicTraceLogConnWarning(
-                    ApiEventTooLong,
-                    Connection,
-                    "App took excessive time (%llu us) in callback.",
-                    (EndTime - StartTime));
-                QUIC_TEL_ASSERTMSG_ARGS(
-                    EndTime - StartTime < QUIC_MAX_CALLBACK_TIME_ERROR,
-                    "App extremely long time in connection callback",
-                    Connection->Registration == NULL ?
-                        NULL : Connection->Registration->AppName,
-                    Event->Type, 0);
-            }
         }
     } else {
         Status = QUIC_STATUS_INVALID_STATE;

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -330,26 +330,11 @@ QuicListenerIndicateEvent(
     )
 {
     QUIC_FRE_ASSERT(Listener->ClientCallbackHandler);
-    uint64_t StartTime = QuicTimeUs64();
-    QUIC_STATUS Status =
+    return
         Listener->ClientCallbackHandler(
             (HQUIC)Listener,
             Listener->ClientContext,
             Event);
-    uint64_t EndTime = QuicTimeUs64();
-    if (EndTime - StartTime > QUIC_MAX_CALLBACK_TIME_WARNING) {
-        QuicTraceLogWarning(
-            ListenerExcessiveAppCallback,
-            "[list][%p] App took excessive time (%llu us) in callback.",
-            Listener,
-            (EndTime - StartTime));
-        QUIC_TEL_ASSERTMSG_ARGS(
-            EndTime - StartTime < QUIC_MAX_CALLBACK_TIME_ERROR,
-            "App extremely long time in listener callback",
-            Listener->Session->Registration->AppName,
-            Event->Type, 0);
-    }
-    return Status;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -338,26 +338,11 @@ QuicStreamIndicateEvent(
 {
     QUIC_STATUS Status;
     if (Stream->ClientCallbackHandler != NULL) {
-        uint64_t StartTime = QuicTimeUs64();
         Status =
             Stream->ClientCallbackHandler(
                 (HQUIC)Stream,
                 Stream->ClientContext,
                 Event);
-        uint64_t EndTime = QuicTimeUs64();
-        if (EndTime - StartTime > QUIC_MAX_CALLBACK_TIME_WARNING) {
-            QuicTraceLogStreamWarning(
-                AppTooLong,
-                Stream,
-                "App took excessive time (%llu us) in callback.",
-                (EndTime - StartTime));
-            QUIC_TEL_ASSERTMSG_ARGS(
-                EndTime - StartTime < QUIC_MAX_CALLBACK_TIME_ERROR,
-                "App extremely long time in stream callback",
-                Stream->Connection->Registration == NULL ?
-                    NULL : Stream->Connection->Registration->AppName,
-                Event->Type, 0);
-        }
     } else {
         Status = QUIC_STATUS_INVALID_STATE;
         QuicTraceLogStreamWarning(


### PR DESCRIPTION
When looking through performance traces, QPC (QueryPerformanceCounter on Windows) seemed to take an unacceptable amount of time for every event indicated up to the app. These checks have never resulted in any actionable bug, and even if we did see the event, it'd be very difficult to say the scheduler wasn't to blame here. So, it seems best just to remove these.