### PR TITLE
Pool Allocator for Default Stream Recv Buffer

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -149,7 +149,8 @@ QuicCryptoInitialize(
             &Crypto->RecvBuffer,
             InitialRecvBufferLength,
             QUIC_DEFAULT_STREAM_FC_WINDOW_SIZE / 2,
-            TRUE);
+            TRUE,
+            NULL);
     if (QUIC_FAILED(Status)) {
         goto Exit;
     }

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -32,6 +32,11 @@ typedef struct QUIC_RECV_BUFFER {
     uint8_t * Buffer;
 
     //
+    // Optional, preallocated initial buffer.
+    //
+    uint8_t * PreallocatedBuffer;
+
+    //
     // Length of memory allocated for 'Buffer'. Dynamically grows up to
     // VirtualBufferLength.
     //
@@ -65,7 +70,8 @@ QuicRecvBufferInitialize(
     _Inout_ QUIC_RECV_BUFFER* RecvBuffer,
     _In_ uint32_t AllocBufferLength,
     _In_ uint32_t VirtualBufferLength,
-    _In_ BOOLEAN CopyOnDrain
+    _In_ BOOLEAN CopyOnDrain,
+    _In_opt_ uint8_t* PreallocatedBuffer
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -442,6 +442,10 @@ QuicSettingsLoad(
             QUIC_SETTING_STREAM_RECV_BUFFER_SIZE,
             (uint8_t*)&Settings->StreamRecvBufferDefault,
             &ValueLen);
+        if (!IS_POWER_OF_TWO(Settings->StreamRecvBufferDefault) ||
+            Settings->StreamRecvBufferDefault < QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE) {
+            Settings->StreamRecvBufferDefault = QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE;
+        }
     }
 
     if (!Settings->AppSet.ConnFlowControlWindow) {

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -54,6 +54,7 @@ QuicWorkerInitialize(
     QuicListInitializeHead(&Worker->Connections);
     QuicListInitializeHead(&Worker->Operations);
     QuicPoolInitialize(FALSE, sizeof(QUIC_STREAM), &Worker->StreamPool);
+    QuicPoolInitialize(FALSE, QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE, &Worker->DefaultReceiveBufferPool);
     QuicPoolInitialize(FALSE, sizeof(QUIC_SEND_REQUEST), &Worker->SendRequestPool);
     QuicSentPacketPoolInitialize(&Worker->SentPacketPool);
     QuicPoolInitialize(FALSE, sizeof(QUIC_API_CONTEXT), &Worker->ApiContextPool);
@@ -92,6 +93,7 @@ Error:
 
     if (QUIC_FAILED(Status)) {
         QuicPoolUninitialize(&Worker->StreamPool);
+        QuicPoolUninitialize(&Worker->DefaultReceiveBufferPool);
         QuicPoolUninitialize(&Worker->SendRequestPool);
         QuicSentPacketPoolUninitialize(&Worker->SentPacketPool);
         QuicPoolUninitialize(&Worker->ApiContextPool);
@@ -131,6 +133,7 @@ QuicWorkerUninitialize(
     QUIC_TEL_ASSERT(QuicListIsEmpty(&Worker->Operations));
 
     QuicPoolUninitialize(&Worker->StreamPool);
+    QuicPoolUninitialize(&Worker->DefaultReceiveBufferPool);
     QuicPoolUninitialize(&Worker->SendRequestPool);
     QuicSentPacketPoolUninitialize(&Worker->SentPacketPool);
     QuicPoolUninitialize(&Worker->ApiContextPool);

--- a/src/core/worker.h
+++ b/src/core/worker.h
@@ -68,6 +68,7 @@ typedef struct QUIC_CACHEALIGN QUIC_WORKER {
     uint64_t DroppedOperationCount;
 
     QUIC_POOL StreamPool; // QUIC_STREAM
+    QUIC_POOL DefaultReceiveBufferPool; // QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE
     QUIC_POOL SendRequestPool; // QUIC_SEND_REQUEST
     QUIC_SENT_PACKET_POOL SentPacketPool; // QUIC_SENT_PACKET_METADATA
     QUIC_POOL ApiContextPool; // QUIC_API_CONTEXT


### PR DESCRIPTION
One more (fairly large) performance bottleneck was the allocation of the stream's receive buffer. This change improves the initial allocation of said buffer, when the default initial size is used (which is the majority case), by using a per-worker/proc pool allocator for the buffer.