### PR TITLE
Refactors Build Artifacts

### DIFF
--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -9,22 +9,16 @@ steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download Build Artifacts
   inputs:
-    artifactName: drop
-    itemPattern: drop/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
-    downloadPath: $(Agent.TempDirectory)
+    artifactName: bin
+    itemPattern: bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+    downloadPath: artifacts
 
 - task: DownloadBuildArtifacts@0
   displayName: Download CLOG Artifacts
   inputs:
-    artifactName: drop
-    itemPattern: drop/clog/**
+    artifactName: bin
+    itemPattern: bin/clog/**
     downloadPath: $(Agent.TempDirectory)
-
-- task: CopyFiles@2
-  displayName: Move Build Artifacts
-  inputs:
-    sourceFolder: $(Agent.TempDirectory)/drop
-    targetFolder: artifacts
 
 - task: PowerShell@2
   displayName: Install Build Artifacts

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -4,6 +4,7 @@ parameters:
   platform: ''
   arch: ''
   tls: ''
+  includeKernel: false
 
 steps:
 - task: DownloadBuildArtifacts@0
@@ -13,12 +14,20 @@ steps:
     itemPattern: bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
     downloadPath: artifacts
 
+- ${{ if eq(parameters.includeKernel, true) }}:
+  - task: DownloadBuildArtifacts@0
+    displayName: Download Kernel Build Artifacts
+    inputs:
+      artifactName: bin
+      itemPattern: bin/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+      downloadPath: artifacts
+
 - task: DownloadBuildArtifacts@0
   displayName: Download CLOG Artifacts
   inputs:
     artifactName: bin
     itemPattern: bin/clog/**
-    downloadPath: $(Agent.TempDirectory)
+    downloadPath: artifacts
 
 - task: PowerShell@2
   displayName: Install Build Artifacts

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -35,13 +35,7 @@ jobs:
       platform: ${{ parameters.platform }}
       arch: ${{ parameters.arch }}
       tls: ${{ parameters.tls }}
-
-  - ${{ if parameters.kernel }}:
-    - template: ./download-artifacts.yml
-      parameters:
-        platform: winkernel
-        arch: ${{ parameters.arch }}
-        tls: ${{ parameters.tls }}
+      includeKernel: ${{ parameters.kernel }}
 
   - task: PowerShell@2
     displayName: Prepare Test Machine

--- a/.azure/templates/upload-artifacts.yml
+++ b/.azure/templates/upload-artifacts.yml
@@ -11,6 +11,6 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Upload Build Artifacts
   inputs:
-    artifactName: drop
+    artifactName: bin
     pathToPublish: $(Build.ArtifactStagingDirectory)
     parallel: true

--- a/.azure/templates/upload-artifacts.yml
+++ b/.azure/templates/upload-artifacts.yml
@@ -4,7 +4,7 @@ steps:
 - task: CopyFiles@2
   displayName: Move Build Artifacts
   inputs:
-    sourceFolder: artifacts
+    sourceFolder: artifacts/bin
     contents: '**/!(*.ilk|*.cer|*.exp|*.lastcodeanalysissucceeded)'
     targetFolder: $(Build.ArtifactStagingDirectory)
 

--- a/docs/InteropServerSetup.md
+++ b/docs/InteropServerSetup.md
@@ -11,13 +11,13 @@ There are a few additional things to note beyond the default build instructions.
 Once built, you can find the `quicinteropserver` in (assuming PowerShell is used to build):
 
 ```
-./artifacts/{platform}/{arch}_{config}_{tls}
+./artifacts/bin/{platform}/{arch}_{config}_{tls}
 ```
 
 For example, if you build with `build.ps1 -Config Release -Tls mitls` on Windows, the output would be in:
 
 ```
-./artifacts/windows/x64_release_mitls
+./artifacts/bin/windows/x64_release_mitls
 ```
 
 The directory contains all the build artifacts, including the base MsQuic library (`msquic.dll` or `libmsquic.so`).

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -146,7 +146,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $BaseArtifactsDir = Join-Path $RootDir "artifacts"
 $BaseBuildDir = Join-Path $RootDir "build"
 
-$ArtifactsDir = Join-Path $BaseArtifactsDir $Platform
+$ArtifactsDir = Join-Path $BaseArtifactsDir "bin" $Platform
 $BuildDir = Join-Path $BaseBuildDir $Platform
 
 $ArtifactsDir = Join-Path $ArtifactsDir "$($Arch)_$($Config)_$($Tls)"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -251,7 +251,7 @@ function CMake-Build {
     CMake-Execute $Arguments
 
     # Copy clog to a common location.
-    $ClogPath = Join-Path $BaseArtifactsDir "clog"
+    $ClogPath = Join-Path $BaseArtifactsDir "bin/clog"
     if (!(Test-Path $ClogPath)) {
         Copy-Item (Join-Path $BuildDir "submodules/clog") -Destination $ClogPath -Recurse
     }

--- a/scripts/install-build-artifacts.ps1
+++ b/scripts/install-build-artifacts.ps1
@@ -36,7 +36,7 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
 # Important directories.
 $RootDir = Split-Path $PSScriptRoot -Parent
-$ArtifactsDir = Join-Path $RootDir "artifacts"
+$ArtifactsDir = Join-Path $RootDir "artifacts/bin"
 
 if ($IsWindows) {
     if (!(Test-Path "C:\Windows\System32\drivers\msquic.sys")) {

--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -110,9 +110,9 @@ $RunExecutable = Join-Path $RootDir "scripts/run-executable.ps1"
 # Path to the quicinterop exectuable.
 $QuicInterop = $null
 if ($IsWindows) {
-    $QuicInterop = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\quicinterop.exe"
+    $QuicInterop = Join-Path $RootDir "\artifacts\bin\windows\$($Arch)_$($Config)_$($Tls)\quicinterop.exe"
 } else {
-    $QuicInterop = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/quicinterop"
+    $QuicInterop = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/quicinterop"
 }
 
 # Make sure the build is present.

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -197,7 +197,7 @@ $RemoteDirectory = Invoke-TestCommand -Session $Session -ScriptBlock {
     Join-Path (Get-Location) "Tests"
 }
 
-$LocalDirectory = Join-Path $RootDir "artifacts"
+$LocalDirectory = Join-Path $RootDir "artifacts/bin"
 
 if ($Local) {
     $RemoteDirectory = $LocalDirectory

--- a/scripts/prepare-package.ps1
+++ b/scripts/prepare-package.ps1
@@ -41,7 +41,7 @@ $Archs = [System.Tuple]::Create("arm","arm","arm"), [System.Tuple]::Create("arm6
          [System.Tuple]::Create("x86","x86","i386"), [System.Tuple]::Create("x64","amd64","amd64")
 foreach ($Config in $Configs) {
     foreach ($Arch in $Archs) {
-        $InputDir = Join-Path $ArtifactsDir "windows/$($Arch.Item1)_$($Config.Item1)_schannel"
+        $InputDir = Join-Path $ArtifactsDir "bin/windows/$($Arch.Item1)_$($Config.Item1)_schannel"
         Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/user")
         Force-Copy (Join-Path $InputDir "msquic.dll") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
         Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
@@ -56,7 +56,7 @@ $Archs = [System.Tuple]::Create("ARM","arm","arm"), [System.Tuple]::Create("ARM6
          [System.Tuple]::Create("Win32","x86","i386"), [System.Tuple]::Create("x64","amd64","amd64")
 foreach ($Config in $Configs) {
     foreach ($Arch in $Archs) {
-        $InputDir = Join-Path $ArtifactsDir "winkernel/$($Arch.Item1)_$($Config.Item1)_schannel"
+        $InputDir = Join-Path $ArtifactsDir "bin/winkernel/$($Arch.Item1)_$($Config.Item1)_schannel"
         Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/kernel")
         Force-Copy (Join-Path $InputDir "msquic.sys") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
         Force-Copy (Join-Path $InputDir "msquictest.sys") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -86,9 +86,9 @@ $RunExecutable = Join-Path $RootDir "scripts/run-executable.ps1"
 # Path to the spinquic exectuable.
 $SpinQuic = $null
 if ($IsWindows) {
-    $SpinQuic = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\spinquic.exe"
+    $SpinQuic = Join-Path $RootDir "\artifacts\bin\windows\$($Arch)_$($Config)_$($Tls)\spinquic.exe"
 } else {
-    $SpinQuic = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/spinquic"
+    $SpinQuic = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/spinquic"
 }
 
 # Make sure the build is present.

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -163,14 +163,14 @@ $MsQuicCoreTest = $null
 $MsQuicPlatTest = $null
 $KernelPath = $null;
 if ($IsWindows) {
-    $MsQuicTest = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\msquictest.exe"
-    $MsQuicCoreTest = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\msquiccoretest.exe"
-    $MsQuicPlatTest = Join-Path $RootDir "\artifacts\windows\$($Arch)_$($Config)_$($Tls)\msquicplatformtest.exe"
-    $KernelPath = Join-Path $RootDir "\artifacts\winkernel\$($Arch)_$($Config)_$($Tls)"
+    $MsQuicTest = Join-Path $RootDir "\artifacts\bin\windows\$($Arch)_$($Config)_$($Tls)\msquictest.exe"
+    $MsQuicCoreTest = Join-Path $RootDir "\artifacts\bin\windows\$($Arch)_$($Config)_$($Tls)\msquiccoretest.exe"
+    $MsQuicPlatTest = Join-Path $RootDir "\artifacts\bin\windows\$($Arch)_$($Config)_$($Tls)\msquicplatformtest.exe"
+    $KernelPath = Join-Path $RootDir "\artifacts\bin\winkernel\$($Arch)_$($Config)_$($Tls)"
 } else {
-    $MsQuicTest = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/msquictest"
-    $MsQuicCoreTest = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/msquiccoretest"
-    $MsQuicPlatTest = Join-Path $RootDir "/artifacts/linux/$($Arch)_$($Config)_$($Tls)/msquicplatformtest"
+    $MsQuicTest = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/msquictest"
+    $MsQuicCoreTest = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/msquiccoretest"
+    $MsQuicPlatTest = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/msquicplatformtest"
 }
 
 # Make sure the build is present.

--- a/src/bin/winkernel/msquic.kernel.vcxproj
+++ b/src/bin/winkernel/msquic.kernel.vcxproj
@@ -81,7 +81,7 @@
     <TargetName>msquic</TargetName>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <EnableInf2cat>false</EnableInf2cat>
-    <OutDir>$(SolutionDir)artifacts\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>
+    <OutDir>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>
     <IntDir>$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\obj\$(ProjectName)\</IntDir>
     <SignMode>Off</SignMode>
   </PropertyGroup>

--- a/src/test/bin/winkernel/msquictest.kernel.vcxproj
+++ b/src/test/bin/winkernel/msquictest.kernel.vcxproj
@@ -82,7 +82,7 @@
     <TargetName>msquictest</TargetName>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <EnableInf2cat>false</EnableInf2cat>
-    <OutDir>$(SolutionDir)artifacts\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>
+    <OutDir>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>
     <IntDir>$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\obj\$(ProjectName)\</IntDir>
     <SignMode>Off</SignMode>
   </PropertyGroup>
@@ -95,7 +95,7 @@
       <AdditionalOptions Condition="'$(Platform)'=='x64'">/Gw /kernel /ZH:SHA_256 -d2jumptablerdata -d2epilogunwindrequirev2</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(SolutionDir)artifacts\winkernel\$(Platform)_$(Configuration)_schannel\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</AdditionalLibraryDirectories>
       <AdditionalDependencies>cng.lib;ksecdd.lib;msnetioid.lib;netio.lib;wdmsec.lib;uuid.lib;msquic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>

--- a/src/tools/dbg/dbg.vcxproj
+++ b/src/tools/dbg/dbg.vcxproj
@@ -53,7 +53,7 @@
     <TargetName>quic</TargetName>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
-    <OutDir>$(SolutionDir)artifacts\windbg\$(Platform)_$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)artifacts\bin\windbg\$(Platform)_$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\windbg\$(Platform)_$(Configuration)\obj\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">


### PR DESCRIPTION
Some refactoring/shuffling of build artifacts so that downloading them can be a bit more efficient. Most of the change just consists of moving the actual build (binary) artifacts into a bin folder and renaming 'drop' to 'bin'.