### PR TITLE
Fix preallocated buffer accidental deallocations in RecvBuffer functions.

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -119,10 +119,11 @@ QuicRecvBufferUninitialize(
         QUIC_FREE(RecvBuffer->Buffer);
     }
     RecvBuffer->Buffer = NULL;
-    if (RecvBuffer->OldBuffer != NULL) {
+    if (RecvBuffer->OldBuffer != NULL &&
+        RecvBuffer->OldBuffer != RecvBuffer->PreallocatedBuffer) {
         QUIC_FREE(RecvBuffer->OldBuffer);
-        RecvBuffer->OldBuffer = NULL;
     }
+    RecvBuffer->OldBuffer = NULL;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -203,7 +203,7 @@ QuicRecvBufferResize(
 
         if (RecvBuffer->ExternalBufferReference && RecvBuffer->OldBuffer == NULL) {
             RecvBuffer->OldBuffer = RecvBuffer->Buffer;
-        } if (RecvBuffer->Buffer != RecvBuffer->PreallocatedBuffer) {
+        } else if (RecvBuffer->Buffer != RecvBuffer->PreallocatedBuffer) {
             QUIC_FREE(RecvBuffer->Buffer);
         }
 


### PR DESCRIPTION
Bug in uninitialize found while trying to debug #627. 

Actual bug found in 2nd commit.

Closes #627 