### PR TITLE
Make code coverage have correct file locations on CI

### DIFF
--- a/.azure/templates/merge-publish-coverage.yml
+++ b/.azure/templates/merge-publish-coverage.yml
@@ -46,3 +46,4 @@ jobs:
     inputs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '**/artifacts/coverage/**/msquiccoverage.xml'
+      pathToSources: $(System.DefaultWorkingDirectory)/


### PR DESCRIPTION
pathToSources causes source files to be correctly looked up.