### PR TITLE
Code Coverage Core Only

### DIFF
--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -49,7 +49,7 @@ jobs:
       pwsh: true
       filePath: scripts/spin.ps1
       ${{ if eq(parameters.codeCoverage, true) }}:
-        arguments: -CodeCoverage -GenerateXmlResults -Timeout 600000 -RepeatCount 6 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+        arguments: -CodeCoverage -LogProfile Basic.Light -GenerateXmlResults -Timeout 600000 -RepeatCount 6 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
       ${{ if eq(parameters.codeCoverage, false) }}:
         arguments: -GenerateXmlResults -Timeout 600000 -RepeatCount 6 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -178,7 +178,7 @@ function Start-Executable {
             }
         } elseif ($CodeCoverage) {
             $pinfo.FileName = "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe"
-            $pinfo.Arguments = "--modules=$(Split-Path $Path -Parent) --cover_children --sources src\core --sources src\inc --sources src\platform --excluded_sources unittest --working_dir $($LogDir) --export_type binary:$(Join-Path $CoverageDir $CoverageName) -- $($Path) $($Arguments)"
+            $pinfo.Arguments = "--modules=$(Split-Path $Path -Parent) --cover_children --sources src\core --excluded_sources unittest --working_dir $($LogDir) --export_type binary:$(Join-Path $CoverageDir $CoverageName) -- $($Path) $($Arguments)"
             $pinfo.WorkingDirectory = $LogDir
         } else {
             $pinfo.FileName = $Path

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -264,7 +264,7 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
         } elseif ($CodeCoverage) {
             $CoverageOutput = Join-Path $OutputDir $CoverageName
             $pinfo.FileName = "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe"
-            $pinfo.Arguments = "--modules=$(Split-Path $Path -Parent) --cover_children --sources src\core --sources src\inc --sources src\platform --excluded_sources unittest --working_dir $($OutputDir) --export_type binary:$($CoverageOutput) -- $($Path) $($Arguments)"
+            $pinfo.Arguments = "--modules=$(Split-Path $Path -Parent) --cover_children --sources src\core --excluded_sources unittest --working_dir $($OutputDir) --export_type binary:$($CoverageOutput) -- $($Path) $($Arguments)"
             $pinfo.WorkingDirectory = $OutputDir
         } else {
             $pinfo.FileName = $Path


### PR DESCRIPTION
This updates code coverage to only look at the core code for now, which is what I'm most interested in (for the time being). Also, it enables some logging for spinquic to get some code coverage in the logging/tracing code paths. From my local execution, this brings coverage up to 80%. Not a bad start!