### PR TITLE
Fix Some Kernel Mode Test Issues

### DIFF
--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -228,11 +228,7 @@ QuicTraceStubVarArgs(
 #define QuicTraceLogInfoEnabled()    EventEnabledQuicLogInfo()
 #define QuicTraceLogVerboseEnabled() EventEnabledQuicLogVerbose()
 
-#ifdef _KERNEL_MODE
-#define QUIC_ETW_BUFFER_LENGTH 64
-#else
 #define QUIC_ETW_BUFFER_LENGTH 128
-#endif
 
 #define LogEtw(EventName, Fmt, ...) \
     if (EventEnabledQuicLog##EventName()) { \

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -657,7 +657,7 @@ void QuicTestValidateConnection()
         // waits a bit to allow for the previous command to be processed so
         // that the second call will fail inline.
         //
-        QuicSleep(100);
+        QuicSleep(500);
 
         TEST_QUIC_STATUS(
             QUIC_STATUS_INVALID_STATE,
@@ -950,7 +950,7 @@ void QuicTestValidateConnection()
             MsQuic->ConnectionClose(Connection.Handle);
 
             //
-            // Enable resumption but ensure failure because the connection 
+            // Enable resumption but ensure failure because the connection
             // isn't in connected state yet.
             //
 


### PR DESCRIPTION
Fixes two things when I investigated a test failure on the latest master run:

- Logs were cut too short, resulting in unhelpful log messages
- The test code didn't wait long enough between ConnectionStart calls.