### PR TITLE
Fix server disconnect failure

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -488,7 +488,7 @@ QuicTestServerDisconnect(
                         ServerLocalAddr.GetPort()));
 
 
-                QuicSleep(100); // Sleep for a little bit.
+                QuicSleep(500); // Sleep for a little bit.
 
                 Client->Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
             }

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -487,7 +487,6 @@ QuicTestServerDisconnect(
                             QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
                         ServerLocalAddr.GetPort()));
 
-
                 QuicSleep(500); // Sleep for a little bit.
 
                 Client->Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);


### PR DESCRIPTION
Fixes a bug I saw in a test failure. The code didn't wait enough and ended up failing. Ideally, we'd have some better way to do this than just sleep and hope...