### PR TITLE
Send and Start Stream in One API Call

### DIFF
--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -421,7 +421,6 @@ QuicDatagramSendFlush(
         ApiQueue = ApiQueue->Next;
         SendRequest->Next = NULL;
 
-        QUIC_DBG_ASSERT(SendRequest->TotalLength != 0);
         QUIC_DBG_ASSERT(!(SendRequest->Flags & QUIC_SEND_FLAG_BUFFERED));
         QUIC_TEL_ASSERT(Datagram->SendEnabled);
 

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -419,6 +419,9 @@ QuicStreamSendBufferRequest(
     QUIC_CONNECTION* Connection = Stream->Connection;
 
     QUIC_DBG_ASSERT(Req->TotalLength <= UINT32_MAX);
+    Req->BufferCount = 1;
+    Req->Buffers = &Req->InternalBuffer;
+    Req->InternalBuffer.Length = (uint32_t)Req->TotalLength;
 
     if (Req->TotalLength != 0) {
         //
@@ -441,9 +444,6 @@ QuicStreamSendBufferRequest(
     } else {
         Req->InternalBuffer.Buffer = NULL;
     }
-    Req->BufferCount = 1;
-    Req->Buffers = &Req->InternalBuffer;
-    Req->InternalBuffer.Length = (uint32_t)Req->TotalLength;
 
     Req->Flags |= QUIC_SEND_FLAG_BUFFERED;
     Stream->SendBufferBookmark = Req->Next;

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -419,9 +419,6 @@ QuicStreamSendBufferRequest(
     QUIC_CONNECTION* Connection = Stream->Connection;
 
     QUIC_DBG_ASSERT(Req->TotalLength <= UINT32_MAX);
-    Req->BufferCount = 1;
-    Req->Buffers = &Req->InternalBuffer;
-    Req->InternalBuffer.Length = (uint32_t)Req->TotalLength;
 
     if (Req->TotalLength != 0) {
         //
@@ -444,6 +441,9 @@ QuicStreamSendBufferRequest(
     } else {
         Req->InternalBuffer.Buffer = NULL;
     }
+    Req->BufferCount = 1;
+    Req->Buffers = &Req->InternalBuffer;
+    Req->InternalBuffer.Length = (uint32_t)Req->TotalLength;
 
     Req->Flags |= QUIC_SEND_FLAG_BUFFERED;
     Stream->SendBufferBookmark = Req->Next;

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -393,7 +393,7 @@ QuicStreamCompleteSendRequest(
         }
 
         (void)QuicStreamIndicateEvent(Stream, &Event);
-    } else {
+    } else if (SendRequest->InternalBuffer.Length != 0) {
         QuicSendBufferFree(
             &Connection->SendBuffer,
             SendRequest->InternalBuffer.Buffer,

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -162,8 +162,9 @@ DEFINE_ENUM_FLAG_OPERATORS(QUIC_RECEIVE_FLAGS);
 typedef enum QUIC_SEND_FLAGS {
     QUIC_SEND_FLAG_NONE                     = 0x0000,
     QUIC_SEND_FLAG_ALLOW_0_RTT              = 0x0001,   // Allows the use of encrypting with 0-RTT key.
-    QUIC_SEND_FLAG_FIN                      = 0x0002,   // Indicates the request is the one last sent on the stream.
-    QUIC_SEND_FLAG_DGRAM_PRIORITY           = 0x0004    // Indicates the datagram is higher priority than others.
+    QUIC_SEND_FLAG_START                    = 0x0002,   // Indicates the request is the one last sent on the stream.
+    QUIC_SEND_FLAG_FIN                      = 0x0004,   // Indicates the request is the one last sent on the stream.
+    QUIC_SEND_FLAG_DGRAM_PRIORITY           = 0x0008    // Indicates the datagram is higher priority than others.
 } QUIC_SEND_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_SEND_FLAGS);

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -183,7 +183,8 @@ SendPingBurst(
             Connection->NewStream(
                 PingStreamShutdown,
                 ((PingConnState*)Connection->Context)->Stats->UnidirectionalStreams ?
-                    QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL : QUIC_STREAM_OPEN_FLAG_NONE);
+                    QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL : QUIC_STREAM_OPEN_FLAG_NONE,
+                PayloadLength == 0 ? NEW_STREAM_START_NONE : NEW_STREAM_START_SYNC);
         if (Stream == nullptr) {
             return false;
         }

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -11,6 +11,12 @@ Abstract:
 
 class TestConnection;
 
+enum NEW_STREAM_START_TYPE {
+    NEW_STREAM_START_NONE,      // Dont' start
+    NEW_STREAM_START_SYNC,      // Start synchronously
+    NEW_STREAM_START_ASYNC      // Start asynchronously
+};
+
 //
 // Callback for processing peer created streams.
 //
@@ -130,7 +136,8 @@ public:
     TestStream*
     NewStream(
         _In_opt_ STREAM_SHUTDOWN_CALLBACK_HANDLER StreamShutdownHandler,
-        _In_ QUIC_STREAM_OPEN_FLAGS Flags
+        _In_ QUIC_STREAM_OPEN_FLAGS Flags,
+        _In_ NEW_STREAM_START_TYPE StartType = NEW_STREAM_START_SYNC
         );
 
     uint32_t GetWaitTimeout() const {

--- a/src/test/lib/TestStream.h
+++ b/src/test/lib/TestStream.h
@@ -54,7 +54,7 @@ struct QuicSendBuffer
         Buffers(new QUIC_BUFFER[bufferCount])
     {
         for (uint32_t i = 0; i < BufferCount; ++i) {
-            this->Buffers[i].Buffer = bufferSize == 0 ? (uint8_t*)(this+1) : new uint8_t[bufferSize];
+            this->Buffers[i].Buffer = bufferSize == 0 ? nullptr : new uint8_t[bufferSize];
             this->Buffers[i].Length = bufferSize;
             QuicZeroMemory(this->Buffers[i].Buffer, this->Buffers[i].Length);
         }
@@ -67,7 +67,7 @@ struct QuicSendBuffer
         BufferCount(1),
         Buffers(new QUIC_BUFFER[1])
     {
-        this->Buffers[0].Buffer = bufferSize == 0 ? (uint8_t*)(this+1) : new uint8_t[bufferSize];
+        this->Buffers[0].Buffer = bufferSize == 0 ? nullptr : new uint8_t[bufferSize];
         memcpy((uint8_t*)this->Buffers[0].Buffer, buffer, bufferSize);
         this->Buffers[0].Length = bufferSize;
     }
@@ -78,9 +78,7 @@ struct QuicSendBuffer
     ~QuicSendBuffer()
     {
         for (uint32_t i = 0; i < BufferCount; ++i) {
-            if (this->Buffers[i].Length) {
-                delete [] this->Buffers[i].Buffer;
-            }
+            delete [] this->Buffers[i].Buffer;
         }
         delete [] this->Buffers;
     }

--- a/src/test/lib/TestStream.h
+++ b/src/test/lib/TestStream.h
@@ -178,6 +178,11 @@ public:
         _In_ QUIC_UINT62 ErrorCode
         );
 
+    QUIC_STATUS
+    Start(
+        _In_ QUIC_STREAM_START_FLAGS Flags
+        );
+
     bool
     StartPing(
         _In_ uint64_t PayloadLength

--- a/src/test/lib/TestStream.h
+++ b/src/test/lib/TestStream.h
@@ -54,7 +54,7 @@ struct QuicSendBuffer
         Buffers(new QUIC_BUFFER[bufferCount])
     {
         for (uint32_t i = 0; i < BufferCount; ++i) {
-            this->Buffers[i].Buffer = new uint8_t[bufferSize];
+            this->Buffers[i].Buffer = bufferSize == 0 ? (uint8_t*)(this+1) : new uint8_t[bufferSize];
             this->Buffers[i].Length = bufferSize;
             QuicZeroMemory(this->Buffers[i].Buffer, this->Buffers[i].Length);
         }
@@ -67,7 +67,7 @@ struct QuicSendBuffer
         BufferCount(1),
         Buffers(new QUIC_BUFFER[1])
     {
-        this->Buffers[0].Buffer = new uint8_t[bufferSize];
+        this->Buffers[0].Buffer = bufferSize == 0 ? (uint8_t*)(this+1) : new uint8_t[bufferSize];
         memcpy((uint8_t*)this->Buffers[0].Buffer, buffer, bufferSize);
         this->Buffers[0].Length = bufferSize;
     }
@@ -78,7 +78,9 @@ struct QuicSendBuffer
     ~QuicSendBuffer()
     {
         for (uint32_t i = 0; i < BufferCount; ++i) {
-            delete [] this->Buffers[i].Buffer;
+            if (this->Buffers[i].Length) {
+                delete [] this->Buffers[i].Buffer;
+            }
         }
         delete [] this->Buffers;
     }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -101,7 +101,7 @@ static HQUIC Registration;
 static QUIC_SEC_CONFIG* GlobalSecurityConfig;
 static std::vector<HQUIC> Sessions;
 
-const uint32_t MaxBufferSizes[] = { 1, 2, 32, 50, 256, 500, 1000, 1024, 1400, 5000, 10000, 64000, 10000000 };
+const uint32_t MaxBufferSizes[] = { 0, 1, 2, 32, 50, 256, 500, 1000, 1024, 1400, 5000, 10000, 64000, 10000000 };
 static const size_t BufferCount = ARRAYSIZE(MaxBufferSizes);
 static QUIC_BUFFER Buffers[BufferCount];
 
@@ -526,7 +526,7 @@ void Spin(LockableVector<HQUIC>& Connections, bool IsServer)
                 auto Stream = ctx->TryGetStream();
                 if (Stream == nullptr) continue;
                 auto Buffer = &Buffers[GetRandom(BufferCount)];
-                MsQuic->StreamSend(Stream, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(8), nullptr);
+                MsQuic->StreamSend(Stream, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(16), nullptr);
             }
             break;
         }


### PR DESCRIPTION
This adds a new flag for `StreamSend` that allows the app to send data and start the stream in a single API call. The reduces the complexity/overhead of streams in the scenarios where a stream is used to send a single complete message. All the app need do is call `StreamOpen` to allocate a stream (cheap, as it uses a lookaside list / pool allocator) and then call `StreamSend` with both the start and fin flags, along with the payload.

Also updates the tests and spinquic to exercise the code paths.