### PR TITLE
Use Master Branch for Readme Shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ protocol. It is cross platform, written in C and designed to be a general purpos
 
 > **Important** The MsQuic library, as well as the protocol itself, is still a work in progress. Version 1 is not yet finalized and may continue to experience breaking changes until it is finalized.
 
-[![Build Status](https://dev.azure.com/ms/msquic/_apis/build/status/CI?branchName=master)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master) [![Test Status](https://img.shields.io/azure-devops/tests/ms/msquic/347)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master) [![Code Coverage](https://img.shields.io/azure-devops/coverage/ms/msquic/347)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master)
+[![Build Status](https://dev.azure.com/ms/msquic/_apis/build/status/CI?branchName=master)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master) [![Test Status](https://img.shields.io/azure-devops/tests/ms/msquic/347/master)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master) [![Code Coverage](https://img.shields.io/azure-devops/coverage/ms/msquic/347/master)](https://dev.azure.com/ms/msquic/_build/latest?definitionId=347&branchName=master)
 
 ## Protocol Features
 


### PR DESCRIPTION
Explicitly point to the master branch, instead of just the most recent build.