### PR TITLE
Increase Receive Buffer Drain Ratio

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -90,6 +90,7 @@ stages:
       platform: windows
       localTls: schannel
       remoteTls: schannel
+      extraName: Loopback
       ${{ if eq(parameters.mode, 'PGO') }}:
         extraArgs: -PGO -Local
       ${{ if eq(parameters.mode, 'Record') }}:
@@ -102,6 +103,7 @@ stages:
       platform: windows
       localTls: schannel
       remoteTls: schannel
+      extraName: Loopback
       arch: x86
       ${{ if eq(parameters.mode, 'PGO') }}:
         extraArgs: -PGO -Local

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -31,17 +31,17 @@ stages:
     runCodesignValidationInjection: false
   jobs:
   # Officially supported configurations.
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
-      arch: x86
-      tls: schannel
-      config: Release
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraBuildArgs: -DisableTest -PGO
-      ${{ if ne(parameters.mode, 'PGO') }}:
-        extraBuildArgs: -DisableTest
+  # - template: ./templates/build-config-user.yml
+  #   parameters:
+  #     image: windows-latest
+  #     platform: windows
+  #     arch: x86
+  #     tls: schannel
+  #     config: Release
+  #     ${{ if eq(parameters.mode, 'PGO') }}:
+  #       extraBuildArgs: -DisableTest -PGO
+  #     ${{ if ne(parameters.mode, 'PGO') }}:
+  #       extraBuildArgs: -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
@@ -70,44 +70,44 @@ stages:
       localTls: schannel
       remoteTls: schannel
       ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO
+        extraArgs: -PGO -Debug
       ${{ if eq(parameters.mode, 'Record') }}:
-        extraArgs: -Record
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: schannel
-      arch: x86
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO
-      ${{ if eq(parameters.mode, 'Record') }}:
-        extraArgs: -Record
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: schannel
-      extraName: Loopback
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO -Local
-      ${{ if eq(parameters.mode, 'Record') }}:
-        extraArgs: -Record -Local
-      ${{ if eq(parameters.mode, 'Normal') }}:
-        extraArgs: -Local
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: schannel
-      extraName: Loopback
-      arch: x86
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO -Local
-      ${{ if eq(parameters.mode, 'Record') }}:
-        extraArgs: -Record -Local
-      ${{ if eq(parameters.mode, 'Normal') }}:
-        extraArgs: -Local
+        extraArgs: -Record -Debug
+  # - template: ./templates/run-performance.yml
+  #   parameters:
+  #     pool: MsQuic-Win-Perf
+  #     platform: windows
+  #     localTls: schannel
+  #     remoteTls: schannel
+  #     arch: x86
+  #     ${{ if eq(parameters.mode, 'PGO') }}:
+  #       extraArgs: -PGO
+  #     ${{ if eq(parameters.mode, 'Record') }}:
+  #       extraArgs: -Record
+  # - template: ./templates/run-performance.yml
+  #   parameters:
+  #     pool: MsQuic-Win-Perf
+  #     platform: windows
+  #     localTls: schannel
+  #     remoteTls: schannel
+  #     extraName: Loopback
+  #     ${{ if eq(parameters.mode, 'PGO') }}:
+  #       extraArgs: -PGO -Local
+  #     ${{ if eq(parameters.mode, 'Record') }}:
+  #       extraArgs: -Record -Local
+  #     ${{ if eq(parameters.mode, 'Normal') }}:
+  #       extraArgs: -Local
+  # - template: ./templates/run-performance.yml
+  #   parameters:
+  #     pool: MsQuic-Win-Perf
+  #     platform: windows
+  #     localTls: schannel
+  #     remoteTls: schannel
+  #     extraName: Loopback
+  #     arch: x86
+  #     ${{ if eq(parameters.mode, 'PGO') }}:
+  #       extraArgs: -PGO -Local
+  #     ${{ if eq(parameters.mode, 'Record') }}:
+  #       extraArgs: -Record -Local
+  #     ${{ if eq(parameters.mode, 'Normal') }}:
+  #       extraArgs: -Local

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -17,6 +17,7 @@ parameters:
   - Normal
   - PGO
   - Record
+  - RecordQUICTrace
 
 #
 # Builds
@@ -73,6 +74,8 @@ stages:
         extraArgs: -PGO
       ${{ if eq(parameters.mode, 'Record') }}:
         extraArgs: -Record
+      ${{ if eq(parameters.mode, 'RecordQUICTrace') }}:
+        extraArgs: -RecordQUIC
   - template: ./templates/run-performance.yml
     parameters:
       pool: MsQuic-Win-Perf
@@ -84,6 +87,8 @@ stages:
         extraArgs: -PGO
       ${{ if eq(parameters.mode, 'Record') }}:
         extraArgs: -Record
+      ${{ if eq(parameters.mode, 'RecordQUICTrace') }}:
+        extraArgs: -RecordQUIC
   - template: ./templates/run-performance.yml
     parameters:
       pool: MsQuic-Win-Perf
@@ -97,6 +102,8 @@ stages:
         extraArgs: -Record -Local
       ${{ if eq(parameters.mode, 'Normal') }}:
         extraArgs: -Local
+      ${{ if eq(parameters.mode, 'RecordQUICTrace') }}:
+        extraArgs: -RecordQUIC -Local
   - template: ./templates/run-performance.yml
     parameters:
       pool: MsQuic-Win-Perf
@@ -111,3 +118,5 @@ stages:
         extraArgs: -Record -Local
       ${{ if eq(parameters.mode, 'Normal') }}:
         extraArgs: -Local
+      ${{ if eq(parameters.mode, 'RecordQUICTrace') }}:
+        extraArgs: -RecordQUIC -Local

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -31,17 +31,17 @@ stages:
     runCodesignValidationInjection: false
   jobs:
   # Officially supported configurations.
-  # - template: ./templates/build-config-user.yml
-  #   parameters:
-  #     image: windows-latest
-  #     platform: windows
-  #     arch: x86
-  #     tls: schannel
-  #     config: Release
-  #     ${{ if eq(parameters.mode, 'PGO') }}:
-  #       extraBuildArgs: -DisableTest -PGO
-  #     ${{ if ne(parameters.mode, 'PGO') }}:
-  #       extraBuildArgs: -DisableTest
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x86
+      tls: schannel
+      config: Release
+      ${{ if eq(parameters.mode, 'PGO') }}:
+        extraBuildArgs: -DisableTest -PGO
+      ${{ if ne(parameters.mode, 'PGO') }}:
+        extraBuildArgs: -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
@@ -70,44 +70,44 @@ stages:
       localTls: schannel
       remoteTls: schannel
       ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO -Debug
+        extraArgs: -PGO
       ${{ if eq(parameters.mode, 'Record') }}:
-        extraArgs: -Record -Debug
-  # - template: ./templates/run-performance.yml
-  #   parameters:
-  #     pool: MsQuic-Win-Perf
-  #     platform: windows
-  #     localTls: schannel
-  #     remoteTls: schannel
-  #     arch: x86
-  #     ${{ if eq(parameters.mode, 'PGO') }}:
-  #       extraArgs: -PGO
-  #     ${{ if eq(parameters.mode, 'Record') }}:
-  #       extraArgs: -Record
-  # - template: ./templates/run-performance.yml
-  #   parameters:
-  #     pool: MsQuic-Win-Perf
-  #     platform: windows
-  #     localTls: schannel
-  #     remoteTls: schannel
-  #     extraName: Loopback
-  #     ${{ if eq(parameters.mode, 'PGO') }}:
-  #       extraArgs: -PGO -Local
-  #     ${{ if eq(parameters.mode, 'Record') }}:
-  #       extraArgs: -Record -Local
-  #     ${{ if eq(parameters.mode, 'Normal') }}:
-  #       extraArgs: -Local
-  # - template: ./templates/run-performance.yml
-  #   parameters:
-  #     pool: MsQuic-Win-Perf
-  #     platform: windows
-  #     localTls: schannel
-  #     remoteTls: schannel
-  #     extraName: Loopback
-  #     arch: x86
-  #     ${{ if eq(parameters.mode, 'PGO') }}:
-  #       extraArgs: -PGO -Local
-  #     ${{ if eq(parameters.mode, 'Record') }}:
-  #       extraArgs: -Record -Local
-  #     ${{ if eq(parameters.mode, 'Normal') }}:
-  #       extraArgs: -Local
+        extraArgs: -Record
+  - template: ./templates/run-performance.yml
+    parameters:
+      pool: MsQuic-Win-Perf
+      platform: windows
+      localTls: schannel
+      remoteTls: schannel
+      arch: x86
+      ${{ if eq(parameters.mode, 'PGO') }}:
+        extraArgs: -PGO
+      ${{ if eq(parameters.mode, 'Record') }}:
+        extraArgs: -Record
+  - template: ./templates/run-performance.yml
+    parameters:
+      pool: MsQuic-Win-Perf
+      platform: windows
+      localTls: schannel
+      remoteTls: schannel
+      extraName: Loopback
+      ${{ if eq(parameters.mode, 'PGO') }}:
+        extraArgs: -PGO -Local
+      ${{ if eq(parameters.mode, 'Record') }}:
+        extraArgs: -Record -Local
+      ${{ if eq(parameters.mode, 'Normal') }}:
+        extraArgs: -Local
+  - template: ./templates/run-performance.yml
+    parameters:
+      pool: MsQuic-Win-Perf
+      platform: windows
+      localTls: schannel
+      remoteTls: schannel
+      extraName: Loopback
+      arch: x86
+      ${{ if eq(parameters.mode, 'PGO') }}:
+        extraArgs: -PGO -Local
+      ${{ if eq(parameters.mode, 'Record') }}:
+        extraArgs: -Record -Local
+      ${{ if eq(parameters.mode, 'Normal') }}:
+        extraArgs: -Local

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -70,6 +70,27 @@ stages:
       localTls: schannel
       remoteTls: schannel
       ${{ if eq(parameters.mode, 'PGO') }}:
+        extraArgs: -PGO
+      ${{ if eq(parameters.mode, 'Record') }}:
+        extraArgs: -Record
+  - template: ./templates/run-performance.yml
+    parameters:
+      pool: MsQuic-Win-Perf
+      platform: windows
+      localTls: schannel
+      remoteTls: schannel
+      arch: x86
+      ${{ if eq(parameters.mode, 'PGO') }}:
+        extraArgs: -PGO
+      ${{ if eq(parameters.mode, 'Record') }}:
+        extraArgs: -Record
+  - template: ./templates/run-performance.yml
+    parameters:
+      pool: MsQuic-Win-Perf
+      platform: windows
+      localTls: schannel
+      remoteTls: schannel
+      ${{ if eq(parameters.mode, 'PGO') }}:
         extraArgs: -PGO -Local
       ${{ if eq(parameters.mode, 'Record') }}:
         extraArgs: -Record -Local

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -55,7 +55,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run Performance Test
-    timeoutInMinutes: 12
+    timeoutInMinutes: 20
     continueOnError: true
     inputs:
       pwsh: true

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -314,12 +314,18 @@ function Invoke-RemoteExe {
         }
 
         if ($Record -and $IsWindows) {
+            Write-Debug "Starting Remote Record"
             $EtwXmlName = $Exe + ".remote.wprp"
             wpr.exe -cancel 2> $null
 
+            Write-Debug "Cancelled any existing record"
+
             $WpaStackWalkProfileXml | Out-File $EtwXmlName
             wpr.exe -start $EtwXmlName -filemode 2> $null
+            Write-Debug "Started Remote Record"
         }
+
+        Write-Debug "Starting remote exe"
 
         & $Exe ($RunArgs).Split(" ")
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -141,7 +141,7 @@ function Invoke-TestCommand {
 function Wait-ForRemoteReady {
     param ($Job, $Matcher)
     $StopWatch =  [system.diagnostics.stopwatch]::StartNew()
-    while ($StopWatch.ElapsedMilliseconds -lt 10000) {
+    while ($StopWatch.ElapsedMilliseconds -lt 25000) {
         $CurrentResults = Receive-Job -Job $Job -Keep
         if (![string]::IsNullOrWhiteSpace($CurrentResults)) {
             $DidMatch = $CurrentResults -match $Matcher

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -11,7 +11,7 @@ $WpaStackWalkProfileXml = `
   <Profiles>
     <SystemCollector Id="SC_HighVolume" Realtime="false">
       <BufferSize Value="1024"/>
-      <Buffers Value="20"/>
+      <Buffers Value="80"/>
     </SystemCollector>
     <SystemProvider Id="SP_CPU">
       <Keywords>

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -313,6 +313,8 @@ function Invoke-RemoteExe {
             $env:LD_LIBRARY_PATH = $BasePath
         }
 
+        Write-Debug "Running ScriptBlock for Remote Command"
+
         if ($Record -and $IsWindows) {
             Write-Debug "Starting Remote Record"
             $EtwXmlName = $Exe + ".remote.wprp"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -363,7 +363,7 @@ function Invoke-LocalExe {
         $EtwXmlName = $Exe + ".local.wprp"
 
         $WpaStackWalkProfileXml | Out-File $EtwXmlName
-        wpr.exe -start $EtwXmlName -filemode 2> $null
+        wpr.exe -start $EtwXmlName -filemode 2> $null | Out-Null
     }
 
     $LocalJob = Start-Job -ScriptBlock { & $Using:Exe ($Using:RunArgs).Split(" ") }
@@ -376,7 +376,7 @@ function Invoke-LocalExe {
 
     if ($Record -and $IsWindows) {
         $EtwName = $Exe + ".local.etl"
-        wpr.exe -stop $EtwName 2> $null
+        wpr.exe -stop $EtwName 2> $null | Out-Null
     }
 
     return $RetVal -join "`n"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -141,7 +141,7 @@ function Invoke-TestCommand {
 function Wait-ForRemoteReady {
     param ($Job, $Matcher)
     $StopWatch =  [system.diagnostics.stopwatch]::StartNew()
-    while ($StopWatch.ElapsedMilliseconds -lt 25000) {
+    while ($StopWatch.ElapsedMilliseconds -lt 10000) {
         $CurrentResults = Receive-Job -Job $Job -Keep
         if (![string]::IsNullOrWhiteSpace($CurrentResults)) {
             $DidMatch = $CurrentResults -match $Matcher
@@ -156,7 +156,7 @@ function Wait-ForRemoteReady {
 
 function Wait-ForRemote {
     param ($Job)
-    Wait-Job -Job $Job -Timeout 10 | Out-Null
+    Wait-Job -Job $Job -Timeout 25 | Out-Null
     Stop-Job -Job $Job | Out-Null
     $RetVal = Receive-Job -Job $Job
     return $RetVal -join "`n"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -35,9 +35,55 @@ $WpaStackWalkProfileXml = `
 </WindowsPerformanceRecorder>
 "@
 
+# WPA Profile for collecting QUIC Logs.
+$WpaQUICLogProfileXml = `
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<WindowsPerformanceRecorder Version="1.0" Author="MsQuic" Copyright="Microsoft Corporation" Company="Microsoft Corporation">
+  <Profiles>
+    <SystemCollector Id="SC_HighVolume" Realtime="false">
+      <BufferSize Value="1024"/>
+      <Buffers Value="80"/>
+    </SystemCollector>
+    <EventCollector Id="EC_LowVolume" Realtime="false" Name="LowVolume">
+      <BufferSize Value="1024"/>
+      <Buffers Value="80"/>
+    </EventCollector>
+    <SystemProvider Id="SP_CPU">
+      <Keywords>
+        <Keyword Value="CpuConfig"/>
+        <Keyword Value="Loader"/>
+        <Keyword Value="ProcessThread"/>
+        <Keyword Value="SampledProfile"/>
+      </Keywords>
+      <Stacks>
+        <Stack Value="SampledProfile"/>
+      </Stacks>
+    </SystemProvider>
+    <EventProvider Id="MsQuicEtwPerf" Name="ff15e657-4f26-570e-88ab-0796b258d11c" NonPagedMemory="true" Level="5">
+      <Keywords>
+        <Keyword Value="0xE0000000"/>
+      </Keywords>
+    </EventProvider>
+    <Profile Id="CPU.Light.File" Name="CPU" Description="CPU Stacks" LoggingMode="File" DetailLevel="Light">
+      <Collectors>
+        <SystemCollectorId Value="SC_HighVolume">
+          <SystemProviderId Value="SP_CPU" />
+        </SystemCollectorId>
+        <EventCollectorId Value="EC_LowVolume">
+          <EventProviders>
+            <EventProviderId Value="MsQuicEtwPerf" />
+          </EventProviders>
+        </EventCollectorId>
+      </Collectors>
+    </Profile>
+  </Profiles>
+</WindowsPerformanceRecorder>
+"@
+
 function Set-ScriptVariables {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
-    param ($Local, $LocalTls, $LocalArch, $RemoteTls, $RemoteArch, $Config, $Publish, $Record)
+    param ($Local, $LocalTls, $LocalArch, $RemoteTls, $RemoteArch, $Config, $Publish, $Record, $RecordQUIC)
     $script:Local = $Local
     $script:LocalTls = $LocalTls
     $script:LocalArch = $LocalArch
@@ -46,6 +92,7 @@ function Set-ScriptVariables {
     $script:Config = $Config
     $script:Publish = $Publish
     $script:Record = $Record
+    $script:RecordQUIC = $RecordQUIC
 }
 
 function Set-Session {
@@ -132,7 +179,7 @@ function Wait-ForRemoteReady {
 
 function Wait-ForRemote {
     param ($Job)
-    Wait-Job -Job $Job -Timeout 10 | Out-Null
+    Wait-Job -Job $Job -Timeout 60 | Out-Null
     Stop-Job -Job $Job | Out-Null
     $RetVal = Receive-Job -Job $Job
     return $RetVal -join "`n"
@@ -307,8 +354,13 @@ function Invoke-RemoteExe {
 
     Write-Debug "Running Remote: $Exe $RunArgs"
 
+    $WpaXml = $WpaStackWalkProfileXml
+    if ($RecordQUIC) {
+        $WpaXml = $WpaQUICLogProfileXml
+    }
+
     return Invoke-TestCommand -Session $Session -ScriptBlock {
-        param ($Exe, $RunArgs, $BasePath, $Record, $WpaStackWalkProfileXml)
+        param ($Exe, $RunArgs, $BasePath, $Record, $WpaXml)
         if ($null -ne $BasePath) {
             $env:LD_LIBRARY_PATH = $BasePath
         }
@@ -316,7 +368,7 @@ function Invoke-RemoteExe {
         if ($Record -and $IsWindows) {
             $EtwXmlName = $Exe + ".remote.wprp"
 
-            $WpaStackWalkProfileXml | Out-File $EtwXmlName
+            $WpaXml | Out-File $EtwXmlName
             wpr.exe -start $EtwXmlName -filemode 2> $null
         }
 
@@ -326,7 +378,7 @@ function Invoke-RemoteExe {
             $EtwName = $Exe + ".remote.etl"
             wpr.exe -stop $EtwName 2> $null
         }
-    } -AsJob -ArgumentList $Exe, $RunArgs, $BasePath, $Record, $WpaStackWalkProfileXml
+    } -AsJob -ArgumentList $Exe, $RunArgs, $BasePath, $Record, $WpaXml
 }
 
 function Get-RemoteFile {
@@ -353,7 +405,12 @@ function Start-Tracing {
     if ($Record -and $IsWindows -and !$Local) {
         $EtwXmlName = $Exe + ".local.wprp"
 
-        $WpaStackWalkProfileXml | Out-File $EtwXmlName
+        $WpaXml = $WpaStackWalkProfileXml
+        if ($RecordQUIC) {
+            $WpaXml = $WpaQUICLogProfileXml
+        }
+
+        $WpaXml | Out-File $EtwXmlName
         wpr.exe -start $EtwXmlName -filemode 2> $null
     }
 }

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -13,7 +13,7 @@ $WpaStackWalkProfileXml = `
       <BufferSize Value="1024"/>
       <Buffers Value="80"/>
     </SystemCollector>
-    <EventCollector Id="EC_LowVolume" Realtime="false">
+    <EventCollector Id="EC_LowVolume" Realtime="false" Name="LowVolume">
       <BufferSize Value="1024"/>
       <Buffers Value="80"/>
     </EventCollector>

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -11,8 +11,12 @@ $WpaStackWalkProfileXml = `
   <Profiles>
     <SystemCollector Id="SC_HighVolume" Realtime="false">
       <BufferSize Value="1024"/>
-      <Buffers Value="20"/>
+      <Buffers Value="80"/>
     </SystemCollector>
+    <EventCollector Id="EC_LowVolume" Realtime="false">
+      <BufferSize Value="1024"/>
+      <Buffers Value="80"/>
+    </EventCollector>
     <SystemProvider Id="SP_CPU">
       <Keywords>
         <Keyword Value="CpuConfig"/>
@@ -41,6 +45,14 @@ $WpaStackWalkProfileXml = `
         <SystemCollectorId Value="SC_HighVolume">
           <SystemProviderId Value="SP_CPU" />
         </SystemCollectorId>
+        <EventCollectorId Value="EC_LowVolume">
+          <EventProviders>
+            <EventProviderId Value="EP_TcpIpEtw" />
+            <EventProviderId Value="EP_WinSockEtw" />
+            <EventProviderId Value="EP_MsQuicEtw_LowVolume_DataPath" />
+            <EventProviderId Value="EP_MsQuicEtw_LowVolume" />
+          </EventProviders>
+        </EventCollectorId>
       </Collectors>
     </Profile>
   </Profiles>

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -24,6 +24,18 @@ $WpaStackWalkProfileXml = `
         <Stack Value="SampledProfile"/>
       </Stacks>
     </SystemProvider>
+    <EventProvider Id="EP_MsQuicEtw_LowVolume" Name="ff15e657-4f26-570e-88ab-0796b258d11c" NonPagedMemory="true" Level="4">
+      <Keywords>
+        <Keyword Value="0x80000000"/>
+      </Keywords>
+    </EventProvider>
+    <EventProvider Id="EP_MsQuicEtw_LowVolume_DataPath" Name="ff15e657-4f26-570e-88ab-0796b258d11c" NonPagedMemory="true">
+      <Keywords>
+        <Keyword Value="0xC0000000"/>
+      </Keywords>
+    </EventProvider>
+    <EventProvider Id="EP_TcpIpEtw" Name="Microsoft-Windows-TCPIP" NonPagedMemory="true" />
+    <EventProvider Id="EP_WinSockEtw" Name="Microsoft-Windows-Winsock-AFD" NonPagedMemory="true" />
     <Profile Id="CPU.Light.File" Name="CPU" Description="CPU Stacks" LoggingMode="File" DetailLevel="Light">
       <Collectors>
         <SystemCollectorId Value="SC_HighVolume">

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -315,10 +315,6 @@ function Invoke-RemoteExe {
 
         if ($Record -and $IsWindows) {
             $EtwXmlName = $Exe + ".remote.wprp"
-            try {
-            	wpr.exe -cancel 2> $null
-            } catch {
-            }
 
             $WpaStackWalkProfileXml | Out-File $EtwXmlName
             wpr.exe -start $EtwXmlName -filemode 2> $null
@@ -363,6 +359,13 @@ function Invoke-LocalExe {
     $FullCommand = "$Exe $RunArgs"
     Write-Debug "Running Locally: $FullCommand"
 
+    if ($Record -and $IsWindows) {
+        $EtwXmlName = $Exe + ".local.wprp"
+
+        $WpaStackWalkProfileXml | Out-File $EtwXmlName
+        wpr.exe -start $EtwXmlName -filemode 2> $null
+    }
+
     $LocalJob = Start-Job -ScriptBlock { & $Using:Exe ($Using:RunArgs).Split(" ") }
 
     # Wait 60 seconds for the job to finish
@@ -370,6 +373,12 @@ function Invoke-LocalExe {
     Stop-Job -Job $LocalJob | Out-Null
 
     $RetVal = Receive-Job -Job $LocalJob
+
+    if ($Record -and $IsWindows) {
+        $EtwName = $Exe + ".local.etl"
+        wpr.exe -stop $EtwName 2> $null
+    }
+
     return $RetVal -join "`n"
 }
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -313,21 +313,16 @@ function Invoke-RemoteExe {
             $env:LD_LIBRARY_PATH = $BasePath
         }
 
-        Write-Debug "Running ScriptBlock for Remote Command"
-
         if ($Record -and $IsWindows) {
-            Write-Debug "Starting Remote Record"
             $EtwXmlName = $Exe + ".remote.wprp"
-            wpr.exe -cancel 2> $null
-
-            Write-Debug "Cancelled any existing record"
+            try {
+            	wpr.exe -cancel 2> $null
+            } catch {
+            }
 
             $WpaStackWalkProfileXml | Out-File $EtwXmlName
             wpr.exe -start $EtwXmlName -filemode 2> $null
-            Write-Debug "Started Remote Record"
         }
-
-        Write-Debug "Starting remote exe"
 
         & $Exe ($RunArgs).Split(" ")
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -359,7 +359,7 @@ function Invoke-LocalExe {
     $FullCommand = "$Exe $RunArgs"
     Write-Debug "Running Locally: $FullCommand"
 
-    if ($Record -and $IsWindows) {
+    if ($Record -and $IsWindows -and !$Local) {
         $EtwXmlName = $Exe + ".local.wprp"
 
         $WpaStackWalkProfileXml | Out-File $EtwXmlName
@@ -374,7 +374,7 @@ function Invoke-LocalExe {
 
     $RetVal = Receive-Job -Job $LocalJob
 
-    if ($Record -and $IsWindows) {
+    if ($Record -and $IsWindows -and !$Local) {
         $EtwName = $Exe + ".local.etl"
         wpr.exe -stop $EtwName 2> $null | Out-Null
     }

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -378,7 +378,7 @@ function Start-Tracing {
         $EtwXmlName = $Exe + ".local.wprp"
 
         $WpaStackWalkProfileXml | Out-File $EtwXmlName
-        wpr.exe -start $EtwXmlName -filemode 2> $null | Out-Null
+        wpr.exe -start $EtwXmlName -filemode 2> $null
     }
 }
 
@@ -386,7 +386,7 @@ function Stop-Tracing {
     param($Exe)
     if ($Record -and $IsWindows -and !$Local) {
         $EtwName = $Exe + ".local.etl"
-        wpr.exe -stop $EtwName 2> $null | Out-Null
+        wpr.exe -stop $EtwName 2> $null
     }
 }
 
@@ -408,7 +408,6 @@ function Invoke-LocalExe {
     Stop-Job -Job $LocalJob | Out-Null
 
     $RetVal = Receive-Job -Job $LocalJob
-
     return $RetVal -join "`n"
 }
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -11,12 +11,8 @@ $WpaStackWalkProfileXml = `
   <Profiles>
     <SystemCollector Id="SC_HighVolume" Realtime="false">
       <BufferSize Value="1024"/>
-      <Buffers Value="80"/>
+      <Buffers Value="20"/>
     </SystemCollector>
-    <EventCollector Id="EC_LowVolume" Realtime="false" Name="LowVolume">
-      <BufferSize Value="1024"/>
-      <Buffers Value="80"/>
-    </EventCollector>
     <SystemProvider Id="SP_CPU">
       <Keywords>
         <Keyword Value="CpuConfig"/>
@@ -28,31 +24,11 @@ $WpaStackWalkProfileXml = `
         <Stack Value="SampledProfile"/>
       </Stacks>
     </SystemProvider>
-    <EventProvider Id="EP_MsQuicEtw_LowVolume" Name="ff15e657-4f26-570e-88ab-0796b258d11c" NonPagedMemory="true" Level="4">
-      <Keywords>
-        <Keyword Value="0x80000000"/>
-      </Keywords>
-    </EventProvider>
-    <EventProvider Id="EP_MsQuicEtw_LowVolume_DataPath" Name="ff15e657-4f26-570e-88ab-0796b258d11c" NonPagedMemory="true">
-      <Keywords>
-        <Keyword Value="0xC0000000"/>
-      </Keywords>
-    </EventProvider>
-    <EventProvider Id="EP_TcpIpEtw" Name="Microsoft-Windows-TCPIP" NonPagedMemory="true" />
-    <EventProvider Id="EP_WinSockEtw" Name="Microsoft-Windows-Winsock-AFD" NonPagedMemory="true" />
     <Profile Id="CPU.Light.File" Name="CPU" Description="CPU Stacks" LoggingMode="File" DetailLevel="Light">
       <Collectors>
         <SystemCollectorId Value="SC_HighVolume">
           <SystemProviderId Value="SP_CPU" />
         </SystemCollectorId>
-        <EventCollectorId Value="EC_LowVolume">
-          <EventProviders>
-            <EventProviderId Value="EP_TcpIpEtw" />
-            <EventProviderId Value="EP_WinSockEtw" />
-            <EventProviderId Value="EP_MsQuicEtw_LowVolume_DataPath" />
-            <EventProviderId Value="EP_MsQuicEtw_LowVolume" />
-          </EventProviders>
-        </EventCollectorId>
       </Collectors>
     </Profile>
   </Profiles>
@@ -156,7 +132,7 @@ function Wait-ForRemoteReady {
 
 function Wait-ForRemote {
     param ($Job)
-    Wait-Job -Job $Job -Timeout 60 | Out-Null
+    Wait-Job -Job $Job -Timeout 10 | Out-Null
     Stop-Job -Job $Job | Out-Null
     $RetVal = Receive-Job -Job $Job
     return $RetVal -join "`n"
@@ -344,11 +320,7 @@ function Invoke-RemoteExe {
             wpr.exe -start $EtwXmlName -filemode 2> $null
         }
 
-        Write-Host "Remote Started"
-
         & $Exe ($RunArgs).Split(" ")
-
-        Write-Host "Remote Ended"
 
         if ($Record -and $IsWindows) {
             $EtwName = $Exe + ".remote.etl"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -156,7 +156,7 @@ function Wait-ForRemoteReady {
 
 function Wait-ForRemote {
     param ($Job)
-    Wait-Job -Job $Job -Timeout 25 | Out-Null
+    Wait-Job -Job $Job -Timeout 60 | Out-Null
     Stop-Job -Job $Job | Out-Null
     $RetVal = Receive-Job -Job $Job
     return $RetVal -join "`n"
@@ -344,7 +344,11 @@ function Invoke-RemoteExe {
             wpr.exe -start $EtwXmlName -filemode 2> $null
         }
 
+        Write-Host "Remote Started"
+
         & $Exe ($RunArgs).Split(" ")
+
+        Write-Host "Remote Ended"
 
         if ($Record -and $IsWindows) {
             $EtwName = $Exe + ".remote.etl"

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -287,7 +287,6 @@ function Invoke-Test {
 
     # Starting the server
     $RemoteJob = Invoke-RemoteExe -Exe $RemoteExe -RunArgs $RemoteArguments
-    Write-Debug "Invoked remote exe"
     $ReadyToStart = Wait-ForRemoteReady -Job $RemoteJob
 
     if (!$ReadyToStart) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -287,6 +287,7 @@ function Invoke-Test {
 
     # Starting the server
     $RemoteJob = Invoke-RemoteExe -Exe $RemoteExe -RunArgs $RemoteArguments
+    Write-Debug "Invoked remote exe"
     $ReadyToStart = Wait-ForRemoteReady -Job $RemoteJob
 
     if (!$ReadyToStart) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -315,7 +315,8 @@ function Invoke-Test {
     }
 
     if ($Record) {
-        Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + ".etl"))
+        Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + "remote.etl"))
+        Copy-Item -Path ($LocalExe + ".local.etl") -Destination (Join-Path $OutputDir ($Test.ToString() + "local.etl"))
     }
 
     if ($PGO) {
@@ -332,6 +333,19 @@ function Invoke-Test {
 }
 
 $LocalDataCache = LocalSetup
+
+if ($Record -and $IsWindows) {
+    try {
+        wpr.exe -cancel 2> $null
+    } catch {
+    }
+    Invoke-TestCommand -Session $Session -ScriptBlock {
+        try {
+            wpr.exe -cancel 2> $null
+        } catch {
+        }
+    }
+}
 
 try {
     $Tests = Get-Tests $TestsFile

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -296,6 +296,8 @@ function Invoke-Test {
 
     $AllRunsResults = @()
 
+    Start-Tracing -Exe $LocalExe
+
     try {
         1..$Test.Iterations | ForEach-Object {
             $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout
@@ -314,10 +316,14 @@ function Invoke-Test {
         Write-Debug $RemoteResults.ToString()
     }
 
+    Stop-Tracing -Exe $LocalExe
+
     if ($Record) {
-        Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + "remote.etl"))
-        if (!$Local) {
-            Copy-Item -Path ($LocalExe + ".local.etl") -Destination (Join-Path $OutputDir ($Test.ToString() + "local.etl"))
+        if ($Local) {
+            Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + ".combined.etl"))
+        } else {
+            Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + ".server.etl"))
+            Copy-Item -Path ($LocalExe + ".local.etl") -Destination (Join-Path $OutputDir ($Test.ToString() + ".client.etl"))
         }
     }
 

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -36,11 +36,14 @@ This script runs performance tests locally for a period of time.
 .PARAMETER Publish
     Publishes the results to the artifacts directory.
 
-.PARAMETER Record
-    Records ETW traces
+.PARAMETER RecordStack
+    Records ETW stack traces
 
 .PARAMETER Timeout
     Timeout in seconds for each individual client test invocation.
+
+.PARAMETER RecordQUIC
+    Record QUIC specific trace events
 
 #>
 
@@ -87,12 +90,16 @@ param (
     [switch]$Local = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Record = $false,
+    [switch]$RecordStack = $false,
 
     [Parameter(Mandatory = $false)]
     [switch]$PGO = $false,
 
-    [int]$Timeout = 60
+    [Parameter(Mandatory = $false)]
+    [int]$Timeout = 60,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$RecordQUIC = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -100,6 +107,8 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent
+
+$Record = $RecordStack -or $RecordQUIC
 
 # Remove any previous remote PowerShell sessions
 Get-PSSession | Remove-PSSession
@@ -148,6 +157,7 @@ Set-ScriptVariables -Local $Local `
                     -Config $Config `
                     -Publish $Publish `
                     -Record $Record
+                    -RecordQUIC $RecordQUIC
 
 if ($Local) {
     $RemoteAddress = "localhost"

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -156,7 +156,7 @@ Set-ScriptVariables -Local $Local `
                     -RemoteArch $RemoteArch `
                     -Config $Config `
                     -Publish $Publish `
-                    -Record $Record
+                    -Record $Record `
                     -RecordQUIC $RecordQUIC
 
 if ($Local) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -316,7 +316,9 @@ function Invoke-Test {
 
     if ($Record) {
         Get-RemoteFile -From ($RemoteExe + ".remote.etl") -To (Join-Path $OutputDir ($Test.ToString() + "remote.etl"))
-        Copy-Item -Path ($LocalExe + ".local.etl") -Destination (Join-Path $OutputDir ($Test.ToString() + "local.etl"))
+        if (!$Local) {
+            Copy-Item -Path ($LocalExe + ".local.etl") -Destination (Join-Path $OutputDir ($Test.ToString() + "local.etl"))
+        }
     }
 
     if ($PGO) {

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -279,7 +279,7 @@ QUIC_STATIC_ASSERT(
 // The flow control window is doubled when more than (1 / ratio) of the current
 // window is delivered to the app within 1 RTT.
 //
-#define QUIC_RECV_BUFFER_DRAIN_RATIO            2
+#define QUIC_RECV_BUFFER_DRAIN_RATIO            8
 
 //
 // The default value for send buffering being enabled or not.


### PR DESCRIPTION
Perf testing was seeing that we were hitting stream flow control rate limiting, causing instabilities in perf results. Increasing the ratio helps solve this issue by hitting that flow control limit much less often.

Also updates the perf CI runner to allow grabbing logs for remote tests.