### PR TITLE
More Code Coverage

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1369,13 +1369,14 @@ QuicBindingDeliverDatagrams(
         }
     }
 
-    if (Connection != NULL) {
-        QuicConnQueueRecvDatagrams(Connection, DatagramChain, DatagramChainLength);
-        QuicConnRelease(Connection, QUIC_CONN_REF_LOOKUP_RESULT);
-        return TRUE;
-    } else {
+    if (Connection == NULL) {
         return FALSE;
     }
+
+    QuicConnQueueRecvDatagrams(Connection, DatagramChain, DatagramChainLength);
+    QuicConnRelease(Connection, QUIC_CONN_REF_LOOKUP_RESULT);
+
+    return TRUE;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1468,38 +1468,40 @@ QuicLibraryGetCurrentStatelessRetryKey(
 {
     int64_t Now = QuicTimeEpochMs64();
     int64_t StartTime = (Now / QUIC_STATELESS_RETRY_KEY_LIFETIME_MS) * QUIC_STATELESS_RETRY_KEY_LIFETIME_MS;
-    int64_t ExpirationTime = StartTime + QUIC_STATELESS_RETRY_KEY_LIFETIME_MS;
 
-    //
-    // If the start time for the current key interval is greater-than-or-equal to the expiration time
-    // of the latest stateless retry key, generate a new key, and rotate the old.
-    //
-    if (StartTime >= MsQuicLib.StatelessRetryKeysExpiration[MsQuicLib.CurrentStatelessRetryKey]) {
-
-        QUIC_KEY* NewKey;
-        uint8_t RawKey[QUIC_AEAD_AES_256_GCM_SIZE];
-        QuicRandom(sizeof(RawKey), RawKey);
-        QUIC_STATUS Status =
-            QuicKeyCreate(
-                QUIC_AEAD_AES_256_GCM,
-                RawKey,
-                &NewKey);
-        if (QUIC_FAILED(Status)) {
-            QuicTraceEvent(
-                LibraryErrorStatus,
-                "[ lib] ERROR, %u, %s.",
-                Status,
-                "Create stateless retry key");
-            return NULL;
-        }
-
-        MsQuicLib.StatelessRetryKeysExpiration[!MsQuicLib.CurrentStatelessRetryKey] = ExpirationTime;
-        QuicKeyFree(MsQuicLib.StatelessRetryKeys[!MsQuicLib.CurrentStatelessRetryKey]);
-        MsQuicLib.StatelessRetryKeys[!MsQuicLib.CurrentStatelessRetryKey] = NewKey;
-        MsQuicLib.CurrentStatelessRetryKey = !MsQuicLib.CurrentStatelessRetryKey;
-
-        return NewKey;
-    } else {
+    if (StartTime < MsQuicLib.StatelessRetryKeysExpiration[MsQuicLib.CurrentStatelessRetryKey]) {
         return MsQuicLib.StatelessRetryKeys[MsQuicLib.CurrentStatelessRetryKey];
     }
+
+    //
+    // If the start time for the current key interval is greater-than-or-equal
+    // to the expiration time of the latest stateless retry key, generate a new
+    // key, and rotate the old.
+    //
+
+    int64_t ExpirationTime = StartTime + QUIC_STATELESS_RETRY_KEY_LIFETIME_MS;
+
+    QUIC_KEY* NewKey;
+    uint8_t RawKey[QUIC_AEAD_AES_256_GCM_SIZE];
+    QuicRandom(sizeof(RawKey), RawKey);
+    QUIC_STATUS Status =
+        QuicKeyCreate(
+            QUIC_AEAD_AES_256_GCM,
+            RawKey,
+            &NewKey);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "Create stateless retry key");
+        return NULL;
+    }
+
+    MsQuicLib.StatelessRetryKeysExpiration[!MsQuicLib.CurrentStatelessRetryKey] = ExpirationTime;
+    QuicKeyFree(MsQuicLib.StatelessRetryKeys[!MsQuicLib.CurrentStatelessRetryKey]);
+    MsQuicLib.StatelessRetryKeys[!MsQuicLib.CurrentStatelessRetryKey] = NewKey;
+    MsQuicLib.CurrentStatelessRetryKey = !MsQuicLib.CurrentStatelessRetryKey;
+
+    return NewKey;
 }


### PR DESCRIPTION
- Updates spinquic to get parameters randomly now.
- Rework a binding code path where the `else` was pointless because it was after a `return`.

Related to #634.