### PR TITLE
Add Pool Tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if (WIN32)
 else()
     set(QUIC_COMMON_FLAGS "")
     set(QUIC_COMMON_DEFINES "")
-    set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-unused-value CACHE INTERNAL "")
+    set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-unused-value -Wmultichar CACHE INTERNAL "")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if (WIN32)
 else()
     set(QUIC_COMMON_FLAGS "")
     set(QUIC_COMMON_DEFINES "")
-    set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-unused-value -Wmultichar CACHE INTERNAL "")
+    set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-unused-value -Wno-multichar CACHE INTERNAL "")
 endif()
 
 if(WIN32)

--- a/src/bin/winkernel/driver.c
+++ b/src/bin/winkernel/driver.c
@@ -80,7 +80,7 @@ Return Value:
     WDF_DRIVER_CONFIG_INIT(&Config, NULL);
     Config.EvtDriverUnload = EvtDriverUnload;
     Config.DriverInitFlags = WdfDriverInitNonPnpDriver;
-    Config.DriverPoolTag = QUIC_POOL_TAG;
+    Config.DriverPoolTag = QUIC_POOL_GENERIC;
 
     Status =
         WdfDriverCreate(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -192,10 +192,12 @@ MsQuicLibraryInitialize(
         QuicPoolInitialize(
             FALSE,
             sizeof(QUIC_CONNECTION),
+            QUIC_POOL_CONN,
             &MsQuicLib.PerProc[i].ConnectionPool);
         QuicPoolInitialize(
             FALSE,
             sizeof(QUIC_TRANSPORT_PARAMETERS),
+            QUIC_POOL_TP,
             &MsQuicLib.PerProc[i].TransportParamPool);
     }
 

--- a/src/core/sent_packet_metadata.c
+++ b/src/core/sent_packet_metadata.c
@@ -67,6 +67,7 @@ QuicSentPacketPoolInitialize(
         QuicPoolInitialize(
             FALSE,  // IsPaged
             PacketMetadataSize,
+            QUIC_POOL_META,
             Pool->Pools + i);
     }
 }

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -53,13 +53,13 @@ QuicWorkerInitialize(
     QuicEventInitialize(&Worker->Ready, FALSE, FALSE);
     QuicListInitializeHead(&Worker->Connections);
     QuicListInitializeHead(&Worker->Operations);
-    QuicPoolInitialize(FALSE, sizeof(QUIC_STREAM), &Worker->StreamPool);
-    QuicPoolInitialize(FALSE, QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE, &Worker->DefaultReceiveBufferPool);
-    QuicPoolInitialize(FALSE, sizeof(QUIC_SEND_REQUEST), &Worker->SendRequestPool);
+    QuicPoolInitialize(FALSE, sizeof(QUIC_STREAM), QUIC_POOL_STREAM, &Worker->StreamPool);
+    QuicPoolInitialize(FALSE, QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE, QUIC_POOL_SBUF, &Worker->DefaultReceiveBufferPool);
+    QuicPoolInitialize(FALSE, sizeof(QUIC_SEND_REQUEST), QUIC_POOL_GENERIC, &Worker->SendRequestPool);
     QuicSentPacketPoolInitialize(&Worker->SentPacketPool);
-    QuicPoolInitialize(FALSE, sizeof(QUIC_API_CONTEXT), &Worker->ApiContextPool);
-    QuicPoolInitialize(FALSE, sizeof(QUIC_STATELESS_CONTEXT), &Worker->StatelessContextPool);
-    QuicPoolInitialize(FALSE, sizeof(QUIC_OPERATION), &Worker->OperPool);
+    QuicPoolInitialize(FALSE, sizeof(QUIC_API_CONTEXT), QUIC_POOL_GENERIC, &Worker->ApiContextPool);
+    QuicPoolInitialize(FALSE, sizeof(QUIC_STATELESS_CONTEXT), QUIC_POOL_GENERIC, &Worker->StatelessContextPool);
+    QuicPoolInitialize(FALSE, sizeof(QUIC_OPERATION), QUIC_POOL_GENERIC, &Worker->OperPool);
 
     Status = QuicTimerWheelInitialize(&Worker->TimerWheel);
     if (QUIC_FAILED(Status)) {

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -63,6 +63,21 @@ typedef struct QUIC_SINGLE_LIST_ENTRY {
 #endif
 #endif
 
+//
+// Different pool tags used for marking allocations.
+//
+
+#define QUIC_POOL_GENERIC   'CIUQ'  // QUIC - Generic QUIC
+#define QUIC_POOL_CONN      'noCQ'  // QCon - QUIC connection
+#define QUIC_POOL_TP        'PTCQ'  // QCTP - QUIC connection transport parameters
+#define QUIC_POOL_STREAM    'mtSQ'  // QStm - QUIC stream
+#define QUIC_POOL_SBUF      'fBSQ'  // QSBf - QUIC stream buffer
+#define QUIC_POOL_META      'MFSQ'  // QSFM - QUIC sent frame metedata
+#define QUIC_POOL_DATA      'atDQ'  // QDta - QUIC datagram buffer
+#define QUIC_POOL_TEST      'tsTQ'  // QTst - QUIC test code
+#define QUIC_POOL_PERF      'frPQ'  // QPrf - QUIC perf code
+#define QUIC_POOL_TOOL      'loTQ'  // QTol - QUIC tool code
+
 #ifdef _KERNEL_MODE
 #define QUIC_PLATFORM_TYPE 1
 #include <quic_platform_winkernel.h>

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -249,6 +249,7 @@ QuicFree(
 #define QUIC_ALLOC_PAGED(Size) QuicAlloc(Size)
 #define QUIC_ALLOC_NONPAGED(Size) QuicAlloc(Size)
 #define QUIC_FREE(Mem) QuicFree((void*)Mem)
+#define QUIC_FREE_TAG(Mem, Tag) QUIC_FREE(Mem)
 
 //
 // Represents a QUIC memory pool used for fixed sized allocations.
@@ -295,6 +296,7 @@ void
 QuicPoolInitialize(
     _In_ BOOLEAN IsPaged,
     _In_ uint32_t Size,
+    _In_ uint32_t Tag,
     _Inout_ QUIC_POOL* Pool
     );
 

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -255,15 +255,14 @@ QuicPlatformLogAssert(
 
 extern uint64_t QuicTotalMemory;
 
-#define QUIC_POOL_TAG 'CIUQ'
-
-#define QUIC_ALLOC_PAGED(Size) ExAllocatePool2(POOL_FLAG_PAGED | POOL_FLAG_UNINITIALIZED, Size, QUIC_POOL_TAG)
-#define QUIC_ALLOC_NONPAGED(Size) ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, Size, QUIC_POOL_TAG)
-#define QUIC_FREE(Mem) ExFreePoolWithTag((void*)Mem, QUIC_POOL_TAG)
+#define QUIC_ALLOC_PAGED(Size) ExAllocatePool2(POOL_FLAG_PAGED | POOL_FLAG_UNINITIALIZED, Size, QUIC_POOL_GENERIC)
+#define QUIC_ALLOC_NONPAGED(Size) ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, Size, QUIC_POOL_GENERIC)
+#define QUIC_FREE(Mem) ExFreePool((void*)Mem)
+#define QUIC_FREE_TAG(Mem, Tag) ExFreePoolWithTag((void*)Mem, Tag)
 
 typedef LOOKASIDE_LIST_EX QUIC_POOL;
 
-#define QuicPoolInitialize(IsPaged, Size, Pool) \
+#define QuicPoolInitialize(IsPaged, Size, Tag, Pool) \
     ExInitializeLookasideListEx( \
         Pool, \
         NULL, \
@@ -271,7 +270,7 @@ typedef LOOKASIDE_LIST_EX QUIC_POOL;
         (IsPaged) ? PagedPool : NonPagedPoolNx, \
         0, \
         Size, \
-        QUIC_POOL_TAG, \
+        QUIC_POOL_GENERIC, \
         0)
 
 #define QuicPoolUninitialize(Pool) ExDeleteLookasideListEx(Pool)
@@ -904,8 +903,8 @@ QuicRandom(
 #define QUIC_SILO_INVALID ((PESILO)(void*)(LONG_PTR)-1)
 
 #define QuicSiloGetCurrentServer() PsGetCurrentServerSilo()
-#define QuicSiloAddRef(Silo) if (Silo != NULL) { ObReferenceObjectWithTag(Silo, QUIC_POOL_TAG); }
-#define QuicSiloRelease(Silo) if (Silo != NULL) { ObDereferenceObjectWithTag(Silo, QUIC_POOL_TAG); }
+#define QuicSiloAddRef(Silo) if (Silo != NULL) { ObReferenceObjectWithTag(Silo, QUIC_POOL_GENERIC); }
+#define QuicSiloRelease(Silo) if (Silo != NULL) { ObDereferenceObjectWithTag(Silo, QUIC_POOL_GENERIC); }
 #define QuicSiloAttach(Silo) PsAttachSiloToCurrentThread(Silo)
 #define QuicSiloDetatch(PrevSilo) PsDetachSiloFromCurrentThread(PrevSilo)
 

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -270,7 +270,7 @@ typedef LOOKASIDE_LIST_EX QUIC_POOL;
         (IsPaged) ? PagedPool : NonPagedPoolNx, \
         0, \
         Size, \
-        QUIC_POOL_GENERIC, \
+        Tag, \
         0)
 
 #define QuicPoolUninitialize(Pool) ExDeleteLookasideListEx(Pool)

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -257,6 +257,7 @@ QuicFree(
 #define QUIC_ALLOC_PAGED(Size) QuicAlloc(Size)
 #define QUIC_ALLOC_NONPAGED(Size) QuicAlloc(Size)
 #define QUIC_FREE(Mem) QuicFree((void*)Mem)
+#define QUIC_FREE_TAG(Mem, Tag) QUIC_FREE(Mem)
 
 typedef struct QUIC_POOL {
     SLIST_HEADER ListHead;
@@ -278,6 +279,7 @@ void
 QuicPoolInitialize(
     _In_ BOOLEAN IsPaged,
     _In_ uint32_t Size,
+    _In_ uint32_t Tag,
     _Inout_ QUIC_POOL* Pool
     )
 {
@@ -287,6 +289,7 @@ QuicPoolInitialize(
     Pool->Size = Size;
     InitializeSListHead(&(Pool)->ListHead);
     UNREFERENCED_PARAMETER(IsPaged);
+    UNREFERENCED_PARAMETER(Tag); // TODO - Use in debug mode?
 }
 
 inline

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -20,8 +20,6 @@ Abstract:
 #include "driver.cpp.clog.h"
 #endif
 
-#define QUIC_PERF_TAG 'frPQ' // QPrf
-
 DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceName, L"\\Device\\quicperformance");
 DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceSymLink, L"\\DosDevices\\quicperformance");
 
@@ -71,28 +69,28 @@ QuicPerfCtlUninitialize(
     );
 
 void* __cdecl operator new (size_t Size) {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_PERF_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
 }
 
 void __cdecl operator delete (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_PERF_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_PERF);
     }
 }
 
 void __cdecl operator delete (_In_opt_ void* Mem, _In_opt_ size_t) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_PERF_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_PERF);
     }
 }
 
 void* __cdecl operator new[](size_t Size) {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_PERF_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
 }
 
 void __cdecl operator delete[](_In_opt_ void* Mem) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_PERF_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_PERF);
     }
 }
 
@@ -133,7 +131,7 @@ DriverEntry(
     WDF_DRIVER_CONFIG_INIT(&Config, NULL);
     Config.EvtDriverUnload = QuicPerfDriverUnload;
     Config.DriverInitFlags = WdfDriverInitNonPnpDriver;
-    Config.DriverPoolTag = QUIC_PERF_TAG;
+    Config.DriverPoolTag = QUIC_POOL_PERF;
 
     Status =
         WdfDriverCreate(

--- a/src/perf/lib/PerfHelpers.h
+++ b/src/perf/lib/PerfHelpers.h
@@ -218,7 +218,7 @@ public:
 
     void Initialize(uint32_t Size, bool Paged = false) {
         QUIC_DBG_ASSERT(Initialized == false);
-        QuicPoolInitialize(Paged, Size, &Pool);
+        QuicPoolInitialize(Paged, Size, QUIC_POOL_PERF, &Pool);
         Initialized = true;
     }
 
@@ -239,7 +239,7 @@ class QuicPoolAllocator {
     QUIC_POOL Pool;
 public:
     QuicPoolAllocator() {
-        QuicPoolInitialize(Paged, sizeof(T), &Pool);
+        QuicPoolInitialize(Paged, sizeof(T), QUIC_POOL_PERF, &Pool);
     }
 
     ~QuicPoolAllocator() {

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -359,11 +359,20 @@ QuicProcessorContextInitialize(
         sizeof(QUIC_DATAPATH_RECV_BLOCK) + Datapath->ClientRecvContextLength;
 
     ProcContext->Index = Index;
-    QuicPoolInitialize(TRUE, RecvPacketLength, &ProcContext->RecvBlockPool);
-    QuicPoolInitialize(TRUE, MAX_UDP_PAYLOAD_LENGTH, &ProcContext->SendBufferPool);
+    QuicPoolInitialize(
+        TRUE,
+        RecvPacketLength,
+        QUIC_POOL_DATA,
+        &ProcContext->RecvBlockPool);
+    QuicPoolInitialize(
+        TRUE,
+        MAX_UDP_PAYLOAD_LENGTH,
+        QUIC_POOL_DATA,
+        &ProcContext->SendBufferPool);
     QuicPoolInitialize(
         TRUE,
         sizeof(QUIC_DATAPATH_SEND_CONTEXT),
+        QUIC_POOL_GENERIC,
         &ProcContext->SendContextPool);
 
     EpollFd = epoll_create1(EPOLL_CLOEXEC);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -405,7 +405,7 @@ QuicSendBufferPoolAlloc(
     _Inout_ PLOOKASIDE_LIST_EX Lookaside
     );
 
-#define QuicSendBufferPoolInitialize(Size, Pool) \
+#define QuicSendBufferPoolInitialize(Size, Tag, Pool) \
     ExInitializeLookasideListEx( \
         Pool, \
         QuicSendBufferPoolAlloc, \
@@ -413,7 +413,7 @@ QuicSendBufferPoolAlloc(
         NonPagedPoolNx, \
         0, \
         Size, \
-        QUIC_POOL_TAG, \
+        Tag, \
         0)
 
 QUIC_RECV_DATAGRAM*
@@ -854,24 +854,29 @@ QuicDataPathInitialize(
         QuicPoolInitialize(
             FALSE,
             sizeof(QUIC_DATAPATH_SEND_CONTEXT),
+            QUIC_POOL_GENERIC,
             &Datapath->ProcContexts[i].SendContextPool);
 
         QuicSendBufferPoolInitialize(
             sizeof(QUIC_DATAPATH_SEND_BUFFER) + MAX_UDP_PAYLOAD_LENGTH,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].SendBufferPool);
 
         QuicSendBufferPoolInitialize(
             sizeof(QUIC_DATAPATH_SEND_BUFFER) + QUIC_LARGE_SEND_BUFFER_SIZE,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].LargeSendBufferPool);
 
         QuicPoolInitialize(
             FALSE,
             RecvDatagramLength,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].RecvDatagramPool);
 
         QuicPoolInitialize(
             FALSE,
             UroDatagramLength,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].UroRecvDatagramPool);
     }
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -648,21 +648,25 @@ QuicDataPathInitialize(
         QuicPoolInitialize(
             FALSE,
             sizeof(QUIC_DATAPATH_SEND_CONTEXT),
+            QUIC_POOL_GENERIC,
             &Datapath->ProcContexts[i].SendContextPool);
 
         QuicPoolInitialize(
             FALSE,
             MAX_UDP_PAYLOAD_LENGTH,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].SendBufferPool);
 
         QuicPoolInitialize(
             FALSE,
             QUIC_LARGE_SEND_BUFFER_SIZE,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].LargeSendBufferPool);
 
         QuicPoolInitialize(
             FALSE,
             RecvDatagramLength,
+            QUIC_POOL_DATA,
             &Datapath->ProcContexts[i].RecvDatagramPool);
 
         Datapath->ProcContexts[i].IOCP =

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -196,9 +196,11 @@ void
 QuicPoolInitialize(
     _In_ BOOLEAN IsPaged,
     _In_ uint32_t Size,
+    _In_ uint32_t Tag,
     _Inout_ QUIC_POOL* Pool
     )
 {
+    UNREFERENCED_PARAMETER(Tag);
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     PlatDispatch->PoolInitialize(IsPaged, Size, Pool);
 #else

--- a/src/test/bin/winkernel/driver.cpp
+++ b/src/test/bin/winkernel/driver.cpp
@@ -17,8 +17,6 @@ Abstract:
 #include "driver.cpp.clog.h"
 #endif
 
-#define QUIC_TEST_TAG 'tsTQ' // QTst
-
 EVT_WDF_DRIVER_UNLOAD QuicTestDriverUnload;
 
 _No_competing_thread_
@@ -34,28 +32,28 @@ QuicTestCtlUninitialize(
     );
 
 void* __cdecl operator new (size_t Size) {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_TEST_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
 }
 
 void __cdecl operator delete (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_TEST_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_TEST);
     }
 }
 
 void __cdecl operator delete (_In_opt_ void* Mem, _In_opt_ size_t) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_TEST_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_TEST);
     }
 }
 
 void* __cdecl operator new[] (size_t Size) {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_TEST_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
 }
 
 void __cdecl operator delete[] (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
-        ExFreePoolWithTag(Mem, QUIC_TEST_TAG);
+        ExFreePoolWithTag(Mem, QUIC_POOL_TEST);
     }
 }
 
@@ -121,7 +119,7 @@ Return Value:
     WDF_DRIVER_CONFIG_INIT(&Config, NULL);
     Config.EvtDriverUnload = QuicTestDriverUnload;
     Config.DriverInitFlags = WdfDriverInitNonPnpDriver;
-    Config.DriverPoolTag = QUIC_TEST_TAG;
+    Config.DriverPoolTag = QUIC_POOL_TEST;
 
     Status =
         WdfDriverCreate(


### PR DESCRIPTION
Adds tags for different allocations. Currently only used in kernel mode and only for lookaside list allocations (since that is where we have a leak).