### PR TITLE
Catch Stream Leaks Earlier

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -345,6 +345,16 @@ QuicConnFree(
     QUIC_TEL_ASSERT(QuicListIsEmpty(&Connection->Streams.ClosedStreams));
     QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
+#if DEBUG
+    while (!QuicListIsEmpty(&Connection->Streams.AllStreams)) {
+        QUIC_STREAM *Stream =
+            QUIC_CONTAINING_RECORD(
+                QuicListRemoveHead(&Connection->Streams.AllStreams),
+                QUIC_STREAM,
+                AllStreamsLink);
+        QUIC_DBG_ASSERTMSG(Stream != NULL, "Stream was leaked!");
+    }
+#endif
     while (!QuicListIsEmpty(&Connection->DestCids)) {
         QUIC_CID_QUIC_LIST_ENTRY *CID =
             QUIC_CONTAINING_RECORD(

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -301,6 +301,9 @@ typedef struct QUIC_CONNECTION {
     long RefCount;
 
 #if DEBUG
+    //
+    // Detailed ref counts
+    //
     short RefTypeCount[QUIC_CONN_REF_COUNT];
 #endif
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -30,8 +30,9 @@ QuicStreamInitialize(
     QUIC_STREAM* Stream;
     uint8_t* PreallocatedRecvBuffer = NULL;
     uint32_t InitialRecvBufferLength;
+    QUIC_WORKER* Worker = Connection->Worker;
 
-    Stream = QuicPoolAlloc(&Connection->Worker->StreamPool);
+    Stream = QuicPoolAlloc(&Worker->StreamPool);
     if (Stream == NULL) {
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Exit;
@@ -91,7 +92,7 @@ QuicStreamInitialize(
 
     InitialRecvBufferLength = Connection->Session->Settings.StreamRecvBufferDefault;
     if (InitialRecvBufferLength == QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE) {
-        PreallocatedRecvBuffer = QuicPoolAlloc(&Connection->Worker->DefaultReceiveBufferPool);
+        PreallocatedRecvBuffer = QuicPoolAlloc(&Worker->DefaultReceiveBufferPool);
         if (PreallocatedRecvBuffer == NULL) {
             Status = QUIC_STATUS_OUT_OF_MEMORY;
             QuicRangeUninitialize(&Stream->SparseAckRanges);
@@ -114,6 +115,12 @@ QuicStreamInitialize(
     Stream->MaxAllowedRecvOffset = Stream->RecvBuffer.VirtualBufferLength;
     Stream->RecvWindowLastUpdate = QuicTimeUs32();
 
+#if DEBUG
+    QuicDispatchLockAcquire(&Connection->Streams.AllStreamsLock);
+    QuicListInsertTail(&Connection->Streams.AllStreams, &Stream->AllStreamsLink);
+    QuicDispatchLockRelease(&Connection->Streams.AllStreamsLock);
+#endif
+
     Stream->Flags.Initialized = TRUE;
     *NewStream = Stream;
     Stream = NULL;
@@ -124,10 +131,10 @@ Exit:
     if (Stream) {
         QuicDispatchLockUninitialize(&Stream->ApiSendRequestLock);
         Stream->Flags.Freed = TRUE;
-        QuicPoolFree(&Connection->Worker->StreamPool, Stream);
+        QuicPoolFree(&Worker->StreamPool, Stream);
     }
     if (PreallocatedRecvBuffer) {
-        QuicPoolFree(&Connection->Worker->DefaultReceiveBufferPool, PreallocatedRecvBuffer);
+        QuicPoolFree(&Worker->DefaultReceiveBufferPool, PreallocatedRecvBuffer);
     }
 
     return Status;
@@ -140,6 +147,8 @@ QuicStreamFree(
     )
 {
     BOOLEAN WasStarted = Stream->Flags.Started;
+    QUIC_CONNECTION* Connection = Stream->Connection;
+    QUIC_WORKER* Worker = Connection->Worker;
 
     QUIC_TEL_ASSERT(Stream->RefCount == 0);
     QUIC_TEL_ASSERT(Stream->Flags.ShutdownComplete);
@@ -152,6 +161,12 @@ QuicStreamFree(
     QUIC_TEL_ASSERT(Stream->ApiSendRequests == NULL);
     QUIC_TEL_ASSERT(Stream->SendRequests == NULL);
 
+#if DEBUG
+    QuicDispatchLockAcquire(&Connection->Streams.AllStreamsLock);
+    QuicListEntryRemove(&Stream->AllStreamsLink);
+    QuicDispatchLockRelease(&Connection->Streams.AllStreamsLock);
+#endif
+
     QuicRecvBufferUninitialize(&Stream->RecvBuffer);
     QuicRangeUninitialize(&Stream->SparseAckRanges);
     QuicDispatchLockUninitialize(&Stream->ApiSendRequestLock);
@@ -159,12 +174,12 @@ QuicStreamFree(
 
     if (Stream->RecvBuffer.PreallocatedBuffer) {
         QuicPoolFree(
-            &Stream->Connection->Worker->DefaultReceiveBufferPool,
+            &Worker->DefaultReceiveBufferPool,
             Stream->RecvBuffer.PreallocatedBuffer);
     }
 
     Stream->Flags.Freed = TRUE;
-    QuicPoolFree(&Stream->Connection->Worker->StreamPool, Stream);
+    QuicPoolFree(&Worker->StreamPool, Stream);
 
     if (WasStarted) {
 #pragma warning(push)

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -213,6 +213,13 @@ typedef struct QUIC_STREAM {
     //
     QUIC_LIST_ENTRY SendLink;
 
+#if DEBUG
+    //
+    // The list entry in the stream set's list of all allocated streams.
+    //
+    QUIC_LIST_ENTRY AllStreamsLink;
+#endif
+
     //
     // The parent connection for this stream.
     //

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -49,6 +49,10 @@ QuicStreamSetInitialize(
     )
 {
     QuicListInitializeHead(&StreamSet->ClosedStreams);
+#if DEBUG
+    QuicListInitializeHead(&StreamSet->AllStreams);
+    QuicDispatchLockInitialize(&StreamSet->AllStreamsLock);
+#endif
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -58,6 +62,9 @@ QuicStreamSetUninitialize(
     )
 {
     if (StreamSet->StreamTable != NULL) {
+#if DEBUG
+        QuicDispatchLockUninitialize(&StreamSet->AllStreamsLock);
+#endif
         QuicHashtableUninitialize(StreamSet->StreamTable);
     }
 }

--- a/src/core/stream_set.h
+++ b/src/core/stream_set.h
@@ -51,6 +51,14 @@ typedef struct QUIC_STREAM_SET {
     //
     QUIC_LIST_ENTRY ClosedStreams;
 
+#if DEBUG
+    //
+    // The list of allocated streams for leak tracking.
+    //
+    QUIC_LIST_ENTRY AllStreams;
+    QUIC_DISPATCH_LOCK AllStreamsLock;
+#endif
+
 } QUIC_STREAM_SET;
 
 //


### PR DESCRIPTION
More info to debug #664.

Updates the connection & stream set to (in debug mode) track all allocated streams and assert if any are left over when the connection is cleaned up.