### PR TITLE
Connection Initialization Cleanup

### DIFF
--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -51,7 +51,7 @@ jobs:
       pwsh: true
       filePath: scripts/spin.ps1
       ${{ if eq(parameters.codeCoverage, true) }}:
-        arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -CodeCoverage -LogProfile Basic.Light
+        arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -CodeCoverage -LogProfile Full.Light
       ${{ if eq(parameters.codeCoverage, false) }}:
         arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 

--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -51,7 +51,7 @@ jobs:
       pwsh: true
       filePath: scripts/spin.ps1
       ${{ if eq(parameters.codeCoverage, true) }}:
-        arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -CodeCoverage -LogProfile Full.Light
+        arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} -CodeCoverage -LogProfile Basic.Light
       ${{ if eq(parameters.codeCoverage, false) }}:
         arguments: -GenerateXmlResults -Timeout ${{ parameters.timeout }} -RepeatCount ${{ parameters.repeat }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -154,7 +154,7 @@ $WerDumpRegPath = "HKLM:\Software\Microsoft\Windows\Windows Error Reporting\Loca
 # Asynchronously starts the executable with the given arguments.
 function Start-Executable {
     $Now = (Get-Date -UFormat "%Y-%m-%dT%T")
-    if ($LogProfile -ne "None") {
+    if ($LogProfile -ne "None" -and !$CodeCoverage) {
         & $LogScript -Start -LogProfile $LogProfile | Out-Null
     }
 
@@ -209,6 +209,13 @@ function Start-Executable {
     $p = New-Object System.Diagnostics.Process
     $p.StartInfo = $pinfo
     $p.Start() | Out-Null
+
+    if ($LogProfile -ne "None" -and $CodeCoverage) {
+        # When measuring code coverage, start logs a little after the exe starts
+        # to trigger the rundown code paths.
+        Sleep -Seconds 5
+        & $LogScript -Start -LogProfile $LogProfile | Out-Null
+    }
 
     [pscustomobject]@{
         Timestamp = $Now

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -312,7 +312,9 @@ function Wait-Executable($Exe) {
 
         if ($KeepOutput) {
             if ($LogProfile -ne "None") {
-                if ($ConvertLogs) {
+                if ($CodeCoverage) {
+                    & $LogScript -Cancel | Out-Null
+                } elseif ($ConvertLogs) {
                     & $LogScript -Stop -OutputDirectory $LogDir -ConvertToText
                 } else {
                     & $LogScript -Stop -OutputDirectory $LogDir | Out-Null

--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -43,38 +43,23 @@ Abstract:
 #endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
+void
 QuicAckTrackerInitialize(
     _Inout_ QUIC_ACK_TRACKER* Tracker
     )
 {
-    QUIC_STATUS Status;
-
     Tracker->AckElicitingPacketsToAcknowledge = 0;
     Tracker->LargestPacketNumberAcknowledged = 0;
     Tracker->LargestPacketNumberRecvTime = 0;
     Tracker->AlreadyWrittenAckFrame = FALSE;
 
-    Status =
-        QuicRangeInitialize(
-            QUIC_MAX_RANGE_DUPLICATE_PACKETS,
-            &Tracker->PacketNumbersReceived);
-    if (QUIC_FAILED(Status)) {
-        goto Error;
-    }
+    QuicRangeInitialize(
+        QUIC_MAX_RANGE_DUPLICATE_PACKETS,
+        &Tracker->PacketNumbersReceived);
 
-    Status =
-        QuicRangeInitialize(
-            QUIC_MAX_RANGE_ACK_PACKETS,
-            &Tracker->PacketNumbersToAck);
-    if (QUIC_FAILED(Status)) {
-        QuicRangeUninitialize(&Tracker->PacketNumbersReceived);
-        goto Error;
-    }
-
-Error:
-
-    return Status;
+    QuicRangeInitialize(
+        QUIC_MAX_RANGE_ACK_PACKETS,
+        &Tracker->PacketNumbersToAck);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/ack_tracker.h
+++ b/src/core/ack_tracker.h
@@ -48,7 +48,7 @@ typedef struct QUIC_ACK_TRACKER {
 // Initializes a new ack tracker.
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
+void
 QuicAckTrackerInitialize(
     _Inout_ QUIC_ACK_TRACKER* Tracker
     );

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -61,8 +61,8 @@ MsQuicConnectionOpen(
 #pragma prefast(suppress: __WARNING_25024, "Pointer cast already validated.")
     Session = (QUIC_SESSION*)SessionHandle;
 
-    Status = QuicConnInitialize(Session, NULL, &Connection);
-    if (QUIC_FAILED(Status)) {
+    if ((Connection = QuicConnAlloc(Session, NULL)) == NULL) {
+        Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -72,6 +72,7 @@ MsQuicConnectionOpen(
     QuicRegistrationQueueNewConnection(Session->Registration, Connection);
 
     *NewConnection = (HQUIC)Connection;
+    Status = QUIC_STATUS_SUCCESS;
 
 Error:
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1121,8 +1121,7 @@ QuicBindingCreateConnection(
             MsQuicLib.UnregisteredSession,
             Datagram);
     if (NewConnection == NULL) {
-        QuicPacketLogDropWithValue(Binding, Packet,
-            "Failed to initialize new connection", Status);
+        QuicPacketLogDrop(Binding, Packet, "Failed to initialize new connection");
         return NULL;
     }
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1116,14 +1116,11 @@ QuicBindingCreateConnection(
     QUIC_CONNECTION* Connection = NULL;
     QUIC_RECV_PACKET* Packet = QuicDataPathRecvDatagramToRecvPacket(Datagram);
 
-    QUIC_CONNECTION* NewConnection;
-    QUIC_STATUS Status =
-        QuicConnInitialize(
+    QUIC_CONNECTION* NewConnection =
+        QuicConnAlloc(
             MsQuicLib.UnregisteredSession,
-            Datagram,
-            &NewConnection);
-    if (QUIC_FAILED(Status)) {
-        QuicConnRelease(NewConnection, QUIC_CONN_REF_HANDLE_OWNER);
+            Datagram);
+    if (NewConnection == NULL) {
         QuicPacketLogDropWithValue(Binding, Packet,
             "Failed to initialize new connection", Status);
         return NULL;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -119,6 +119,19 @@ QuicConnAlloc(
     QuicSendInitialize(&Connection->Send);
     QuicLossDetectionInitialize(&Connection->LossDetection);
     QuicDatagramInitialize(&Connection->Datagram);
+    QuicRangeInitialize(
+        QUIC_MAX_RANGE_DECODE_ACKS,
+        &Connection->DecodedAckRanges);
+
+    for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); i++) {
+        if (QUIC_FAILED(
+            QuicPacketSpaceInitialize(
+                Connection,
+                (QUIC_ENCRYPT_LEVEL)i,
+                &Connection->Packets[i]))) {
+            goto Error;
+        }
+    }
 
     QUIC_PATH* Path = &Connection->Paths[0];
     QuicPathInitialize(Connection, Path);
@@ -205,6 +218,10 @@ QuicConnAlloc(
             SourceCid->CID.SequenceNumber,
             LOG_BINARY(SourceCid->CID.Length, SourceCid->CID.Data));
 
+        //
+        // Server lazily finishes initialization in response to first operation.
+        //
+
     } else {
         Connection->Type = QUIC_HANDLE_TYPE_CLIENT;
         Connection->State.ExternalOwner = TRUE;
@@ -224,6 +241,12 @@ QuicConnAlloc(
             Connection,
             Path->DestCid->CID.SequenceNumber,
             LOG_BINARY(Path->DestCid->CID.Length, Path->DestCid->CID.Data));
+
+        Connection->State.Initialized = TRUE;
+        QuicTraceEvent(
+            ConnInitializeComplete,
+            "[conn][%p] Initialize complete",
+            Connection);
     }
 
     QuicSessionRegisterConnection(Session, Connection);
@@ -233,87 +256,13 @@ QuicConnAlloc(
 Error:
 
     if (Connection != NULL) {
-        QuicConnRelease(Connection, QUIC_CONN_REF_HANDLE_OWNER);
-    }
-
-    return NULL;
-}
-
-_IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
-QuicConnInitialize(
-    _In_ QUIC_SESSION* Session,
-    _In_opt_ const QUIC_RECV_DATAGRAM* const Datagram, // NULL for client side
-    _Outptr_ _At_(*NewConnection, __drv_allocatesMem(Mem))
-        QUIC_CONNECTION** NewConnection
-    )
-{
-    QUIC_STATUS Status;
-    uint32_t InitStep = 0;
-
-    QUIC_CONNECTION* Connection = QuicConnAlloc(Session, Datagram);
-    if (Connection == NULL) {
-        Status = QUIC_STATUS_OUT_OF_MEMORY;
-        goto Error;
-    }
-    InitStep++; // Step 1
-
-    for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); i++) {
-        Status =
-            QuicPacketSpaceInitialize(
-                Connection,
-                (QUIC_ENCRYPT_LEVEL)i,
-                &Connection->Packets[i]);
-        if (QUIC_FAILED(Status)) {
-            goto Error;
-        }
-    }
-
-    //
-    // N.B. Initializing packet space can fail part-way through, so it must be
-    //      cleaned up even if it doesn't complete. Do not separate it from
-    //      allocation.
-    //
-    Status =
-        QuicRangeInitialize(
-            QUIC_MAX_RANGE_DECODE_ACKS,
-            &Connection->DecodedAckRanges);
-    if (QUIC_FAILED(Status)) {
-        goto Error;
-    }
-    InitStep++; // Step 2
-
-    if (Datagram == NULL) {
-        Connection->State.Initialized = TRUE;
-        QuicTraceEvent(
-            ConnInitializeComplete,
-            "[conn][%p] Initialize complete",
-            Connection);
-    } else {
-        //
-        // Server lazily finishes initialzation in response to first operation.
-        //
-    }
-
-    *NewConnection = Connection;
-
-    return QUIC_STATUS_SUCCESS;
-
-Error:
-
-    switch (InitStep) {
-    case 2:
-        QuicRangeUninitialize(&Connection->DecodedAckRanges);
-        __fallthrough;
-    case 1:
+        Connection->State.HandleClosed = TRUE;
+        Connection->State.Uninitialized = TRUE;
         for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); i++) {
             if (Connection->Packets[i] != NULL) {
                 QuicPacketSpaceUninitialize(Connection->Packets[i]);
             }
         }
-
-        Connection->State.HandleClosed = TRUE;
-        Connection->State.Uninitialized = TRUE;
         if (Datagram != NULL) {
             QUIC_FREE(
                 QUIC_CONTAINING_RECORD(
@@ -323,10 +272,9 @@ Error:
             Connection->SourceCids.Next = NULL;
         }
         QuicConnRelease(Connection, QUIC_CONN_REF_HANDLE_OWNER);
-        break;
     }
 
-    return Status;
+    return NULL;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -820,12 +820,13 @@ QuicConnRemoveOutFlowBlockedReason(
 // a datagram is the cause of the creation, and is passed in.
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
-QuicConnInitialize(
+__drv_allocatesMem(Mem)
+_Must_inspect_result_
+_Success_(return != NULL)
+QUIC_CONNECTION*
+QuicConnAlloc(
     _In_ QUIC_SESSION* Session,
-    _In_opt_ const QUIC_RECV_DATAGRAM* const Datagram,
-    _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem))
-        QUIC_CONNECTION** Connection
+    _In_opt_ const QUIC_RECV_DATAGRAM* const Datagram
     );
 
 //

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -120,7 +120,6 @@ QuicCryptoInitialize(
 
     QUIC_PASSIVE_CODE();
 
-    QuicZeroMemory(Crypto, sizeof(QUIC_CRYPTO)); // TODO - Unnecessary as the parent Connection was already zeroed out?
     QuicRangeInitialize(
         QUIC_MAX_RANGE_ALLOC_SIZE,
         &Crypto->SparseAckRanges);

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -537,10 +537,7 @@ QuicCrytpoTlsGetCompleteTlsMessagesLength(
 {
     uint32_t MessagesLength = 0;
 
-    do {
-        if (BufferLength < TLS_MESSAGE_HEADER_LENGTH) {
-            break;
-        }
+    while (BufferLength >= TLS_MESSAGE_HEADER_LENGTH) {
 
         uint32_t MessageLength =
             TLS_MESSAGE_HEADER_LENGTH + TlsReadUint24(Buffer + 1);
@@ -551,8 +548,7 @@ QuicCrytpoTlsGetCompleteTlsMessagesLength(
         MessagesLength += MessageLength;
         Buffer += MessageLength;
         BufferLength -= MessageLength;
-
-    } while (BufferLength > 0);
+    }
 
     return MessagesLength;
 }

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -25,39 +25,6 @@ QuicUint8Encode(
     return Buffer + sizeof(uint8_t);
 }
 
-_Post_equal_to_(Buffer + sizeof(uint16_t))
-uint8_t*
-QuicUint16Encode(
-    _In_ uint16_t Value,
-    _Out_writes_bytes_all_(sizeof(uint16_t))
-        uint8_t* Buffer
-    )
-{
-    *(uint16_t*)Buffer = QuicByteSwapUint16(Value);
-    return Buffer + sizeof(uint16_t);
-}
-
-_Success_(return != FALSE)
-BOOLEAN
-QuicUint16Decode(
-    _In_ uint16_t BufferLength,
-    _In_reads_bytes_(BufferLength)
-        const uint8_t * const Buffer,
-    _Inout_
-    _Deref_in_range_(0, BufferLength)
-    _Deref_out_range_(0, BufferLength)
-        uint16_t* Offset,
-    _Out_ uint16_t* Value
-    )
-{
-    if (*Offset + sizeof(uint16_t) > BufferLength) {
-        return FALSE;
-    }
-    *Value = QuicByteSwapUint16(*(const uint16_t * const)(Buffer + *Offset));
-    *Offset += sizeof(uint16_t);
-    return TRUE;
-}
-
 _Success_(return != FALSE)
 BOOLEAN
 QuicAckHeaderEncode(
@@ -1114,7 +1081,7 @@ QuicConnCloseFrameDecode(
     Frame->ApplicationClosed = FrameType == QUIC_FRAME_CONNECTION_CLOSE_1;
     Frame->FrameType = 0; // Default to make OACR happy.
     if (!QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->ErrorCode) ||
-        (!Frame->ApplicationClosed && 
+        (!Frame->ApplicationClosed &&
          !QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->FrameType)) ||
         !QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->ReasonPhraseLength) ||
         (uint64_t)BufferLength < *Offset + Frame->ReasonPhraseLength) {
@@ -1416,7 +1383,7 @@ QuicFrameLog(
         }
 
         QuicTraceLogVerbose(
-            FrameLogCrypto, 
+            FrameLogCrypto,
             "[%c][%cX][%llu]   CRYPTO Offset:%llu Len:%hu",
             PtkConnPre(Connection),
             PktRxPre(Rx),

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -199,6 +199,11 @@ MsQuicLibraryInitialize(
             sizeof(QUIC_TRANSPORT_PARAMETERS),
             QUIC_POOL_TP,
             &MsQuicLib.PerProc[i].TransportParamPool);
+        QuicPoolInitialize(
+            FALSE,
+            sizeof(QUIC_PACKET_SPACE),
+            QUIC_POOL_TP,
+            &MsQuicLib.PerProc[i].PacketSpacePool);
     }
 
     Status =
@@ -245,6 +250,7 @@ Error:
             for (uint8_t i = 0; i < MsQuicLib.PartitionCount; ++i) {
                 QuicPoolUninitialize(&MsQuicLib.PerProc[i].ConnectionPool);
                 QuicPoolUninitialize(&MsQuicLib.PerProc[i].TransportParamPool);
+                QuicPoolUninitialize(&MsQuicLib.PerProc[i].PacketSpacePool);
             }
             QUIC_FREE(MsQuicLib.PerProc);
             MsQuicLib.PerProc = NULL;
@@ -316,6 +322,7 @@ MsQuicLibraryUninitialize(
     for (uint8_t i = 0; i < MsQuicLib.PartitionCount; ++i) {
         QuicPoolUninitialize(&MsQuicLib.PerProc[i].ConnectionPool);
         QuicPoolUninitialize(&MsQuicLib.PerProc[i].TransportParamPool);
+        QuicPoolUninitialize(&MsQuicLib.PerProc[i].PacketSpacePool);
     }
     QUIC_FREE(MsQuicLib.PerProc);
     MsQuicLib.PerProc = NULL;

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -51,6 +51,11 @@ typedef struct QUIC_CACHEALIGN QUIC_LIBRARY_PP {
     //
     QUIC_POOL TransportParamPool;
 
+    //
+    // Pool for QUIC_PACKET_SPACE.
+    //
+    QUIC_POOL PacketSpacePool;
+
 } QUIC_LIBRARY_PP;
 
 //

--- a/src/core/packet_space.c
+++ b/src/core/packet_space.c
@@ -23,7 +23,8 @@ QuicPacketSpaceInitialize(
     _Out_ QUIC_PACKET_SPACE** NewPackets
     )
 {
-    QUIC_PACKET_SPACE* Packets = QUIC_ALLOC_NONPAGED(sizeof(QUIC_PACKET_SPACE)); // TODO - Pool alloc?
+    uint8_t CurProcIndex = QuicLibraryGetCurrentPartition();
+    QUIC_PACKET_SPACE* Packets = QuicPoolAlloc(&MsQuicLib.PerProc[CurProcIndex].PacketSpacePool);
     if (Packets == NULL) {
         QuicTraceEvent(
             AllocFailure,
@@ -62,7 +63,8 @@ QuicPacketSpaceUninitialize(
 
     QuicAckTrackerUninitialize(&Packets->AckTracker);
 
-    QUIC_FREE(Packets);
+    uint8_t CurProcIndex = QuicLibraryGetCurrentPartition();
+    QuicPoolFree(&MsQuicLib.PerProc[CurProcIndex].PacketSpacePool, Packets);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/packet_space.c
+++ b/src/core/packet_space.c
@@ -23,39 +23,24 @@ QuicPacketSpaceInitialize(
     _Out_ QUIC_PACKET_SPACE** NewPackets
     )
 {
-    QUIC_STATUS Status;
-    QUIC_PACKET_SPACE* Packets;
-
-    Packets = QUIC_ALLOC_NONPAGED(sizeof(QUIC_PACKET_SPACE));
+    QUIC_PACKET_SPACE* Packets = QUIC_ALLOC_NONPAGED(sizeof(QUIC_PACKET_SPACE)); // TODO - Pool alloc?
     if (Packets == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "packet space",
             sizeof(QUIC_PACKET_SPACE));
-        Status = QUIC_STATUS_OUT_OF_MEMORY;
-        goto Error;
+        return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
     QuicZeroMemory(Packets, sizeof(QUIC_PACKET_SPACE));
     Packets->Connection = Connection;
     Packets->EncryptLevel = EncryptLevel;
-
-    Status = QuicAckTrackerInitialize(&Packets->AckTracker);
-    if (QUIC_FAILED(Status)) {
-        goto Error;
-    }
+    QuicAckTrackerInitialize(&Packets->AckTracker);
 
     *NewPackets = Packets;
-    Packets = NULL;
 
-Error:
-
-    if (Packets != NULL) {
-        QUIC_FREE(Packets);
-    }
-
-    return Status;
+    return QUIC_STATUS_SUCCESS;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/range.h
+++ b/src/core/range.h
@@ -9,7 +9,6 @@
 #define QUIC_RANGE_USE_BINARY_SEARCH    1
 
 #define QUIC_RANGE_INITIAL_SUB_COUNT    8
-#define QUIC_RANGE_PREALLOC_SUB_RANGES  1
 
 typedef struct QUIC_SUBRANGE {
 
@@ -64,12 +63,10 @@ typedef struct QUIC_RANGE {
     _Field_range_(sizeof(QUIC_SUBRANGE), sizeof(QUIC_SUBRANGE) * QUIC_MAX_RANGE_ALLOC_SIZE)
     uint32_t MaxAllocSize;
 
-#if QUIC_RANGE_PREALLOC_SUB_RANGES
     //
     // Allocates a number of subranges along with the parent object.
     //
     QUIC_SUBRANGE PreAllocSubRanges[QUIC_RANGE_INITIAL_SUB_COUNT];
-#endif
 
 } QUIC_RANGE;
 
@@ -228,7 +225,7 @@ QuicRangeSearch(
 #endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
+void
 QuicRangeInitialize(
     _In_ uint32_t MaxAllocSize,
     _Out_ QUIC_RANGE* Range

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -226,17 +226,6 @@ QuicRecvBufferHasUnreadData(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-BOOLEAN
-QuicRecvBufferAlreadyReadData(
-    _In_ QUIC_RECV_BUFFER* RecvBuffer,
-    _In_ uint64_t BufferOffset,
-    _In_ uint16_t BufferLength
-    )
-{
-    return BufferOffset + BufferLength <= RecvBuffer->BaseOffset;
-}
-
-_IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QuicRecvBufferWrite(
     _In_ QUIC_RECV_BUFFER* RecvBuffer,

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -48,7 +48,7 @@ Abstract:
 #endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-QUIC_STATUS
+QUIC_STATUS // TODO - Can only fail if PreallocatedBuffer == NULL
 QuicRecvBufferInitialize(
     _Inout_ QUIC_RECV_BUFFER* RecvBuffer,
     _In_ uint32_t AllocBufferLength,
@@ -80,19 +80,7 @@ QuicRecvBufferInitialize(
         }
     }
 
-    Status =
-        QuicRangeInitialize(
-            QUIC_MAX_RANGE_ALLOC_SIZE,
-            &RecvBuffer->WrittenRanges);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            AllocFailure,
-            "Allocation of '%s' failed. (%llu bytes)",
-            "recv_buffer written ranged",
-            QUIC_MAX_RANGE_ALLOC_SIZE);
-        QUIC_FREE(RecvBuffer->Buffer);
-        goto Error;
-    }
+    QuicRangeInitialize(QUIC_MAX_RANGE_ALLOC_SIZE, &RecvBuffer->WrittenRanges);
 
     RecvBuffer->AllocBufferLength = AllocBufferLength;
     RecvBuffer->VirtualBufferLength = VirtualBufferLength;

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -109,17 +109,6 @@ QuicRecvBufferHasUnreadData(
     );
 
 //
-// Returns TRUE if the data was already read out of the receive buffer.
-//
-_IRQL_requires_max_(DISPATCH_LEVEL)
-BOOLEAN
-QuicRecvBufferAlreadyReadData(
-    _In_ QUIC_RECV_BUFFER* RecvBuffer,
-    _In_ uint64_t BufferOffset,
-    _In_ uint16_t BufferLength
-    );
-
-//
 // Buffers a (possibly out-of-order or duplicate) range of bytes.
 //
 // Returns TRUE if in-order bytes are ready to be delivered

--- a/src/core/unittest/FrameTest.cpp
+++ b/src/core/unittest/FrameTest.cpp
@@ -38,8 +38,8 @@ TEST_P(AckFrameTest, AckFrameEncodeDecode)
 
     QuicZeroMemory(Buffer, sizeof(Buffer));
 
-    TEST_QUIC_SUCCEEDED(QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckRange));
-    TEST_QUIC_SUCCEEDED(QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &DecodedAckRange));
+    QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckRange);
+    QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &DecodedAckRange);
 
     ASSERT_TRUE(QuicRangeAddRange(&AckRange, MinPktNum, ContigPktCount, &Unused) != nullptr);
     ASSERT_TRUE(QuicRangeAddValue(&AckRange, MaxPktNum));
@@ -79,7 +79,7 @@ TEST_P(AckFrameTest, DecodeAckFrameFail) {
     BOOLEAN InvalidFrame = FALSE;
     QUIC_RANGE DecodedAckBlocks;
     QUIC_VAR_INT AckDelay = 0;
-    TEST_QUIC_SUCCEEDED(QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &DecodedAckBlocks));
+    QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &DecodedAckBlocks);
     Buffer[0] = (uint8_t)GetParam();
 
     //

--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -48,7 +48,7 @@ TEST(SpinFrame, SpinFrame1000000)
     uint8_t BufferLength;
     uint8_t FrameType;
 
-    TEST_QUIC_SUCCEEDED(QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckBlocks));
+    QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckBlocks);
 
     //
     // This test generates random "frames" of data to be decoded by the framing


### PR DESCRIPTION
`QuicRangeInitialize` can no longer fail. This allows for a certain amount of cleanup for all the callers, resulting in some of them not being able to fail either. This results in even smaller cleanup code if those things fail to initialize (allocation failures). It should actually increase (by a small amount) code coverage because there are fewer lines that are never hit because of initialization/allocation failure.