### PR TITLE
ECN Send Path Abstraction

### DIFF
--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -142,13 +142,13 @@ QuicAckTrackerAckPacket(
     }
 
     switch (ECN) {
-        case QUIC_ECN_ECT_0:
-            Tracker->NonZeroRecvECN = TRUE;
-            Tracker->ReceivedECN.ECT_0_Count++;
-            break;
         case QUIC_ECN_ECT_1:
             Tracker->NonZeroRecvECN = TRUE;
             Tracker->ReceivedECN.ECT_1_Count++;
+            break;
+        case QUIC_ECN_ECT_0:
+            Tracker->NonZeroRecvECN = TRUE;
+            Tracker->ReceivedECN.ECT_0_Count++;
             break;
         case QUIC_ECN_CE:
             Tracker->NonZeroRecvECN = TRUE;

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -675,7 +675,10 @@ QuicBindingProcessStatelessOperation(
         OperationType);
 
     QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-        QuicDataPathBindingAllocSendContext(Binding->DatapathBinding, 0);
+        QuicDataPathBindingAllocSendContext(
+            Binding->DatapathBinding,
+            QUIC_ECN_NON_ECT,
+            0);
     if (SendContext == NULL) {
         QuicTraceEvent(
             AllocFailure,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -184,6 +184,7 @@ QuicPacketBuilderPrepare(
             Builder->SendContext =
                 QuicDataPathBindingAllocSendContext(
                     Builder->Path->Binding->DatapathBinding,
+                    QUIC_ECN_NON_ECT,
                     IsPathMtuDiscovery ?
                         0 :
                         MaxUdpPayloadSizeForFamily(

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -44,8 +44,8 @@ extern "C" {
 typedef enum QUIC_ECN_TYPE {
 
     QUIC_ECN_NON_ECT = 0x0, // Non ECN-Capable Transport, Non-ECT
-    QUIC_ECN_ECT_0   = 0x1, // ECN Capable Transport, ECT(0)
-    QUIC_ECN_ECT_1   = 0x2, // ECN Capable Transport, ECT(1)
+    QUIC_ECN_ECT_1   = 0x1, // ECN Capable Transport, ECT(1)
+    QUIC_ECN_ECT_0   = 0x2, // ECN Capable Transport, ECT(0)
     QUIC_ECN_CE      = 0x3  // Congestion Encountered, CE
 
 } QUIC_ECN_TYPE;
@@ -390,6 +390,7 @@ _Success_(return != NULL)
 QUIC_DATAPATH_SEND_CONTEXT*
 QuicDataPathBindingAllocSendContext(
     _In_ QUIC_DATAPATH_BINDING* Binding,
+    _In_ QUIC_ECN_TYPE ECN,
     _In_ uint16_t MaxPacketSize
     );
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1778,7 +1778,7 @@ QuicDataPathBindingReturnRecvDatagrams(
 QUIC_DATAPATH_SEND_CONTEXT*
 QuicDataPathBindingAllocSendContext(
     _In_ QUIC_DATAPATH_BINDING* Binding,
-    QUIC_ECN_NON_ECT,
+    _In_ QUIC_ECN_TYPE ECN,
     _In_ uint16_t MaxPacketSize
     )
 {

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1806,7 +1806,7 @@ QuicDataPathBindingAllocSendContext(
 
     QuicZeroMemory(SendContext, sizeof(*SendContext));
     SendContext->Owner = ProcContext;
-    SendContext->ECN;
+    SendContext->ECN = ECN;
 
 Exit:
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -96,6 +96,11 @@ typedef struct QUIC_DATAPATH_SEND_CONTEXT {
     BOOLEAN Pending;
 
     //
+    // The type of ECN markings needed for send.
+    //
+    QUIC_ECN_TYPE ECN;
+
+    //
     // The proc context owning this send context.
     //
     struct QUIC_DATAPATH_PROC_CONTEXT *Owner;
@@ -1773,6 +1778,7 @@ QuicDataPathBindingReturnRecvDatagrams(
 QUIC_DATAPATH_SEND_CONTEXT*
 QuicDataPathBindingAllocSendContext(
     _In_ QUIC_DATAPATH_BINDING* Binding,
+    QUIC_ECN_NON_ECT,
     _In_ uint16_t MaxPacketSize
     )
 {
@@ -1800,6 +1806,7 @@ QuicDataPathBindingAllocSendContext(
 
     QuicZeroMemory(SendContext, sizeof(*SendContext));
     SendContext->Owner = ProcContext;
+    SendContext->ECN;
 
 Exit:
 
@@ -1944,6 +1951,8 @@ QuicDataPathBindingSend(
                 1,
                 SendContext->Buffers[i].Length,
                 CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress));
+
+            // TODO - Use SendContext->ECN if not QUIC_ECN_NON_ECT
 
             SentByteCount =
                 sendto(

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -211,6 +211,11 @@ typedef struct QUIC_DATAPATH_SEND_CONTEXT {
     uint32_t TotalSize;
 
     //
+    // The type of ECN markings needed for send.
+    //
+    QUIC_ECN_TYPE ECN;
+
+    //
     // The number of WSK buffers allocated.
     //
     UINT8 WskBufferCount;
@@ -2203,6 +2208,7 @@ _Success_(return != NULL)
 QUIC_DATAPATH_SEND_CONTEXT*
 QuicDataPathBindingAllocSendContext(
     _In_ QUIC_DATAPATH_BINDING* Binding,
+    _In_ QUIC_ECN_TYPE ECN,
     _In_ UINT16 MaxPacketSize
     )
 {
@@ -2216,6 +2222,7 @@ QuicDataPathBindingAllocSendContext(
 
     if (SendContext != NULL) {
         SendContext->Owner = ProcContext;
+        SendContext->ECN = ECN;
         SendContext->WskBufs = NULL;
         SendContext->TailBuf = NULL;
         SendContext->TotalSize = 0;
@@ -2649,6 +2656,8 @@ QuicDataPathBindingSendTo(
     PWSACMSGHDR CMsg = NULL;
     ULONG CMsgLen = 0;
 
+    // TODO - Use SendContext->ECN if not QUIC_ECN_NON_ECT
+
     if (SendContext->SegmentSize > 0) {
         CMsg = (PWSACMSGHDR)CMsgBuffer;
         CMsgLen += WSA_CMSG_SPACE(sizeof(*SegmentSize));
@@ -2734,6 +2743,8 @@ QuicDataPathBindingSendFromTo(
     BYTE CMsgBuffer[WSA_CMSG_SPACE(sizeof(IN6_PKTINFO)) + WSA_CMSG_SPACE(sizeof(*SegmentSize))];
     PWSACMSGHDR CMsg = (PWSACMSGHDR)CMsgBuffer;
     ULONG CMsgLen;
+
+    // TODO - Use SendContext->ECN if not QUIC_ECN_NON_ECT
 
     if (LocalAddress->si_family == AF_INET) {
         CMsgLen = WSA_CMSG_SPACE(sizeof(IN_PKTINFO));

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -156,6 +156,11 @@ typedef struct QUIC_DATAPATH_SEND_CONTEXT {
     UINT16 SegmentSize;
 
     //
+    // The type of ECN markings needed for send.
+    //
+    QUIC_ECN_TYPE ECN;
+
+    //
     // The current number of WsaBuffers used.
     //
     UINT8 WsaBufferCount;
@@ -2115,6 +2120,7 @@ _Success_(return != NULL)
 QUIC_DATAPATH_SEND_CONTEXT*
 QuicDataPathBindingAllocSendContext(
     _In_ QUIC_DATAPATH_BINDING* Binding,
+    _In_ QUIC_ECN_TYPE ECN,
     _In_ uint16_t MaxPacketSize
     )
 {
@@ -2128,6 +2134,7 @@ QuicDataPathBindingAllocSendContext(
 
     if (SendContext != NULL) {
         SendContext->Owner = ProcContext;
+        SendContext->ECN = ECN;
         SendContext->SegmentSize =
             (Binding->Datapath->Features & QUIC_DATAPATH_FEATURE_SEND_SEGMENTATION)
                 ? MaxPacketSize : 0;
@@ -2444,6 +2451,8 @@ QuicDataPathBindingSendTo(
     WSAMhdr.Control.buf = NULL;
     WSAMhdr.Control.len = 0;
 
+    // TODO - Use SendContext->ECN if not QUIC_ECN_NON_ECT
+
     PWSACMSGHDR CMsg;
     BYTE CtrlBuf[WSA_CMSG_SPACE(sizeof(*SegmentSize))];
 
@@ -2563,6 +2572,8 @@ QuicDataPathBindingSendFromTo(
     WSAMhdr.namelen = sizeof(MappedRemoteAddress);
     WSAMhdr.lpBuffers = SendContext->WsaBuffers;
     WSAMhdr.dwBufferCount = SendContext->WsaBufferCount;
+
+    // TODO - Use SendContext->ECN if not QUIC_ECN_NON_ECT
 
     PWSACMSGHDR CMsg;
     BYTE CtrlBuf[WSA_CMSG_SPACE(sizeof(IN6_PKTINFO)) + WSA_CMSG_SPACE(sizeof(*SegmentSize))];

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -188,7 +188,7 @@ protected:
             if (recvBuffer->Tuple->LocalAddress.Ipv4.sin_port == RecvContext->ServerAddress.Ipv4.sin_port) {
 
                 auto ServerSendContext =
-                    QuicDataPathBindingAllocSendContext(binding, 0);
+                    QuicDataPathBindingAllocSendContext(binding, QUIC_ECN_NON_ECT, 0);
                 ASSERT_NE(nullptr, ServerSendContext);
 
                 auto ServerDatagram =
@@ -392,7 +392,7 @@ TEST_P(DataPathTest, Data)
     ASSERT_NE(nullptr, client);
 
     auto ClientSendContext =
-        QuicDataPathBindingAllocSendContext(client, 0);
+        QuicDataPathBindingAllocSendContext(client, QUIC_ECN_NON_ECT, 0);
     ASSERT_NE(nullptr, ClientSendContext);
 
     auto ClientDatagram =
@@ -471,7 +471,7 @@ TEST_P(DataPathTest, DataRebind)
     ASSERT_NE(nullptr, client);
 
     auto ClientSendContext =
-        QuicDataPathBindingAllocSendContext(client, 0);
+        QuicDataPathBindingAllocSendContext(client, QUIC_ECN_NON_ECT, 0);
     ASSERT_NE(nullptr, ClientSendContext);
 
     auto ClientDatagram =
@@ -502,7 +502,7 @@ TEST_P(DataPathTest, DataRebind)
     ASSERT_NE(nullptr, client);
 
     ClientSendContext =
-        QuicDataPathBindingAllocSendContext(client, 0);
+        QuicDataPathBindingAllocSendContext(client, QUIC_ECN_NON_ECT, 0);
     ASSERT_NE(nullptr, ClientSendContext);
 
     ClientDatagram =

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -183,7 +183,8 @@ struct DrillSender {
         const uint16_t DatagramLength = (uint16_t) PacketBuffer->size();
 
         QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(Binding, DatagramLength);
+            QuicDataPathBindingAllocSendContext(
+                Binding, QUIC_ECN_NON_ECT, DatagramLength);
 
         QUIC_BUFFER* SendBuffer =
             QuicDataPathBindingAllocSendDatagram(SendContext, DatagramLength);

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -107,7 +107,8 @@ RunAttackRandom(
     while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs) {
 
         QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(Binding, Length);
+            QuicDataPathBindingAllocSendContext(
+                Binding, QUIC_ECN_NON_ECT, Length);
         if (SendContext == nullptr) {
             printf("QuicDataPathBindingAllocSendContext failed\n");
             return;
@@ -211,7 +212,8 @@ RunAttackValidInitial(
     while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs) {
 
         QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(Binding, DatagramLength);
+            QuicDataPathBindingAllocSendContext(
+                Binding, QUIC_ECN_NON_ECT, DatagramLength);
         VERIFY(SendContext);
 
         while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs &&


### PR DESCRIPTION
Adds an abstraction layer to allow for a specific ECN marking to be sent on a send context. Also fixes a bug @larseggert pointed out where I had flipped the values of two ECN types.

Another step towards #559.