### PR TITLE
Switch all C++ new in kernel mode to nothrow new

### DIFF
--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -179,14 +179,14 @@ class QuicApiTable : public QUIC_API_TABLE {
     QUIC_STATUS Init;
     const QUIC_API_TABLE* ApiTable{nullptr};
 public:
-    QuicApiTable() {
+    QuicApiTable() noexcept {
         if (QUIC_SUCCEEDED(Init = MsQuicOpen(&ApiTable))) {
             QUIC_API_TABLE* thisTable = this;
             QuicCopyMemory(thisTable, ApiTable, sizeof(*ApiTable));
         }
     }
 
-    ~QuicApiTable() {
+    ~QuicApiTable() noexcept {
         if (QUIC_SUCCEEDED(Init)) {
             MsQuicClose(ApiTable);
             ApiTable = nullptr;
@@ -195,7 +195,7 @@ public:
         }
     }
 
-    QUIC_STATUS InitStatus() const {
+    QUIC_STATUS InitStatus() const noexcept {
         return Init;
     }
 };
@@ -204,7 +204,7 @@ class MsQuicRegistration {
     HQUIC Registration;
     QUIC_STATUS InitStatus;
 public:
-    MsQuicRegistration() {
+    MsQuicRegistration() noexcept {
         QuicZeroMemory(&Registration, sizeof(Registration));
         if (QUIC_FAILED(
             InitStatus =
@@ -214,16 +214,16 @@ public:
             Registration = nullptr;
         }
     }
-    ~MsQuicRegistration() {
+    ~MsQuicRegistration() noexcept {
         if (Registration != nullptr) {
             MsQuic->RegistrationClose(Registration);
         }
     }
-    QUIC_STATUS GetInitStatus() const { return InitStatus; }
-    bool IsValid() const { return Registration != nullptr; }
+    QUIC_STATUS GetInitStatus() const noexcept { return InitStatus; }
+    bool IsValid() const noexcept { return Registration != nullptr; }
     MsQuicRegistration(MsQuicRegistration& other) = delete;
     MsQuicRegistration operator=(MsQuicRegistration& Other) = delete;
-    operator HQUIC () const {
+    operator HQUIC () const noexcept {
         return Registration;
     }
 };
@@ -235,7 +235,7 @@ public:
     HQUIC Handle {nullptr};
     MsQuicSession(
         _In_ const MsQuicRegistration& Reg,
-        _In_z_ const char* RawAlpn = "MsQuicTest")
+        _In_z_ const char* RawAlpn = "MsQuicTest") noexcept
         : Handle(nullptr), CloseAllConnectionsOnDelete(false) {
         if (!Reg.IsValid()) {
             InitStatus = Reg.GetInitStatus();
@@ -258,7 +258,7 @@ public:
 
 #ifndef QUIC_SKIP_GLOBAL_CONSTRUCTORS
 
-    MsQuicSession(_In_z_ const char* RawAlpn = "MsQuicTest")
+    MsQuicSession(_In_z_ const char* RawAlpn = "MsQuicTest") noexcept
         : Handle(nullptr), CloseAllConnectionsOnDelete(false) {
         QUIC_BUFFER Alpn;
         Alpn.Buffer = (uint8_t*)RawAlpn;
@@ -274,7 +274,7 @@ public:
             Handle = nullptr;
         }
     }
-    MsQuicSession(_In_z_ const char* RawAlpn1, _In_z_ const char* RawAlpn2)
+    MsQuicSession(_In_z_ const char* RawAlpn1, _In_z_ const char* RawAlpn2) noexcept
         : Handle(nullptr), CloseAllConnectionsOnDelete(false) {
         QUIC_BUFFER Alpns[2];
         Alpns[0].Buffer = (uint8_t*)RawAlpn1;
@@ -293,7 +293,7 @@ public:
         }
     }
 #endif
-    ~MsQuicSession() {
+    ~MsQuicSession() noexcept {
         if (Handle != nullptr) {
             if (CloseAllConnectionsOnDelete) {
                 MsQuic->SessionShutdown(
@@ -304,29 +304,29 @@ public:
             MsQuic->SessionClose(Handle);
         }
     }
-    QUIC_STATUS GetInitStatus() const { return InitStatus; }
-    bool IsValid() const {
+    QUIC_STATUS GetInitStatus() const noexcept { return InitStatus; }
+    bool IsValid() const noexcept {
         return Handle != nullptr;
     }
     MsQuicSession(MsQuicSession& other) = delete;
     MsQuicSession operator=(MsQuicSession& Other) = delete;
-    operator HQUIC () const {
+    operator HQUIC () const noexcept {
         return Handle;
     }
-    void SetAutoCleanup() {
+    void SetAutoCleanup() noexcept {
         CloseAllConnectionsOnDelete = true;
     }
     void Shutdown(
         _In_ QUIC_CONNECTION_SHUTDOWN_FLAGS Flags,
         _In_ QUIC_UINT62 ErrorCode
-        ) {
+        ) noexcept {
         MsQuic->SessionShutdown(Handle, Flags, ErrorCode);
     }
     QUIC_STATUS
     SetTlsTicketKey(
         _In_reads_bytes_(44)
             const uint8_t* const Buffer
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -338,7 +338,7 @@ public:
     QUIC_STATUS
     SetPeerBidiStreamCount(
         uint16_t value
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -350,7 +350,7 @@ public:
     QUIC_STATUS
     SetPeerUnidiStreamCount(
         uint16_t value
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -362,7 +362,7 @@ public:
     QUIC_STATUS
     SetIdleTimeout(
         uint64_t value  // milliseconds
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -374,7 +374,7 @@ public:
     QUIC_STATUS
     SetDisconnectTimeout(
         uint32_t value  // milliseconds
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -386,7 +386,7 @@ public:
     QUIC_STATUS
     SetMaxBytesPerKey(
         uint64_t value
-        ) {
+        ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -398,7 +398,7 @@ public:
     QUIC_STATUS
     SetDatagramReceiveEnabled(
         bool value
-        ) {
+        ) noexcept {
         BOOLEAN Value = value ? TRUE : FALSE;
         return
             MsQuic->SetParam(
@@ -411,7 +411,7 @@ public:
     QUIC_STATUS
     SetServerResumptionLevel(
         QUIC_SERVER_RESUMPTION_LEVEL Level
-    ) {
+    ) noexcept {
         return
             MsQuic->SetParam(
                 Handle,
@@ -428,7 +428,7 @@ struct MsQuicListener {
     QUIC_LISTENER_CALLBACK_HANDLER Handler { nullptr };
     void* Context{ nullptr };
 
-    MsQuicListener(const MsQuicSession& Session) {
+    MsQuicListener(const MsQuicSession& Session) noexcept {
         if (!Session.IsValid()) {
             InitStatus = Session.GetInitStatus();
             return;
@@ -459,68 +459,68 @@ struct MsQuicListener {
     Start(
         _In_ QUIC_ADDR* Address,
         _In_ QUIC_LISTENER_CALLBACK_HANDLER _Handler,
-        _In_ void* _Context) {
+        _In_ void* _Context) noexcept {
         Handler = _Handler;
         Context = _Context;
         return MsQuic->ListenerStart(Handle, Address);
     }
 
     QUIC_STATUS
-    ListenerCallback(HQUIC Listener, QUIC_LISTENER_EVENT* Event) {
+    ListenerCallback(HQUIC Listener, QUIC_LISTENER_EVENT* Event) noexcept {
         return Handler(Listener, Context, Event);
     }
 
-    QUIC_STATUS GetInitStatus() const { return InitStatus; }
+    QUIC_STATUS GetInitStatus() const noexcept { return InitStatus; }
     bool IsValid() const {
         return Handle != nullptr;
     }
     MsQuicListener(MsQuicListener& other) = delete;
     MsQuicListener operator=(MsQuicListener& Other) = delete;
-    operator HQUIC () const {
+    operator HQUIC () const noexcept {
         return Handle;
     }
 };
 
 struct ListenerScope {
     HQUIC Handle;
-    ListenerScope() : Handle(nullptr) { }
-    ListenerScope(HQUIC handle) : Handle(handle) { }
-    ~ListenerScope() { if (Handle) { MsQuic->ListenerClose(Handle); } }
-    operator HQUIC() const { return Handle; }
+    ListenerScope() noexcept : Handle(nullptr) { }
+    ListenerScope(HQUIC handle) noexcept : Handle(handle) { }
+    ~ListenerScope() noexcept { if (Handle) { MsQuic->ListenerClose(Handle); } }
+    operator HQUIC() const noexcept { return Handle; }
 };
 
 struct ConnectionScope {
     HQUIC Handle;
-    ConnectionScope() : Handle(nullptr) { }
-    ConnectionScope(HQUIC handle) : Handle(handle) { }
-    ~ConnectionScope() { if (Handle) { MsQuic->ConnectionClose(Handle); } }
-    operator HQUIC() const { return Handle; }
+    ConnectionScope() noexcept : Handle(nullptr) { }
+    ConnectionScope(HQUIC handle) noexcept : Handle(handle) { }
+    ~ConnectionScope() noexcept { if (Handle) { MsQuic->ConnectionClose(Handle); } }
+    operator HQUIC() const noexcept { return Handle; }
 };
 
 struct StreamScope {
     HQUIC Handle;
-    StreamScope() : Handle(nullptr) { }
-    StreamScope(HQUIC handle) : Handle(handle) { }
-    ~StreamScope() { if (Handle) { MsQuic->StreamClose(Handle); } }
-    operator HQUIC() const { return Handle; }
+    StreamScope() noexcept : Handle(nullptr) { }
+    StreamScope(HQUIC handle) noexcept : Handle(handle) { }
+    ~StreamScope() noexcept { if (Handle) { MsQuic->StreamClose(Handle); } }
+    operator HQUIC() const noexcept { return Handle; }
 };
 
 struct EventScope {
     QUIC_EVENT Handle;
-    EventScope() { QuicEventInitialize(&Handle, FALSE, FALSE); }
-    EventScope(QUIC_EVENT event) : Handle(event) { }
-    ~EventScope() { QuicEventUninitialize(Handle); }
-    operator QUIC_EVENT() const { return Handle; }
+    EventScope() noexcept { QuicEventInitialize(&Handle, FALSE, FALSE); }
+    EventScope(QUIC_EVENT event) noexcept : Handle(event) { }
+    ~EventScope() noexcept { QuicEventUninitialize(Handle); }
+    operator QUIC_EVENT() const noexcept { return Handle; }
 };
 
 struct QuicBufferScope {
     QUIC_BUFFER* Buffer;
-    QuicBufferScope() : Buffer(nullptr) { }
-    QuicBufferScope(uint32_t Size) : Buffer((QUIC_BUFFER*) new uint8_t[sizeof(QUIC_BUFFER) + Size]) {
+    QuicBufferScope() noexcept : Buffer(nullptr) { }
+    QuicBufferScope(uint32_t Size) noexcept : Buffer((QUIC_BUFFER*) new uint8_t[sizeof(QUIC_BUFFER) + Size]) {
         QuicZeroMemory(Buffer, sizeof(*Buffer) + Size);
         Buffer->Length = Size;
         Buffer->Buffer = (uint8_t*)(Buffer + 1);
     }
-    operator QUIC_BUFFER* () { return Buffer; }
-    ~QuicBufferScope() { if (Buffer) { delete[](uint8_t*) Buffer; } }
+    operator QUIC_BUFFER* () noexcept { return Buffer; }
+    ~QuicBufferScope() noexcept { if (Buffer) { delete[](uint8_t*) Buffer; } }
 };

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -11,6 +11,7 @@ Abstract:
 
 #include "PerfHelpers.h"
 #include "PerfIoctls.h"
+#include <new.h>
 
 #ifdef QUIC_CLOG
 #include "drivermain.cpp.clog.h"
@@ -68,6 +69,11 @@ void* __cdecl operator new (size_t Size) {
     return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
 }
 
+_Ret_maybenull_ _Post_writable_byte_size_(_Size)
+void* __cdecl operator new (size_t Size, const std::nothrow_t&) throw(){
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
+}
+
 void __cdecl operator delete (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
         ExFreePoolWithTag(Mem, QUIC_POOL_PERF);
@@ -80,11 +86,16 @@ void __cdecl operator delete (_In_opt_ void* Mem, _In_opt_ size_t) {
     }
 }
 
-void* __cdecl operator new[](size_t Size) {
+void* __cdecl operator new[] (size_t Size) {
     return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
 }
 
-void __cdecl operator delete[](_In_opt_ void* Mem) {
+_Ret_maybenull_ _Post_writable_byte_size_(_Size)
+void* __cdecl operator new[] (size_t Size, const std::nothrow_t&) throw(){
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_PERF);
+}
+
+void __cdecl operator delete[] (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
         ExFreePoolWithTag(Mem, QUIC_POOL_PERF);
     }

--- a/src/perf/lib/PerfHelpers.h
+++ b/src/perf/lib/PerfHelpers.h
@@ -255,16 +255,16 @@ template<typename T, bool Paged = false>
 class QuicPoolAllocator {
     QUIC_POOL Pool;
 public:
-    QuicPoolAllocator() {
+    QuicPoolAllocator() noexcept {
         QuicPoolInitialize(Paged, sizeof(T), QUIC_POOL_PERF, &Pool);
     }
 
-    ~QuicPoolAllocator() {
+    ~QuicPoolAllocator() noexcept {
         QuicPoolUninitialize(&Pool);
     }
 
     template <class... Args>
-    T* Alloc(Args&&... args) {
+    T* Alloc(Args&&... args) noexcept {
         void* Raw = QuicPoolAlloc(&Pool);
         if (Raw == nullptr) {
             return nullptr;
@@ -272,7 +272,7 @@ public:
         return new (Raw) T (QuicForward<Args>(args)...);
     }
 
-    void Free(T* Obj) {
+    void Free(T* Obj) noexcept {
         if (Obj == nullptr) {
             return;
         }

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -116,7 +116,11 @@ ThroughputClient::Init(
     TryGetValue(argc, argv, "iocount", &IoCount);
 
     size_t Len = strlen(Target);
-    TargetData.reset(new char[Len + 1]);
+    char* LocalTarget = new(std::nothrow) char[Len + 1];
+    if (LocalTarget == nullptr) {
+        return QUIC_STATUS_OUT_OF_MEMORY;
+    }
+    TargetData.reset(LocalTarget);
     QuicCopyMemory(TargetData.get(), Target, Len);
     TargetData[Len] = '\0';
 

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -51,7 +51,10 @@ QuicMainStart(
     TryGetValue(argc, argv, "ServerMode", &ServerMode);
 
     QUIC_STATUS Status;
-    MsQuic = new QuicApiTable;
+    MsQuic = new(std::nothrow) QuicApiTable;
+    if (MsQuic == nullptr) {
+        return QUIC_STATUS_OUT_OF_MEMORY;
+    }
     if (QUIC_FAILED(Status = MsQuic->InitStatus())) {
         delete MsQuic;
         MsQuic = nullptr;
@@ -60,9 +63,9 @@ QuicMainStart(
 
     if (IsValue(TestName, "Throughput")) {
         if (ServerMode) {
-            TestToRun = new ThroughputServer(SelfSignedConfig);
+            TestToRun = new(std::nothrow) ThroughputServer(SelfSignedConfig);
         } else {
-            TestToRun = new ThroughputClient;
+            TestToRun = new(std::nothrow) ThroughputClient;
         }
     } else {
         delete MsQuic;

--- a/src/test/bin/winkernel/driver.cpp
+++ b/src/test/bin/winkernel/driver.cpp
@@ -11,6 +11,7 @@ Abstract:
 
 #include <quic_platform.h>
 #include <MsQuicTests.h>
+#include <new.h>
 
 #include "quic_trace.h"
 #ifdef QUIC_CLOG
@@ -35,6 +36,11 @@ void* __cdecl operator new (size_t Size) {
     return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
 }
 
+_Ret_maybenull_ _Post_writable_byte_size_(_Size)
+void* __cdecl operator new (size_t Size, const std::nothrow_t&) throw(){
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
+}
+
 void __cdecl operator delete (_In_opt_ void* Mem) {
     if (Mem != nullptr) {
         ExFreePoolWithTag(Mem, QUIC_POOL_TEST);
@@ -48,6 +54,11 @@ void __cdecl operator delete (_In_opt_ void* Mem, _In_opt_ size_t) {
 }
 
 void* __cdecl operator new[] (size_t Size) {
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
+}
+
+_Ret_maybenull_ _Post_writable_byte_size_(_Size)
+void* __cdecl operator new[] (size_t Size, const std::nothrow_t&) throw(){
     return ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, QUIC_POOL_TEST);
 }
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -1013,7 +1013,7 @@ ListenerAcceptCallback(
     )
 {
     TestConnection** NewConnection = (TestConnection**)Listener->Context;
-    *NewConnection = new TestConnection(ConnectionHandle);
+    *NewConnection = new(std::nothrow) TestConnection(ConnectionHandle);
     if (*NewConnection == nullptr || !(*NewConnection)->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
         delete *NewConnection;

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -35,7 +35,7 @@ ListenerAcceptConnection(
     )
 {
     ServerAcceptContext* AcceptContext = (ServerAcceptContext*)Listener->Context;
-    *AcceptContext->NewConnection = new TestConnection(ConnectionHandle);
+    *AcceptContext->NewConnection = new(std::nothrow) TestConnection(ConnectionHandle);
     if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
         delete *AcceptContext->NewConnection;

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -294,19 +294,19 @@ QuicTestValidateConnectionEvents1(
     )
 {
     ConnValidator Client(
-        new ConnEventValidator* [4] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [4] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
     ConnValidator Server(
-        new ConnEventValidator* [5] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [5] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
@@ -356,19 +356,19 @@ QuicTestValidateConnectionEvents2(
     )
 {
     ConnValidator Client(
-        new ConnEventValidator* [5] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [5] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
     ConnValidator Server(
-        new ConnEventValidator* [4] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [4] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
@@ -418,21 +418,21 @@ QuicTestValidateConnectionEvents3(
     )
 {
     ConnValidator Client(
-        new ConnEventValidator* [4] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION, false, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [4] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION, false, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
     ConnValidator Server(
-        new ConnEventValidator* [7] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, false, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [7] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, false, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
     );
@@ -610,38 +610,38 @@ QuicTestValidateStreamEvents1(
     { // Stream scope
 
     StreamValidator ClientStream(
-        new StreamEventValidator* [6] {
-            new StreamEventValidator(QUIC_STREAM_EVENT_START_COMPLETE),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
-            new StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
+        new(std::nothrow) StreamEventValidator* [6] {
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_START_COMPLETE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
             nullptr
         });
     StreamValidator ServerStream(
-        new StreamEventValidator* [4] {
-            new StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN, QUIC_EVENT_ACTION_SHUTDOWN_STREAM),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) StreamEventValidator* [4] {
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN, QUIC_EVENT_ACTION_SHUTDOWN_STREAM),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         });
 
     Client.SetExpectedEvents(
-        new ConnEventValidator* [6] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [6] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         });
     Server.SetExpectedEvents(
-        new ConnEventValidator* [6] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new NewStreamEventValidator(&ServerStream),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [6] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) NewStreamEventValidator(&ServerStream),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         });
 
@@ -719,30 +719,30 @@ QuicTestValidateStreamEvents2(
     { // Stream scope
 
     StreamValidator ClientStream(
-        new StreamEventValidator* [5] {
-            new StreamEventValidator(QUIC_STREAM_EVENT_START_COMPLETE),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE),
-            new StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+        new(std::nothrow) StreamEventValidator* [5] {
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_START_COMPLETE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
             nullptr
         });
 
     Client.SetExpectedEvents(
-        new ConnEventValidator* [7] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [7] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         });
     Server.SetExpectedEvents(
-        new ConnEventValidator* [5] {
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+        new(std::nothrow) ConnEventValidator* [5] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         });
 

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -22,7 +22,7 @@ DatapathHooks* DatapathHooks::Instance;
 
 void QuicTestInitialize()
 {
-    DatapathHooks::Instance = new DatapathHooks;
+    DatapathHooks::Instance = new(std::nothrow) DatapathHooks;
 }
 
 void QuicTestUninitialize()
@@ -44,7 +44,7 @@ QuicTestPrimeResumption(
     struct PrimeResumption {
         _Function_class_(NEW_CONNECTION_CALLBACK) static void
         ListenerAccept(_In_ TestListener* /* Listener */, _In_ HQUIC ConnectionHandle) {
-            auto NewConnection = new TestConnection(ConnectionHandle);
+            auto NewConnection = new(std::nothrow) TestConnection(ConnectionHandle);
             if (NewConnection == nullptr || !NewConnection->IsValid()) {
                 TEST_FAILURE("Failed to accept new TestConnection.");
                 delete NewConnection;
@@ -104,7 +104,7 @@ ListenerAcceptConnection(
     )
 {
     ServerAcceptContext* AcceptContext = (ServerAcceptContext*)Listener->Context;
-    *AcceptContext->NewConnection = new TestConnection(ConnectionHandle);
+    *AcceptContext->NewConnection = new(std::nothrow) TestConnection(ConnectionHandle);
     if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
         delete *AcceptContext->NewConnection;
@@ -852,7 +852,7 @@ ListenerRejectConnection(
     _In_ HQUIC ConnectionHandle
     )
 {
-    auto Connection = new TestConnection(ConnectionHandle);
+    auto Connection = new(std::nothrow) TestConnection(ConnectionHandle);
     if (Connection == nullptr || !Connection->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
         delete Connection;

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -98,7 +98,7 @@ struct PrivateTransportHelper : QUIC_PRIVATE_TRANSPORT_PARAMETER
         if (Enabled) {
             Type = PRIVATE_TP_TYPE;
             Length = PRIVATE_TP_LENGTH;
-            Buffer = new uint8_t[PRIVATE_TP_LENGTH];
+            Buffer = new(std::nothrow) uint8_t[PRIVATE_TP_LENGTH];
             TEST_TRUE(Buffer != nullptr);
         } else {
             Buffer = nullptr;

--- a/src/test/lib/TestStream.cpp
+++ b/src/test/lib/TestStream.cpp
@@ -42,7 +42,7 @@ TestStream::FromStreamHandle(
     )
 {
     auto IsUnidirectionalStream = !!(Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL);
-    auto Stream = new TestStream(QuicStreamHandle, StreamShutdownHandler, IsUnidirectionalStream, false);
+    auto Stream = new(std::nothrow) TestStream(QuicStreamHandle, StreamShutdownHandler, IsUnidirectionalStream, false);
     if (Stream == nullptr || !Stream->IsValid()) {
         TEST_FAILURE("Failed to create new TestStream.");
         delete Stream;
@@ -72,7 +72,7 @@ TestStream::FromConnectionHandle(
         TEST_FAILURE("MsQuic->StreamOpen failed, 0x%x.", Status);
         return nullptr;
     }
-    auto Stream = new TestStream(QuicStreamHandle, StreamShutdownHandler, IsUnidirectionalStream, true);
+    auto Stream = new(std::nothrow) TestStream(QuicStreamHandle, StreamShutdownHandler, IsUnidirectionalStream, true);
     if (Stream == nullptr || !Stream->IsValid()) {
         TEST_FAILURE("Failed to create new TestStream.");
         delete Stream;
@@ -122,7 +122,7 @@ TestStream::StartPing(
 
     do {
         auto SendBufferLength = (uint32_t)min(BytesToSend, MaxSendLength);
-        auto SendBuffer = new QuicSendBuffer(MaxSendBuffers, SendBufferLength);
+        auto SendBuffer = new(std::nothrow) QuicSendBuffer(MaxSendBuffers, SendBufferLength);
         if (SendBuffer == nullptr) {
             TEST_FAILURE("Failed to alloc QuicSendBuffer");
             return false;
@@ -240,7 +240,7 @@ TestStream::HandleStreamRecv(
         }
 
         if (!IsUnidirectional) {
-            auto SendBuffer = new QuicSendBuffer(Length, Buffer);
+            auto SendBuffer = new(std::nothrow) QuicSendBuffer(Length, Buffer);
 
             QUIC_STATUS Status =
                 MsQuic->StreamSend(

--- a/src/test/lib/TestStream.h
+++ b/src/test/lib/TestStream.h
@@ -51,10 +51,10 @@ struct QuicSendBuffer
         uint32_t bufferSize
         ) :
         BufferCount(bufferCount),
-        Buffers(new QUIC_BUFFER[bufferCount])
+        Buffers(new(std::nothrow) QUIC_BUFFER[bufferCount])
     {
         for (uint32_t i = 0; i < BufferCount; ++i) {
-            this->Buffers[i].Buffer = bufferSize == 0 ? nullptr : new uint8_t[bufferSize];
+            this->Buffers[i].Buffer = bufferSize == 0 ? nullptr : new(std::nothrow) uint8_t[bufferSize];
             this->Buffers[i].Length = bufferSize;
             QuicZeroMemory(this->Buffers[i].Buffer, this->Buffers[i].Length);
         }
@@ -65,9 +65,9 @@ struct QuicSendBuffer
         const uint8_t * buffer
         ) :
         BufferCount(1),
-        Buffers(new QUIC_BUFFER[1])
+        Buffers(new(std::nothrow) QUIC_BUFFER[1])
     {
-        this->Buffers[0].Buffer = bufferSize == 0 ? nullptr : new uint8_t[bufferSize];
+        this->Buffers[0].Buffer = bufferSize == 0 ? nullptr : new(std::nothrow) uint8_t[bufferSize];
         memcpy((uint8_t*)this->Buffers[0].Buffer, buffer, bufferSize);
         this->Buffers[0].Length = bufferSize;
     }


### PR DESCRIPTION
By default, even in kernel mode, new will immediately call the constructor, before you even have a chance to check for null. nothrow new checks for null before calling the constructor, so the checks are actually valid.

Only needed to happen in the perf and test libs that are ran in kernel mode.


We will need to be sure this happens for all kernel mode allocations in the future.
