### PR TITLE
Add option to run clang-tidy and cppcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ option(QUIC_UWP_BUILD "Build for UWP" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 option(QUIC_SOURCE_LINK "Enables source linking on MSVC" ON)
 option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)
+option(QUIC_CODE_CHECK "Run static code checkers" OFF)
 
 # FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
 if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
@@ -376,6 +377,35 @@ if(QUIC_TLS STREQUAL "mitls")
     add_subdirectory(submodules/everest/msquic/msvc/evercrypt)
     add_subdirectory(submodules/everest/msquic/msvc/mitls)
     add_subdirectory(submodules/everest/msquic/msvc/quiccrypto)
+endif()
+
+if(QUIC_CODE_CHECK)
+    find_program(CLANGTIDY NAMES clang-tidy)
+    if(CLANGTIDY)
+        message(STATUS "Found clang-tidy: ${CLANGTIDY}")
+        set(CLANG_TIDY_CHECKS *
+            # add checks to ignore here, e.g.,
+            # -hicpp-no-assembler
+            # -hicpp-signed-bitwise
+            # ...
+        )
+        string(REPLACE ";" "," CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS}")
+        set(CMAKE_C_CLANG_TIDY ${CLANGTIDY} -checks=${CLANG_TIDY_CHECKS}
+            -system-headers)
+        set(CMAKE_CXX_CLANG_TIDY ${CMAKE_C_CLANG_TIDY})
+    else()
+        message(STATUS "clang-tidy not found")
+    endif()
+
+    find_program(CPPCHECK NAMES cppcheck)
+    if(CPPCHECK)
+        message(STATUS "Found cppcheck: ${CPPCHECK}")
+        set(CMAKE_C_CPPCHECK ${CPPCHECK} -q --inline-suppr
+            --enable=warning,style,performance,portability -D__linux__)
+        set(CMAKE_CXX_CPPCHECK ${CMAKE_C_CPPCHECK})
+    else()
+        message(STATUS "cppcheck not found")
+    endif()
 endif()
 
 add_subdirectory(src/inc)


### PR DESCRIPTION
When these checkers are enabled, there are *tons* of issues flagged. Many definitely should be suppressed, but I wasn't sure, which.