### PR TITLE
Add RPS into perf test suite

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -110,5 +110,74 @@
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": "Closed.*\\(TX.*bytes @ (.*) kbps\\)",
         "Units": "kbps"
+    },
+    {
+        "TestName": "RPS",
+        "Remote": {
+            "Platform": "Windows",
+            "Tls": ["stub", "schannel", "mitls"],
+            "Arch": ["x64", "x86", "arm", "arm64"],
+            "Exe": "quicperf",
+            "Arguments": {
+                "All": "-TestName:RPS -ServerMode:1 -iter:10",
+                "Loopback": "-selfsign:1",
+                "Remote": "-thumbprint:$Thumbprint -machine_cert:1 -cert_store:My"
+            }
+        },
+        "Local": {
+            "Platform": "Windows",
+            "Tls": ["stub", "schannel", "mitls"],
+            "Arch": ["x64", "x86", "arm", "arm64"],
+            "Exe": "quicperf",
+            "Arguments": {
+                "All": "-TestName:RPS -target:$RemoteAddress",
+                "Loopback": "",
+                "Remote": ""
+            }
+        },
+        "Variables": [
+            {
+                "Name": "ConnectionCount",
+                "Local": {
+                    "1000": "-conns:1000"
+                },
+                "Remote": {
+                    "1000": ""
+                },
+                "Default": "1000"
+            },
+            {
+                "Name": "RequestSize",
+                "Local": {
+                    "0": "-request:0"
+                },
+                "Remote": {
+                    "0": ""
+                },
+
+                "Default": "0"
+            },
+            {
+                "Name": "ResponseSize",
+                "Local": {
+                    "0": "",
+                    "512": "",
+                    "4096": "",
+                    "16384": ""
+                },
+                "Remote": {
+                    "0": "-response:0",
+                    "512": "-response:512",
+                    "4096": "-response:4096",
+                    "16384": "-response:16384"
+                },
+                "Default": "4096"
+            }
+        ],
+        "AllowLoopback": false,
+        "Iterations": 5,
+        "RemoteReadyMatcher": "Started!",
+        "ResultsMatcher": "Result: (.*) RPS",
+        "Units": "RPS"
     }
 ]


### PR DESCRIPTION
With the sidechannel exit, remote tests should work again.