### PR TITLE
Some improvements to docker interop logging

### DIFF
--- a/scripts/run_endpoint.sh
+++ b/scripts/run_endpoint.sh
@@ -21,13 +21,12 @@ fi
 # - CLIENT_PARAMS contains user-supplied command line parameters
 
 # Start LTTng live streaming.
-mkdir /log
-lttng -q create msquiclive --live 10000
+lttng -q create msquiclive --live 1000
 lttng enable-event --userspace CLOG_*
 lttng start
 babeltrace -i lttng-live net://localhost
 babeltrace --names all -i lttng-live net://localhost/host/`hostname`/msquiclive \
-    | clog2text_lttng -s clog.sidecar --t --c > /log/quic.log &
+    | stdbuf -i0 -o0 clog2text_lttng -s clog.sidecar --t --c > /logs/quic.log &
 
 if [ "$ROLE" == "client" ]; then
     # Wait for the simulator to start up.


### PR DESCRIPTION
* Create logs in the right place (/logs not /log)

* Unbuffer clog2text_lttng.

I only tested the "handshake" test case. With these changes, quic.log is now
always created. But there is still a race condition of some sort, because in
most of the runs, all it contains is something like "Decoded 0 in
00:00:00.0018700". In some runs, however, almost 50K of log are written.