### PR TITLE
Fix schannel resumption tests to run faster.

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2224,12 +2224,11 @@ QuicTlsProcessData(
     }
 
     if (!TlsContext->IsServer && State->BufferOffset1Rtt > 0 &&
-        State->ReadKeys[QUIC_PACKET_KEY_HANDSHAKE] == NULL) {
+        State->HandshakeComplete) {
         //
-        // Schannel currently sends the NST with server_finished.
-        // We need to wait for the handshake to be confirmed before
-        // setting the flag, since we don't know if we're received
-        // the ticket yet.
+        // Schannel currently sends the NST after receiving client finished.
+        // We need to wait for the handshake to be complete before setting
+        // the flag, since we don't know if we've received the ticket yet.
         //
         TlsContext->TicketReceived = TRUE;
     }


### PR DESCRIPTION
The resumption tests on Schannel take 2 seconds longer than the other TLS platforms because there's no clear indication when the resumption ticket has been received, so it retries until timeout.
This fixes that retry loop by setting a boolean when the test can be reasonably certain the resumption ticket has arrived.
Fixes #571 