### PR TITLE
Add assertions to enqueue connection operation to help solve 698

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -665,14 +665,13 @@ QuicConnQueueOper(
     _In_ QUIC_OPERATION* Oper
     )
 {
-    if (QuicOperationEnqueue(&Connection->OperQ, Oper)) {
-#if DEBUG
-        if (!Connection->State.Initialized) {
-            QUIC_DBG_ASSERT(QuicConnIsServer(Connection));
-            QUIC_DBG_ASSERT(Connection->SourceCids.Next != NULL);
-        }
+    #if DEBUG
+    if (!Connection->State.Initialized) {
+        QUIC_DBG_ASSERT(QuicConnIsServer(Connection));
+        QUIC_DBG_ASSERT(Connection->SourceCids.Next != NULL);
+    }
 #endif
-
+    if (QuicOperationEnqueue(&Connection->OperQ, Oper)) {
         //
         // The connection needs to be queued on the worker because this was the
         // first operation in our OperQ.

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -666,6 +666,13 @@ QuicConnQueueOper(
     )
 {
     if (QuicOperationEnqueue(&Connection->OperQ, Oper)) {
+#if DEBUG
+        if (!Connection->State.Initialized) {
+            QUIC_DBG_ASSERT(QuicConnIsServer(Connection));
+            QUIC_DBG_ASSERT(Connection->SourceCids.Next != NULL);
+        }
+#endif
+
         //
         // The connection needs to be queued on the worker because this was the
         // first operation in our OperQ.


### PR DESCRIPTION
We haven't seen it again, but when it does happen, having the assert here will make it much easier to detect the source. When it happens on the other side of the queue, its hard to tell what the source actually is. Related to #698.