### PR TITLE
Filter out failing ECT tests on internal pipeline

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -136,6 +136,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
+      extraArgs: -Filter -*DataPathTest/DataPathTest.DataECT0/4:DataPathTest/DataPathTest.DataECT0/6
 
 #
 # Build Verification Tests (Kernel Mode)


### PR DESCRIPTION
They've been failing ever since #676 was merged because the filter was missing.