### PR TITLE
Fix Datagram buffer resulting in a null deref in an OOM scenario

### DIFF
--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1921,6 +1921,7 @@ QuicDataPathBindingAllocSendDatagram(
             "Allocation of '%s' failed. (%llu bytes)",
             "Send Buffer",
             0);
+        Buffer = NULL;
         goto Exit;
     }
 


### PR DESCRIPTION
Closes #742