### PR TITLE
More codeql

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+---
+name: "CodeQL config"
+
+queries:
+ - uses: security-extended  # security-and-quality (very verbose)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, more-codeql]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [master, more-codeql]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
@@ -40,6 +40,7 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: cpp
+          config-file: ./.github/codeql/codeql-config.yml
 
       # Analyze this build.
       - run: |

--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -45,7 +45,7 @@ TEST(SpinFrame, SpinFrame1000000)
     uint16_t Offset;
     BOOLEAN InvalidFrame;
     uint8_t Buffer[255];
-    uint8_t BufferLength;
+    uint8_t BufferLength = 0;
     uint8_t FrameType;
 
     QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckBlocks);

--- a/src/core/unittest/VarIntTest.cpp
+++ b/src/core/unittest/VarIntTest.cpp
@@ -24,6 +24,7 @@ uint64_t Encode(uint64_t Value)
 uint64_t Decode(uint64_t Encoded)
 {
     uint64_t Decoded;
+    QuicRandom(sizeof(Decoded), &Decoded)
     uint16_t Offset = 0;
     EXPECT_NE(QuicVarIntDecode(sizeof(Encoded), (uint8_t*)&Encoded, &Offset, &Decoded), (BOOLEAN)0);
     return Decoded;
@@ -60,7 +61,7 @@ TEST(VarIntTest, RandomEncodeDecode)
         //
         // Generate a random value and make sure the top 2 bits aren't set.
         //
-        uint64_t Value;
+        uint64_t Value = 0;
         TEST_QUIC_SUCCEEDED(QuicRandom(sizeof(Value), &Value));
         Value &= ~(3ULL << 62);
 

--- a/src/core/unittest/VarIntTest.cpp
+++ b/src/core/unittest/VarIntTest.cpp
@@ -24,7 +24,7 @@ uint64_t Encode(uint64_t Value)
 uint64_t Decode(uint64_t Encoded)
 {
     uint64_t Decoded;
-    QuicRandom(sizeof(Decoded), &Decoded)
+    QuicRandom(sizeof(Decoded), &Decoded);
     uint16_t Offset = 0;
     EXPECT_NE(QuicVarIntDecode(sizeof(Encoded), (uint8_t*)&Encoded, &Offset, &Decoded), (BOOLEAN)0);
     return Decoded;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -803,7 +803,7 @@ TEST_P(TlsTest, KeyUpdate)
         ClientContext.InitializeClient(ClientSession);
         DoHandshake(ServerContext, ClientContext);
 
-        QUIC_PACKET_KEY* UpdateWriteKey, *UpdateReadKey = nullptr;
+        QUIC_PACKET_KEY* UpdateWriteKey = nullptr, *UpdateReadKey = nullptr;
 
         VERIFY_QUIC_SUCCESS(
             QuicPacketKeyUpdate(


### PR DESCRIPTION
This PR enables some additional CodeQL checks, and has fixes for some of the nits that were found this way.

Some others remain: https://github.com/larseggert/msquic/security/code-scanning?query=tool%3ACodeQL+is%3Aopen+ref%3Arefs%2Fheads%2Fmore-codeql