### PR TITLE
Windows Usermode Datapath ECN Implementation

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -136,7 +136,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*DataPathTest/DataPathTest.DataECT0/4:DataPathTest/DataPathTest.DataECT0/6
+      extraArgs: -Filter
 
 #
 # Build Verification Tests (Kernel Mode)

--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -136,7 +136,6 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter
 
 #
 # Build Verification Tests (Kernel Mode)

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -246,7 +246,6 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter
   - template: ./templates/run-bvt.yml
     parameters:
       image: windows-latest

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -246,14 +246,14 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*DataPathTest/DataPathTest.DataECT0/4:DataPathTest/DataPathTest.DataECT0/6
+      extraArgs: -Filter
   - template: ./templates/run-bvt.yml
     parameters:
       image: windows-latest
       platform: windows
       tls: mitls
       logProfile: Full.Light
-      extraArgs: -Filter -*Unreachable/0:CryptTest/CryptTest.Encryption/2:TlsTest.CertificateError:DataPathTest/DataPathTest.DataECT0/4:DataPathTest/DataPathTest.DataECT0/6
+      extraArgs: -Filter -*Unreachable/0:CryptTest/CryptTest.Encryption/2:TlsTest.CertificateError
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest


### PR DESCRIPTION
Next step for #559. Implements the ECN send/recv code in Windows user mode. Removes the filters for the associated tests.