### PR TITLE
Fix Bad TLS Events

### DIFF
--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -16912,7 +16912,7 @@
     },
     "OpenSslContextCreated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Created",
+      "TraceString": "[conn][%p] TLS context Created",
       "UniqueId": "OpenSslContextCreated",
       "splitArgs": [
         {
@@ -16930,7 +16930,7 @@
         "EncodedArgNumber": 2,
         "MacroConfiguration": {
           "linux": "lttng_plus",
-          "stubs": "empty",
+          "stubs": "stubs",
           "windows_kernel": "empty",
           "windows": "empty"
         },
@@ -19442,7 +19442,7 @@
     },
     "SchannelContextCreated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Created",
+      "TraceString": "[conn][%p] TLS context Created",
       "UniqueId": "SchannelContextCreated",
       "splitArgs": [
         {
@@ -24051,10 +24051,6 @@
         "TraceID": "OpenSslAddHandshakeData"
       },
       {
-        "UniquenessHash": "4da3df45-2fb3-acc2-d0d8-9326e14a8988",
-        "TraceID": "OpenSslContextCreated"
-      },
-      {
         "UniquenessHash": "a241a44d-19e5-3ddd-03b3-2e65b093720f",
         "TraceID": "OpenSslContextCleaningUp"
       },
@@ -24321,10 +24317,6 @@
       {
         "UniquenessHash": "1197fc0e-03e3-58cf-6637-f912c96fa67b",
         "TraceID": "SchannelMissingData"
-      },
-      {
-        "UniquenessHash": "c40f92e3-2ef4-35f3-6710-6b43ce3ece32",
-        "TraceID": "SchannelContextCreated"
       },
       {
         "UniquenessHash": "771d2d3f-b8cd-0a3d-ac59-eac4d476390e",
@@ -24633,6 +24625,14 @@
       {
         "UniquenessHash": "d3788ab1-cacd-d552-e06c-2e7bee8b6da9",
         "TraceID": "StubTlsContextCreated"
+      },
+      {
+        "UniquenessHash": "e1629f75-f460-8951-5138-b0602b8f4db0",
+        "TraceID": "OpenSslContextCreated"
+      },
+      {
+        "UniquenessHash": "18fa206f-59b9-158c-7fa9-904ae6cb9663",
+        "TraceID": "SchannelContextCreated"
       }
     ]
   }

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -15438,7 +15438,7 @@
     },
     "StubTlsContextCreated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Created",
+      "TraceString": "[conn][%p] TLS context Created",
       "UniqueId": "StubTlsContextCreated",
       "splitArgs": [
         {
@@ -15456,7 +15456,7 @@
         "EncodedArgNumber": 2,
         "MacroConfiguration": {
           "linux": "lttng_plus",
-          "stubs": "empty",
+          "stubs": "stubs",
           "windows_kernel": "empty",
           "windows": "empty"
         },
@@ -21678,7 +21678,6 @@
       "splitArgs": [
         {
           "VariableInfo": {
-            "UserSpecifiedUnModified": "\n            CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters)",
             "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters)",
             "SuggestedTelemetryName": "arg2"
           },
@@ -23844,10 +23843,6 @@
         "TraceID": "StubTlsProducedData"
       },
       {
-        "UniquenessHash": "df763e59-5b73-45da-9374-93b112b3ad87",
-        "TraceID": "StubTlsContextCreated"
-      },
-      {
         "UniquenessHash": "16a301c5-8f8d-0d34-6fb9-0a608367097e",
         "TraceID": "StubTlsUsing0Rtt"
       },
@@ -24634,6 +24629,10 @@
       {
         "UniquenessHash": "10ce7ee9-cfcc-e364-e24c-71e1913cb472",
         "TraceID": "PerfCountersRundown"
+      },
+      {
+        "UniquenessHash": "d3788ab1-cacd-d552-e06c-2e7bee8b6da9",
+        "TraceID": "StubTlsContextCreated"
       }
     ]
   }

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1171,7 +1171,7 @@ QuicTlsInitialize(
     QuicTraceLogConnVerbose(
         OpenSslContextCreated,
         TlsContext->Connection,
-        "Created");
+        "TLS context Created");
 
     if (!Config->IsServer) {
 

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1418,11 +1418,14 @@ QuicTlsInitialize(
 
     TlsContext->IsServer = Config->IsServer;
     TlsContext->TlsSession = Config->TlsSession;
+    TlsContext->Connection = Config->Connection;
+    TlsContext->ReceiveTPCallback = Config->ReceiveTPCallback;
+    TlsContext->SNI = Config->ServerName;
 
     QuicTraceLogConnVerbose(
         SchannelContextCreated,
         TlsContext->Connection,
-        "Created");
+        "TLS context Created");
 
     TlsContext->AppProtocolsSize = AppProtocolsSize;
     TlsContext->ApplicationProtocols = (SEC_APPLICATION_PROTOCOLS*)(TlsContext + 1);
@@ -1446,9 +1449,6 @@ QuicTlsInitialize(
     // Associate the existing security config with this TLS context.
     //
     TlsContext->SecConfig = QuicTlsSecConfigAddRef(Config->SecConfig);
-    TlsContext->Connection = Config->Connection;
-    TlsContext->ReceiveTPCallback = Config->ReceiveTPCallback;
-    TlsContext->SNI = Config->ServerName;
 
     State->EarlyDataState = QUIC_TLS_EARLY_DATA_UNSUPPORTED; // 0-RTT not currently supported.
 

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -817,7 +817,7 @@ QuicTlsInitialize(
     QuicTraceLogConnVerbose(
         StubTlsContextCreated,
         TlsContext->Connection,
-        "Created");
+        "TLS context Created");
 
     if (Config->ServerName != NULL) {
         const size_t ServerNameLength =


### PR DESCRIPTION
I fixes the TLS created events to give more context, and in the schannel case, properly pass the right argument (not null).

@chgray, I updated the strings and rand clog in dev mode for all the affected TLS configurations, but it seems clog only updated stub for some reason.