### PR TITLE
Fix Incorrect numa node initialization with 2 numa nodes but 1 group

### DIFF
--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -711,6 +711,7 @@ typedef struct {
     uint16_t Group;
     uint32_t Index; // In Group;
     uint32_t NumaNode;
+    uint64_t MaskInGroup;
 
 } QUIC_PROCESSOR_INFO;
 

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -207,7 +207,7 @@ QuicProcessorInfoInit(
             if (Info->Relationship == RelationGroup) {
                 uint32_t ProcessorOffset = 0;
                 for (WORD i = 0; i < Info->Group.ActiveGroupCount; ++i) {
-                    uint64_t IndexToSet = Index - ProcessorOffset;
+                    uint32_t IndexToSet = Index - ProcessorOffset;
                     QUIC_DBG_ASSERT(IndexToSet < 64);
                     if (IndexToSet < Info->Group.GroupInfo[i].ActiveProcessorCount) {
                         QuicProcessorInfo[Index].Group = i;

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -208,7 +208,7 @@ QuicProcessorInfoInit(
                 uint32_t ProcessorOffset = 0;
                 for (WORD i = 0; i < Info->Group.ActiveGroupCount; ++i) {
                     uint64_t IndexToSet = Index - ProcessorOffset;
-                    QUIC_FRE_ASSERT(IndexToSet < 64);
+                    QUIC_DBG_ASSERT(IndexToSet < 64);
                     if (IndexToSet < Info->Group.GroupInfo[i].ActiveProcessorCount) {
                         QuicProcessorInfo[Index].Group = i;
                         QuicProcessorInfo[Index].Index = IndexToSet;

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -207,10 +207,12 @@ QuicProcessorInfoInit(
             if (Info->Relationship == RelationGroup) {
                 uint32_t ProcessorOffset = 0;
                 for (WORD i = 0; i < Info->Group.ActiveGroupCount; ++i) {
-                    if (Index - ProcessorOffset < Info->Group.GroupInfo[i].ActiveProcessorCount) {
+                    uint64_t IndexToSet = Index - ProcessorOffset;
+                    QUIC_FRE_ASSERT(IndexToSet < 64);
+                    if (IndexToSet < Info->Group.GroupInfo[i].ActiveProcessorCount) {
                         QuicProcessorInfo[Index].Group = i;
-                        QuicProcessorInfo[Index].Index = Index - ProcessorOffset;
-                        QuicProcessorInfo[Index].MaskInGroup = 1ull << (Index - ProcessorOffset);
+                        QuicProcessorInfo[Index].Index = IndexToSet;
+                        QuicProcessorInfo[Index].MaskInGroup = 1ull << IndexToSet;
                         goto FindNumaNode;
                     }
                     ProcessorOffset += Info->Group.GroupInfo[i].ActiveProcessorCount;

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -210,6 +210,7 @@ QuicProcessorInfoInit(
                     if (Index - ProcessorOffset < Info->Group.GroupInfo[i].ActiveProcessorCount) {
                         QuicProcessorInfo[Index].Group = i;
                         QuicProcessorInfo[Index].Index = Index - ProcessorOffset;
+                        QuicProcessorInfo[Index].MaskInGroup = 1ull << (Index - ProcessorOffset);
                         goto FindNumaNode;
                     }
                     ProcessorOffset += Info->Group.GroupInfo[i].ActiveProcessorCount;
@@ -231,7 +232,8 @@ FindNumaNode:
             PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX Info =
                 (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(Buffer + Offset);
             if (Info->Relationship == RelationNumaNode) {
-                if (Info->NumaNode.GroupMask.Group == QuicProcessorInfo[Index].Group) {
+                if (Info->NumaNode.GroupMask.Group == QuicProcessorInfo[Index].Group &&
+                    (Info->NumaNode.GroupMask.Mask & QuicProcessorInfo[Index].MaskInGroup) != 0) {
                     QuicProcessorInfo[Index].NumaNode = Info->NumaNode.NodeNumber;
                     QuicTraceLogInfo(
                         ProcessorInfo,


### PR DESCRIPTION
We were only matching the group, but not the specific processor in the group. Use a mask to find the specific processor to match.