### PR TITLE
Fix Abortive Stream Tests leaking a stream on the remote side.

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -756,6 +756,7 @@ QuicAbortiveConnectionHandler(
                 (void*) QuicAbortiveStreamHandler,
                 Context);
 
+            TestContext->Stream.Handle = Event->PEER_STREAM_STARTED.Stream;
             if (TestContext->Server &&
                 !TestContext->Flags.ClientShutdown &&
                 !TestContext->Flags.SendDataOnStream) {
@@ -770,7 +771,6 @@ QuicAbortiveConnectionHandler(
                 }
                 QuicEventSet(TestContext->TestEvent.Handle);
             }
-            TestContext->Stream.Handle = Event->PEER_STREAM_STARTED.Stream;
             QuicEventSet(TestContext->StreamEvent.Handle);
             return QUIC_STATUS_SUCCESS;
         case QUIC_CONNECTION_EVENT_CONNECTED:


### PR DESCRIPTION
It seems to be a race between the stream handle being set in the connection callback, and the test context being finished.

Fixes #537  (I think this was the actual issue there)