### PR TITLE
Fix Thread Create Failure Crash

### DIFF
--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -120,7 +120,7 @@ QuicWorkerUninitialize(
     // Wait for the thread to finish.
     //
     QuicEventSet(Worker->Ready);
-    if (Worker->Thread != NULL) {
+    if (Worker->Thread) {
         QuicThreadWait(&Worker->Thread);
         QuicThreadDelete(&Worker->Thread);
     }

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -30,6 +30,12 @@ Abstract:
 QUIC_THREAD_CALLBACK(QuicWorkerThread, Context);
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicWorkerUninitialize(
+    _In_ QUIC_WORKER* Worker
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicWorkerInitialize(
     _In_opt_ const void* Owner,

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -841,16 +841,10 @@ QuicThreadCreate(
                 &UnicodeName,
                 sizeof(UNICODE_STRING));
         QUIC_DBG_ASSERT(QUIC_SUCCEEDED(Status));
-        if (QUIC_FAILED(Status)) {
-            goto Cleanup;
-        }
+        Status = QUIC_STATUS_SUCCESS;
     }
 Cleanup:
     NtClose(ThreadHandle);
-    if (QUIC_FAILED(Status) && *Thread != NULL) {
-        ObDereferenceObject(*Thread);
-        *Thread = NULL;
-    }
 Error:
     return Status;
 }

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -620,6 +620,13 @@ QuicPerfCtlReadPrints(
     ThreadConfig.Context = Client;
     Client->Request = Request;
     if (QUIC_FAILED(Status = QuicThreadCreate(&ThreadConfig, &Client->Thread))) {
+        if (Client->Thread != nullptr) {
+            Client->Canceled = true;
+            QuicEventSet(Client->StopEvent);
+            QuicThreadWait(&Client->Thread);
+            QuicThreadDelete(&Client->Thread);
+            Client->Thread = nullptr;
+        }
         WdfRequestCompleteWithInformation(
             Request,
             Status,

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -620,7 +620,7 @@ QuicPerfCtlReadPrints(
     ThreadConfig.Context = Client;
     Client->Request = Request;
     if (QUIC_FAILED(Status = QuicThreadCreate(&ThreadConfig, &Client->Thread))) {
-        if (Client->Thread != nullptr) {
+        if (Client->Thread) {
             Client->Canceled = true;
             QuicEventSet(Client->StopEvent);
             QuicThreadWait(&Client->Thread);


### PR DESCRIPTION
In the rare case that creating and configuring a thread on kernel mode failed, it wasn't properly cleaning everything up.