### PR TITLE
Fix issues with perf test matrix

### DIFF
--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -786,15 +786,18 @@ function Get-TestMatrix {
             $RemoteArgs += " " + $Test.Remote.Arguments.Remote
         }
 
+        $DefaultLocalArgs = $LocalArgs
+        $DefaultRemoteArgs = $RemoteArgs
+
         $VariableValues = @{}
         foreach ($VarKey in $DefaultVals.Keys) {
             $VariableValues.Add($VarKey, $DefaultVals[$VarKey].DefaultKey)
-            $LocalArgs += (" " + $DefaultVals[$VarKey].LocalValue)
-            $RemoteArgs += (" " + $DefaultVals[$VarKey].RemoteValue)
+            $DefaultLocalArgs += (" " + $DefaultVals[$VarKey].LocalValue)
+            $DefaultRemoteArgs += (" " + $DefaultVals[$VarKey].RemoteValue)
         }
 
         # Create the default test
-        $TestRunDef = [TestRunDefinition]::new($Test, $LocalArgs, $RemoteArgs, $VariableValues)
+        $TestRunDef = [TestRunDefinition]::new($Test, $DefaultLocalArgs, $DefaultRemoteArgs, $VariableValues)
         $ToRunTests += $TestRunDef
 
         foreach ($Var in $Test.Variables) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -105,7 +105,7 @@ param (
     [switch]$PGO = $false,
 
     [Parameter(Mandatory = $false)]
-    [int]$Timeout = 60,
+    [int]$Timeout = 120,
 
     [Parameter(Mandatory = $false)]
     [switch]$RecordQUIC = $false,


### PR DESCRIPTION
Matrix values were incorrect, and defaults were always being used. Throughput this didn't matter, RPS it did matter a lot. Also increases the test timeout, some of the RPS tests take longer to finish