### PR TITLE
Throw Away Connections from Bad Initial Packets

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5037,7 +5037,8 @@ QuicConnRecvDatagrams(
     }
 
     if (QuicConnIsServer(Connection) &&
-        Connection->Stats.Recv.ValidPackets == 0) {
+        Connection->Stats.Recv.ValidPackets == 0 &&
+        !Connection->State.ClosedLocally) {
         //
         // The packet(s) that created this connection weren't valid. We should
         // immediately throw away the connection.

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3635,6 +3635,8 @@ QuicConnRecvDecryptAndAuthenticate(
         return FALSE;
     }
 
+    Connection->Stats.Recv.ValidPackets++;
+
     //
     // Validate the header's reserved bits now that the packet has been
     // decrypted.
@@ -5032,6 +5034,19 @@ QuicConnRecvDatagrams(
 
     if (ReleaseChain != NULL) {
         QuicDataPathBindingReturnRecvDatagrams(ReleaseChain);
+    }
+
+    if (QuicConnIsServer(Connection) &&
+        Connection->Stats.Recv.ValidPackets == 0) {
+        //
+        // The packet(s) that created this connection weren't valid. We should
+        // immediately throw away the connection.
+        //
+        QuicTraceLogConnWarning(
+            InvalidInitialPackets,
+            Connection,
+            "Aborting connection with invalid initial packets");
+        QuicConnSilentlyAbort(Connection);
     }
 
     //

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -244,6 +244,7 @@ typedef struct QUIC_CONN_STATS {
         uint64_t DroppedPackets;        // Includes DuplicatePackets.
         uint64_t DuplicatePackets;
         uint64_t DecryptionFailures;    // Count of packets that failed to decrypt.
+        uint64_t ValidPackets;          // Count of packets that successfully decrypted or had no encryption.
 
         uint64_t TotalBytes;            // Sum of UDP payloads
         uint64_t TotalStreamBytes;      // Sum of stream payloads

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -21697,6 +21697,33 @@
         },
         "CustomSettings": null
       }
+    },
+    "InvalidInitialPackets": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Aborting connection with invalid initial packets",
+      "UniqueId": "InvalidInitialPackets",
+      "splitArgs": [
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "Connection",
+            "SuggestedTelemetryName": "arg1"
+          },
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macro": {
+        "MacroName": "QuicTraceLogConnWarning",
+        "EncodedPrefix": "[conn][%p] ",
+        "EncodedArgNumber": 2,
+        "MacroConfiguration": {
+          "linux": "lttng_plus",
+          "stubs": "stubs",
+          "windows_kernel": "empty",
+          "windows": "empty"
+        },
+        "CustomSettings": null
+      }
     }
   },
   "Version": 1,
@@ -24633,6 +24660,10 @@
       {
         "UniquenessHash": "18fa206f-59b9-158c-7fa9-904ae6cb9663",
         "TraceID": "SchannelContextCreated"
+      },
+      {
+        "UniquenessHash": "77212d61-9925-bec1-4c5b-749d4fff7279",
+        "TraceID": "InvalidInitialPackets"
       }
     ]
   }


### PR DESCRIPTION
Fixes #788 by throwing away connections that don't have valid initial packets.