### PR TITLE
Remove Packet Number from Packet Drop Events

### DIFF
--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -729,22 +729,20 @@ QuicPacketLogDrop(
         QuicDataPathRecvPacketToRecvDatagram(Packet);
 
     if (Packet->AssignedToConnection) {
-        InterlockedIncrement64((int64_t*) &((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
+        InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
             ConnDropPacket,
-            "[conn][%p] DROP packet[%llu] Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+            "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber,
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
             Reason);
     } else {
-        InterlockedIncrement64((int64_t*) &((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
+        InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
             BindingDropPacket,
-            "[bind][%p] DROP packet[%llu] Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+            "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber,
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
             Reason);
@@ -765,23 +763,21 @@ QuicPacketLogDropWithValue(
         QuicDataPathRecvPacketToRecvDatagram(Packet);
 
     if (Packet->AssignedToConnection) {
-        InterlockedIncrement64((int64_t*) & ((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
+        InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
             ConnDropPacketEx,
-            "[conn][%p] DROP packet[%llu] Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+            "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber,
             Value,
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
             Reason);
     } else {
-        InterlockedIncrement64((int64_t*) &((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
+        InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
             BindingDropPacketEx,
-            "[bind][%p] DROP packet[%llu] %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
+            "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
-            Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber,
             Value,
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
             CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -1393,10 +1393,6 @@
                 name="Owner"
                 />
             <data
-                inType="win:UInt64"
-                name="PktNum"
-                />
-            <data
                 inType="win:UInt8"
                 name="LocalAddrLength"
                 />
@@ -1425,10 +1421,6 @@
             <data
                 inType="win:Pointer"
                 name="Owner"
-                />
-            <data
-                inType="win:UInt64"
-                name="PktNum"
                 />
             <data
                 inType="win:UInt64"
@@ -3021,11 +3013,11 @@
             />
         <string
             id="Etw.ConnDropPacket"
-            value="[conn][%1] DROP packet[%2] Dst=%4 Src=%6 Reason=%7."
+            value="[conn][%1] DROP packet Dst=%4 Src=%6 Reason=%7."
             />
         <string
             id="Etw.ConnDropPacketEx"
-            value="[conn][%1] DROP packet[%2] Dst=%5 Src=%7 Reason=%8, %3."
+            value="[conn][%1] DROP packet Dst=%5 Src=%7 Reason=%8, %3."
             />
         <string
             id="Etw.ConnError"
@@ -3293,11 +3285,11 @@
             />
         <string
             id="Etw.BindingDropPacket"
-            value="[bind][%1] DROP packet[%2] Dst=%4 Src=%6 Reason=%7."
+            value="[bind][%1] DROP packet Dst=%4 Src=%6 Reason=%7."
             />
         <string
             id="Etw.BindingDropPacketEx"
-            value="[bind][%1] DROP packet[%2] Dst=%5 Src=%7 Reason=%8, %3."
+            value="[bind][%1] DROP packet Dst=%5 Src=%7 Reason=%8, %3."
             />
         <string
             id="Etw.BindingError"

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -3013,11 +3013,11 @@
             />
         <string
             id="Etw.ConnDropPacket"
-            value="[conn][%1] DROP packet Dst=%4 Src=%6 Reason=%7."
+            value="[conn][%1] DROP packet Dst=%3 Src=%5 Reason=%6."
             />
         <string
             id="Etw.ConnDropPacketEx"
-            value="[conn][%1] DROP packet Dst=%5 Src=%7 Reason=%8, %3."
+            value="[conn][%1] DROP packet Dst=%4 Src=%6 Reason=%7, %2."
             />
         <string
             id="Etw.ConnError"
@@ -3285,11 +3285,11 @@
             />
         <string
             id="Etw.BindingDropPacket"
-            value="[bind][%1] DROP packet Dst=%4 Src=%6 Reason=%7."
+            value="[bind][%1] DROP packet Dst=%3 Src=%5 Reason=%6."
             />
         <string
             id="Etw.BindingDropPacketEx"
-            value="[bind][%1] DROP packet Dst=%5 Src=%7 Reason=%8, %3."
+            value="[bind][%1] DROP packet Dst=%4 Src=%6 Reason=%7, %2."
             />
         <string
             id="Etw.BindingError"

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -17537,10 +17537,10 @@
         "CustomSettings": null
       }
     },
-    "ConnDropPacket": {
+    "BindingDropPacketEx": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] DROP packet[%llu] Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
-      "UniqueId": "ConnDropPacket",
+      "TraceString": "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
+      "UniqueId": "BindingDropPacketEx",
       "splitArgs": [
         {
           "VariableInfo": {
@@ -17552,66 +17552,7 @@
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "BindingDropPacket": {
-      "ModuleProperites": {},
-      "TraceString": "[bind][%p] DROP packet[%llu] Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
-      "UniqueId": "BindingDropPacket",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber",
+            "UserSuppliedTrimmed": "Value",
             "SuggestedTelemetryName": "arg3"
           },
           "DefinationEncoding": "llu",
@@ -17657,7 +17598,7 @@
     },
     "ConnDropPacketEx": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] DROP packet[%llu] Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "TraceString": "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
       "UniqueId": "ConnDropPacketEx",
       "splitArgs": [
         {
@@ -17670,7 +17611,7 @@
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber",
+            "UserSuppliedTrimmed": "Value",
             "SuggestedTelemetryName": "arg3"
           },
           "DefinationEncoding": "llu",
@@ -17678,15 +17619,15 @@
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "Value",
+            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
             "SuggestedTelemetryName": "arg4"
           },
-          "DefinationEncoding": "llu",
+          "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
+            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
             "SuggestedTelemetryName": "arg5"
           },
           "DefinationEncoding": "!ADDR!",
@@ -17694,19 +17635,11 @@
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
+            "UserSuppliedTrimmed": "Reason",
             "SuggestedTelemetryName": "arg6"
           },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "s",
-          "MacroVariableName": "arg7"
+          "MacroVariableName": "arg6"
         }
       ],
       "macro": {
@@ -17722,10 +17655,10 @@
         "CustomSettings": null
       }
     },
-    "BindingDropPacketEx": {
+    "BindingDropPacket": {
       "ModuleProperites": {},
-      "TraceString": "[bind][%p] DROP packet[%llu] %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
-      "UniqueId": "BindingDropPacketEx",
+      "TraceString": "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "UniqueId": "BindingDropPacket",
       "splitArgs": [
         {
           "VariableInfo": {
@@ -17737,43 +17670,78 @@
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumberSet ? UINT64_MAX : Packet->PacketNumber",
+            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
             "SuggestedTelemetryName": "arg3"
           },
-          "DefinationEncoding": "llu",
+          "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "Value",
+            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
             "SuggestedTelemetryName": "arg4"
           },
-          "DefinationEncoding": "llu",
+          "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         },
         {
           "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
+            "UserSuppliedTrimmed": "Reason",
             "SuggestedTelemetryName": "arg5"
           },
-          "DefinationEncoding": "!ADDR!",
+          "DefinationEncoding": "s",
           "MacroVariableName": "arg5"
+        }
+      ],
+      "macro": {
+        "MacroName": "QuicTraceEvent",
+        "EncodedPrefix": null,
+        "EncodedArgNumber": 1,
+        "MacroConfiguration": {
+          "linux": "lttng_plus",
+          "stubs": "stubs",
+          "windows_kernel": "empty",
+          "windows": "empty"
+        },
+        "CustomSettings": null
+      }
+    },
+    "ConnDropPacket": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "UniqueId": "ConnDropPacket",
+      "splitArgs": [
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "Owner",
+            "SuggestedTelemetryName": "arg2"
+          },
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
+            "SuggestedTelemetryName": "arg3"
+          },
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
         },
         {
           "VariableInfo": {
             "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg6"
+            "SuggestedTelemetryName": "arg4"
           },
           "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg6"
+          "MacroVariableName": "arg4"
         },
         {
           "VariableInfo": {
             "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg7"
+            "SuggestedTelemetryName": "arg5"
           },
           "DefinationEncoding": "s",
-          "MacroVariableName": "arg7"
+          "MacroVariableName": "arg5"
         }
       ],
       "macro": {
@@ -24087,22 +24055,6 @@
         "TraceID": "ListenerStarted"
       },
       {
-        "UniquenessHash": "2cb7fb05-fb1a-60ec-7a8b-d18c9d49b481",
-        "TraceID": "ConnDropPacket"
-      },
-      {
-        "UniquenessHash": "f603a0b1-0e10-d5f3-c1b9-2d9b9c4451bb",
-        "TraceID": "BindingDropPacket"
-      },
-      {
-        "UniquenessHash": "4fd4e8e2-526f-acb6-d7ba-59f1a4973b05",
-        "TraceID": "ConnDropPacketEx"
-      },
-      {
-        "UniquenessHash": "4eee119a-1325-3a27-60c0-9c033c17e4ec",
-        "TraceID": "BindingDropPacketEx"
-      },
-      {
         "UniquenessHash": "4a17af8c-bd56-a1f2-d3d6-b28b75030213",
         "TraceID": "DatapathRecv"
       },
@@ -24633,6 +24585,22 @@
       {
         "UniquenessHash": "18fa206f-59b9-158c-7fa9-904ae6cb9663",
         "TraceID": "SchannelContextCreated"
+      },
+      {
+        "UniquenessHash": "946d7a4f-ca9f-b676-8fef-1661da5703cd",
+        "TraceID": "ConnDropPacket"
+      },
+      {
+        "UniquenessHash": "aff4ab67-a70e-f05b-c51d-9b97628c141e",
+        "TraceID": "BindingDropPacket"
+      },
+      {
+        "UniquenessHash": "7b8fcbcd-b097-9b8b-3d56-a2ca2d8b5cb8",
+        "TraceID": "ConnDropPacketEx"
+      },
+      {
+        "UniquenessHash": "262f6b18-033f-5ef9-44eb-b2bebae16084",
+        "TraceID": "BindingDropPacketEx"
       }
     ]
   }

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -24614,6 +24614,10 @@
         "TraceID": "SchannelContextCreated"
       },
       {
+        "UniquenessHash": "77212d61-9925-bec1-4c5b-749d4fff7279",
+        "TraceID": "InvalidInitialPackets"
+      },
+      {
         "UniquenessHash": "946d7a4f-ca9f-b676-8fef-1661da5703cd",
         "TraceID": "ConnDropPacket"
       },
@@ -24628,10 +24632,6 @@
       {
         "UniquenessHash": "262f6b18-033f-5ef9-44eb-b2bebae16084",
         "TraceID": "BindingDropPacketEx"
-      },
-      {
-        "UniquenessHash": "77212d61-9925-bec1-4c5b-749d4fff7279",
-        "TraceID": "InvalidInitialPackets"
       }
     ]
   }

--- a/src/tools/etw/quicetw.h
+++ b/src/tools/etw/quicetw.h
@@ -422,12 +422,10 @@ typedef struct QUIC_EVENT_DATA_CONNECTION {
             UINT16 ProbeCount;
         } LossDetectionTimerSet;
         struct {
-            UINT64 PktNum;
             UINT8 Addrs[1]; // LocalAddr, RemoteAddr
             // char Reason[];
         } DropPacket;
         struct {
-            UINT64 PktNum;
             UINT64 Value;
             UINT8 Addrs[1]; // LocalAddr, RemoteAddr
             // char Reason[];
@@ -570,11 +568,9 @@ typedef struct QUIC_EVENT_DATA_BINDING {
             UINT8 Addrs[1]; // LocalAddr, RemoteAddr
         } Created, Rundown;
         struct {
-            UINT64 PktNum;
             UINT8 Addrs[1]; // LocalAddr, RemoteAddr
         } DropPacket;
         struct {
-            UINT64 PktNum;
             UINT64 Value;
             UINT8 Addrs[1]; // LocalAddr, RemoteAddr
         } DropPacketEx;

--- a/src/tools/etw/trace.c
+++ b/src/tools/etw/trace.c
@@ -766,13 +766,8 @@ QuicTraceConnEvent(
         Addrs = DecodeAddr(Addrs, LocalAddrStr);
         Addrs = DecodeAddr(Addrs, RemoteAddrStr);
         char* Reason = (char*)Addrs;
-        if (EvData->DropPacket.PktNum != ULLONG_MAX) {
-            printf("DROP packet Num=%llu Src=%s Dst=%s Reason=%s\n",
-                EvData->DropPacket.PktNum, RemoteAddrStr, LocalAddrStr, Reason);
-        } else {
-            printf("DROP packet Src=%s Dst=%s Reason=%s\n",
-                RemoteAddrStr, LocalAddrStr, Reason);
-        }
+        printf("DROP packet Src=%s Dst=%s Reason=%s\n",
+            RemoteAddrStr, LocalAddrStr, Reason);
         break;
     }
     case EventId_QuicConnDropPacketEx: {
@@ -782,13 +777,8 @@ QuicTraceConnEvent(
         Addrs = DecodeAddr(Addrs, LocalAddrStr);
         Addrs = DecodeAddr(Addrs, RemoteAddrStr);
         char* Reason = (char*)Addrs;
-        if (EvData->DropPacketEx.PktNum != ULLONG_MAX) {
-            printf("DROP packet Num=%llu Src=%s Dst=%s Reason=%s, %llu\n",
-                EvData->DropPacketEx.PktNum, RemoteAddrStr, LocalAddrStr, Reason, EvData->DropPacketEx.Value);
-        } else {
-            printf("DROP packet Src=%s Dst=%s Reason=%s, %llu\n",
-                RemoteAddrStr, LocalAddrStr, Reason, EvData->DropPacketEx.Value);
-        }
+        printf("DROP packet Src=%s Dst=%s Reason=%s, %llu\n",
+            RemoteAddrStr, LocalAddrStr, Reason, EvData->DropPacketEx.Value);
         break;
     }
     case EventId_QuicConnError: {
@@ -1016,13 +1006,8 @@ QuicTraceBindingEvent(
         Addrs = DecodeAddr(Addrs, LocalAddrStr);
         Addrs = DecodeAddr(Addrs, RemoteAddrStr);
         char* Reason = (char*)Addrs;
-        if (EvData->DropPacket.PktNum != ULLONG_MAX) {
-            printf("DROP packet Num=%llu Src=%s Dst=%s Reason=%s\n",
-                EvData->DropPacket.PktNum, LocalAddrStr, RemoteAddrStr, Reason);
-        } else {
-            printf("DROP packet Src=%s Dst=%s Reason=%s\n",
-                LocalAddrStr, RemoteAddrStr, Reason);
-        }
+        printf("DROP packet Src=%s Dst=%s Reason=%s\n",
+            LocalAddrStr, RemoteAddrStr, Reason);
         break;
     }
     case EventId_QuicBindingDropPacketEx: {
@@ -1032,13 +1017,8 @@ QuicTraceBindingEvent(
         Addrs = DecodeAddr(Addrs, LocalAddrStr);
         Addrs = DecodeAddr(Addrs, RemoteAddrStr);
         char* Reason = (char*)Addrs;
-        if (EvData->DropPacketEx.PktNum != ULLONG_MAX) {
-            printf("DROP packet Num=%llu Src=%s Dst=%s Reason=%s, %llu\n",
-                EvData->DropPacketEx.PktNum, LocalAddrStr, RemoteAddrStr, Reason, EvData->DropPacketEx.Value);
-        } else {
-            printf("DROP packet Src=%s Dst=%s Reason=%s, %llu\n",
-                LocalAddrStr, RemoteAddrStr, Reason, EvData->DropPacketEx.Value);
-        }
+        printf("DROP packet Src=%s Dst=%s Reason=%s, %llu\n",
+            LocalAddrStr, RemoteAddrStr, Reason, EvData->DropPacketEx.Value);
         break;
     }
     case EventId_QuicBindingError: {


### PR DESCRIPTION
The packet number is almost never valid for dropped packets (because it's before decryption) and when it is valid, it doesn't really help. It's just wasted space.