### PR TITLE
Add vpid and vtid to lttng logs

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -109,6 +109,7 @@ function Log-Start {
                 Invoke-Expression $Command | Write-Debug
             }
             lttng enable-event --userspace CLOG_* | Write-Debug
+            lttng add-context --userspace --type=vpid --type=vtid | Write-Debug
             lttng start | Write-Debug
 
             if ($Stream) {

--- a/scripts/run_endpoint.sh
+++ b/scripts/run_endpoint.sh
@@ -23,6 +23,7 @@ fi
 # Start LTTng live streaming.
 lttng -q create msquiclive --live 1000
 lttng enable-event --userspace CLOG_*
+lttng add-context --userspace --type=vpid --type=vtid
 lttng start
 babeltrace -i lttng-live net://localhost
 babeltrace --names all -i lttng-live net://localhost/host/`hostname`/msquiclive \


### PR DESCRIPTION
They need to be explicitly enabled with a context, so this enables them in the 2 places we grab logs from.