### PR TITLE
Close connection on AEAD integrity failure

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3631,6 +3631,9 @@ QuicConnRecvDecryptAndAuthenticate(
         Connection->Stats.Recv.DecryptionFailures++;
         QuicPacketLogDrop(Connection, Packet, "Decryption failure");
         QuicPerfCounterIncrement(QUIC_PERF_COUNTER_PKTS_DECRYPTION_FAIL);
+        if (Connection->Stats.Recv.DecryptionFailures >= QUIC_AEAD_INTEGRITY_LIMIT) {
+            QuicConnTransportError(Connection, QUIC_ERROR_AEAD_LIMIT_REACHED);
+        }
 
         return FALSE;
     }

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -69,6 +69,11 @@
 //
 #define QUIC_ERROR_CRYPTO_BUFFER_EXCEEDED       0xD
 //
+// An endpoint has exceeded the maximum number of failed packet decryptions
+// over its lifetime
+//
+#define QUIC_ERROR_AEAD_LIMIT_REACHED           0xE
+//
 // The cryptographic handshake failed. A range of 256 values is reserved for
 // carrying error codes specific to the cryptographic handshake that is used.
 // Codes for errors occurring when TLS is used for the crypto handshake are

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -409,6 +409,13 @@ QUIC_STATIC_ASSERT(
 //
 #define QUIC_TLS_RESUMPTION_TICKET_VERSION      1
 
+//
+// The AEAD Integrity limit for maximum failed decryption packets over the
+// lifetime of a connection. Set to the lowest limit, which is for
+// AEAD_AES_128_CCM at 2^23.5 (rounded down)
+//
+#define QUIC_AEAD_INTEGRITY_LIMIT 0xB503F3
+
 /*************************************************************
                   PERSISTENT SETTINGS
 *************************************************************/

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -414,7 +414,7 @@ QUIC_STATIC_ASSERT(
 // lifetime of a connection. Set to the lowest limit, which is for
 // AEAD_AES_128_CCM at 2^23.5 (rounded down)
 //
-#define QUIC_AEAD_INTEGRITY_LIMIT 0xB503F3
+#define QUIC_AEAD_INTEGRITY_LIMIT               11863283
 
 /*************************************************************
                   PERSISTENT SETTINGS

--- a/src/tools/etw/quicetw.h
+++ b/src/tools/etw/quicetw.h
@@ -1140,6 +1140,7 @@ inline void ReadCid(_In_z_ const char* Cid)
 #define QUIC_ERROR_TRANSPORT_PARAMETER_ERROR    0x8
 #define QUIC_ERROR_PROTOCOL_VIOLATION           0xA
 #define QUIC_ERROR_CRYPTO_BUFFER_EXCEEDED       0xD
+#define QUIC_ERROR_AEAD_LIMIT_REACHED           0xE
 
 #define QUIC_ERROR_CRYPTO_ERROR_MASK            0x1FF
 
@@ -1164,6 +1165,7 @@ QuicErrorToString(
         case QUIC_ERROR_TRANSPORT_PARAMETER_ERROR:  return "TRANSPORT_PARAMETER_ERROR";
         case QUIC_ERROR_PROTOCOL_VIOLATION:         return "PROTOCOL_VIOLATION";
         case QUIC_ERROR_CRYPTO_BUFFER_EXCEEDED:     return "CRYPTO_BUFFER_EXCEEDED";
+        case QUIC_ERROR_AEAD_LIMIT_REACHED:         return "AEAD_LIMIT_REACHED";
         default:                                    return "UNDEFINED ERROR CODE";
         }
     } else if (ErrorCode < 0x200) {


### PR DESCRIPTION
Updates to the spec in https://github.com/quicwg/base-drafts/commit/71a1ff22aef4a3f948b032447dd5bb36e7314e18 require a connection to be closed on too many failed packet decryptions globally across a connection.

The lowest limit was chosen, at 2^23.5 (rounded down)

Closes #557

Still need to add tests