### PR TITLE
Fix Wrap Around Bug with Partition Count

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -200,7 +200,7 @@ MsQuicLibraryInitialize(
     //
     MsQuicLib.ProcessorCount = (uint16_t) QuicProcActiveCount();
     QUIC_FRE_ASSERT(MsQuicLib.ProcessorCount > 0);
-    MsQuicLib.PartitionCount = (uint8_t)MsQuicLib.ProcessorCount;
+    MsQuicLib.PartitionCount = (uint8_t)min(MsQuicLib.ProcessorCount, UINT8_MAX-1);
     if (MsQuicLib.PartitionCount  > (uint32_t)MsQuicLib.Settings.MaxPartitionCount) {
         MsQuicLib.PartitionCount  = (uint32_t)MsQuicLib.Settings.MaxPartitionCount;
     }


### PR DESCRIPTION
Fixes #808, a bug where `(uint8_t)(256)` results in us setting `PartitionCount` to zero.