### PR TITLE
Pack QUIC_SENT_PACKET_METADATA manually to remove the need for pragma pack

### DIFF
--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -97,6 +97,7 @@ typedef struct QUIC_SENT_PACKET_METADATA {
     uint64_t PacketNumber;
     uint32_t SentTime; // In microseconds
     uint16_t PacketLength;
+    uint8_t PathId;
 
     //
     // Hints about the QUIC packet and included frames.
@@ -106,21 +107,10 @@ typedef struct QUIC_SENT_PACKET_METADATA {
     //
     // Frames included in this packet.
     //
-    uint8_t FrameCount  : 4;
-    uint8_t PathId      : 4;
+    uint8_t FrameCount;
     QUIC_SENT_FRAME_METADATA Frames[0];
 
 } QUIC_SENT_PACKET_METADATA;
-
-QUIC_STATIC_ASSERT(
-    QUIC_MAX_PATH_COUNT <= 16,
-    "Must have a max path count of less then 16"
-);
-
-QUIC_STATIC_ASSERT(
-    QUIC_MAX_FRAMES_PER_PACKET <= 16,
-    "Must have a max frames per packet of less then 16"
-);
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 inline

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -791,8 +791,8 @@ QuicStreamWriteOneFrame(
     PacketMetadata->Flags.IsAckEliciting = TRUE;
     PacketMetadata->Frames[PacketMetadata->FrameCount].Type = QUIC_FRAME_STREAM;
     PacketMetadata->Frames[PacketMetadata->FrameCount].STREAM.Stream = Stream;
-    PacketMetadata->Frames[PacketMetadata->FrameCount].STREAM.Offset = Frame.Offset;
-    PacketMetadata->Frames[PacketMetadata->FrameCount].STREAM.Length = (uint16_t)Frame.Length;
+    PacketMetadata->Frames[PacketMetadata->FrameCount].StreamOffset = Frame.Offset;
+    PacketMetadata->Frames[PacketMetadata->FrameCount].StreamLength = (uint16_t)Frame.Length;
     PacketMetadata->Frames[PacketMetadata->FrameCount].Flags = 0;
     if (Stream->SendFlags & QUIC_STREAM_SEND_FLAG_OPEN) {
         Stream->SendFlags &= ~QUIC_STREAM_SEND_FLAG_OPEN;
@@ -1157,8 +1157,8 @@ QuicStreamOnLoss(
 
     uint32_t AddSendFlags = 0;
 
-    uint64_t Start = FrameMetadata->STREAM.Offset;
-    uint64_t End = Start + FrameMetadata->STREAM.Length;
+    uint64_t Start = FrameMetadata->StreamOffset;
+    uint64_t End = Start + FrameMetadata->StreamLength;
 
     if ((FrameMetadata->Flags & QUIC_SENT_FRAME_FLAG_STREAM_OPEN) &&
         !Stream->Flags.SendOpenAcked) {
@@ -1293,8 +1293,8 @@ QuicStreamOnAck(
     _In_ QUIC_SENT_FRAME_METADATA* FrameMetadata
     )
 {
-    uint64_t Offset = FrameMetadata->STREAM.Offset;
-    uint32_t Length = FrameMetadata->STREAM.Length;
+    uint64_t Offset = FrameMetadata->StreamOffset;
+    uint32_t Length = FrameMetadata->StreamLength;
 
     //
     // The offset directly following this frame.


### PR DESCRIPTION
This causes everything to be aligned correctly, removing potential bugs and performance penalties for unaligned reads and writes.

This commit currently loses 1 byte per packet, but gains 4 per frame. However, with a future optimization for StreamOffset, we can actually lose 4 bytes per frame, which will be a net win.

Solves #806 and many more silent packed bugs.