### PR TITLE
Limit RPS tests to 8 cores less then max on systems with more then 60 cores.

### DIFF
--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -121,11 +121,11 @@ RpsClient::Start(
 
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     uint32_t ActiveProcCount = QuicProcActiveCount();
-    if (ActiveProcCount >= 8) {
+    if (ActiveProcCount >= 60) {
         //
         // If we have enough cores, leave 2 cores for OS overhead
         //
-        ActiveProcCount -= 2;
+        ActiveProcCount -= 24;
     }
     for (uint32_t i = 0; i < ConnectionCount; ++i) {
         HQUIC Connection = nullptr;

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -123,9 +123,9 @@ RpsClient::Start(
     uint32_t ActiveProcCount = QuicProcActiveCount();
     if (ActiveProcCount >= 60) {
         //
-        // If we have enough cores, leave 2 cores for OS overhead
+        // If we have enough cores, leave 8 cores for OS overhead
         //
-        ActiveProcCount -= 24;
+        ActiveProcCount -= 8;
     }
     for (uint32_t i = 0; i < ConnectionCount; ++i) {
         HQUIC Connection = nullptr;


### PR DESCRIPTION
It definitely seems to make the RPS tests more stable. Also, the threshold is high enough where it won't trigger on the lab machines.