### PR TITLE
Clean up packet space in QuicConnFree

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -304,6 +304,9 @@ QuicConnFree(
                 AllStreamsLink);
         QUIC_DBG_ASSERTMSG(Stream != NULL, "Stream was leaked!");
     }
+    for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); i++) {
+        QUIC_FRE_ASSERT(Connection->Packets[i] == NULL);
+    }
 #endif
     while (!QuicListIsEmpty(&Connection->DestCids)) {
         QUIC_CID_QUIC_LIST_ENTRY *CID =


### PR DESCRIPTION
We have a leak, but its hard to detect where. By asserting that its already been cleaned up, we should be able to debug a bit easier