### PR TITLE
Reduce Test Cases for OpenSSL on Windows

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -277,7 +277,7 @@ stages:
       image: windows-latest
       platform: windows
       tls: openssl
-      extraArgs: -Filter -*TlsTest.CertificateError:ParameterValidation.ValidateServerSecConfig:*AbortiveShutdown*:Basic/WithFamilyArgs.Unreachable/0
+      extraArgs: -Filter -*TlsTest.CertificateError:ParameterValidation.ValidateServerSecConfig:Basic/WithFamilyArgs.Unreachable/0:AppData/*:Misc/*
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest


### PR DESCRIPTION
Fixes #825. Reduces the number of test cases run on OpenSSL to reduce total execution time.