### PR TITLE
Remove SourceCid entry from cid list under lock.

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -454,10 +454,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicBindingRemoveSourceConnectionID(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCid
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid,
+    _In_ QUIC_SINGLE_LIST_ENTRY** Entry
     )
 {
-    QuicLookupRemoveLocalCid(&Binding->Lookup, SourceCid);
+    QuicLookupRemoveLocalCid(&Binding->Lookup, SourceCid, Entry);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -338,7 +338,8 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicBindingRemoveSourceConnectionID(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCid
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid,
+    _In_ QUIC_SINGLE_LIST_ENTRY** Entry
     );
 
 //

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1050,14 +1050,14 @@ QuicConnGetSourceCidFromSeq(
             if (RemoveFromList) {
                 QuicBindingRemoveSourceConnectionID(
                     Connection->Paths[0].Binding,
-                    SourceCid);
+                    SourceCid,
+                    Entry);
                 QuicTraceEvent(
                     ConnSourceCidRemoved,
                     "[conn][%p] (SeqNum=%llu) Removed Source CID: %!CID!",
                     Connection,
                     SourceCid->CID.SequenceNumber,
                     CLOG_BYTEARRAY(SourceCid->CID.Length, SourceCid->CID.Data));
-                *Entry = (*Entry)->Next;
             }
             *IsLastCid = Connection->SourceCids.Next == NULL;
             return SourceCid;

--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -820,12 +820,14 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicLookupRemoveLocalCid(
     _In_ QUIC_LOOKUP* Lookup,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCid
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid,
+    _In_ QUIC_SINGLE_LIST_ENTRY** Entry
     )
 {
     QuicDispatchRwLockAcquireExclusive(&Lookup->RwLock);
     QuicLookupRemoveLocalCidInt(Lookup, SourceCid);
     SourceCid->CID.IsInLookupTable = FALSE;
+    *Entry = (*Entry)->Next;
     QuicDispatchRwLockReleaseExclusive(&Lookup->RwLock);
     QuicConnRelease(SourceCid->Connection, QUIC_CONN_REF_LOOKUP_TABLE);
 }

--- a/src/core/lookup.h
+++ b/src/core/lookup.h
@@ -166,7 +166,8 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicLookupRemoveLocalCid(
     _In_ QUIC_LOOKUP* Lookup,
-    _In_ QUIC_CID_HASH_ENTRY* SourceCid
+    _In_ QUIC_CID_HASH_ENTRY* SourceCid,
+    _In_ QUIC_SINGLE_LIST_ENTRY** Entry
     );
 
 //


### PR DESCRIPTION
Without the lock, CID cleanup would race with a new packet from the binding.

Closes #476 