### PR TITLE
Add Missing Wireshark Build Dependency

### DIFF
--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,17 +19,9 @@ jobs:
         steps:
         - checkout: none
         - script: |
-            sudo apt-get install -y cmake libglib2.0-dev libgcrypt20-dev flex \
-              bison byacc libpcap-dev ninja-build
-            wget https://www.wireshark.org/download/src/wireshark-latest.tar.xz
-            tar -xvf wireshark-latest.tar.xz
-            rm wireshark-latest.tar.xz
-            mv ./wireshark-* ./wireshark
-            cd wireshark
-            cmake -GNinja -DBUILD_wireshark=0 -DBUILD_sdjournal=0 \
-              -DBUILD_sshdump=0 -DBUILD_ciscodump=0 .
-            ninja
-            sudo ninja install
+            wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
+            unzip ./download?job=build%3Adebian-stable
+            sudo dpkg -i debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,6 +19,13 @@ jobs:
         steps:
         - checkout: none
         - script: |
+            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
+              libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
+              libpcap-dev bison flex make python3 perl libgcrypt-dev \
+              libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \
+              libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
+              libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
+              xsltpro libspeexdsp-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo apt install ./debian-packages/*

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -28,7 +28,7 @@ jobs:
               xsltpro libspeexdsp-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo apt install ./debian-packages/*
+            sudo dpkg -i --force-depends ./debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -26,9 +26,15 @@ jobs:
               libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
               libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
               xsltpro libspeexdsp-dev
-            wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
-            unzip ./download?job=build%3Adebian-stable
-            sudo dpkg -i --force-depends --force-yes ./debian-packages/*
+            wget https://www.wireshark.org/download/src/wireshark-latest.tar.xz
+            tar -xvf wireshark-latest.tar.xz
+            rm wireshark-latest.tar.xz
+            mv ./wireshark-* ./wireshark
+            cd wireshark
+            cmake -GNinja -DBUILD_wireshark=0 -DBUILD_sdjournal=0 \
+              -DBUILD_sshdump=0 -DBUILD_ciscodump=0 .
+            ninja
+            sudo ninja install
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -21,7 +21,7 @@ jobs:
         - script: |
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo apt install debian-packages/*
+            sudo gdebi debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -21,7 +21,11 @@ jobs:
         - script: |
             sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
               libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
-              libpcap-dev bison flex make python3 perl libgcrypt-dev
+              libpcap-dev bison flex make python3 perl libgcrypt-dev \
+              libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \
+              libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
+              libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
+              xsltpro libspeexdsp-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo dpkg -i debian-packages/*

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,6 +19,9 @@ jobs:
         steps:
         - checkout: none
         - script: |
+            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
+              libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
+              libpcap-dev bison flex make python3 perl libgcrypt-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo dpkg -i debian-packages/*

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,7 +19,9 @@ jobs:
         steps:
         - checkout: none
         - script: |
-            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
+            sudo apt-get install -y cmake libglib2.0-dev libgcrypt20-dev flex \
+              bison byacc libpcap-dev ninja-build
+            sudo apt-get install -y cmake libglib2.0-dev qttools5-dev qttools5-dev-tools \
               libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
               libpcap-dev bison flex make python3 perl libgcrypt-dev \
               libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -29,6 +29,7 @@ jobs:
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo dpkg -i --force-depends ./debian-packages/*
+            sudo apt-get -f install
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,11 +19,9 @@ jobs:
         steps:
         - checkout: none
         - script: |
-            sudo apt install gdebi-core
-            sudo apt-get install -y libgcrypt-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo gdebi ./debian-packages/*
+            sudo apt install ./debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -20,17 +20,16 @@ jobs:
         - checkout: none
         - script: |
             sudo apt-get install -y cmake libglib2.0-dev libgcrypt20-dev flex \
-              bison byacc libpcap-dev ninja-build
-            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
-              libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
-              libpcap-dev bison flex make python3 perl libgcrypt-dev \
-              libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \
-              libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
-              libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
-              xsltpro libspeexdsp-dev
-            wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
-            unzip ./download?job=build%3Adebian-stable
-            sudo dpkg -i --force-depends ./debian-packages/*
+              bison byacc libpcap-dev ninja-build libc-ares-dev
+            wget https://www.wireshark.org/download/src/wireshark-latest.tar.xz
+            tar -xvf wireshark-latest.tar.xz
+            rm wireshark-latest.tar.xz
+            mv ./wireshark-* ./wireshark
+            cd wireshark
+            cmake -GNinja -DBUILD_wireshark=0 -DBUILD_sdjournal=0 \
+              -DBUILD_sshdump=0 -DBUILD_ciscodump=0 .
+            ninja
+            sudo ninja install
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -28,8 +28,7 @@ jobs:
               xsltpro libspeexdsp-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo dpkg -i --force-depends ./debian-packages/*
-            sudo apt-get -f install
+            sudo dpkg -i --force-depends --force-yes ./debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,16 +19,10 @@ jobs:
         steps:
         - checkout: none
         - script: |
-            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
-              libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
-              libpcap-dev bison flex make python3 perl libgcrypt-dev \
-              libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \
-              libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
-              libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
-              xsltpro libspeexdsp-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo dpkg -i debian-packages/*
+            sudo dpkg -i debian-packages/* || true
+            sudo apt-get -f install
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -20,9 +20,10 @@ jobs:
         - checkout: none
         - script: |
             sudo apt install gdebi-core
+            sudo apt-get install -y libgcrypt-dev
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo gdebi debian-packages/*
+            sudo gdebi ./debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -22,7 +22,7 @@ jobs:
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo dpkg -i debian-packages/* || true
-            sudo apt-get -f install
+            sudo apt -f install
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -21,8 +21,7 @@ jobs:
         - script: |
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
-            sudo dpkg -i debian-packages/* || true
-            sudo apt -f install
+            sudo apt install debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -21,22 +21,16 @@ jobs:
         - script: |
             sudo apt-get install -y cmake libglib2.0-dev libgcrypt20-dev flex \
               bison byacc libpcap-dev ninja-build
-            sudo apt-get install -y cmake libglib2.0-dev qttools5-dev qttools5-dev-tools \
+            sudo apt-get install -y libglib2.0-dev qttools5-dev qttools5-dev-tools \
               libqt5svg5-dev qtmultimedia5-dev qt5-default libc-ares-dev \
               libpcap-dev bison flex make python3 perl libgcrypt-dev \
               libnl-3-dev libkrb5-dev libsmi2-dev asciidoctor libsbc-dev liblua5.2-dev \
               libnl-cli-3-dev libparse-yapp-perl libcap-dev liblz4-dev libsnappy-dev \
               libzstd-dev libspandsp-dev libxml2-dev libminizip-dev ninja-build \
               xsltpro libspeexdsp-dev
-            wget https://www.wireshark.org/download/src/wireshark-latest.tar.xz
-            tar -xvf wireshark-latest.tar.xz
-            rm wireshark-latest.tar.xz
-            mv ./wireshark-* ./wireshark
-            cd wireshark
-            cmake -GNinja -DBUILD_wireshark=0 -DBUILD_sdjournal=0 \
-              -DBUILD_sshdump=0 -DBUILD_ciscodump=0 .
-            ninja
-            sudo ninja install
+            wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
+            unzip ./download?job=build%3Adebian-stable
+            sudo dpkg -i --force-depends ./debian-packages/*
           displayName: Install Wireshark
 
         - script: |

--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -19,6 +19,7 @@ jobs:
         steps:
         - checkout: none
         - script: |
+            sudo apt install gdebi-core
             wget https://gitlab.com/wireshark/wireshark/-/jobs/artifacts/master/download?job=build%3Adebian-stable
             unzip ./download?job=build%3Adebian-stable
             sudo gdebi debian-packages/*


### PR DESCRIPTION
Fixes the run-qns.yml pipeline Wireshark build errors.