### PR TITLE
Refactor Ideal Processor Usage

### DIFF
--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -84,12 +84,10 @@ MsQuicRegistrationOpen(
     switch (Registration->ExecProfile) {
     default:
     case QUIC_EXECUTION_PROFILE_LOW_LATENCY:
-        WorkerThreadFlags =
-            QUIC_THREAD_FLAG_SET_IDEAL_PROC;
+        WorkerThreadFlags = QUIC_THREAD_FLAG_NONE;
         break;
     case QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT:
         WorkerThreadFlags =
-            QUIC_THREAD_FLAG_SET_IDEAL_PROC |
             QUIC_THREAD_FLAG_SET_AFFINITIZE;
         Registration->SplitPartitioning = TRUE;
         break;

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -97,7 +97,6 @@ MsQuicRegistrationOpen(
         break;
     case QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME:
         WorkerThreadFlags =
-            QUIC_THREAD_FLAG_SET_IDEAL_PROC |
             QUIC_THREAD_FLAG_SET_AFFINITIZE;
         break;
     }

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -71,6 +71,17 @@ typedef struct QUIC_SINGLE_LIST_ENTRY {
 #define QUIC_POOL_PERF      'frPQ'  // QPrf - QUIC perf code
 #define QUIC_POOL_TOOL      'loTQ'  // QTol - QUIC tool code
 
+typedef enum QUIC_THREAD_FLAGS {
+    QUIC_THREAD_FLAG_NONE               = 0x0000,
+    QUIC_THREAD_FLAG_SET_IDEAL_PROC     = 0x0001,
+    QUIC_THREAD_FLAG_SET_AFFINITIZE     = 0x0002,
+    QUIC_THREAD_FLAG_HIGH_PRIORITY      = 0x0004
+} QUIC_THREAD_FLAGS;
+
+#ifdef DEFINE_ENUM_FLAG_OPERATORS
+DEFINE_ENUM_FLAG_OPERATORS(QUIC_THREAD_FLAGS);
+#endif
+
 #ifdef _KERNEL_MODE
 #define QUIC_PLATFORM_TYPE 1
 #include <quic_platform_winkernel.h>

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -624,10 +624,6 @@ typedef pthread_t QUIC_THREAD;
 
 typedef void* (* LPTHREAD_START_ROUTINE)(void *);
 
-#define QUIC_THREAD_FLAG_SET_IDEAL_PROC     0x0001
-#define QUIC_THREAD_FLAG_SET_AFFINITIZE     0x0002
-#define QUIC_THREAD_FLAG_HIGH_PRIORITY      0x0004
-
 typedef struct QUIC_THREAD_CONFIG {
     uint16_t Flags;
     uint16_t IdealProcessor;

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -799,8 +799,7 @@ QuicThreadCreate(
             goto Cleanup;
         }
     }
-    if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) &&
-        !(Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
+    if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         Status =
             ZwSetInformationThread(
                 ThreadHandle,

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -804,8 +804,7 @@ QuicThreadCreate(
     }
     Group.Group = ProcInfo->Group;
     SetThreadGroupAffinity(*Thread, &Group, NULL);
-    if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC &&
-        !(Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE)) {
+    if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
         SetThreadIdealProcessor(*Thread, ProcInfo->Index);
     }
     if (Config->Flags & QUIC_THREAD_FLAG_HIGH_PRIORITY) {

--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -109,7 +109,7 @@ HpsClient::Start(
         Contexts[Proc].Processor = (uint16_t)Proc;
 
         QUIC_THREAD_CONFIG ThreadConfig = {
-            QUIC_THREAD_FLAG_SET_IDEAL_PROC | QUIC_THREAD_FLAG_SET_AFFINITIZE,
+            QUIC_THREAD_FLAG_SET_AFFINITIZE,
             (uint16_t)Proc,
             "HPS Worker",
             HpsWorkerThread,

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -699,22 +699,20 @@ QuicThreadCreate(
     }
 
 #ifdef __GLIBC__
-    if (Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
-        // There is no way to set an ideal processor in Linux, so just set affinity
-        if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
-            cpu_set_t CpuSet;
-            CPU_ZERO(&CpuSet);
-            CPU_SET(Config->IdealProcessor, &CpuSet);
-            if (!pthread_attr_setaffinity_np(&Attr, sizeof(CpuSet), &CpuSet)) {
-                QuicTraceEvent(
-                    LibraryError,
-                    "[ lib] ERROR, %s.",
-                    "pthread_attr_setaffinity_np failed");
-            }
-        } else {
-            // TODO - Set Linux equivalent of NUMA affinity.
+    if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
+        cpu_set_t CpuSet;
+        CPU_ZERO(&CpuSet);
+        CPU_SET(Config->IdealProcessor, &CpuSet);
+        if (!pthread_attr_setaffinity_np(&Attr, sizeof(CpuSet), &CpuSet)) {
+            QuicTraceEvent(
+                LibraryError,
+                "[ lib] ERROR, %s.",
+                "pthread_attr_setaffinity_np failed");
         }
+    } else {
+        // TODO - Set Linux equivalent of NUMA affinity.
     }
+    // There is no way to set an ideal processor in Linux.
 #endif
 
     if (Config->Flags & QUIC_THREAD_FLAG_HIGH_PRIORITY) {
@@ -739,8 +737,7 @@ QuicThreadCreate(
     }
 
 #ifndef __GLIBC__
-    if (Status == QUIC_STATUS_SUCCESS && Config->Flags & QUIC_THREAD_FLAG_SET_IDEAL_PROC) {
-        // There is no way to set an ideal processor in Linux, so just set affinity
+    if (Status == QUIC_STATUS_SUCCESS) {
         if (Config->Flags & QUIC_THREAD_FLAG_SET_AFFINITIZE) {
             cpu_set_t CpuSet;
             CPU_ZERO(&CpuSet);

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -335,7 +335,7 @@ void RunAttack()
 
     for (uint32_t i = 0; i < ThreadCount; ++i) {
         QUIC_THREAD_CONFIG ThreadConfig = {
-            QUIC_THREAD_FLAG_SET_IDEAL_PROC | QUIC_THREAD_FLAG_SET_AFFINITIZE,
+            QUIC_THREAD_FLAG_SET_AFFINITIZE,
             (uint8_t)(i % ProcCount),
             "AttackRunner",
             RunAttackThread,


### PR DESCRIPTION
Recent perf tests seem to indicate setting ideal processor actually hurts performance. This change refactors how we use that thread config flag, and removes it for default configurations.