### PR TITLE
Add diagnostic prints to quicinterop

### DIFF
--- a/scripts/run_endpoint.sh
+++ b/scripts/run_endpoint.sh
@@ -7,7 +7,7 @@ if [ -n "$TESTCASE" ]; then
     case "$TESTCASE" in
     # TODO: add supported test cases here
     "versionnegotiation"|"handshake"|"transfer"|"retry"|"resumption"|\
-    "multiconnect")
+    "multiconnect"|"ecn"|"keyupdate")
         ;;
     *)
         exit 127

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -196,6 +196,9 @@ public:
             return false;
         }
 
+        if (CustomUrlPath) {
+            printf("Sending request: %s", SendRequest.Buffer);
+        }
         if (QUIC_FAILED(
             MsQuic->StreamSend(
                 Stream,
@@ -241,6 +244,7 @@ public:
                         break;
                     }
                 }
+                uint64_t TotalBytesWritten = 0;
                 for (uint32_t i = 0; i < Event->RECEIVE.BufferCount; ++i) {
                     uint32_t DataLength = Event->RECEIVE.Buffers[i].Length;
                     if (fwrite(
@@ -251,12 +255,17 @@ public:
                         printf("Failed to write to file!\n");
                         break;
                     }
+                    TotalBytesWritten += DataLength;
                 }
+                printf("Wrote %llu bytes to file.\n", (long long unsigned int)TotalBytesWritten);
             }
             break;
         case QUIC_STREAM_EVENT_SEND_COMPLETE:
             break;
         case QUIC_STREAM_EVENT_PEER_SEND_ABORTED:
+            if (CustomUrlPath) {
+                printf("Peer aborted send!\n");
+            }
             QuicEventSet(pThis->RequestComplete);
             break;
         case QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN:

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -269,10 +269,10 @@ public:
                 int64_t ReceiveTimeDiff = (int64_t)QuicTimeDiff64(pThis->LastReceiveDuration, ReceiveDuration);
                 printf(
                     "Wrote %llu bytes to file.(%llu ms/%lld ms/%lld ms)\n",
-                    (long long unsigned int)TotalBytesWritten,
-                    (long long unsigned int)QuicTimeDiff64(pThis->DownloadStartTime, Now),
-                    (long long int)ReceiveDuration,
-                    (long long int)ReceiveTimeDiff);
+                    (unsigned long long)TotalBytesWritten,
+                    (unsigned long long)QuicTimeDiff64(pThis->DownloadStartTime, Now),
+                    (long long)ReceiveDuration,
+                    (long long)ReceiveTimeDiff);
                 pThis->LastReceiveTime = Now;
                 pThis->LastReceiveDuration = ReceiveDuration;
             }
@@ -282,7 +282,7 @@ public:
         case QUIC_STREAM_EVENT_PEER_SEND_ABORTED:
             if (CustomUrlPath) {
                 printf("Peer aborted send! (%llu ms)\n",
-                    (long long unsigned int)QuicTimeDiff64(pThis->DownloadStartTime, Now));
+                    (unsigned long long)QuicTimeDiff64(pThis->DownloadStartTime, Now));
             }
             QuicEventSet(pThis->RequestComplete);
             break;
@@ -297,7 +297,7 @@ public:
         case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {
             if (pThis->File) {
                 printf("Request closed incomplete. (%llu ms)\n",
-                    (long long unsigned int)QuicTimeDiff64(pThis->DownloadStartTime, Now));
+                    (unsigned long long)QuicTimeDiff64(pThis->DownloadStartTime, Now));
                 fclose(pThis->File); // Didn't get closed properly.
                 pThis->File = nullptr;
             }

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -239,10 +239,10 @@ public:
         )
     {
         InteropStream* pThis = (InteropStream*)Context;
+        int64_t Now = QuicTimeMs64();
         switch (Event->Type) {
         case QUIC_STREAM_EVENT_RECEIVE:
             if (CustomUrlPath) {
-                int64_t Now = QuicTimeMs64();
                 if (pThis->File == nullptr) {
                     pThis->DownloadStartTime = Now;
                     const char* FileName = strrchr(pThis->RequestPath, '/') + 1;
@@ -281,7 +281,8 @@ public:
             break;
         case QUIC_STREAM_EVENT_PEER_SEND_ABORTED:
             if (CustomUrlPath) {
-                printf("Peer aborted send!\n");
+                printf("Peer aborted send! (%llu ms)\n",
+                    (long long unsigned int)QuicTimeDiff64(pThis->DownloadStartTime, Now));
             }
             QuicEventSet(pThis->RequestComplete);
             break;
@@ -295,7 +296,8 @@ public:
             break;
         case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {
             if (pThis->File) {
-                printf("Request closed incomplete.\n");
+                printf("Request closed incomplete. (%llu ms)\n",
+                    (long long unsigned int)QuicTimeDiff64(pThis->DownloadStartTime, Now));
                 fclose(pThis->File); // Didn't get closed properly.
                 pThis->File = nullptr;
             }


### PR DESCRIPTION
These diagnostic prints are only used in QNS.