### PR TITLE
Use certs provided by interop framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,6 @@ ENV     PATH="/root/.dotnet/tools:${PATH}"
 RUN     cmake -DQUIC_BUILD_TEST=OFF -DQUIC_BUILD_PERF=OFF \
             -DQUIC_ENABLE_LOGGING=on ..
 RUN     cmake --build .
-RUN     openssl ecparam -out server.eckey -noout -name prime256v1 -genkey
-RUN	    openssl pkcs8 -topk8 -inform pem -in server.eckey -nocrypt \
-            -out server.key
-RUN     openssl req -batch -new -key server.key -days 9365 -nodes -x509 \
-            -subj "/" -addext "subjectAltName = DNS:server" -out server.crt
 
 FROM    martenseemann/quic-network-simulator-endpoint
 RUN     apt-get update -y \

--- a/scripts/run_endpoint.sh
+++ b/scripts/run_endpoint.sh
@@ -64,6 +64,8 @@ if [ "$ROLE" == "client" ]; then
         done
     else
         echo "Requests parameter: ${REQUESTS[@]}"
+        # FIXME: there doesn't seem to be a way to specify to use /certs/ca.pem
+        # for certificate verification
         quicinterop ${CLIENT_PARAMS} -custom:server -port:443 -urls:"${REQUESTS[@]}" -version:-16777187
     fi
     # Wait for the logs to flush to disk.
@@ -79,5 +81,5 @@ elif [ "$ROLE" == "server" ]; then
     esac
 
     quicinteropserver ${SERVER_PARAMS} -root:/www -listen:* -port:443 \
-        -file:/server.crt -key:/server.key 2>&1
+        -file:/certs/cert.pem -key:/certs/priv.key 2>&1
 fi


### PR DESCRIPTION
**FIXME:** There doesn't seem to be a way to specify to use `/certs/ca.pem` for certificate verification by the `quicinterop` client?