### PR TITLE
Work Around BCrypt IV Issues

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -917,13 +917,13 @@ QuicBindingProcessStatelessOperation(
         Token.Encrypted.OrigConnIdLength = RecvPacket->DestCidLen;
 
         uint8_t Iv[QUIC_MAX_IV_LENGTH];
-        if (MsQuicLib.CidTotalLength >= sizeof(Iv)) {
-            QuicCopyMemory(Iv, NewDestCid, sizeof(Iv));
-            for (uint8_t i = sizeof(Iv); i < MsQuicLib.CidTotalLength; ++i) {
-                Iv[i % sizeof(Iv)] ^= NewDestCid[i];
+        if (MsQuicLib.CidTotalLength >= QUIC_IV_LENGTH) {
+            QuicCopyMemory(Iv, NewDestCid, QUIC_IV_LENGTH);
+            for (uint8_t i = QUIC_IV_LENGTH; i < MsQuicLib.CidTotalLength; ++i) {
+                Iv[i % QUIC_IV_LENGTH] ^= NewDestCid[i];
             }
         } else {
-            QuicZeroMemory(Iv, sizeof(Iv));
+            QuicZeroMemory(Iv, QUIC_IV_LENGTH);
             QuicCopyMemory(Iv, NewDestCid, MsQuicLib.CidTotalLength);
         }
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -916,7 +916,7 @@ QuicBindingProcessStatelessOperation(
         QuicCopyMemory(Token.Encrypted.OrigConnId, RecvPacket->DestCid, RecvPacket->DestCidLen);
         Token.Encrypted.OrigConnIdLength = RecvPacket->DestCidLen;
 
-        uint8_t Iv[QUIC_IV_LENGTH];
+        uint8_t Iv[QUIC_MAX_IV_LENGTH];
         if (MsQuicLib.CidTotalLength >= sizeof(Iv)) {
             QuicCopyMemory(Iv, NewDestCid, sizeof(Iv));
             for (uint8_t i = sizeof(Iv); i < MsQuicLib.CidTotalLength; ++i) {

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -466,7 +466,7 @@ QuicRetryTokenDecrypt(
     //
     QuicCopyMemory(Token, TokenBuffer, sizeof(QUIC_RETRY_TOKEN_CONTENTS));
 
-    uint8_t Iv[QUIC_IV_LENGTH];
+    uint8_t Iv[QUIC_MAX_IV_LENGTH];
     if (MsQuicLib.CidTotalLength >= sizeof(Iv)) {
         QuicCopyMemory(Iv, Packet->DestCid, sizeof(Iv));
         for (uint8_t i = sizeof(Iv); i < MsQuicLib.CidTotalLength; ++i) {

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -467,13 +467,13 @@ QuicRetryTokenDecrypt(
     QuicCopyMemory(Token, TokenBuffer, sizeof(QUIC_RETRY_TOKEN_CONTENTS));
 
     uint8_t Iv[QUIC_MAX_IV_LENGTH];
-    if (MsQuicLib.CidTotalLength >= sizeof(Iv)) {
-        QuicCopyMemory(Iv, Packet->DestCid, sizeof(Iv));
-        for (uint8_t i = sizeof(Iv); i < MsQuicLib.CidTotalLength; ++i) {
-            Iv[i % sizeof(Iv)] ^= Packet->DestCid[i];
+    if (MsQuicLib.CidTotalLength >= QUIC_IV_LENGTH) {
+        QuicCopyMemory(Iv, Packet->DestCid, QUIC_IV_LENGTH);
+        for (uint8_t i = QUIC_IV_LENGTH; i < MsQuicLib.CidTotalLength; ++i) {
+            Iv[i % QUIC_IV_LENGTH] ^= Packet->DestCid[i];
         }
     } else {
-        QuicZeroMemory(Iv, sizeof(Iv));
+        QuicZeroMemory(Iv, QUIC_IV_LENGTH);
         QuicCopyMemory(Iv, Packet->DestCid, MsQuicLib.CidTotalLength);
     }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3449,7 +3449,7 @@ QuicConnRecvDecryptAndAuthenticate(
             QUIC_STATELESS_RESET_TOKEN_LENGTH);
     }
 
-    uint8_t Iv[QUIC_IV_LENGTH];
+    uint8_t Iv[QUIC_MAX_IV_LENGTH];
     QuicCryptoCombineIvAndPacketNumber(
         Connection->Crypto.TlsState.ReadKeys[Packet->KeyType]->Iv,
         (uint8_t*) &Packet->PacketNumber,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -704,7 +704,7 @@ QuicPacketBuilderFinalize(
 
         uint8_t* Payload = Header + Builder->HeaderLength;
 
-        uint8_t Iv[QUIC_IV_LENGTH];
+        uint8_t Iv[QUIC_MAX_IV_LENGTH];
         QuicCryptoCombineIvAndPacketNumber(Builder->Key->Iv, (uint8_t*) &Builder->Metadata->PacketNumber, Iv);
 
         QUIC_STATUS Status;

--- a/src/inc/quic_crypt.h
+++ b/src/inc/quic_crypt.h
@@ -41,6 +41,11 @@ typedef struct QUIC_HASH QUIC_HASH;
 #define QUIC_IV_LENGTH 12
 
 //
+// The maximum buffer length of the IV need by the platform layer.
+//
+#define QUIC_MAX_IV_LENGTH 48
+
+//
 // The length of buffer used for header protection sampling.
 //
 #define QUIC_HP_SAMPLE_LENGTH 16

--- a/src/inc/quic_crypt.h
+++ b/src/inc/quic_crypt.h
@@ -43,7 +43,11 @@ typedef struct QUIC_HASH QUIC_HASH;
 //
 // The maximum buffer length of the IV need by the platform layer.
 //
-#define QUIC_MAX_IV_LENGTH 48
+#ifdef _WIN32
+#define QUIC_MAX_IV_LENGTH 48 // BCrypt requires block size
+#else
+#define QUIC_MAX_IV_LENGTH QUIC_IV_LENGTH
+#endif
 
 //
 // The length of buffer used for header protection sampling.


### PR DESCRIPTION
Apparently, even though the IV is 12 bytes, BCrypt will read/write the buffer up to the block size (!) so we need to make sure we allocate enough space on the stack.