### PR TITLE
Version Negotiation Cleanup

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1092,6 +1092,21 @@ QuicBindingPreprocessDatagram(
             }
             return FALSE;
         }
+
+        if (Binding->Exclusive) {
+            if (Packet->DestCidLen != 0) {
+                QuicPacketLogDrop(Binding, Packet, "Non-zero length CID on exclusive binding");
+                return FALSE;
+            }
+        } else {
+            if (Packet->DestCidLen == 0) {
+                QuicPacketLogDrop(Binding, Packet, "Zero length DestCid");
+                return FALSE;
+            } else if (Packet->DestCidLen < QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH) {
+                QuicPacketLogDrop(Binding, Packet, "Less than min length CID on non-exclusive binding");
+                return FALSE;
+            }
+        }
     }
 
     *ReleaseDatagram = FALSE;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2828,11 +2828,13 @@ QuicConnRecvVerNeg(
         }
     }
 
-    if (SupportedVersion != 0) {
-        //
-        // TODO - Remove once version negotiation extension support is added.
-        //
+    if (SupportedVersion != 0) { // TODO - Remove once version negotiation extension support is added.
         QuicPacketLogDrop(Connection, Packet, "Version Negotation is unsupported");
+        QuicConnCloseLocally(
+            Connection,
+            QUIC_CLOSE_INTERNAL_SILENT | QUIC_CLOSE_QUIC_STATUS,
+            (uint64_t)QUIC_STATUS_VER_NEG_ERROR,
+            NULL);
         return;
     }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2773,12 +2773,6 @@ QuicConnUpdateDestCid(
     return TRUE;
 }
 
-
-//
-// Version negotiation is removed for the first version of QUIC.
-// When it is put back, it will probably be implemented as in this
-// function.
-//
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicConnRecvVerNeg(
@@ -2794,8 +2788,8 @@ QuicConnRecvVerNeg(
         (const uint32_t*)(
         Packet->VerNeg->DestCid +
         Packet->VerNeg->DestCidLength +
-        sizeof(uint8_t) + // sourceCID length field size
-        Packet->VerNeg->DestCid[Packet->VerNeg->DestCidLength]);  // this is the sourceCID length
+        sizeof(uint8_t) +                                         // SourceCidLength field size
+        Packet->VerNeg->DestCid[Packet->VerNeg->DestCidLength]);  // SourceCidLength
     uint16_t ServerVersionListLength =
         (Packet->BufferLength - (uint16_t)((uint8_t*)ServerVersionList - Packet->Buffer)) / sizeof(uint32_t);
 
@@ -2820,11 +2814,8 @@ QuicConnRecvVerNeg(
         // Check to see if this is the current version.
         //
         if (ServerVersionList[i] == Connection->Stats.QuicVersion) {
-            QuicTraceLogConnVerbose(
-                InvalidVerNeg,
-                Connection,
-                "Dropping version negotation that includes the current version");
-            goto Exit;
+            QuicPacketLogDrop(Connection, Packet, "Version Negotation that includes the current version");
+            return;
         }
 
         //
@@ -2837,34 +2828,35 @@ QuicConnRecvVerNeg(
         }
     }
 
-    //
-    // Did we find a supported version?
-    //
-    if (FALSE) { // TODO: remove this once Version Negotiation is supported.
-
-        Connection->Stats.QuicVersion = SupportedVersion;
-        QuicConnOnQuicVersionSet(Connection);
-
+    if (SupportedVersion != 0) {
         //
-        // Match found! Start connecting with selected version.
+        // TODO - Remove once version negotiation extension support is added.
         //
-        QuicConnRestart(Connection, TRUE);
+        QuicPacketLogDrop(Connection, Packet, "Version Negotation is unsupported");
+        return;
+    }
 
-    } else {
-
+    if (SupportedVersion == 0) {
         //
         // No match! Connection failure.
         //
+        QuicTraceLogConnError(
+            RecvVerNegNoMatch,
+            Connection,
+            "Version Negotation contained no supported versions");
         QuicConnCloseLocally(
             Connection,
             QUIC_CLOSE_INTERNAL_SILENT | QUIC_CLOSE_QUIC_STATUS,
             (uint64_t)QUIC_STATUS_VER_NEG_ERROR,
             NULL);
+        return;
     }
 
-Exit:
-
-    return;
+    /* TODO - Add version negotiation extension support
+    Connection->Stats.QuicVersion = SupportedVersion;
+    QuicConnOnQuicVersionSet(Connection);
+    QuicConnRestart(Connection, TRUE);
+    */
 }
 
 
@@ -3110,28 +3102,22 @@ QuicConnRecvHeader(
     // Check invariants and packet version.
     //
 
-    if (!Packet->ValidatedHeaderInv &&
-        !QuicPacketValidateInvariant(Connection, Packet, Connection->State.ShareBinding)) {
-        return FALSE;
+    if (!Packet->ValidatedHeaderInv) {
+        QUIC_DBG_ASSERT(Packet->DestCid != NULL); // This should only hit for coalesced packets.
+        if (!QuicPacketValidateInvariant(Connection, Packet, Connection->State.ShareBinding)) {
+            return FALSE;
+        }
     }
 
     if (!Packet->IsShortHeader) {
         if (Packet->Invariant->LONG_HDR.Version != Connection->Stats.QuicVersion) {
             if (Packet->Invariant->LONG_HDR.Version == QUIC_VERSION_VER_NEG) {
+                //
+                // Version negotiation packet received.
+                //
                 Connection->Stats.VersionNegotiation = TRUE;
-
-                //
-                // Version negotiation is removed for the first version of QUIC.
-                // When it is put back, it will probably be implemented as in this
-                // function:
-                // QuicConnRecvVerNeg(Connection, Packet);
-                //
-                // For now, since there is a single version, receiving
-                // a version negotation packet means there is a version
-                // mismatch, so abandon the connect attempt.
-                //
-
                 QuicConnRecvVerNeg(Connection, Packet);
+
             } else {
                 QuicPacketLogDropWithValue(Connection, Packet, "Invalid version", QuicByteSwapUint32(Packet->Invariant->LONG_HDR.Version));
             }
@@ -3145,6 +3131,16 @@ QuicConnRecvHeader(
     }
 
     QUIC_FRE_ASSERT(QuicIsVersionSupported(Connection->Stats.QuicVersion));
+
+#if DEBUG
+    if (!Packet->IsShortHeader) {
+        if (Connection->State.ShareBinding) {
+            QUIC_DBG_ASSERT(Packet->DestCidLen >= QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH);
+        } else {
+            QUIC_DBG_ASSERT(Packet->DestCidLen == 0);
+        }
+    }
+#endif
 
     //
     // Begin non-version-independent logic. When future versions are supported,

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -113,20 +113,6 @@ QuicPacketValidateInvariant(
             QuicPacketLogDrop(Owner, Packet, "LH no room for DestCid");
             return FALSE;
         }
-        if (IsBindingShared) {
-            if (DestCidLen == 0) {
-                QuicPacketLogDrop(Owner, Packet, "Zero length DestCid");
-                return FALSE;
-            } else if (DestCidLen < QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH) {
-                QuicPacketLogDrop(Owner, Packet, "Less than min length CID on non-exclusive binding");
-                return FALSE;
-            }
-        } else {
-            if (DestCidLen != 0) {
-                QuicPacketLogDrop(Owner, Packet, "Non-zero length CID on exclusive binding");
-                return FALSE;
-            }
-        }
 
         DestCid = Packet->Invariant->LONG_HDR.DestCid;
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1237,6 +1237,33 @@
         "CustomSettings": null
       }
     },
+    "RecvVerNegNoMatch": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Version Negotation contained no supported versions",
+      "UniqueId": "RecvVerNegNoMatch",
+      "splitArgs": [
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "Connection",
+            "SuggestedTelemetryName": "arg1"
+          },
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macro": {
+        "MacroName": "QuicTraceLogConnError",
+        "EncodedPrefix": "[conn][%p] ",
+        "EncodedArgNumber": 2,
+        "MacroConfiguration": {
+          "linux": "lttng_plus",
+          "stubs": "stubs",
+          "windows_kernel": "empty",
+          "windows": "empty"
+        },
+        "CustomSettings": null
+      }
+    },
     "ApiEventNoHandler": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Event silently discarded (no handler).",
@@ -2346,33 +2373,6 @@
           },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "InvalidVerNeg": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Dropping version negotation that includes the current version",
-      "UniqueId": "InvalidVerNeg",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
         }
       ],
       "macro": {
@@ -21384,6 +21384,10 @@
         "TraceID": "PacketRxNotAcked"
       },
       {
+        "UniquenessHash": "c9015186-9937-78ff-24f3-2f08dc9d3c95",
+        "TraceID": "RecvVerNegNoMatch"
+      },
+      {
         "UniquenessHash": "c69c6d33-2838-013a-936c-7fbc085570b4",
         "TraceID": "ApiEventNoHandler"
       },
@@ -21526,10 +21530,6 @@
       {
         "UniquenessHash": "62fa7337-1321-2cd0-f7cc-236d893ed747",
         "TraceID": "VerNegItem"
-      },
-      {
-        "UniquenessHash": "ed33a4f4-4591-33d1-1760-74e7f873aa11",
-        "TraceID": "InvalidVerNeg"
       },
       {
         "UniquenessHash": "3405b409-bdc8-a1c4-cc9a-6dc3c0f86f01",


### PR DESCRIPTION
- Fixes an issue where the server would only send a Version Negotiation packet if it matching V1's CID requirements. V2 might have different requirements...
- Some other general clean up of code, logging and comments.