### PR TITLE
More Version Negotiation Improvements

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -34,7 +34,7 @@ typedef struct QUIC_PATH QUIC_PATH;
 #define QUIC_MIN_INITIAL_PACKET_LENGTH          1200
 
 //
-// The minimum UDP payload size across all supported versions. Used to decided
+// The minimum UDP payload size across all supported versions. Used to decide
 // on whether to send a version negotiation packet in response to an unsupported
 // QUIC version.
 //

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -28,9 +28,17 @@ typedef struct QUIC_PATH QUIC_PATH;
 #define QUIC_INITIAL_RTT                        333 // millisec
 
 //
-// The minimum QUIC Packet Size (UDP payload size) for initial QUIC packets.
+// The minimum (version 1) QUIC Packet Size (UDP payload size) for initial QUIC
+// packets.
 //
 #define QUIC_MIN_INITIAL_PACKET_LENGTH          1200
+
+//
+// The minimum UDP payload size across all supported versions. Used to decided
+// on whether to send a version negotiation packet in response to an unsupported
+// QUIC version.
+//
+#define QUIC_MIN_UDP_PAYLOAD_LENGTH_FOR_VN      QUIC_MIN_INITIAL_PACKET_LENGTH
 
 //
 // The initial congestion window.

--- a/src/inc/quic_versions.h
+++ b/src/inc/quic_versions.h
@@ -54,7 +54,6 @@ QuicIsVersionSupported(
     )
 {
     switch (Version) {
-    case QUIC_VERSION_VER_NEG:
     case QUIC_VERSION_DRAFT_27:
     case QUIC_VERSION_DRAFT_28:
     case QUIC_VERSION_DRAFT_29:


### PR DESCRIPTION
- Fixes some of the logic around calls/usage of the `QuicIsVersionSupported` function. It no longer includes the version negotiation. Updates the one caller where it needed that to be included. All the rest were bugs.
- Updates the logic to validate the minimum UDP length before sending a VN packet.