### PR TITLE
Properly count protocol errors in perf counters.

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1567,17 +1567,12 @@ QuicConnTryClose(
         if (ResultQuicStatus) {
             Connection->CloseStatus = (QUIC_STATUS)ErrorCode;
             Connection->CloseErrorCode = QUIC_ERROR_INTERNAL_ERROR;
-            //
-            // Errors 0x1-0xF are quic errors, as are 0x100-0xFF. For future proofing,
-            // consider the whole range of 0x1-0x1FF as a protocol error.
-            //
-            if (ErrorCode > 0 &&
-                ErrorCode <= 0x1FF) {
-                QuicPerfCounterIncrement(QUIC_PERF_COUNTER_CONN_PROTOCOL_ERRORS);
-            }
         } else {
             Connection->CloseStatus = QuicErrorCodeToStatus(ErrorCode);
             Connection->CloseErrorCode = ErrorCode;
+            if (QuicErrorIsProtocolError(ErrorCode)) {
+                QuicPerfCounterIncrement(QUIC_PERF_COUNTER_CONN_PROTOCOL_ERRORS);
+            }
         }
 
         if (Flags & QUIC_CLOSE_APPLICATION) {

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1567,8 +1567,12 @@ QuicConnTryClose(
         if (ResultQuicStatus) {
             Connection->CloseStatus = (QUIC_STATUS)ErrorCode;
             Connection->CloseErrorCode = QUIC_ERROR_INTERNAL_ERROR;
-            if (ErrorCode != QUIC_STATUS_CONNECTION_IDLE &&
-                ErrorCode != QUIC_STATUS_CONNECTION_TIMEOUT) {
+            //
+            // Errors 0x1-0xF are quic errors, as are 0x100-0xFF. For future proofing,
+            // consider the whole range of 0x1-0x1FF as a protocol error.
+            //
+            if (ErrorCode > 0 &&
+                ErrorCode <= 0x1FF) {
                 QuicPerfCounterIncrement(QUIC_PERF_COUNTER_CONN_PROTOCOL_ERRORS);
             }
         } else {

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -89,6 +89,9 @@
 #define QUIC_ERROR_CRYPTO_HANDSHAKE_FAILURE         QUIC_ERROR_CRYPTO_ERROR(40)  // TLS error code for 'handshake_failure'
 #define QUIC_ERROR_CRYPTO_NO_APPLICATION_PROTOCOL   QUIC_ERROR_CRYPTO_ERROR(120) // TLS error code for 'no_application_protocol'
 
+//
+// Used for determining which errors to count for performance counters.
+//
 inline
 BOOLEAN
 QuicErrorIsProtocolError(

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -89,6 +89,17 @@
 #define QUIC_ERROR_CRYPTO_HANDSHAKE_FAILURE         QUIC_ERROR_CRYPTO_ERROR(40)  // TLS error code for 'handshake_failure'
 #define QUIC_ERROR_CRYPTO_NO_APPLICATION_PROTOCOL   QUIC_ERROR_CRYPTO_ERROR(120) // TLS error code for 'no_application_protocol'
 
+inline
+BOOLEAN
+QuicErrorIsProtocolError(
+    _In_ QUIC_VAR_INT ErrorCode
+    )
+{
+    return
+        ErrorCode >= QUIC_ERROR_FLOW_CONTROL_ERROR &&
+        ErrorCode <= QUIC_ERROR_AEAD_LIMIT_REACHED;
+}
+
 //
 // Different types of QUIC frames
 //

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -662,3 +662,8 @@ void
 QuicConfigurationRelease(
     _In_ QUIC_CONFIGURATION* Configuration
     );
+
+BOOLEAN
+QuicErrorIsProtocolError(
+    _In_ QUIC_VAR_INT ErrorCode
+    );

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -16,6 +16,7 @@ Abstract:
 --*/
 
 #include "platform_internal.h"
+#include "quic_var_int.h"
 #ifdef QUIC_CLOG
 #include "inline.c.clog.h"
 #endif
@@ -270,4 +271,9 @@ BOOLEAN
 QuicAddrToString(
     _In_ const QUIC_ADDR* Addr,
     _Out_ QUIC_ADDR_STR* AddrStr
+    );
+
+BOOLEAN
+QuicErrorIsProtocolError(
+    _In_ QUIC_VAR_INT ErrorCode
     );

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -16,7 +16,6 @@ Abstract:
 --*/
 
 #include "platform_internal.h"
-#include "frame.h"
 #ifdef QUIC_CLOG
 #include "inline.c.clog.h"
 #endif
@@ -271,9 +270,4 @@ BOOLEAN
 QuicAddrToString(
     _In_ const QUIC_ADDR* Addr,
     _Out_ QUIC_ADDR_STR* AddrStr
-    );
-
-BOOLEAN
-QuicErrorIsProtocolError(
-    _In_ QUIC_VAR_INT ErrorCode
     );

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -16,7 +16,7 @@ Abstract:
 --*/
 
 #include "platform_internal.h"
-#include "quic_var_int.h"
+#include "frame.h"
 #ifdef QUIC_CLOG
 #include "inline.c.clog.h"
 #endif


### PR DESCRIPTION
Before, anything not a few small errors was counted. Now, only things that are explicitly protocol errors are counted as protocol errors.


Closes #889 