### PR TITLE
Reallocate TLS Buffer (OpenSSL)

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -526,7 +526,7 @@ QuicTlsAddHandshakeDataCallback(
         // new data.
         //
         uint16_t NewBufferAllocLength = TlsState->BufferAllocLength;
-        while (Length + TlsState->BufferLength > (size_t)TlsState->BufferAllocLength) {
+        while (Length + TlsState->BufferLength > (size_t)NewBufferAllocLength) {
             NewBufferAllocLength <<= 1;
         }
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -493,7 +493,7 @@ int
 QuicTlsAddHandshakeDataCallback(
     _In_ SSL *Ssl,
     _In_ OSSL_ENCRYPTION_LEVEL Level,
-    _In_reads_(len) const uint8_t *Data,
+    _In_reads_(Length) const uint8_t *Data,
     _In_ size_t Length
     )
 {
@@ -510,14 +510,44 @@ QuicTlsAddHandshakeDataCallback(
         Length,
         Level);
 
-    if (Length + TlsState->BufferLength > (size_t)TlsState->BufferAllocLength) {
+    if (Length + TlsState->BufferLength > 0xF000) {
         QuicTraceEvent(
             TlsError,
             "[ tls][%p] ERROR, %s.",
             TlsContext->Connection,
-            "Buffer overflow for output handshake data");
+            "Too much handshake data");
         TlsContext->ResultFlags |= QUIC_TLS_RESULT_ERROR;
         return -1;
+    }
+
+    if (Length + TlsState->BufferLength > (size_t)TlsState->BufferAllocLength) {
+        //
+        // Double the allocated buffer length until there's enough room for the
+        // new data.
+        //
+        uint16_t NewBufferAllocLength = TlsState->BufferAllocLength;
+        while (Length + TlsState->BufferLength > (size_t)TlsState->BufferAllocLength) {
+            NewBufferAllocLength <<= 1;
+        }
+
+        uint8_t* NewBuffer = QUIC_ALLOC_NONPAGED(NewBufferAllocLength);
+        if (NewBuffer == NULL) {
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "New crypto buffer",
+                NewBufferAllocLength);
+            TlsContext->ResultFlags |= QUIC_TLS_RESULT_ERROR;
+            return -1;
+        }
+
+        QuicCopyMemory(
+            NewBuffer,
+            TlsState->Buffer,
+            TlsState->BufferLength);
+        QUIC_FREE(TlsState->Buffer);
+        TlsState->Buffer = NewBuffer;
+        TlsState->BufferAllocLength = NewBufferAllocLength;
     }
 
     switch (KeyType) {


### PR DESCRIPTION
Fixes #900. Updates the OpenSSL code to reallocate the output TLS buffer if we don't have enough room. Note, the same bug exists in each TLS implementation, but the fixes will require specific code changes for each. Additionally, if it weren't for this specific interop failure, I'm not sure if we would fix this problem; at least not in the same way.