### PR TITLE
Support Random Memory Allocation Failures (For Testing)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)
 option(QUIC_CODE_CHECK "Run static code checkers" OFF)
 option(QUIC_OPTIMIZE_LOCAL "Optimize code for local machine architecture" OFF)
 option(QUIC_CI "CI Specific build optimizations" OFF)
+option(QUIC_RANDOM_ALLOC_FAIL "Randomly fails allocation calls" OFF)
 
 # FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
 if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
@@ -216,6 +217,10 @@ endif()
 
 list(APPEND QUIC_COMMON_DEFINES VER_BUILD_ID=${QUIC_VER_BUILD_ID})
 list(APPEND QUIC_COMMON_DEFINES VER_SUFFIX=${QUIC_VER_SUFFIX})
+
+if(QUIC_RANDOM_ALLOC_FAIL)
+    list(APPEND QUIC_COMMON_DEFINES QUIC_RANDOM_ALLOC_FAIL)
+endif()
 
 if(WIN32)
     # Generate the MsQuicEtw header file.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -69,6 +69,9 @@ This script provides helpers for building msquic.
 .PARAMETER CI
     Build is occuring from CI
 
+.PARAMETER RandomAllocFail
+    Enables random allocation failures.
+
 .EXAMPLE
     build.ps1
 
@@ -143,7 +146,10 @@ param (
     [switch]$ConfigureOnly = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$CI = $false
+    [switch]$CI = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$RandomAllocFail = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -286,6 +292,9 @@ function CMake-Generate {
         $Arguments += " -DQUIC_CI=ON"
         $Arguments += " -DQUIC_VER_BUILD_ID=$env:BUILD_BUILDID"
         $Arguments += " -DQUIC_VER_SUFFIX=-official"
+    }
+    if ($RandomAllocFail) {
+        $Arguments += " -DQUIC_RANDOM_ALLOC_FAIL=on"
     }
     $Arguments += " ../../.."
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2750,6 +2750,7 @@ QuicConnUpdateDestCid(
                     Packet->SourceCid);
             if (DestCid == NULL) {
                 Connection->DestCidCount--;
+                Connection->Paths[0].DestCid = NULL;
                 QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, "Out of memory");
                 return FALSE;
             } else {
@@ -6251,7 +6252,7 @@ QuicConnDrainOperations(
 
     QUIC_PASSIVE_CODE();
 
-    if (!Connection->State.Initialized) {
+    if (!Connection->State.Initialized && !Connection->State.Uninitialized) {
         //
         // TODO - Try to move this only after the connection is accepted by the
         // listener. But that's going to be pretty complicated.

--- a/src/core/sent_packet_metadata.c
+++ b/src/core/sent_packet_metadata.c
@@ -96,7 +96,9 @@ QuicSentPacketPoolGetPacketMetadata(
     QUIC_SENT_PACKET_METADATA* Metadata =
         QuicPoolAlloc(Pool->Pools + FrameCount - 1);
 #if DEBUG
-    Metadata->Flags.Freed = FALSE;
+    if (Metadata != NULL) {
+        Metadata->Flags.Freed = FALSE;
+    }
 #endif
     return Metadata;
 }

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -175,8 +175,12 @@ QuicAlloc(
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     return PlatDispatch->Alloc(ByteCount);
 #else
+#ifdef QUIC_RANDOM_ALLOC_FAIL
+    return ((rand() % 100) == 1) ? NULL : malloc(ByteCount);
+#else
     return malloc(ByteCount);
-#endif
+#endif // QUIC_RANDOM_ALLOC_FAIL
+#endif // QUIC_PLATFORM_DISPATCH_TABLE
 }
 
 void

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -429,7 +429,11 @@ QuicAlloc(
     )
 {
     QUIC_DBG_ASSERT(QuicPlatform.Heap);
+#ifdef QUIC_RANDOM_ALLOC_FAIL
+    return ((rand() % 100) == 1) ? NULL : HeapAlloc(QuicPlatform.Heap, 0, ByteCount);
+#else
     return HeapAlloc(QuicPlatform.Heap, 0, ByteCount);
+#endif // QUIC_RANDOM_ALLOC_FAIL
 }
 
 void


### PR DESCRIPTION
Related to #752.

- Adds a build flag to enable 1/100 allocation failure chance.
- Ran spinquic a few times and fixed a few bugs I found. Still not 100% fixed. Some asserts hit, but I'm not sure those asserts are valid in the case of OOM. Spinquic also hung on shutdown (which I haven't investigated yet).
- I only ran this on Windows.