### PR TITLE
Fix interop client to support resumption tickets and zeroRTT.

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5508,7 +5508,7 @@ QuicConnParamSet(
 
         break;
 
-    case QUIC_PARAM_CONN_RESUMPTION_STATE: {
+    case QUIC_PARAM_CONN_RESUMPTION_TICKET: {
         if (BufferLength == 0 || Buffer == NULL) {
             Status = QUIC_STATUS_INVALID_PARAMETER;
             break;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -522,7 +522,7 @@ typedef enum QUIC_PARAM_LEVEL {
 #ifdef QUIC_API_ENABLE_INSECURE_FEATURES
 #define QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION         15  // uint8_t (BOOLEAN)
 #endif
-#define QUIC_PARAM_CONN_RESUMPTION_STATE                16  // uint8_t[]
+#define QUIC_PARAM_CONN_RESUMPTION_TICKET               16  // uint8_t[]
 
 //
 // Parameters for QUIC_PARAM_LEVEL_TLS.

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -466,7 +466,7 @@ QuicTestValidateConnectionEvents3(
         MsQuic->SetParam(
             Client.Handle,
             QUIC_PARAM_LEVEL_CONNECTION,
-            QUIC_PARAM_CONN_RESUMPTION_STATE,
+            QUIC_PARAM_CONN_RESUMPTION_TICKET,
             ResumptionTicket->Length,
             ResumptionTicket->Buffer));
     QUIC_FREE(ResumptionTicket);

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -702,7 +702,7 @@ TestConnection::SetResumptionTicket(
         MsQuic->SetParam(
             QuicConnection,
             QUIC_PARAM_LEVEL_CONNECTION,
-            QUIC_PARAM_CONN_RESUMPTION_STATE,
+            QUIC_PARAM_CONN_RESUMPTION_TICKET,
             NewResumptionTicket->Length,
             NewResumptionTicket->Buffer);
 }

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -415,9 +415,7 @@ public:
         QuicEventUninitialize(QuackAckReceived);
         QuicEventUninitialize(ConnectionComplete);
         delete [] NegotiatedAlpn;
-        if (ResumptionTicket) {
-            delete [] ResumptionTicket;
-        }
+        delete [] ResumptionTicket;
     }
     bool SetKeepAlive(uint32_t KeepAliveMs) {
         QUIC_SETTINGS Settings{0};

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -342,7 +342,10 @@ class InteropConnection {
     QUIC_EVENT RequestComplete;
     QUIC_EVENT QuackAckReceived;
     QUIC_EVENT ShutdownComplete;
+    QUIC_EVENT TicketReceived;
     char* NegotiatedAlpn;
+    const uint8_t* ResumptionTicket;
+    uint32_t ResumptionTicketLength;
 public:
     bool VersionUnsupported : 1;
     bool Connected : 1;
@@ -352,6 +355,8 @@ public:
         Configuration(Configuration),
         Connection(nullptr),
         NegotiatedAlpn(nullptr),
+        ResumptionTicket(nullptr),
+        ResumptionTicketLength(0),
         VersionUnsupported(false),
         Connected(false),
         Resumed(false),
@@ -361,6 +366,7 @@ public:
         QuicEventInitialize(&RequestComplete, TRUE, FALSE);
         QuicEventInitialize(&QuackAckReceived, TRUE, FALSE);
         QuicEventInitialize(&ShutdownComplete, TRUE, FALSE);
+        QuicEventInitialize(&TicketReceived, TRUE, FALSE);
 
         VERIFY_QUIC_SUCCESS(
             MsQuic->ConnectionOpen(
@@ -403,11 +409,15 @@ public:
         Streams.clear();
         Shutdown();
         MsQuic->ConnectionClose(Connection);
+        QuicEventUninitialize(TicketReceived);
         QuicEventUninitialize(ShutdownComplete);
         QuicEventUninitialize(RequestComplete);
         QuicEventUninitialize(QuackAckReceived);
         QuicEventUninitialize(ConnectionComplete);
         delete [] NegotiatedAlpn;
+        if (ResumptionTicket) {
+            delete [] ResumptionTicket;
+        }
     }
     bool SetKeepAlive(uint32_t KeepAliveMs) {
         QUIC_SETTINGS Settings{0};
@@ -434,6 +444,16 @@ public:
                     QUIC_PARAM_CONN_SETTINGS,
                     sizeof(Settings),
                     &Settings));
+    }
+    bool SetResumptionTicket(const uint8_t* Ticket, uint32_t TicketLength) {
+        return
+            QUIC_SUCCEEDED(
+                MsQuic->SetParam(
+                    Connection,
+                    QUIC_PARAM_LEVEL_CONNECTION,
+                    QUIC_PARAM_CONN_RESUMPTION_STATE,
+                    TicketLength,
+                    Ticket));
     }
     bool ConnectToServer(const char* ServerName, uint16_t ServerPort) {
         if (QUIC_SUCCEEDED(
@@ -500,21 +520,7 @@ public:
             ReceivedQuackAck;
     }
     bool WaitForTicket() {
-        int TryCount = 0;
-        uint32_t TicketLength = 0;
-        while (TryCount++ < 20) {
-            if (QUIC_STATUS_BUFFER_TOO_SMALL ==
-                MsQuic->GetParam(
-                    Connection,
-                    QUIC_PARAM_LEVEL_CONNECTION,
-                    QUIC_PARAM_CONN_RESUMPTION_STATE,
-                    &TicketLength,
-                    nullptr)) {
-                break;
-            }
-            QuicSleep(100);
-        }
-        return true; // TryCount < 20;
+        return QuicEventWaitWithTimeout(TicketReceived, WaitTimeoutMs);
     }
     bool UsedZeroRtt() {
         bool Result = true;
@@ -596,6 +602,15 @@ public:
         }
         return false;
     }
+    bool GetResumptionTicket(const uint8_t** Ticket, uint32_t* TicketLength) {
+        if (!WaitForTicket() || ResumptionTicket == nullptr) {
+            return false;
+        }
+        *Ticket = new uint8_t[ResumptionTicketLength];
+        memcpy((uint8_t*)*Ticket, ResumptionTicket, ResumptionTicketLength);
+        *TicketLength = ResumptionTicketLength;
+        return true;
+    }
 private:
     static
     _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -646,6 +661,17 @@ private:
                 pThis->ReceivedQuackAck = true;
                 QuicEventSet(pThis->QuackAckReceived);
             }
+            break;
+        case QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED:
+            if (Event->RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength) {
+                pThis->ResumptionTicketLength = Event->RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength;
+                pThis->ResumptionTicket = new uint8_t[pThis->ResumptionTicketLength];
+                memcpy(
+                    (uint8_t*)pThis->ResumptionTicket,
+                    Event->RESUMPTION_TICKET_RECEIVED.ResumptionTicket,
+                    Event->RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength);
+            }
+            QuicEventSet(pThis->TicketReceived);
             break;
         default:
             break;
@@ -757,14 +783,26 @@ RunInteropTest(
     case Resumption:
     case StatelessRetry:
     case PostQuantum: {
+        const uint8_t* ResumptionTicket = nullptr;
+        uint32_t ResumptionTicketLength = 0;
         if (Feature == Resumption) {
             InteropConnection Connection(Configuration);
             if (!Connection.ConnectToServer(Endpoint.ServerName, Port) ||
                 !Connection.WaitForTicket()) {
+                printf("Failed waiting for ticket\n");
+                break;
+            }
+            if (!Connection.GetResumptionTicket(&ResumptionTicket, &ResumptionTicketLength)) {
+                printf("Failed to get resumption ticket\n");
                 break;
             }
         }
         InteropConnection Connection(Configuration, false, Feature == PostQuantum);
+        if (Feature == Resumption) {
+            if (!Connection.SetResumptionTicket(ResumptionTicket, ResumptionTicketLength)) {
+                printf("Failed to SET resumption ticket\n");
+            }
+        }
         if (Connection.ConnectToServer(Endpoint.ServerName, Port)) {
             Connection.GetQuicVersion(QuicVersionUsed);
             Connection.GetNegotiatedAlpn(NegotiatedAlpn);
@@ -784,19 +822,30 @@ RunInteropTest(
                 Success = Connection.SendHttpRequests();
             }
         }
+        if (ResumptionTicket) {
+            delete [] ResumptionTicket;
+        }
         break;
     }
 
     case StreamData:
     case ZeroRtt: {
+        const uint8_t* ResumptionTicket = nullptr;
+        uint32_t ResumptionTicketLength = 0;
         if (Feature == ZeroRtt) {
             InteropConnection Connection(Configuration);
             if (!Connection.ConnectToServer(Endpoint.ServerName, Port) ||
                 !Connection.WaitForTicket()) {
                 break;
             }
+            if (!Connection.GetResumptionTicket(&ResumptionTicket, &ResumptionTicketLength)) {
+                break;
+            }
         }
         InteropConnection Connection(Configuration, false);
+        if (Feature == ZeroRtt) {
+            Connection.SetResumptionTicket(ResumptionTicket, ResumptionTicketLength);
+        }
         if (Connection.SendHttpRequests(false) &&
             Connection.ConnectToServer(Endpoint.ServerName, Port) &&
             Connection.WaitForHttpResponses()) {
@@ -807,6 +856,9 @@ RunInteropTest(
             } else {
                 Success = true;
             }
+        }
+        if (ResumptionTicket) {
+            delete [] ResumptionTicket;
         }
         break;
     }

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -602,13 +602,13 @@ public:
         }
         return false;
     }
-    bool GetResumptionTicket(const uint8_t** Ticket, uint32_t* TicketLength) {
+    bool GetResumptionTicket(const uint8_t*& Ticket, uint32_t& TicketLength) {
         if (!WaitForTicket() || ResumptionTicket == nullptr) {
             return false;
         }
-        *Ticket = new uint8_t[ResumptionTicketLength];
-        memcpy((uint8_t*)*Ticket, ResumptionTicket, ResumptionTicketLength);
-        *TicketLength = ResumptionTicketLength;
+        Ticket = new uint8_t[ResumptionTicketLength];
+        memcpy((uint8_t*)Ticket, ResumptionTicket, ResumptionTicketLength);
+        TicketLength = ResumptionTicketLength;
         return true;
     }
 private:
@@ -788,20 +788,14 @@ RunInteropTest(
         if (Feature == Resumption) {
             InteropConnection Connection(Configuration);
             if (!Connection.ConnectToServer(Endpoint.ServerName, Port) ||
-                !Connection.WaitForTicket()) {
-                printf("Failed waiting for ticket\n");
-                break;
-            }
-            if (!Connection.GetResumptionTicket(&ResumptionTicket, &ResumptionTicketLength)) {
-                printf("Failed to get resumption ticket\n");
+                !Connection.WaitForTicket() ||
+                !Connection.GetResumptionTicket(ResumptionTicket, ResumptionTicketLength)) {
                 break;
             }
         }
         InteropConnection Connection(Configuration, false, Feature == PostQuantum);
         if (Feature == Resumption) {
-            if (!Connection.SetResumptionTicket(ResumptionTicket, ResumptionTicketLength)) {
-                printf("Failed to SET resumption ticket\n");
-            }
+            Connection.SetResumptionTicket(ResumptionTicket, ResumptionTicketLength);
         }
         if (Connection.ConnectToServer(Endpoint.ServerName, Port)) {
             Connection.GetQuicVersion(QuicVersionUsed);
@@ -835,10 +829,8 @@ RunInteropTest(
         if (Feature == ZeroRtt) {
             InteropConnection Connection(Configuration);
             if (!Connection.ConnectToServer(Endpoint.ServerName, Port) ||
-                !Connection.WaitForTicket()) {
-                break;
-            }
-            if (!Connection.GetResumptionTicket(&ResumptionTicket, &ResumptionTicketLength)) {
+                !Connection.WaitForTicket() ||
+                !Connection.GetResumptionTicket(ResumptionTicket, ResumptionTicketLength)) {
                 break;
             }
         }

--- a/src/tools/ping/PingConnection.cpp
+++ b/src/tools/ping/PingConnection.cpp
@@ -305,7 +305,7 @@ PingConnection::ProcessEvent(
                 MsQuic->GetParam(
                     QuicConnection,
                     QUIC_PARAM_LEVEL_CONNECTION,
-                    QUIC_PARAM_CONN_RESUMPTION_STATE,
+                    QUIC_PARAM_CONN_RESUMPTION_TICKET,
                     &SerializedResumptionStateLength,
                     SerializedResumptionState))) {
                 printf("[%p] Resumption state (%u bytes):\n", QuicConnection, SerializedResumptionStateLength);

--- a/src/tools/sample/sample.cpp
+++ b/src/tools/sample/sample.cpp
@@ -739,7 +739,7 @@ RunClient(
         //
         uint8_t ResumptionTicket[1024];
         uint16_t TicketLength = (uint16_t)DecodeHexBuffer(ResumptionTicketString, sizeof(ResumptionTicket), ResumptionTicket);
-        if (QUIC_FAILED(Status = MsQuic->SetParam(Connection, QUIC_PARAM_LEVEL_CONNECTION, QUIC_PARAM_CONN_RESUMPTION_STATE, TicketLength, ResumptionTicket))) {
+        if (QUIC_FAILED(Status = MsQuic->SetParam(Connection, QUIC_PARAM_LEVEL_CONNECTION, QUIC_PARAM_CONN_RESUMPTION_TICKET, TicketLength, ResumptionTicket))) {
             printf("SetParam(QUIC_PARAM_CONN_RESUMPTION_TICKET) failed, 0x%x!\n", Status);
             goto Error;
         }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -374,7 +374,7 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection)
     case QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION:                   // uint8_t (BOOLEAN)
         Helper.SetUint8(QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION, (uint8_t)GetRandom(2));
         break;
-    case QUIC_PARAM_CONN_RESUMPTION_STATE:                          // uint8_t[]
+    case QUIC_PARAM_CONN_RESUMPTION_TICKET:                          // uint8_t[]
         // TODO
         break;
     default:

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -374,7 +374,7 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection)
     case QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION:                   // uint8_t (BOOLEAN)
         Helper.SetUint8(QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION, (uint8_t)GetRandom(2));
         break;
-    case QUIC_PARAM_CONN_RESUMPTION_TICKET:                          // uint8_t[]
+    case QUIC_PARAM_CONN_RESUMPTION_TICKET:                         // uint8_t[]
         // TODO
         break;
     default:


### PR DESCRIPTION
The interop client support of 0-RTT and Resumption was broken when the refactor to remove the Session layer was completed.
This change adds that support back.