### PR TITLE
Properly set thread affinity for throughput tests

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -18,7 +18,7 @@
             "Arch": ["x64", "x86", "arm", "arm64"],
             "Exe": "quicperf",
             "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -core:0 -uni:1 -upload:2000000000",
+                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000",
                 "Loopback": "",
                 "Remote": ""
             }
@@ -130,7 +130,7 @@
             "Arch": ["x64", "x86", "arm", "arm64"],
             "Exe": "quicperf",
             "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -core:0 -uni:1 -download:2000000000",
+                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000",
                 "Loopback": "",
                 "Remote": ""
             }

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -18,7 +18,7 @@
             "Arch": ["x64", "x86", "arm", "arm64"],
             "Exe": "quicperf",
             "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000",
+                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -core:0 -uni:1 -upload:2000000000",
                 "Loopback": "",
                 "Remote": ""
             }
@@ -130,7 +130,7 @@
             "Arch": ["x64", "x86", "arm", "arm64"],
             "Exe": "quicperf",
             "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000",
+                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -core:0 -uni:1 -download:2000000000",
                 "Loopback": "",
                 "Remote": ""
             }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -65,7 +65,7 @@ QuicConnAlloc(
     )
 {
     BOOLEAN IsServer = Datagram != NULL;
-    uint32_t CurProcIndex = QuicProcCurrentNumber() & 0xFFFFFFFE;
+    uint32_t CurProcIndex = QuicProcCurrentNumber();
 
     //
     // For client, the datapath partitioning info is not known yet, so just use

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -65,7 +65,7 @@ QuicConnAlloc(
     )
 {
     BOOLEAN IsServer = Datagram != NULL;
-    uint32_t CurProcIndex = QuicProcCurrentNumber();
+    uint32_t CurProcIndex = QuicProcCurrentNumber() & 0xFFFFFFFE;
 
     //
     // For client, the datapath partitioning info is not known yet, so just use

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -757,6 +757,7 @@ QuicConvertFromMappedV6(
     );
 
 #define QuicSetCurrentThreadProcessorAffinity(ProcessorIndex) QUIC_STATUS_SUCCESS
+#define QuicSetCurrentThreadGroupAffinity(ProcessorGroup) QUIC_STATUS_SUCCESS
 
 #define QUIC_CPUID(FunctionId, eax, ebx, ecx, dx)
 

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -947,6 +947,23 @@ QuicSetCurrentThreadProcessorAffinity(
             sizeof(Affinity));
 }
 
+inline
+QUIC_STATUS
+QuicSetCurrentThreadGroupAffinity(
+    _In_ uint16_t ProcessorGroup
+    )
+{
+    GROUP_AFFINITY Affinity = {0};
+    Affinity.Mask = (KAFFINITY)(~0ull);
+    Affinity.Group = ProcessorGroup;
+    return
+        ZwSetInformationThread(
+            PsGetCurrentThread(),
+            ThreadGroupInformation,
+            &Affinity,
+            sizeof(Affinity));
+}
+
 #define QuicCompartmentIdGetCurrent() NdisGetThreadObjectCompartmentId(PsGetCurrentThread())
 #define QuicCompartmentIdSetCurrent(CompartmentId) \
     NdisSetThreadObjectCompartmentId(PsGetCurrentThread(), CompartmentId)

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -47,16 +47,9 @@ Environment:
 #include <msquic_winkernel.h>
 #pragma warning(pop)
 
-_IRQL_requires_max_(PASSIVE_LEVEL)
-NTSYSAPI
-NTSTATUS
-NTAPI
-ZwSetInformationThread(
-    _In_ HANDLE ThreadHandle,
-    _In_ THREADINFOCLASS ThreadInformationClass,
-    _In_reads_bytes_(ThreadInformationLength) PVOID ThreadInformation,
-    _In_ ULONG ThreadInformationLength
-    );
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
@@ -69,10 +62,6 @@ ZwQueryInformationThread (
     _In_ ULONG ThreadInformationLength,
     _Out_opt_ PULONG ReturnLength
     );
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
 
 #if DBG
 #define DEBUG 1

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -47,7 +47,6 @@ Environment:
 #include <msquic_winkernel.h>
 #pragma warning(pop)
 
-#if (NTDDI_VERSION >= NTDDI_WIN2K) // Copied from zwapi_x.h.
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
 NTSTATUS
@@ -58,7 +57,18 @@ ZwSetInformationThread(
     _In_reads_bytes_(ThreadInformationLength) PVOID ThreadInformation,
     _In_ ULONG ThreadInformationLength
     );
-#endif
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSYSAPI
+NTSTATUS
+NTAPI
+ZwQueryInformationThread (
+    _In_ HANDLE ThreadHandle,
+    _In_ THREADINFOCLASS ThreadInformationClass,
+    _In_ PVOID ThreadInformation,
+    _In_ ULONG ThreadInformationLength,
+    _Out_opt_ PULONG ReturnLength
+    );
 
 #if defined(__cplusplus)
 extern "C" {
@@ -959,10 +969,11 @@ QuicSetCurrentThreadGroupAffinity(
     if (QUIC_FAILED(
         Status =
             ZwQueryInformationThread(
-            PsGetCurrentThread(),
-            ThreadGroupInformation,
-            &ExistingAffinity,
-            sizeof(ExistingAffinity))) {
+                PsGetCurrentThread(),
+                ThreadGroupInformation,
+                &ExistingAffinity,
+                sizeof(ExistingAffinity),
+                NULL))) {
         return Status;
     }
 

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -954,7 +954,7 @@ QuicSetCurrentThreadGroupAffinity(
     )
 {
     GROUP_AFFINITY Affinity = {0};
-    Affinity.Mask = (KAFFINITY)(~0ull);
+    Affinity.Mask = (KAFFINITY)(-1);
     Affinity.Group = ProcessorGroup;
     return
         ZwSetInformationThread(

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -954,7 +954,19 @@ QuicSetCurrentThreadGroupAffinity(
     )
 {
     GROUP_AFFINITY Affinity = {0};
-    Affinity.Mask = (KAFFINITY)(-1);
+    GROUP_AFFINITY ExistingAffinity = {0};
+    QUIC_STATUS Status;
+    if (QUIC_FAILED(
+        Status =
+            ZwQueryInformationThread(
+            PsGetCurrentThread(),
+            ThreadGroupInformation,
+            &ExistingAffinity,
+            sizeof(ExistingAffinity))) {
+        return Status;
+    }
+
+    Affinity.Mask = ExistingAffinity.Mask;
     Affinity.Group = ProcessorGroup;
     return
         ZwSetInformationThread(

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -925,7 +925,7 @@ NdisSetThreadObjectCompartmentId(
 inline
 QUIC_STATUS
 QuicSetCurrentThreadProcessorAffinity(
-    _In_ uint8_t ProcessorIndex
+    _In_ uint16_t ProcessorIndex
     )
 {
     PROCESSOR_NUMBER ProcInfo;

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -934,8 +934,23 @@ QuicSetCurrentThreadGroupAffinity(
 
 #else
 
-#define QuicSetCurrentThreadProcessorAffinity(ProcessorIndex) QUIC_STATUS_SUCCESS
-#define QuicSetCurrentThreadGroupAffinity(ProcessorGroup) QUIC_STATUS_SUCCESS
+inline
+QUIC_STATUS
+QuicSetCurrentThreadProcessorAffinity(
+    _In_ uint16_t
+    )
+{
+    return QUIC_STATUS_SUCCESS;
+}
+
+inline
+QUIC_STATUS
+QuicSetCurrentThreadGroupAffinity(
+    _In_ uint16_t
+    )
+{
+    return QUIC_STATUS_SUCCESS;
+}
 
 #endif
 

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -924,7 +924,7 @@ QuicSetCurrentThreadGroupAffinity(
     )
 {
     GROUP_AFFINITY Group = {0};
-    Group.Mask = (KAFFINITY)(~0ull);
+    Group.Mask = (KAFFINITY)(-1);
     Group.Group = ProcessorGroup;
     if (SetThreadGroupAffinity(GetCurrentThread(), &Group, NULL)) {
         return QUIC_STATUS_SUCCESS;

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -924,7 +924,11 @@ QuicSetCurrentThreadGroupAffinity(
     )
 {
     GROUP_AFFINITY Group = {0};
-    Group.Mask = (KAFFINITY)(-1);
+    GROUP_AFFINITY ExistingGroup = {0};
+    if (!GetThreadGroupAffinity(GetCurrentThread(), &ExistingGroup)) {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+    Group.Mask = ExistingGroup.Mask;
     Group.Group = ProcessorGroup;
     if (SetThreadGroupAffinity(GetCurrentThread(), &Group, NULL)) {
         return QUIC_STATUS_SUCCESS;

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -900,7 +900,7 @@ QuicRandom(
 inline
 QUIC_STATUS
 QuicSetCurrentThreadProcessorAffinity(
-    _In_ uint8_t ProcessorIndex
+    _In_ uint16_t ProcessorIndex
     )
 {
     const QUIC_PROCESSOR_INFO* ProcInfo = &QuicProcessorInfo[ProcessorIndex];

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -917,9 +917,25 @@ QuicSetCurrentThreadProcessorAffinity(
 #define QuicCompartmentIdSetCurrent(CompartmentId) \
     HRESULT_FROM_WIN32(SetCurrentThreadCompartmentId(CompartmentId))
 
+inline
+QUIC_STATUS
+QuicSetCurrentThreadGroupAffinity(
+    _In_ uint16_t ProcessorGroup
+    )
+{
+    GROUP_AFFINITY Group = {0};
+    Group.Mask = (KAFFINITY)(~0ull);
+    Group.Group = ProcessorGroup;
+    if (SetThreadGroupAffinity(GetCurrentThread(), &Group, NULL)) {
+        return QUIC_STATUS_SUCCESS;
+    }
+    return HRESULT_FROM_WIN32(GetLastError());
+}
+
 #else
 
 #define QuicSetCurrentThreadProcessorAffinity(ProcessorIndex) QUIC_STATUS_SUCCESS
+#define QuicSetCurrentThreadGroupAffinity(ProcessorGroup) QUIC_STATUS_SUCCESS
 
 #endif
 

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -937,18 +937,20 @@ QuicSetCurrentThreadGroupAffinity(
 inline
 QUIC_STATUS
 QuicSetCurrentThreadProcessorAffinity(
-    _In_ uint16_t
+    _In_ uint16_t ProcessorIndex
     )
 {
+    UNREFERENCED_PARAMETER(ProcessorIndex);
     return QUIC_STATUS_SUCCESS;
 }
 
 inline
 QUIC_STATUS
 QuicSetCurrentThreadGroupAffinity(
-    _In_ uint16_t
+    _In_ uint16_t ProcessorGroup
     )
 {
+    UNREFERENCED_PARAMETER(ProcessorGroup);
     return QUIC_STATUS_SUCCESS;
 }
 

--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -133,11 +133,8 @@ HpsClient::Start(
     uint32_t ThreadToSetAffinityTo = QuicProcActiveCount();
     if (ThreadToSetAffinityTo > 2) {
         ThreadToSetAffinityTo -= 2;
-        //
-        // TODO: Fix QuicSetCurrentThreadProcessorAffinity to take 16 bits
-        //
         Status =
-            QuicSetCurrentThreadProcessorAffinity((uint8_t)ThreadToSetAffinityTo);
+            QuicSetCurrentThreadProcessorAffinity((uint16_t)ThreadToSetAffinityTo);
     }
 
     return Status;

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -134,7 +134,7 @@ RpsClient::Start(
     for (uint32_t i = 0; i < ConnectionCount; ++i) {
         HQUIC Connection = nullptr;
 
-        Status = QuicSetCurrentThreadProcessorAffinity((uint8_t)(i % ActiveProcCount));
+        Status = QuicSetCurrentThreadProcessorAffinity((uint16_t)(i % ActiveProcCount));
         if (QUIC_FAILED(Status)) {
             WriteOutput("Setting Thread Group Failed 0x%x\n", Status);
             return Status;
@@ -231,11 +231,8 @@ RpsClient::Start(
     uint32_t ThreadToSetAffinityTo = QuicProcActiveCount();
     if (ThreadToSetAffinityTo > 2) {
         ThreadToSetAffinityTo -= 2;
-        //
-        // TODO: Fix QuicSetCurrentThreadProcessorAffinity to take 16 bits
-        //
         Status =
-            QuicSetCurrentThreadProcessorAffinity((uint8_t)ThreadToSetAffinityTo);
+            QuicSetCurrentThreadProcessorAffinity((uint16_t)ThreadToSetAffinityTo);
     }
 
 

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -26,6 +26,7 @@ PrintHelp(
         "  -target:<####>              The target server to connect to.\n"
 #if _WIN32
         "  -comp:<####>                The compartment ID to run in.\n"
+        "  -core:<####>                The CPU core to use for the main thread.\n"
 #endif
         "  -bind:<addr>                A local IP address to bind to.\n"
         "  -port:<####>                The UDP port of the server. (def:%u)\n"
@@ -105,7 +106,15 @@ ThroughputClient::Init(
 
     if (QUIC_FAILED(QuicSetCurrentThreadGroupAffinity(0))) {
         WriteOutput("Failed to set thread group affinity\n");
-        return QUIC_STATUS_INTERNAL_ERROR;
+        return QUIC_STATUS_INVALID_STATE;
+    }
+
+    uint16_t CpuCore;
+    if (TryGetValue(argc, argv, "core", &CpuCore)) {
+        if (QUIC_FAILED(QuicSetCurrentThreadProcessorAffinity(CpuCore))) {
+            WriteOutput("Failed to set core\n");
+            return QUIC_STATUS_INVALID_PARAMETER;
+        }
     }
 
     TryGetValue(argc, argv, "sendbuf", &UseSendBuffer);

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -26,7 +26,6 @@ PrintHelp(
         "  -target:<####>              The target server to connect to.\n"
 #if _WIN32
         "  -comp:<####>                The compartment ID to run in.\n"
-        "  -core:<####>                The CPU core to use for the main thread.\n"
 #endif
         "  -bind:<addr>                A local IP address to bind to.\n"
         "  -port:<####>                The UDP port of the server. (def:%u)\n"

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -104,12 +104,10 @@ ThroughputClient::Init(
     }
 #endif
 
-#ifdef QuicSetCurrentThreadAffinityMask
-    uint8_t CpuCore;
+    uint16_t CpuCore;
     if (TryGetValue(argc, argv, "core",  &CpuCore)) {
-        QuicSetCurrentThreadAffinityMask((DWORD_PTR)(1ull << CpuCore));
+        (void)QuicSetCurrentThreadProcessorAffinity(CpuCore);
     }
-#endif
 
     TryGetValue(argc, argv, "sendbuf", &UseSendBuffer);
 

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -104,16 +104,18 @@ ThroughputClient::Init(
     }
 #endif
 
-    if (QUIC_FAILED(QuicSetCurrentThreadGroupAffinity(0))) {
+    QUIC_STATUS Status;
+
+    if (QUIC_FAILED(Status = QuicSetCurrentThreadGroupAffinity(0))) {
         WriteOutput("Failed to set thread group affinity\n");
-        return QUIC_STATUS_INVALID_STATE;
+        return Status;
     }
 
     uint16_t CpuCore;
     if (TryGetValue(argc, argv, "core", &CpuCore)) {
-        if (QUIC_FAILED(QuicSetCurrentThreadProcessorAffinity(CpuCore))) {
+        if (QUIC_FAILED(Status = QuicSetCurrentThreadProcessorAffinity(CpuCore))) {
             WriteOutput("Failed to set core\n");
-            return QUIC_STATUS_INVALID_PARAMETER;
+            return Status;
         }
     }
 

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -104,9 +104,9 @@ ThroughputClient::Init(
     }
 #endif
 
-    uint16_t CpuCore;
-    if (TryGetValue(argc, argv, "core",  &CpuCore)) {
-        (void)QuicSetCurrentThreadProcessorAffinity(CpuCore);
+    if (QUIC_FAILED(QuicSetCurrentThreadGroupAffinity(0))) {
+        WriteOutput("Failed to set thread group affinity\n");
+        return QUIC_STATUS_INTERNAL_ERROR;
     }
 
     TryGetValue(argc, argv, "sendbuf", &UseSendBuffer);


### PR DESCRIPTION
We were not setting this before, causing low performance for download performance tests. 

Should fix #917 