### PR TITLE
Rename bin artifact name to artifacts

### DIFF
--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -10,7 +10,7 @@ jobs:
   - task: DownloadBuildArtifacts@0
     displayName: Download Build Artifacts
     inputs:
-      artifactName: bin
+      artifactName: artifacts
       itemPattern: bin/win*/*_schannel/**
       downloadPath: artifacts
 

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -12,6 +12,7 @@ jobs:
     inputs:
       artifactName: artifacts
       itemPattern: artifacts/bin/win*/*_schannel/**
+      downloadPath: $(Build.SourcesDirectory)
 
   - task: PowerShell@2
     displayName: Prepare Package Files

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Download Build Artifacts
     inputs:
       artifactName: artifacts
-      itemPattern: bin/win*/*_schannel/**
+      itemPattern: artifacts/win*/*_schannel/**
       downloadPath: artifacts
 
   - task: PowerShell@2

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -11,8 +11,7 @@ jobs:
     displayName: Download Build Artifacts
     inputs:
       artifactName: artifacts
-      itemPattern: artifacts/win*/*_schannel/**
-      downloadPath: artifacts
+      itemPattern: artifacts/bin/win*/*_schannel/**
 
   - task: PowerShell@2
     displayName: Prepare Package Files

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -12,6 +12,7 @@ steps:
   inputs:
     artifactName: artifacts
     itemPattern: artifacts/bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+    downloadPath: $(Build.SourcesDirectory)
 
 - ${{ if eq(parameters.includeKernel, true) }}:
   - task: DownloadBuildArtifacts@0
@@ -19,6 +20,7 @@ steps:
     inputs:
       artifactName: artifacts
       itemPattern: artifacts/bin/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+      downloadPath: $(Build.SourcesDirectory)
 
 - task: PowerShell@2
   displayName: Install Build Artifacts

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -10,7 +10,7 @@ steps:
 - task: DownloadBuildArtifacts@0
   displayName: Download Build Artifacts
   inputs:
-    artifactName: bin
+    artifactName: artifacts
     itemPattern: bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
     downloadPath: artifacts
 
@@ -18,7 +18,7 @@ steps:
   - task: DownloadBuildArtifacts@0
     displayName: Download Kernel Build Artifacts
     inputs:
-      artifactName: bin
+      artifactName: artifacts
       itemPattern: bin/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
       downloadPath: artifacts
 

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -11,16 +11,14 @@ steps:
   displayName: Download Build Artifacts
   inputs:
     artifactName: artifacts
-    itemPattern: artifacts/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
-    downloadPath: artifacts
+    itemPattern: artifacts/bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
 
 - ${{ if eq(parameters.includeKernel, true) }}:
   - task: DownloadBuildArtifacts@0
     displayName: Download Kernel Build Artifacts
     inputs:
       artifactName: artifacts
-      itemPattern: artifacts/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
-      downloadPath: artifacts
+      itemPattern: artifacts/bin/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
 
 - task: PowerShell@2
   displayName: Install Build Artifacts

--- a/.azure/templates/download-artifacts.yml
+++ b/.azure/templates/download-artifacts.yml
@@ -11,7 +11,7 @@ steps:
   displayName: Download Build Artifacts
   inputs:
     artifactName: artifacts
-    itemPattern: bin/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+    itemPattern: artifacts/${{ parameters.platform }}/${{ parameters.arch }}_*_${{ parameters.tls }}/**
     downloadPath: artifacts
 
 - ${{ if eq(parameters.includeKernel, true) }}:
@@ -19,7 +19,7 @@ steps:
     displayName: Download Kernel Build Artifacts
     inputs:
       artifactName: artifacts
-      itemPattern: bin/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
+      itemPattern: artifacts/winkernel/${{ parameters.arch }}_*_${{ parameters.tls }}/**
       downloadPath: artifacts
 
 - task: PowerShell@2

--- a/.azure/templates/upload-artifacts.yml
+++ b/.azure/templates/upload-artifacts.yml
@@ -6,7 +6,7 @@ steps:
   inputs:
     sourceFolder: artifacts/bin
     contents: '**/!(*.ilk|*.cer|*.exp|*.lastcodeanalysissucceeded)'
-    targetFolder: $(Build.ArtifactStagingDirectory)
+    targetFolder: $(Build.ArtifactStagingDirectory)/bin
 
 - task: DeleteFiles@1
   displayName: Clear Artifacts

--- a/.azure/templates/upload-artifacts.yml
+++ b/.azure/templates/upload-artifacts.yml
@@ -16,7 +16,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Upload Build Artifacts
   inputs:
-    artifactName: bin
+    artifactName: artifacts
     pathToPublish: $(Build.ArtifactStagingDirectory)
     parallel: true
 


### PR DESCRIPTION
Because of IIS, bin is a disallowed folder, so rename to artifacts so files can be properly downloaded.

https://github.com/microsoft/azure-pipelines-tasks/issues/13322