### PR TITLE
Server Prefetch QUIC TP

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1153,9 +1153,11 @@ QuicConnReceiveTP(
     _In_reads_(TPLength) const uint8_t* TPBuffer
     )
 {
+    QUIC_DBG_ASSERT(!QuicConnIsServer(Connection));
+
     if (!QuicCryptoTlsDecodeTransportParameters(
             Connection,
-            !QuicConnIsServer(Connection),
+            TRUE,
             TPBuffer,
             TPLength,
             &Connection->PeerTransportParams)) {
@@ -1555,6 +1557,8 @@ QuicCryptoProcessData(
                 //
                 goto Error;
             }
+
+            QuicConnProcessPeerTransportParameters(Connection, FALSE);
 
             QuicRecvBufferDrain(&Crypto->RecvBuffer, 0);
             QuicCryptoValidate(Crypto);

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -303,18 +303,20 @@ QuicDatagramOnSendStateChanged(
 
     Datagram->MaxSendLength = NewMaxSendLength;
 
-    QUIC_CONNECTION_EVENT Event;
-    Event.Type = QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED;
-    Event.DATAGRAM_STATE_CHANGED.SendEnabled = SendEnabled;
-    Event.DATAGRAM_STATE_CHANGED.MaxSendLength = NewMaxSendLength;
+    if (Connection->State.ExternalOwner) {
+        QUIC_CONNECTION_EVENT Event;
+        Event.Type = QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED;
+        Event.DATAGRAM_STATE_CHANGED.SendEnabled = SendEnabled;
+        Event.DATAGRAM_STATE_CHANGED.MaxSendLength = NewMaxSendLength;
 
-    QuicTraceLogConnVerbose(
-        IndicateDatagramStateChanged,
-        Connection,
-        "Indicating QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
-        Event.DATAGRAM_STATE_CHANGED.SendEnabled,
-        Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
-    (void)QuicConnIndicateEvent(Connection, &Event);
+        QuicTraceLogConnVerbose(
+            IndicateDatagramStateChanged,
+            Connection,
+            "Indicating QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
+            Event.DATAGRAM_STATE_CHANGED.SendEnabled,
+            Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
+        (void)QuicConnIndicateEvent(Connection, &Event);
+    }
 
     if (!SendEnabled) {
         QuicDatagramSendShutdown(Datagram);

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -311,7 +311,7 @@ QuicDatagramOnSendStateChanged(
     QuicTraceLogConnVerbose(
         IndicateDatagramStateChanged,
         Connection,
-        "Indicating DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
+        "Indicating QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
         Event.DATAGRAM_STATE_CHANGED.SendEnabled,
         Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
     (void)QuicConnIndicateEvent(Connection, &Event);

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -505,8 +505,9 @@ QuicListenerClaimConnection(
 
     QuicTraceLogVerbose(
         ListenerIndicateNewConnection,
-        "[list][%p] Indicating NEW_CONNECTION",
-        Listener);
+        "[list][%p] Indicating NEW_CONNECTION %p",
+        Listener,
+        Connection);
 
     QUIC_STATUS Status = QuicListenerIndicateEvent(Listener, &Event);
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -9558,7 +9558,7 @@
     },
     "ListenerIndicateNewConnection": {
       "ModuleProperites": {},
-      "TraceString": "[list][%p] Indicating NEW_CONNECTION",
+      "TraceString": "[list][%p] Indicating NEW_CONNECTION %p",
       "UniqueId": "ListenerIndicateNewConnection",
       "splitArgs": [
         {
@@ -9568,6 +9568,14 @@
           },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
+        },
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "Connection",
+            "SuggestedTelemetryName": "arg3"
+          },
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg3"
         }
       ],
       "macro": {
@@ -22198,7 +22206,7 @@
         "TraceID": "PerfCountersRundown"
       },
       {
-        "UniquenessHash": "ffc33ba8-4bc7-9e30-e207-f1d3cb6bb3f2",
+        "UniquenessHash": "f27f1ff0-edfe-bf39-708a-f9da7a2b4d3d",
         "TraceID": "ListenerIndicateNewConnection"
       },
       {

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -6537,7 +6537,7 @@
     },
     "IndicateDatagramStateChanged": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
       "UniqueId": "IndicateDatagramStateChanged",
       "splitArgs": [
         {
@@ -18973,49 +18973,6 @@
         "CustomSettings": null
       }
     },
-    "TlsErrorStatus": {
-      "ModuleProperites": {},
-      "TraceString": "[ tls][%p] ERROR, %u, %s.",
-      "UniqueId": "TlsErrorStatus",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"QuicTlsDerivePacketProtectionKey failed\"",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
     "SchannelInitialized": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Library initialized",
@@ -19633,6 +19590,49 @@
         "MacroName": "QuicTraceLogConnVerbose",
         "EncodedPrefix": "[conn][%p] ",
         "EncodedArgNumber": 2,
+        "MacroConfiguration": {
+          "linux": "lttng_plus",
+          "stubs": "stubs",
+          "windows_kernel": "empty",
+          "windows": "empty"
+        },
+        "CustomSettings": null
+      }
+    },
+    "TlsErrorStatus": {
+      "ModuleProperites": {},
+      "TraceString": "[ tls][%p] ERROR, %u, %s.",
+      "UniqueId": "TlsErrorStatus",
+      "splitArgs": [
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "TlsContext->Connection",
+            "SuggestedTelemetryName": "arg2"
+          },
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "Status",
+            "SuggestedTelemetryName": "arg3"
+          },
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "\"Convert SNI to unicode\"",
+            "SuggestedTelemetryName": "arg4"
+          },
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macro": {
+        "MacroName": "QuicTraceEvent",
+        "EncodedPrefix": null,
+        "EncodedArgNumber": 1,
         "MacroConfiguration": {
           "linux": "lttng_plus",
           "stubs": "stubs",
@@ -21906,7 +21906,7 @@
         "TraceID": "DatagramSendShutdown"
       },
       {
-        "UniquenessHash": "bfbc130b-6496-c8c1-c193-82dc7dbfb83e",
+        "UniquenessHash": "67a8d85c-7122-a922-2370-3f841ac174ed",
         "TraceID": "IndicateDatagramStateChanged"
       },
       {
@@ -23302,10 +23302,6 @@
         "TraceID": "OpenSslProcessData"
       },
       {
-        "UniquenessHash": "7312d23f-2305-b54b-e1da-81597fabe281",
-        "TraceID": "TlsErrorStatus"
-      },
-      {
         "UniquenessHash": "a0f9d887-3cc8-3dd3-f2c7-8143878abe6e",
         "TraceID": "SchannelInitialized"
       },
@@ -23388,6 +23384,10 @@
       {
         "UniquenessHash": "183e91b7-6ad7-7a8b-0d77-94004bde6757",
         "TraceID": "SchannelProcessingData"
+      },
+      {
+        "UniquenessHash": "7312d23f-2305-b54b-e1da-81597fabe281",
+        "TraceID": "TlsErrorStatus"
       },
       {
         "UniquenessHash": "64ef2389-7553-24d5-62f5-94fa1ab55eac",

--- a/src/platform/tls_mitls.c
+++ b/src/platform/tls_mitls.c
@@ -1402,37 +1402,37 @@ QuicTlsOnNegotiate(
                 "Failed to find a matching ALPN");
             goto Exit;
         }
-    }
 
-    //
-    // Decode and validate peer's QUIC transport parameters.
-    //
+        //
+        // Decode and validate peer's QUIC transport parameters.
+        //
 
-    if (!FFI_mitls_find_custom_extension(
-            TlsContext->IsServer,
-            RawExtensions,
-            RawExtensionsLength,
-            TLS_EXTENSION_TYPE_QUIC_TRANSPORT_PARAMETERS,
-            &ExtensionData,
-            &ExtensionDataLength)) {
-        QuicTraceEvent(
-            TlsError,
-            "[ tls][%p] ERROR, %s.",
-            TlsContext->Connection,
-            "Missing QUIC transport parameters");
-        goto Exit;
-    }
+        if (!FFI_mitls_find_custom_extension(
+                TlsContext->IsServer,
+                RawExtensions,
+                RawExtensionsLength,
+                TLS_EXTENSION_TYPE_QUIC_TRANSPORT_PARAMETERS,
+                &ExtensionData,
+                &ExtensionDataLength)) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Missing QUIC transport parameters");
+            goto Exit;
+        }
 
-    if (!TlsContext->ReceiveTPCallback(
-            TlsContext->Connection,
-            (uint16_t)ExtensionDataLength,
-            ExtensionData)) {
-        QuicTraceEvent(
-            TlsError,
-            "[ tls][%p] ERROR, %s.",
-            TlsContext->Connection,
-            "Failed to process the QUIC transport parameters");
-        goto Exit;
+        if (!TlsContext->ReceiveTPCallback(
+                TlsContext->Connection,
+                (uint16_t)ExtensionDataLength,
+                ExtensionData)) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Failed to process the QUIC transport parameters");
+            goto Exit;
+        }
     }
 
     Action = TLS_nego_accept;

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -423,14 +423,6 @@ QuicTlsClientHelloCallback(
         return SSL_CLIENT_HELLO_ERROR;
     }
 
-    if (!TlsContext->ReceiveTPCallback(
-            TlsContext->Connection,
-            (uint16_t)TransportParamLen,
-            TransportParams)) {
-        TlsContext->ResultFlags |= QUIC_TLS_RESULT_ERROR;
-        return SSL_CLIENT_HELLO_ERROR;
-    }
-
     return SSL_CLIENT_HELLO_SUCCESS;
 }
 

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1589,7 +1589,9 @@ QuicTlsWriteDataToSchannel(
     }
 
     SUBSCRIBE_GENERIC_TLS_EXTENSION SubscribeExt;
-    if (*InBufferLength != 0 && !TlsContext->PeerTransportParamsReceived) {
+    if (*InBufferLength != 0 &&
+        !TlsContext->IsServer &&
+        !TlsContext->PeerTransportParamsReceived) {
         //
         // Subscribe to get the peer's transport parameters, if available.
         //
@@ -1736,7 +1738,7 @@ QuicTlsWriteDataToSchannel(
         // The handshake has completed. This may or may not result in more data
         // that needs to be sent back in response (depending on client/server).
         //
-        if (!TlsContext->PeerTransportParamsReceived) {
+        if (!TlsContext->IsServer && !TlsContext->PeerTransportParamsReceived) {
             QuicTraceEvent(
                 TlsError,
                 "[ tls][%p] ERROR, %s.",

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -564,12 +564,7 @@ QuicTlsServerProcess(
                 break;
             }
             case TlsExt_QuicTransportParameters: {
-                const QUIC_TLS_QUIC_TP_EXT* QuicTP = (QUIC_TLS_QUIC_TP_EXT*)ExtList;
-                TlsContext->ReceiveTPCallback(
-                    TlsContext->Connection,
-                    ExtLength,
-                    QuicTP->TP);
-                break;
+                break; // Unused
             }
             default:
                 QUIC_FRE_ASSERT(FALSE);

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -316,7 +316,6 @@ QuicTestValidateConnectionEvents1(
     );
     ConnValidator Server(
         new(std::nothrow) ConnEventValidator* [6] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true), // This comes AFTER shutdown in miTLS
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true), // This comes AFTER shutdown in miTLS
@@ -375,7 +374,6 @@ QuicTestValidateConnectionEvents2(
     );
     ConnValidator Server(
         new(std::nothrow) ConnEventValidator* [4] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
@@ -442,9 +440,7 @@ QuicTestValidateConnectionEvents3(
     );
     ConnValidator Server(
         new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true, true), // This comes AFTER shutdown in miTLS
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true, true), // This comes AFTER shutdown in miTLS
@@ -582,7 +578,6 @@ QuicTestValidateStreamEvents1(
         });
     Server.SetExpectedEvents(
         new(std::nothrow) ConnEventValidator* [6] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
@@ -677,7 +672,6 @@ QuicTestValidateStreamEvents2(
         });
     Server.SetExpectedEvents(
         new(std::nothrow) ConnEventValidator* [6] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true), // This comes AFTER shutdown in miTLS
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, 0, true), // This comes AFTER shutdown in miTLS


### PR DESCRIPTION
Updates the QUIC crypto TLS processing code to extract QUIC TP along with ALPN and SNI when pre-processing the client hello. This has a few affects:

1. Improves performance (amount dependent on TLS) because we are already reading the memory and have cache locality. We might as well do it with the rest.
2. Allows for the transport parameters to be fully available **before** the listener accept callback, which allows the listener to make its accept/reject decision based on the initial transport parameter values.
3. Allows for the server's outgoing transport parameters to be decided **based on** the clients TP now. This is useful for extension negotiation.