### PR TITLE
Fix Negotiation of Disable 1-RTT Encryption

### DIFF
--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -104,15 +104,12 @@ PerfServer::ListenerCallback(
     switch (Event->Type) {
     case QUIC_LISTENER_EVENT_NEW_CONNECTION: {
         BOOLEAN value = TRUE;
-        if (QUIC_FAILED(
-            MsQuic->SetParam(
-                Event->NEW_CONNECTION.Connection,
-                QUIC_PARAM_LEVEL_CONNECTION,
-                QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION,
-                sizeof(value),
-                &value))) {
-            WriteOutput("MsQuic->SetParam (CONN_DISABLE_1RTT_ENCRYPTION) failed!\n");
-        }
+        MsQuic->SetParam(
+            Event->NEW_CONNECTION.Connection,
+            QUIC_PARAM_LEVEL_CONNECTION,
+            QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION,
+            sizeof(value),
+            &value);
         QUIC_CONNECTION_CALLBACK_HANDLER Handler =
             [](HQUIC Conn, void* Context, QUIC_CONNECTION_EVENT* Event) -> QUIC_STATUS {
                 return ((PerfServer*)Context)->

--- a/src/tools/ping/PingConnection.cpp
+++ b/src/tools/ping/PingConnection.cpp
@@ -89,7 +89,8 @@ PingConnection::Initialize(
                 QUIC_PARAM_LEVEL_CONNECTION,
                 QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION,
                 sizeof(value),
-                &value))) {
+                &value)) &&
+            !IsServer) {
             printf("MsQuic->SetParam (CONN_DISABLE_1RTT_ENCRYPTION) failed!\n");
         }
     }


### PR DESCRIPTION
Recent change to prefetch QUIC TP introduced a bug in the negotiation of the disable 1-RTT encryption extension. Server ended up disabling encryption even if the client didn't also negotiate this. This PR updates the code paths to handle the server side setting it's option after the client's TPs have already been received.