### PR TITLE
Add Missing ALPNs to Interop Server

### DIFF
--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -17,6 +17,8 @@ const char* RootFolderPath;
 const char* UploadFolderPath;
 
 const QUIC_BUFFER SupportedALPNs[] = {
+    { sizeof("hq-32") - 1, (uint8_t*)"hq-32" },
+    { sizeof("hq-31") - 1, (uint8_t*)"hq-31" },
     { sizeof("hq-30") - 1, (uint8_t*)"hq-30" },
     { sizeof("hq-29") - 1, (uint8_t*)"hq-29" },
     { sizeof("hq-28") - 1, (uint8_t*)"hq-28" },


### PR DESCRIPTION
Seems I forgot to update this tool twice in a row... Thanks @larseggert for pointing this out.