### PR TITLE
Disallow 0 sizes in tput tests, make 0 in all perf tests an error

### DIFF
--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -511,6 +511,9 @@ function Publish-ThroughputTestResults {
 
     if ($FullLastResult -ne "") {
         $MedianLastResult = Get-MedianTestResults -FullResults $FullLastResult.individualRunResults
+        if ($MedianLastResult -eq 0) {
+            Write-Error "Cannot have a last result median of 0"
+        }
         $PercentDiff = 100 * (($MedianCurrentResult - $MedianLastResult) / $MedianLastResult)
         $PercentDiffStr = $PercentDiff.ToString("#.##")
         if ($PercentDiff -ge 0) {
@@ -609,6 +612,9 @@ function Publish-RPSTestResults {
 
     if ($FullLastResult -ne "") {
         $MedianLastResult = Get-MedianTestResults -FullResults $FullLastResult.individualRunResults
+        if ($MedianLastResult -eq 0) {
+            Write-Error "Cannot have a last result median of 0"
+        }
         $PercentDiff = 100 * (($MedianCurrentResult - $MedianLastResult) / $MedianLastResult)
         $PercentDiffStr = $PercentDiff.ToString("#.##")
         if ($PercentDiff -ge 0) {
@@ -691,6 +697,9 @@ function Publish-HPSTestResults {
 
     if ($FullLastResult -ne "") {
         $MedianLastResult = Get-MedianTestResults -FullResults $FullLastResult.individualRunResults
+        if ($MedianLastResult -eq 0) {
+            Write-Error "Cannot have a last result median of 0"
+        }
         $PercentDiff = 100 * (($MedianCurrentResult - $MedianLastResult) / $MedianLastResult)
         $PercentDiffStr = $PercentDiff.ToString("#.##")
         if ($PercentDiff -ge 0) {

--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -161,7 +161,11 @@ HpsClient::Wait(
     }
 
     uint32_t HPS = (uint32_t)((CompletedConnections * 1000ull) / (uint64_t)RunTime);
-    WriteOutput("Result: %u HPS\n", HPS);
+    if (HPS == 0) {
+        WriteOutput("Error: No handshakes were completed\n");
+    } else {
+        WriteOutput("Result: %u HPS\n", HPS);
+    }
     //WriteOutput("Result: %u HPS (%ull create, %ull start, %ull complete)\n",
     //    HPS, CreatedConnections, StartedConnections, CompletedConnections);
     Registration.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -232,7 +232,12 @@ RpsClient::Wait(
     Running = false;
 
     uint32_t RPS = (uint32_t)((CompletedRequests * 1000ull) / (uint64_t)RunTime);
-    WriteOutput("Result: %u RPS\n", RPS);
+
+    if (RPS == 0) {
+        WriteOutput("Error: No requests were completed\n");
+    } else {
+        WriteOutput("Result: %u RPS\n", RPS);
+    }
     //WriteOutput("Result: %u RPS (%ull start, %ull send completed, %ull completed)\n",
     //    RPS, StartedRequests, SendCompletedRequests, CompletedRequests);
 


### PR DESCRIPTION
0 size for upload or download doesn't make sense, as that case is handled by RPS, and you get no data (other then a single useless latency number) out of in in tput.

Then make 0 for all 3 tests an error, so 0's don't accidentally get uploaded to the server.

Also makes the test runner error if a 0 is received