### PR TITLE
Refactor ISB Indications

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -300,12 +300,6 @@ QUIC_STATIC_ASSERT(
 #define QUIC_DEFAULT_IDEAL_SEND_BUFFER_SIZE     0x20000 // 131072
 
 //
-// Defines the theshold of the current ideal send buffer that bytes in flight
-// must reach before we will double the ideal send buffer.
-//
-#define QUIC_IDEAL_SEND_BUFFER_THRESHOLD(ISB)   ((ISB) / 4)
-
-//
 // The max ideal send buffer size (in bytes). Note that this is not
 // a hard max on the number of bytes buffered for the connection.
 //

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -196,11 +196,11 @@ QuicGetNextIdealBytes(
     uint32_t Threshold = QUIC_DEFAULT_IDEAL_SEND_BUFFER_SIZE;
 
     //
-    // We calculate the theshold as an exponential grown based on the default
-    // up to the max, rounding up to the next threshold when equal.
+    // We calculate the threshold as an exponential growth from the default
+    // value up to the max, rounding up to the next threshold when equal.
     //
     while (Threshold <= BaseValue) {
-        uint32_t NextThreshold = (Threshold * 3) / 2; // 1.5x growth
+        uint32_t NextThreshold = Threshold + (Threshold / 2); // 1.5x growth
         if (NextThreshold > QUIC_MAX_IDEAL_SEND_BUFFER_SIZE) {
             Threshold = QUIC_MAX_IDEAL_SEND_BUFFER_SIZE;
             break;

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -187,34 +187,63 @@ QuicSendBufferFill(
     }
 }
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+uint32_t
+QuicGetNextIdealBytes(
+    _In_ uint32_t BaseValue
+    )
+{
+    uint32_t Threshold = QUIC_DEFAULT_IDEAL_SEND_BUFFER_SIZE;
+
+    //
+    // We calculate the theshold as an exponential grown based on the default
+    // up to the max, rounding up to the next threshold when equal.
+    //
+    while (Threshold <= BaseValue) {
+        uint32_t NextThreshold = (Threshold * 3) / 2; // 1.5x growth
+        if (NextThreshold > QUIC_MAX_IDEAL_SEND_BUFFER_SIZE) {
+            Threshold = QUIC_MAX_IDEAL_SEND_BUFFER_SIZE;
+            break;
+        }
+        Threshold = NextThreshold;
+    }
+
+    return Threshold;
+}
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicSendBufferStreamAdjust(
     _In_ QUIC_STREAM* Stream
     )
 {
-    uint64_t ByteCount =
-        min((uint32_t)Stream->Connection->SendBuffer.IdealBytes, Stream->SendWindow);
-
     //
-    // Only indicate events for significant changes in ISB.
+    // Calculate the value to actually indicate to the app for this stream as
+    // a minimum of the connection-wide IdealBytes and the value based on the
+    // stream's estimated SendWindow.
     //
-    if (ByteCount > Stream->LastIdealSendBuffer / 2 &&
-        ByteCount < Stream->LastIdealSendBuffer * 2) {
-        return;
+    uint64_t ByteCount = Stream->Connection->SendBuffer.IdealBytes;
+    if ((uint64_t)Stream->SendWindow < ByteCount) {
+        const uint64_t SendWindowIdealBytes =
+            QuicGetNextIdealBytes(Stream->SendWindow);
+        if (SendWindowIdealBytes < ByteCount) {
+            ByteCount = SendWindowIdealBytes;
+        }
     }
 
-    Stream->LastIdealSendBuffer = ByteCount;
+    if (Stream->LastIdealSendBuffer != ByteCount) {
+        Stream->LastIdealSendBuffer = ByteCount;
 
-    QUIC_STREAM_EVENT Event;
-    Event.Type = QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE;
-    Event.IDEAL_SEND_BUFFER_SIZE.ByteCount = ByteCount;
-    QuicTraceLogStreamVerbose(
-        IndicateIdealSendBuffer,
-        Stream,
-        "Indicating QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE = %llu",
-        Event.IDEAL_SEND_BUFFER_SIZE.ByteCount);
-    (void)QuicStreamIndicateEvent(Stream, &Event);
+        QUIC_STREAM_EVENT Event;
+        Event.Type = QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE;
+        Event.IDEAL_SEND_BUFFER_SIZE.ByteCount = ByteCount;
+        QuicTraceLogStreamVerbose(
+            IndicateIdealSendBuffer,
+            Stream,
+            "Indicating QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE = %llu",
+            Event.IDEAL_SEND_BUFFER_SIZE.ByteCount);
+        (void)QuicStreamIndicateEvent(Stream, &Event);
+    }
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -228,17 +257,15 @@ QuicSendBufferConnectionAdjust(
         return; // Nothing to do.
     }
 
-    //
-    // If the current IdealBytes is close to limiting throughput, double it.
-    // Since we grow exponentially, this will not happen frequently.
+    const uint64_t NewIdealBytes =
+        QuicGetNextIdealBytes(Connection->CongestionControl.BytesInFlightMax);
+
     //
     // TODO: Currently, IdealBytes only grows and never shrinks. Add appropriate
     // shrinking logic.
     //
-    if (Connection->CongestionControl.BytesInFlightMax >
-        QUIC_IDEAL_SEND_BUFFER_THRESHOLD(Connection->SendBuffer.IdealBytes)) {
-        Connection->SendBuffer.IdealBytes =
-            min(2 * Connection->CongestionControl.BytesInFlightMax, QUIC_MAX_IDEAL_SEND_BUFFER_SIZE);
+    if (NewIdealBytes < Connection->SendBuffer.IdealBytes) {
+        Connection->SendBuffer.IdealBytes = NewIdealBytes;
 
         QUIC_HASHTABLE_ENUMERATOR Enumerator;
         QUIC_HASHTABLE_ENTRY* Entry;

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -264,7 +264,7 @@ QuicSendBufferConnectionAdjust(
     // TODO: Currently, IdealBytes only grows and never shrinks. Add appropriate
     // shrinking logic.
     //
-    if (NewIdealBytes < Connection->SendBuffer.IdealBytes) {
+    if (NewIdealBytes > Connection->SendBuffer.IdealBytes) {
         Connection->SendBuffer.IdealBytes = NewIdealBytes;
 
         QUIC_HASHTABLE_ENUMERATOR Enumerator;


### PR DESCRIPTION
In high BDP scenarios (e.g. 60+ ms RTT and 2+ Gbps links), tests showed that the calculation for ISB (ideal send buffer, or how much send data to keep queued) was resulting in the connection becoming application limited. This was caused by the way we tried to limit the number of these indications up to the app. We ended up not indicating the latest values because they hadn't reached "the threshold" yet.

This changes how we calculate and use the indication threshold. A 1.5x growth rate is used for calculating the thresholds and the ISB is rounded up to the next threshold so there is never underestimation.