### PR TITLE
Add -Wno-strict-aliasing for gcc earlier than 7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,9 @@ else()
     set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits
         -Wno-unknown-pragmas -Wno-multichar -Wno-missing-field-initializers
         CACHE INTERNAL "")
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+        list(APPEND QUIC_WARNING_FLAGS -Wno-strict-aliasing)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND QUIC_WARNING_FLAGS -Wno-missing-braces -Wno-microsoft-anon-tag)
     endif()
 endif()


### PR DESCRIPTION
Older gcc versions throw warnings (which will be treated as errors due to
-Werror) of the form "dereferencing type-punned pointer will break
strict-aliasing rules" in a bunch of places in the code. Since newer gcc
versions no longer do so, it seems safe to suppress these warnings.