### PR TITLE
Add support for embedding pull tags in windows user mode alloc

### DIFF
--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -222,7 +222,7 @@ QuicCidNewRandomDestination(
         QUIC_ALLOC_NONPAGED(
             sizeof(QUIC_CID_QUIC_LIST_ENTRY) +
             QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH,
-            QUIC_POOL_CIDHASH);
+            QUIC_POOL_CIDLIST);
 
     if (Entry != NULL) {
         QuicZeroMemory(&Entry->CID, sizeof(Entry->CID));
@@ -250,7 +250,7 @@ QuicCidNewDestination(
         QUIC_ALLOC_NONPAGED(
             sizeof(QUIC_CID_QUIC_LIST_ENTRY) +
             Length,
-            QUIC_POOL_CIDHASH);
+            QUIC_POOL_CIDLIST);
 
     if (Entry != NULL) {
         QuicZeroMemory(&Entry->CID, sizeof(Entry->CID));

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -324,7 +324,7 @@ QuicConnFree(
                 QuicListRemoveHead(&Connection->DestCids),
                 QUIC_CID_QUIC_LIST_ENTRY,
                 Link);
-        QUIC_FREE(CID, QUIC_POOL_CIDHASH);
+        QUIC_FREE(CID, QUIC_POOL_CIDLIST);
     }
     if (Connection->State.Registered) {
         QuicDispatchLockAcquire(&Connection->Registration->ConnectionLock);
@@ -2748,7 +2748,7 @@ QuicConnUpdateDestCid(
             // so we must allocate a new one and free the old one.
             //
             QuicListEntryRemove(&DestCid->Link);
-            QUIC_FREE(DestCid, QUIC_POOL_CIDHASH);
+            QUIC_FREE(DestCid, QUIC_POOL_CIDLIST);
             DestCid =
                 QuicCidNewDestination(
                     Packet->SourceCidLen,

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -424,13 +424,7 @@ QuicRandom(
 #endif
 
 #ifdef DEBUG
-#ifdef _WIN64
-// 64 bit
-#define AllocOffset 16
-#else
-// 32 bit
-#define AllocOffset 8
-#endif
+#define AllocOffset (sizeof(void*) * 2)
 #endif
 
 _Ret_maybenull_
@@ -443,7 +437,6 @@ QuicAlloc(
     )
 {
     QUIC_DBG_ASSERT(QuicPlatform.Heap);
-
 #ifdef QUIC_RANDOM_ALLOC_FAIL
     uint8_t Rand; QuicRandom(sizeof(Rand), &Rand);
     if ((Rand % 100) == 1) return NULL;

--- a/src/platform/tls_mitls.c
+++ b/src/platform/tls_mitls.c
@@ -694,7 +694,7 @@ QuicTlsUninitialize(
                     TlsContext->miTlsTicket.ticket,
                     QUIC_TLS_TICKET,
                     Buffer);
-            QUIC_FREE(SerializedTicket, QUIC_POOL_TLS_EXTRAS);
+            QUIC_FREE(SerializedTicket, QUIC_POOL_CRYPTO_RESUMPTION_TICKET);
         }
 
         if (TlsContext->SNI != NULL) {
@@ -702,7 +702,7 @@ QuicTlsUninitialize(
         }
 
         if (TlsContext->Extensions[1].ext_data != NULL) {
-            QUIC_FREE(TlsContext->Extensions[1].ext_data, QUIC_POOL_TLS_EXTRAS);
+            QUIC_FREE(TlsContext->Extensions[1].ext_data, QUIC_POOL_TLS_TRANSPARAMS);
         }
 
         QUIC_FREE(TlsContext, QUIC_POOL_TLS_CTX);

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -167,7 +167,7 @@ protected:
             Config.AlpnBuffer = Alpn;
             Config.AlpnBufferLength = sizeof(Alpn);
             Config.LocalTPBuffer =
-                (uint8_t*)QUIC_ALLOC_NONPAGED(QuicTlsTPHeaderSize + TPLen, QUIC_POOL_TEST);
+                (uint8_t*)QUIC_ALLOC_NONPAGED(QuicTlsTPHeaderSize + TPLen, QUIC_POOL_TLS_TRANSPARAMS);
             Config.LocalTPLength = QuicTlsTPHeaderSize + TPLen;
             Config.Connection = (QUIC_CONNECTION*)this;
             Config.ProcessCompleteCallback = OnProcessComplete;
@@ -195,7 +195,7 @@ protected:
             Config.AlpnBuffer = MultipleAlpns ? MultiAlpn : Alpn;
             Config.AlpnBufferLength = MultipleAlpns ? sizeof(MultiAlpn) : sizeof(Alpn);
             Config.LocalTPBuffer =
-                (uint8_t*)QUIC_ALLOC_NONPAGED(QuicTlsTPHeaderSize + TPLen, QUIC_POOL_TEST);
+                (uint8_t*)QUIC_ALLOC_NONPAGED(QuicTlsTPHeaderSize + TPLen, QUIC_POOL_TLS_TRANSPARAMS);
             Config.LocalTPLength = QuicTlsTPHeaderSize + TPLen;
             Config.Connection = (QUIC_CONNECTION*)this;
             Config.ProcessCompleteCallback = OnProcessComplete;


### PR DESCRIPTION
Only in debug mode, but will both make debugging easier, and will help make sure all the pool tags are correct.

Found a few bugs in which pool tags were used, so those are fixed.