### PR TITLE
A few more WPA code quality cleanups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -99,12 +99,6 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 csharp_prefer_simple_default_expression = true:suggestion
 
-# Default severity for analyzer diagnostics with category 'Naming'
-dotnet_analyzer_diagnostic.category-Naming.severity = none
-
-# Default severity for analyzer diagnostics with category 'Design'
-dotnet_analyzer_diagnostic.category-Design.severity = none
-
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true:silent
 csharp_style_expression_bodied_constructors = true:silent

--- a/src/tools/wpa/DataModel/QuicConnection.cs
+++ b/src/tools/wpa/DataModel/QuicConnection.cs
@@ -50,7 +50,7 @@ namespace MsQuicTracing.DataModel
 
         //public List<QuicStream> Streams { get; } = new List<QuicStream>();
 
-        private List<QuicEvent> Events = new List<QuicEvent>();
+        private readonly List<QuicEvent> Events = new List<QuicEvent>();
 
         public IReadOnlyList<QuicScheduleData> ScheduleEvents
         {

--- a/src/tools/wpa/DataModel/QuicObjectSet.cs
+++ b/src/tools/wpa/DataModel/QuicObjectSet.cs
@@ -36,7 +36,7 @@ namespace MsQuicTracing.DataModel
             }
         }
 
-        public QuicObjectKey(QuicEvent evt) : this(evt.PointerSize, evt.ObjectPointer, evt.ProcessId)
+        internal QuicObjectKey(QuicEvent evt) : this(evt.PointerSize, evt.ObjectPointer, evt.ProcessId)
         {
         }
 
@@ -81,11 +81,11 @@ namespace MsQuicTracing.DataModel
 
         public int Count => activeTable.Count + inactiveList.Count;
 
-        private ushort CreateEventId;
+        private readonly ushort CreateEventId;
 
-        private ushort DestroyedEventId;
+        private readonly ushort DestroyedEventId;
 
-        private Func<ulong, uint, T> ObjectConstructor;
+        private readonly Func<ulong, uint, T> ObjectConstructor;
 
         public QuicObjectSet(ushort createEventId, ushort destroyedEventId, Func<ulong, uint, T> constructor)
         {
@@ -98,7 +98,7 @@ namespace MsQuicTracing.DataModel
 
         public T? RemoveActiveObject(QuicObjectKey key) => activeTable.Remove(key, out var value) ? value : null;
 
-        public T? FindById(UInt32 id)
+        public T? FindById(uint id)
         {
             T? value = activeTable.Where(it => it.Value.Id == id).Select(it => it.Value).FirstOrDefault();
             if (value is null)
@@ -153,7 +153,7 @@ namespace MsQuicTracing.DataModel
             inactiveList.Sort((a, b) => (int)(a.Id - b.Id));
         }
 
-        public List<T> GetObjects()
+        public IReadOnlyList<T> GetObjects()
         {
             List<T> allObjects = new List<T>();
             allObjects.AddRange(inactiveList);

--- a/src/tools/wpa/DataModel/QuicState.cs
+++ b/src/tools/wpa/DataModel/QuicState.cs
@@ -10,9 +10,9 @@ namespace MsQuicTracing.DataModel
 {
     public sealed class QuicState
     {
-        public List<QuicWorker> Workers => WorkerSet.GetObjects();
+        public IReadOnlyList<QuicWorker> Workers => WorkerSet.GetObjects();
 
-        public List<QuicConnection> Connections => ConnectionSet.GetObjects();
+        public IReadOnlyList<QuicConnection> Connections => ConnectionSet.GetObjects();
 
         private QuicObjectSet<QuicWorker> WorkerSet { get; } =
             new QuicObjectSet<QuicWorker>(QuicWorker.CreateEventId, QuicWorker.DestroyedEventId, QuicWorker.New);
@@ -20,7 +20,7 @@ namespace MsQuicTracing.DataModel
         private QuicObjectSet<QuicConnection> ConnectionSet { get; } =
             new QuicObjectSet<QuicConnection>(QuicConnection.CreateEventId, QuicConnection.DestroyedEventId, QuicConnection.New);
 
-        private List<QuicEvent> Events = new List<QuicEvent>();
+        private readonly List<QuicEvent> Events = new List<QuicEvent>();
 
         internal void AddEvent(QuicEvent evt)
         {

--- a/src/tools/wpa/DataModel/QuicWorker.cs
+++ b/src/tools/wpa/DataModel/QuicWorker.cs
@@ -40,7 +40,7 @@ namespace MsQuicTracing.DataModel
 
         public uint CurrentConnections { get; private set; }
 
-        private List<QuicEvent> Events = new List<QuicEvent>();
+        private readonly List<QuicEvent> Events = new List<QuicEvent>();
 
         public IReadOnlyList<QuicActivityData> ActivityEvents
         {

--- a/src/tools/wpa/QuicEventCooker.cs
+++ b/src/tools/wpa/QuicEventCooker.cs
@@ -48,6 +48,7 @@ namespace MsQuicTracing
 
         public DataProcessingResult CookDataElement(QuicEvent data, object context, CancellationToken cancellationToken)
         {
+            Debug.Assert(!(data is null));
             State.AddEvent(data);
             return DataProcessingResult.Processed;
         }

--- a/src/tools/wpa/QuicEventDataSource.csproj
+++ b/src/tools/wpa/QuicEventDataSource.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <RootNamespace>MsQuicTracing</RootNamespace>
-    <NoWarn>1701;1702;CA1036;CA1815</NoWarn>
+    <NoWarn>1701;1702;CA1036;CA1815;CA1720;CA1008;CA1711;CA1028</NoWarn>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Copyright>Microsoft Corporation</Copyright>


### PR DESCRIPTION
It's much better to suppress the compiler styles we don't want in the csproj rather then the editorconfig, as that way the project stays independent of the repo. Otherwise if for some reason we move the plugin source or build without the repo, it wouldn't build.

Also fixes a few missing readonly variables, and 1 missing public Debug.Assert.

Also converts some things public things that could be IReadOnlyLists to IReadOnlyLists.