### PR TITLE
Remove Unsafe library in favor of unsafe block.

### DIFF
--- a/src/tools/wpa/DataModel/QuicEventPayload.cs
+++ b/src/tools/wpa/DataModel/QuicEventPayload.cs
@@ -42,10 +42,10 @@ namespace MsQuicTracing.DataModel
 
     internal static class SpanHelpers
     {
-        internal static T ReadValue<T>(this ref ReadOnlySpan<byte> data) where T : unmanaged
+        internal static unsafe T ReadValue<T>(this ref ReadOnlySpan<byte> data) where T : unmanaged
         {
             T val = MemoryMarshal.Cast<byte, T>(data)[0];
-            data = data.Slice(Unsafe.SizeOf<T>());
+            data = data.Slice(sizeof(T));
             return val;
         }
         internal static ulong ReadPointer(this ref ReadOnlySpan<byte> data, int pointerSize)

--- a/src/tools/wpa/QuicEventDataSource.csproj
+++ b/src/tools/wpa/QuicEventDataSource.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -12,6 +12,7 @@
     <PackageProjectUrl>https://github.com/microsoft/msquic</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/msquic.git</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
@@ -21,7 +22,6 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.44" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.17" />
     <PackageReference Include="Microsoft.Performance.SDK" Version="0.108.2" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)LICENSE">


### PR DESCRIPTION
I had forgetten that the unmanaged generic restriction allows sizeof(T). So switching to that rather then including an extra dependency, as less deps is better for plugins