### PR TITLE
Switch to using EventData backing memory directly

### DIFF
--- a/src/tools/wpa/DataModel/ETW/QuicEtwEvent.cs
+++ b/src/tools/wpa/DataModel/ETW/QuicEtwEvent.cs
@@ -160,7 +160,7 @@ namespace MsQuicTracing.DataModel.ETW
             }
         }
 
-        internal QuicEtwEvent(TraceEvent evt, Timestamp timestamp)
+        internal unsafe QuicEtwEvent(TraceEvent evt, Timestamp timestamp)
         {
             Provider = evt.ProviderGuid;
             ID = (QuicEventId)evt.ID;
@@ -170,15 +170,15 @@ namespace MsQuicTracing.DataModel.ETW
             Processor = (ushort)evt.ProcessorNumber;
             TimeStamp = timestamp;
             ObjectType = ComputeObjectType(evt);
+            ReadOnlySpan<byte> data = new ReadOnlySpan<byte>(evt.DataStart.ToPointer(), evt.EventDataLength);
             if (ObjectType != QuicObjectType.Global)
             {
-                ReadOnlySpan<byte> data = evt.EventData();
                 ObjectPointer = data.ReadPointer(PointerSize);
                 Payload = DecodePayload(ID, data, PointerSize);
             }
             else
             {
-                Payload = DecodePayload(ID, evt.EventData(), PointerSize);
+                Payload = DecodePayload(ID, data, PointerSize);
             }
         }
     }


### PR DESCRIPTION
EventData() would allocate a new array and copy. This instead just uses the DataStart and length directly to create a span to the backing memory directly.

The copy code can be seen here, so we're not going Out of Bounds or anything.
https://github.com/microsoft/perfview/blob/master/src/TraceEvent/TraceEvent.cs#L1258

