### PR TITLE
Add LibrarySendRetryStateUpdated Event

### DIFF
--- a/src/core/library.h
+++ b/src/core/library.h
@@ -88,6 +88,11 @@ typedef struct QUIC_LIBRARY {
     BOOLEAN InUse;
 
     //
+    // Indicates if the stateless retry feature is currently enabled.
+    //
+    BOOLEAN SendRetryEnabled;
+
+    //
     // Index for the current stateless retry token key.
     //
     BOOLEAN CurrentStatelessRetryKey;
@@ -156,7 +161,13 @@ typedef struct QUIC_LIBRARY {
     uint64_t ConnectionCorrelationId;
 
     //
-    // The estiamted current total memory usage for handshake connections.
+    // The maximum total memory usage for handshake connections before the retry
+    // feature gets enabled.
+    //
+    uint64_t HandshakeMemoryLimit;
+
+    //
+    // The estimated current total memory usage for handshake connections.
     //
     uint64_t CurrentHandshakeMemoryUsage;
 
@@ -486,4 +497,22 @@ _Ret_maybenull_
 QUIC_KEY*
 QuicLibraryGetStatelessRetryKeyForTimestamp(
     _In_ int64_t Timestamp
+    );
+
+//
+// Called when a new (server) connection is added in the handshake state.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicLibraryOnHandshakeConnectionAdded(
+    void
+    );
+
+//
+// Called when a connection leaves the handshake state.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicLibraryOnHandshakeConnectionRemoved(
+    void
     );

--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -556,9 +556,7 @@ QuicLookupInsertRemoteHash(
 
     Connection->RemoteHashEntry = Entry;
 
-    InterlockedExchangeAdd64(
-        (int64_t*)&MsQuicLib.CurrentHandshakeMemoryUsage,
-        (int64_t)QUIC_CONN_HANDSHAKE_MEMORY_USAGE);
+    QuicLibraryOnHandshakeConnectionAdded();
 
     if (UpdateRefCount) {
         QuicConnAddRef(Connection, QUIC_CONN_REF_LOOKUP_TABLE);
@@ -847,9 +845,7 @@ QuicLookupRemoveRemoteHash(
     QUIC_CONNECTION* Connection = RemoteHashEntry->Connection;
     QUIC_DBG_ASSERT(Lookup->MaximizePartitioning);
 
-    InterlockedExchangeAdd64(
-        (int64_t*)&MsQuicLib.CurrentHandshakeMemoryUsage,
-        -1 * (int64_t)QUIC_CONN_HANDSHAKE_MEMORY_USAGE);
+    QuicLibraryOnHandshakeConnectionRemoved();
 
     QuicDispatchRwLockAcquireExclusive(&Lookup->RwLock);
     QUIC_DBG_ASSERT(Connection->RemoteHashEntry != NULL);

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -531,6 +531,12 @@
                 name="Message"
                 />
           </template>
+          <template tid="tid_BOOL">
+            <data
+                inType="win:UInt8"
+                name="Value"
+                />
+          </template>
           <template tid="tid_LIBRARY_INIT">
             <data
                 inType="win:UInt32"
@@ -1780,6 +1786,15 @@
               symbol="QuicPerfCountersRundown"
               template="tid_LIBRARY_PERF_COUNTERS"
               value="15"
+              />
+          <event
+              keywords="ut:LowVolume"
+              level="win:Informational"
+              message="$(string.Etw.LibrarySendRetryStateUpdated)"
+              opcode="Global"
+              symbol="QuicLibrarySendRetryStateUpdated"
+              template="tid_BOOL"
+              value="16"
               />
           <!-- 1024 - 2047 | Registration Events -->
           <event
@@ -3336,6 +3351,10 @@
         <string
             id="Etw.PerfCountersRundown"
             value="[ lib] Perf counters Rundown"
+            />
+        <string
+            id="Etw.LibrarySendRetryStateUpdated"
+            value="[ lib] New SendRetryEnabled state, %1"
             />
         <!-- Map/enum strings -->
         <string

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -9529,6 +9529,33 @@
         "CustomSettings": null
       }
     },
+    "LibrarySendRetryStateUpdated": {
+      "ModuleProperites": {},
+      "TraceString": "[ lib] New SendRetryEnabled state, %hhu",
+      "UniqueId": "LibrarySendRetryStateUpdated",
+      "splitArgs": [
+        {
+          "VariableInfo": {
+            "UserSuppliedTrimmed": "MsQuicLib.SendRetryEnabled",
+            "SuggestedTelemetryName": "arg2"
+          },
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macro": {
+        "MacroName": "QuicTraceEvent",
+        "EncodedPrefix": null,
+        "EncodedArgNumber": 1,
+        "MacroConfiguration": {
+          "linux": "lttng_plus",
+          "stubs": "stubs",
+          "windows_kernel": "empty",
+          "windows": "empty"
+        },
+        "CustomSettings": null
+      }
+    },
     "PerfCountersRundown": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Perf counters Rundown, Counters=%!CID!",
@@ -22200,6 +22227,10 @@
       {
         "UniquenessHash": "4810c9e0-dcf7-bc55-81bb-684627b092b1",
         "TraceID": "LibraryRundown"
+      },
+      {
+        "UniquenessHash": "e1750b05-bb04-6a2d-d4d6-99892dd266cd",
+        "TraceID": "LibrarySendRetryStateUpdated"
       },
       {
         "UniquenessHash": "10ce7ee9-cfcc-e364-e24c-71e1913cb472",

--- a/src/plugins/wpa/DataModel/QuicEvent.cs
+++ b/src/plugins/wpa/DataModel/QuicEvent.cs
@@ -38,6 +38,8 @@ namespace MsQuicTracing.DataModel
         ApiExit,
         ApiExitStatus,
         ApiWaitOperation,
+        PerfCountersRundown,
+        LibrarySendRetryStateUpdated,
 
         WorkerCreated = 2048,
         WorkerStart,

--- a/src/tools/etw/quicetw.h
+++ b/src/tools/etw/quicetw.h
@@ -86,6 +86,7 @@ typedef enum QUIC_EVENT_ID_GLOBAL {
     EventId_QuicApiExitStatus,
     EventId_QuicApiWaitOperation,
     EventId_QuicPerfCountersRundown,
+    EventId_QuicLibrarySendRetryStateUpdated,
 
     EventId_QuicLibraryCount
 } QUIC_EVENT_ID_GLOBAL;
@@ -129,6 +130,9 @@ typedef struct QUIC_EVENT_DATA_GLOBAL {
             uint16_t CounterLen;
             int64_t Counters[QUIC_PERF_COUNTER_MAX];
         } PerfCounters;
+        struct {
+            UINT8 Value;
+        } LibrarySendRetryStateUpdated;
     };
 } QUIC_EVENT_DATA_GLOBAL;
 #pragma pack(pop)


### PR DESCRIPTION
Fixes #935. Adds a new event to indicate if the library is currently sending stateless retry packets in response to new connection attempts or not.