### PR TITLE
Fail build if throughput up test has a 5% or more performance drop

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -114,6 +114,7 @@ stages:
       localTls: schannel
       remoteTls: ${{ parameters.tls }}
       arch: ${{ parameters.arch }}
+      failOnRegression: 0
       ${{ if ne(parameters.testToRun, 'all') }}:
         testToRun: ${{ parameters.testToRun }}
       ${{ if eq(parameters.kernelmode, true) }}:

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -74,7 +74,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/performance.ps1
-      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} -Local -TestToRun '${{ parameters.testToRun }}'
+      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} ${{ parameters.failOnRegression }} -Local -TestToRun '${{ parameters.testToRun }}'
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -13,6 +13,7 @@ parameters:
   kernelMode: ''
   testTypes: 'Remote,Loopback'
   testToRun: ''
+  failOnRegression: 1
 
 jobs:
 - job: performance_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.localTls }}_${{ parameters.remoteTls }}_${{ parameters.extraName }}
@@ -63,7 +64,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/performance.ps1
-      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} -TestToRun '${{ parameters.testToRun }}'
+      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} ${{ parameters.failOnRegression }} -TestToRun '${{ parameters.testToRun }}'
 
   - task: PowerShell@2
     condition: contains('${{ parameters.testTypes }}', 'Loopback')

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -64,7 +64,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/performance.ps1
-      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} ${{ parameters.failOnRegression }} -TestToRun '${{ parameters.testToRun }}'
+      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} -FailOnRegression ${{ parameters.failOnRegression }} -TestToRun '${{ parameters.testToRun }}'
 
   - task: PowerShell@2
     condition: contains('${{ parameters.testTypes }}', 'Loopback')
@@ -74,7 +74,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/performance.ps1
-      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} ${{ parameters.failOnRegression }} -Local -TestToRun '${{ parameters.testToRun }}'
+      arguments: -Config ${{ parameters.config }} -LocalTls ${{ parameters.localTls }} -RemoteTls ${{ parameters.remoteTls }} -LocalArch ${{ parameters.arch }} -RemoteArch ${{ parameters.arch }} ${{ parameters.kernelMode }} ${{ parameters.extraArgs }} -FailOnRegression ${{ parameters.failOnRegression }} -Local -TestToRun '${{ parameters.testToRun }}'
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -53,7 +53,8 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"]
+        "Formats": ["{0} kbps"],
+        "RegressionThreshold": "-5.0"
     },
     {
         "TestName": "ThroughputUp",
@@ -109,7 +110,8 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"]
+        "Formats": ["{0} kbps"],
+        "RegressionThreshold": "-10.0"
     },
     {
         "TestName": "ThroughputDown",
@@ -153,7 +155,8 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"]
+        "Formats": ["{0} kbps"],
+        "RegressionThreshold": "-5.0"
     },
     {
         "TestName": "ThroughputDown",
@@ -197,7 +200,8 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"]
+        "Formats": ["{0} kbps"],
+        "RegressionThreshold": "-10.0"
     },
     {
         "TestName": "RPS",
@@ -266,7 +270,8 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": "Result: (.*) RPS, Min: (.*), Max: (.*), 50th: (.*), 90th: (.*), 99th: (.*), 99.9th: (.*), 99.99th: (.*), 99.999th: (.*), 99.9999th: (.*), StdErr: (.*)",
-        "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"]
+        "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"],
+        "RegressionThreshold": "-50.0"
     },
     {
         "TestName": "HPS",
@@ -297,6 +302,7 @@
         "Iterations": 5,
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": "Result: (.*) HPS.*",
-        "Formats": ["{0} HPS"]
+        "Formats": ["{0} HPS"],
+        "RegressionThreshold": "-10.0"
     }
 ]

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -54,7 +54,7 @@
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
         "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-5.0"
+        "RegressionThreshold": "-8.0"
     },
     {
         "TestName": "ThroughputUp",
@@ -156,7 +156,7 @@
         "RemoteReadyMatcher": "Started!",
         "ResultsMatcher": ".*@ (.*) kbps.*",
         "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-5.0"
+        "RegressionThreshold": "-8.0"
     },
     {
         "TestName": "ThroughputDown",

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -538,6 +538,9 @@ function Write-Failures() {
     }
 }
 
+# Fail loopback tests if < 50%
+$LocalRegressionThreshold = -50.0
+
 function Get-LatestThroughputRemoteTestResults([ThroughputRequest]$Request) {
     $Uri = "https://msquicperformanceresults.azurewebsites.net/throughput/get"
     $RequestJson = ConvertTo-Json -InputObject $Request
@@ -608,6 +611,8 @@ function Publish-ThroughputTestResults {
             if ($Test.VariableName -ne "Encryption") {
                 $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
             }
+        } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -724,6 +729,8 @@ function Publish-RPSTestResults {
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
             $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+        } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -814,6 +821,8 @@ function Publish-HPSTestResults {
         Write-Output "Median: $CurrentFormatted ($PercentDiffStr%)"
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+        } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
             $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
         }
     } else {

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -939,6 +939,7 @@ class TestRunDefinition {
         $this.Loopback = $script:Local
         $this.AllowLoopback = $existingDef.AllowLoopback
         $this.Formats = $existingDef.Formats
+        $this.RegressionThreshold = $existingDef.RegressionThreshold
     }
 
     [string]ToString() {

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -896,7 +896,7 @@ class TestRunDefinition {
     [boolean]$Loopback;
     [boolean]$AllowLoopback;
     [string[]]$Formats;
-    [boolean]$RegressionThreshold;
+    [double]$RegressionThreshold;
 
     TestRunDefinition (
         [TestDefinition]$existingDef,
@@ -1101,7 +1101,7 @@ class TestDefinition {
     [string]$ResultsMatcher;
     [boolean]$AllowLoopback;
     [string[]]$Formats;
-    [boolean]$RegressionThreshold;
+    [double]$RegressionThreshold;
 
     [string]ToString() {
         $Platform = $this.Remote.Platform

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -525,6 +525,19 @@ class ThroughputRequest {
     }
 }
 
+$Failures = New-Object Collections.Generic.List[string]
+
+function Write-Failures() {
+    $DidFail = $false
+    foreach ($Failure in $Failures) {
+        $DidFail = $true
+        Write-Output $Failure
+    }
+    if ($DidFail) {
+        Write-Error "Performance test failures occured"
+    }
+}
+
 function Get-LatestThroughputRemoteTestResults([ThroughputRequest]$Request) {
     $Uri = "https://msquicperformanceresults.azurewebsites.net/throughput/get"
     $RequestJson = ConvertTo-Json -InputObject $Request
@@ -594,7 +607,7 @@ function Publish-ThroughputTestResults {
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local) {
             if ($ServerToClient -eq $false -and $PercentDiff -lt $ThroughputUpRegressionThreshold) {
-                Write-Error "Performance regression. Failing Test"
+                $Failures.Add("Performance regression in Throutput Up Test. $PercentDiffStr%")
             }
         }
     } else {

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -534,7 +534,7 @@ function Write-Failures() {
         Write-Output $Failure
     }
     if ($DidFail) {
-        Write-Error "Performance test failures occured"
+        Write-Error "Performance test failures occurred"
     }
 }
 
@@ -609,10 +609,10 @@ function Publish-ThroughputTestResults {
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
             #Skip no encrypt
             if ($Test.VariableName -ne "Encryption") {
-                $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+                $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
             }
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -728,9 +728,9 @@ function Publish-RPSTestResults {
         Write-Output "Median: $CurrentFormatted ($PercentDiffStr%)"
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -821,9 +821,9 @@ function Publish-HPSTestResults {
         Write-Output "Median: $CurrentFormatted ($PercentDiffStr%)"
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr%")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -609,10 +609,10 @@ function Publish-ThroughputTestResults {
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
             #Skip no encrypt
             if ($Test.VariableName -ne "Encryption") {
-                $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
+                $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $($Test.RegressionThreshold)")
             }
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $LocalRegressionThreshold")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -728,9 +728,9 @@ function Publish-RPSTestResults {
         Write-Output "Median: $CurrentFormatted ($PercentDiffStr%)"
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $($Test.RegressionThreshold)")
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $LocalRegressionThreshold")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"
@@ -821,9 +821,9 @@ function Publish-HPSTestResults {
         Write-Output "Median: $CurrentFormatted ($PercentDiffStr%)"
         Write-Output "Master: $LastFormatted"
         if ($FailOnRegression -and !$Local -and $PercentDiff -lt $Test.RegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $($Test.RegressionThreshold))")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $($Test.RegressionThreshold)")
         } elseif ($FailOnRegression -and $PercentDiff -lt $LocalRegressionThreshold) {
-            $Failures.Add("Performance regression in $Test. $PercentDiffStr% (threshold: $LocalRegressionThreshold)")
+            $Failures.Add("Performance regression in $Test. $PercentDiffStr% < $LocalRegressionThreshold")
         }
     } else {
         Write-Output "Median: $CurrentFormatted"

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -447,6 +447,8 @@ try {
         Copy-Item "$LocalExePath\msquic.pgd" $OutputDir
     }
 
+    Write-Failures
+
 } finally {
     if ($null -ne $Session) {
         Remove-PSSession -Session $Session

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -51,6 +51,9 @@ This script runs performance tests locally for a period of time.
 .PARAMETER TestToRun
     Run a specific test name
 
+.PARAMETER FailOnRegression
+    Fail tests on perf regression (Currently only throughput up)
+
 #>
 
 param (
@@ -111,7 +114,10 @@ param (
     [switch]$RecordQUIC = $false,
 
     [Parameter(Mandatory = $false)]
-    [string]$TestToRun = ""
+    [string]$TestToRun = "",
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$FailOnRegression = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -209,7 +215,8 @@ Set-ScriptVariables -Local $Local `
                     -RecordQUIC $RecordQUIC `
                     -RemoteAddress $RemoteAddress `
                     -Session $Session `
-                    -Kernel $Kernel
+                    -Kernel $Kernel `
+                    -FailOnRegression $FailOnRegression
 
 $RemotePlatform = Invoke-TestCommand -Session $Session -ScriptBlock {
     if ($IsWindows) {


### PR DESCRIPTION
Closes #949. Once we can stabilize the rests of the tests, we should make those failures as well.