### PR TITLE
Turn on null checks in wpacmd

### DIFF
--- a/src/plugins/wpa/DataModel/QuicEventPayload.cs
+++ b/src/plugins/wpa/DataModel/QuicEventPayload.cs
@@ -317,11 +317,9 @@ namespace MsQuicTracing.DataModel
 
         public ushort SegmentSize { get; protected set; }
 
-#pragma warning disable CS8618 // Non-nullable field is uninitialized.
-        public IPEndPoint RemoteAddress { get; protected set; }
+        public IPEndPoint RemoteAddress { get; protected set; } = null!;
 
-        public IPEndPoint LocalAddress { get; protected set; }
-#pragma warning restore CS8618 // Non-nullable field is uninitialized.
+        public IPEndPoint LocalAddress { get; protected set; } = null!;
     }
 
     public class QuicDatapathRecvPayload
@@ -330,11 +328,9 @@ namespace MsQuicTracing.DataModel
 
         public ushort SegmentSize { get; protected set; }
 
-#pragma warning disable CS8618 // Non-nullable field is uninitialized.
-        public IPEndPoint LocalAddress { get; protected set; }
+        public IPEndPoint LocalAddress { get; protected set; } = null!;
 
-        public IPEndPoint RemoteAddress { get; protected set; }
-#pragma warning restore CS8618 // Non-nullable field is uninitialized.
+        public IPEndPoint RemoteAddress { get; protected set; } = null!;
     }
 
     #endregion

--- a/src/plugins/wpacmd/QuicEtw.csproj
+++ b/src/plugins/wpacmd/QuicEtw.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Performance.SDK" Version="0.108.2" />


### PR DESCRIPTION
I'm fine not adding the code analysis plugin to this, which is the more aggressive one, but since we have this enabled in the plugin we should enable it in the cmd program. It should be a lot less invasive here, as we're the caller, so we can check everything. Also not enabling warnings as errors here, although we can if you want.

Also switches to null! to bypass the nullable warning in Payload rather then pragma. They do the same thing in execution, but the null! is clearer in intent.