### PR TITLE
Fix C11 mode being set on windows.

### DIFF
--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -12,7 +12,10 @@ target_compile_definitions(inc INTERFACE ${QUIC_COMMON_DEFINES})
 target_include_directories(inc INTERFACE ${QUIC_INCLUDE_DIR})
 
 target_compile_features(inc INTERFACE cxx_std_17)
-target_compile_features(inc INTERFACE c_std_11)
+
+if (NOT MSVC)
+    target_compile_features(inc INTERFACE c_std_11)
+endif()
 
 if (NOT MSVC AND QUIC_ENABLE_SANITIZERS)
     target_link_libraries(inc INTERFACE -fsanitize=address,leak,undefined)


### PR DESCRIPTION
In VS 16.8, C11 mode is broken including Windows.h. We want to skip this mode setting on Windows, and only enable it on linux