### PR TITLE
Fix the key string for TestName

### DIFF
--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -69,7 +69,11 @@ QuicMainStart(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    const char* TestName = GetValue(argc, argv, "test");
+    const char* TestName = GetValue(argc, argv, "TestName");
+    if (TestName == nullptr) {
+        TestName = GetValue(argc, argv, "test");
+    }
+
     ServerMode = TestName == nullptr;
 
     QUIC_STATUS Status;


### PR DESCRIPTION
When `test` is used, at least in Ubuntu 18.04 LTS, the line 111-116 failed to parse the `argv` and get the input value.