### PR TITLE
Use clog 0.1.9

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Building MsQuic
 
-The full MsQuic build system relies on [CMake](https://cmake.org/) (3.16 or better), [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) (3.1 SDK) and [Powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (7.0 or better) on all platforms.
+The full MsQuic build system relies on [CMake](https://cmake.org/) (3.16 or better), [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) (Core 3.1 or 5.0 SDK) and [Powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (7.0 or better) on all platforms.
 
 > **Note** - clone the repo recursively or run `git submodule update --init --recursive`
 to get all the submodules.

--- a/scripts/install-powershell-docker.sh
+++ b/scripts/install-powershell-docker.sh
@@ -12,10 +12,10 @@ dotnet tool install -g powershell
 
 mkdir nuget
 
-wget https://github.com/microsoft/CLOG/releases/download/v0.1.8/Microsoft.Logging.CLOG.0.1.8.nupkg
-mv Microsoft.Logging.CLOG.0.1.8.nupkg nuget/Microsoft.Logging.CLOG.0.1.8.nupkg
+wget https://github.com/microsoft/CLOG/releases/download/v0.1.9/Microsoft.Logging.CLOG.0.1.9.nupkg
+mv Microsoft.Logging.CLOG.0.1.9.nupkg nuget/Microsoft.Logging.CLOG.0.1.9.nupkg
 dotnet tool install --global --add-source nuget Microsoft.Logging.CLOG
 
-wget https://github.com/microsoft/CLOG/releases/download/v0.1.8/Microsoft.Logging.CLOG2Text.Lttng.0.1.8.nupkg
-mv Microsoft.Logging.CLOG2Text.Lttng.0.1.8.nupkg nuget/Microsoft.Logging.CLOG2Text.Lttng.0.1.8.nupkg
+wget https://github.com/microsoft/CLOG/releases/download/v0.1.9/Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg
+mv Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg nuget/Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg
 dotnet tool install --global --add-source nuget Microsoft.Logging.CLOG2Text.Lttng

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -32,7 +32,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $NuGetPath = Join-Path $RootDir "nuget"
 
 # Well-known location for clog packages.
-$ClogVersion = "0.1.8"
+$ClogVersion = "0.1.9"
 $ClogDownloadUrl = "https://github.com/microsoft/CLOG/releases/download/v$ClogVersion"
 
 $MessagesAtEnd = New-Object Collections.Generic.List[string]


### PR DESCRIPTION
This enables using .NET 5 as well as .NET Core 3.1. Docs have been updated to note this