### PR TITLE
Make QNS templates use latest ubuntu image

### DIFF
--- a/.azure/templates/run-qns.yml
+++ b/.azure/templates/run-qns.yml
@@ -15,6 +15,8 @@ jobs:
       - job:
         displayName: ${{ client }} -> ${{ server }}
         dependsOn: ${{ parameters.dependsOn }}
+        pool:
+          vmImage: 'ubuntu-latest'
         variables:
           runCodesignValidationInjection: false
         steps:


### PR DESCRIPTION
Default is Ubuntu 16.04, which has Python 3.5, which isn't supported anymore by a dependency of the QNS runner. Just update to the latest to solve the issue