### PR TITLE
WanPerf Pipeline

### DIFF
--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -24,7 +24,7 @@ stages:
     parameters:
       image: windows-latest
       platform: windows
-      arch: amd64
+      arch: x64
       tls: schannel
       config: Release
       extraBuildArgs: -DisableTest -DisableTools

--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -8,6 +8,24 @@ pr: none
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
+parameters:
+- name: iterations
+  type: number
+  displayName: Iterations
+  default: 5
+- name: durationMs
+  type: string
+  displayName: Duration (ms)
+  default: '10000'
+- name: rateMbps
+  type: string
+  displayName: Rate (Mbps)
+  default: '(10,50,100)'
+- name: rttMs
+  type: string
+  displayName: RTT (ms)
+  default: '50'
+
 stages:
 
 #
@@ -39,3 +57,8 @@ stages:
   - build_windows
   jobs:
   - template: ./templates/run-wanperf.yml
+    parameters:
+      iterations: ${{ parameters.iterations }}
+      durationMs: ${{ parameters.durationMs }}
+      rateMbps: ${{ parameters.rateMbps }}
+      rttMs: ${{ parameters.rttMs }}

--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -34,7 +34,7 @@ stages:
 #
 
 - stage: performance
-  displayName: WAN Performance Testing (${{ parameters.mode }})
+  displayName: WAN Performance Testing
   dependsOn:
   - build_windows
   jobs:

--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -1,0 +1,41 @@
+#
+# Continuous Integration (CI)
+# This pipeline builds and runs MsQuic performance tests.
+#
+
+trigger: none
+pr: none
+
+name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
+
+stages:
+
+#
+# Builds
+#
+
+- stage: build_windows
+  displayName: Build Windows
+  dependsOn: []
+  variables:
+    runCodesignValidationInjection: false
+  jobs:
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: amd64
+      tls: schannel
+      config: Release
+      extraBuildArgs: -DisableTest -DisableTools
+
+#
+# Performance Tests
+#
+
+- stage: performance
+  displayName: WAN Performance Testing (${{ parameters.mode }})
+  dependsOn:
+  - build_windows
+  jobs:
+  - template: ./templates/run-wanperf.yml

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -20,16 +20,8 @@ jobs:
     container: ${{ parameters.container }}
   steps:
   - checkout: self
-    submodules: recursive
     ${{ if eq(parameters.platform, 'windows') }}:
       path: msquic
-
-  - task: Cache@2
-    inputs:
-      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_3" | .gitmodules'
-      path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
-    displayName: Cache OpenSSL
-    condition: eq('${{ parameters.tls }}', 'openssl')
 
   - task: UseDotNet@2
     displayName: 'Use .NET Core sdk'
@@ -50,7 +42,14 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
-      arguments: -Configuration Build
+      arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -Extra ${{ parameters.extraBuildArgs }}
+
+  - task: Cache@2
+    inputs:
+      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_3" | .gitmodules'
+      path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
+    displayName: Cache OpenSSL
+    condition: eq('${{ parameters.tls }}', 'openssl')
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -42,7 +42,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
-      arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -Extra ''${{ parameters.extraBuildArgs }}''
+      arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -Extra '${{ parameters.extraBuildArgs }}'
 
   - task: Cache@2
     inputs:

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -42,7 +42,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
-      arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -Extra ${{ parameters.extraBuildArgs }}
+      arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -Extra ''${{ parameters.extraBuildArgs }}''
 
   - task: Cache@2
     inputs:

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -49,11 +49,11 @@ jobs:
       key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_3" | .gitmodules'
       path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
     displayName: Cache OpenSSL
-    condition: eq('${{ parameters.tls }}', 'openssl')
+    condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'))
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)
-    condition: contains('${{ parameters.config }}', 'Debug')
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Debug'))
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
@@ -61,7 +61,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Build Source Code (Release)
-    condition: contains('${{ parameters.config }}', 'Release')
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Release'))
     inputs:
       pwsh: true
       filePath: scripts/build.ps1

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -11,14 +11,13 @@ jobs:
     vmImage: windows-latest
   steps:
   - checkout: self
-    submodules: recursive
     path: msquic
 
   - task: PowerShell@2
     displayName: Prepare Build Machine
     inputs:
       pwsh: true
-      filePath: scripts/prepare-machine.ps1
+      filePath: scripts/prepare-machine.ps1 -InitSubmodules -Tls schannel -Kernel
       arguments: -Configuration Build
 
   - task: NuGetCommand@2
@@ -28,7 +27,7 @@ jobs:
 
   - task: VSBuild@1
     displayName: Build Source Code (Debug)
-    condition: contains('${{ parameters.config }}', 'Debug')
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Debug'))
     inputs:
       solution: msquic.kernel.sln
       platform: ${{ parameters.arch }}
@@ -37,7 +36,7 @@ jobs:
 
   - task: VSBuild@1
     displayName: Build Source Code (Release)
-    condition: contains('${{ parameters.config }}', 'Release')
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Release'))
     inputs:
       solution: msquic.kernel.sln
       platform: ${{ parameters.arch }}

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -17,8 +17,8 @@ jobs:
     displayName: Prepare Build Machine
     inputs:
       pwsh: true
-      filePath: scripts/prepare-machine.ps1 -InitSubmodules -Tls schannel -Kernel
-      arguments: -Configuration Build
+      filePath: scripts/prepare-machine.ps1
+      arguments: -Configuration Build -InitSubmodules -Tls schannel -Kernel
 
   - task: NuGetCommand@2
     displayName: Nuget Restore

--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -1,0 +1,49 @@
+# This template contains steps to run WAN performance tests for a single configuration.
+
+parameters:
+  pool: 'MsQuic-Win-Latest'
+  image: ''
+  platform: 'windows'
+  config: 'Release'
+  arch: 'x64'
+  tls: 'schannel'
+
+jobs:
+- job: performance_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}
+  displayName: ${{ parameters.platform }} ${{ parameters.arch }} ${{ parameters.tls }}
+  ${{ if ne(parameters.pool, '') }}:
+    pool: ${{ parameters.pool }}
+    workspace:
+      clean: all
+  ${{ if eq(parameters.pool, '') }}:
+    pool:
+      vmImage: ${{ parameters.image }}
+  variables:
+  - name: runCodesignValidationInjection
+    value: false
+  - name: skipComponentGovernanceDetection
+    value: true
+  - group: DeploymentKeys
+  steps:
+  - checkout: self
+
+  - template: ./download-artifacts.yml
+    parameters:
+      platform: ${{ parameters.platform }}
+      arch: ${{ parameters.arch }}
+      tls: ${{ parameters.tls }}
+
+  - task: PowerShell@2
+    displayName: Prepare Test Machine
+    inputs:
+      pwsh: true
+      filePath: scripts/prepare-machine.ps1
+      arguments: -Configuration Test
+
+  - task: PowerShell@2
+    displayName: Run WAN Performance Test
+    timeoutInMinutes: 45
+    inputs:
+      pwsh: true
+      filePath: scripts/emulated-performance.ps1
+      arguments: -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50

--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -7,6 +7,10 @@ parameters:
   config: 'Release'
   arch: 'x64'
   tls: 'schannel'
+  iterations: '5'
+  rateMbps: '(10,50,100)'
+  durationMs: '10'
+  rttMs: '50'
 
 jobs:
 - job: performance_${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}
@@ -42,8 +46,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run WAN Performance Test
-    timeoutInMinutes: 45
     inputs:
       pwsh: true
       filePath: scripts/emulated-performance.ps1
-      arguments: -Debug -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -NumIterations ${{ parameters.iterations }} -BottleneckMbps ${{ parameters.rateMbps }} -DurationMs ${{ parameters.durationMs }} -RttMs ${{ parameters.rttMs }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}

--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -46,4 +46,4 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/emulated-performance.ps1
-      arguments: -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50
+      arguments: -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}

--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -46,4 +46,4 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/emulated-performance.ps1
-      arguments: -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -Debug -NumIterations 10 -BottleneckMbps (10,50,100) -DurationMs 10000 -RttMs 50 -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -92,6 +92,9 @@ if ("" -eq $Tls) {
     }
 }
 
+# Root directory of the project.
+$RootDir = Split-Path $PSScriptRoot -Parent
+
 # Path to the quicperf exectuable.
 $QuicPerf = $null
 if ($IsWindows) {

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -103,6 +103,9 @@ if ($IsWindows) {
     $QuicPerf = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/quicperf"
 }
 
+Get-NetAdapter
+ipconfig -all
+
 # Start the perf server listening.
 $pinfo = New-Object System.Diagnostics.ProcessStartInfo
 $pinfo.FileName = $QuicPerf
@@ -161,7 +164,7 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
 
             # Run the throughput upload test with the current configuration.
             $Output = iex "$QuicPerf -test:tput -bind:192.168.1.12 -target:192.168.1.11 -sendbuf:0 -upload:$ThisDurationMs -timed:1 -pacing:$ThisPacing"
-            if (!$Output.Contains("App Main returning status 0")) {
+            if (!$Output.Contains("App Main returning status 0") -or $Output.Contains("Error:")) {
                 Write-Error $Output
             }
 

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -112,11 +112,6 @@ if ($IsWindows) {
     $QuicPerf = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/quicperf"
 }
 
-# TEMP
-cp c:\windows\system32\dswdevice.exe C:\duonic\
-C:\duonic\duonic.ps1 -uninstall
-C:\duonic\duonic.ps1 -install
-
 Get-NetAdapter | Write-Debug
 ipconfig -all | Write-Debug
 

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -5,6 +5,15 @@ This script runs performance tests with various emulated network conditions. Not
 this script requires duonic to be preinstalled on the system and quicperf.exe to
 be in the current directory.
 
+.PARAMETER Config
+    Specifies the build configuration to test.
+
+.PARAMETER Arch
+    The CPU architecture to test.
+
+.PARAMETER Tls
+    The TLS library test.
+
 .PARAMETER RttMs
     The round trip time(s) for the emulated network.
 
@@ -103,8 +112,12 @@ if ($IsWindows) {
     $QuicPerf = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/quicperf"
 }
 
-Get-NetAdapter
-ipconfig -all
+# TEMP
+C:\duonic\duonic.ps1 -uninstall
+C:\duonic\duonic.ps1 -install
+
+Get-NetAdapter | Write-Debug
+ipconfig -all | Write-Debug
 
 # Start the perf server listening.
 $pinfo = New-Object System.Diagnostics.ProcessStartInfo

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -113,6 +113,7 @@ if ($IsWindows) {
 }
 
 # TEMP
+cp c:\windows\system32\dswdevice.exe C:\duonic\
 C:\duonic\duonic.ps1 -uninstall
 C:\duonic\duonic.ps1 -install
 

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -139,12 +139,14 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
 
     # Configure duonic for the desired network emulation options.
     Write-Debug "Configure NIC: Rtt=$ThisRttMs ms, Bottneck=[$ThisBottleneckMbps mbps, $ThisBottleneckBufferPackets packets], RandomLoss=1/$ThisRandomLossDenominator, ReorderDelayDelta=$ThisReorderDelayDeltaMs ms, RandomReorder=1/$ThisRandomReorderDenominator"
-    Set-NetAdapterAdvancedProperty duo? -DisplayName DelayMs -RegistryValue ([convert]::ToInt32($ThisRttMs/2)) -NoRestart
+    $DelayMs = [convert]::ToInt32([int]($ThisRttMs)/2)
+    Set-NetAdapterAdvancedProperty duo? -DisplayName DelayMs -RegistryValue $DelayMs -NoRestart
     Set-NetAdapterAdvancedProperty duo? -DisplayName RateLimitMbps -RegistryValue $ThisBottleneckMbps -NoRestart
     Set-NetAdapterAdvancedProperty duo? -DisplayName QueueLimitPackets -RegistryValue $ThisBottleneckBufferPackets -NoRestart
     Set-NetAdapterAdvancedProperty duo? -DisplayName RandomLossDenominator -RegistryValue $ThisRandomLossDenominator -NoRestart
     Set-NetAdapterAdvancedProperty duo? -DisplayName ReorderDelayDeltaMs -RegistryValue $ThisRandomReorderDenominator -NoRestart
     Set-NetAdapterAdvancedProperty duo? -DisplayName RandomReorderDenominator -RegistryValue $ThisReorderDelayDeltaMs -NoRestart
+    Write-Debug "Restarting NIC"
     Restart-NetAdapter duo?
     Start-Sleep 5 # (wait for duonic to restart)
 

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -83,10 +83,7 @@ param (
     [Int32[]]$Pacing = (0, 1),
 
     [Parameter(Mandatory = $false)]
-    [Int32]$NumIterations = 1,
-
-    [Parameter(Mandatory = $false)]
-    [string]$BaseBath = ""
+    [Int32]$NumIterations = 1
 )
 
 Set-StrictMode -Version 'Latest'

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -7,6 +7,15 @@ on the provided configuration.
 .PARAMETER Configuration
     The type of configuration to install dependencies for.
 
+.PARAMETER InitSubmodules
+    Dynamically initializes submodules based Tls and Extra configuration knobs.
+
+.PARAMETER Tls
+    The TLS library in use.
+
+.PARAMETER Extra
+    Any extra build flags being used.
+
 .EXAMPLE
     prepare-machine.ps1 -Configuration Build
 
@@ -24,10 +33,10 @@ param (
     [switch]$InitSubmodules,
 
     [Parameter(Mandatory = $false)]
-    [string]$Tls,
+    [string]$Tls = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$Extra
+    [string]$Extra = ""
 )
 
 #Requires -RunAsAdministrator

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -37,6 +37,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [string]$Extra = ""
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Kernel,
 )
 
 #Requires -RunAsAdministrator
@@ -77,6 +80,11 @@ if ($InitSubmodules) {
     if (!$Extra.Contains("-DisableTest")) {
         Write-Host "Initializing googletest submodule"
         git submodule update --remote submodules/googletest
+
+        if ($Kernel) {
+            Write-Host "Initializing wil submodule"
+            git submodule update --remote submodules/wil
+        }
     }
 }
 

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -71,22 +71,22 @@ if ($InitSubmodules) {
 
     if ($Tls -eq "openssl") {
         Write-Host "Initializing openssl submodule"
-        git submodule init openssl
+        git submodule init submodules/openssl
         git submodule update
     } elseif ($Tls -eq "mitls") {
         Write-Host "Initializing everest submodule"
-        git submodule init everest
+        git submodule init submodules/everest
         git submodule update
     }
 
     if (!$Extra.Contains("-DisableTest")) {
         Write-Host "Initializing googletest submodule"
-        git submodule init googletest
+        git submodule init submodules/googletest
         git submodule update
 
         if ($Kernel) {
             Write-Host "Initializing wil submodule"
-            git submodule init wil
+            git submodule init submodules/wil
             git submodule update
         }
     }

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -55,19 +55,19 @@ if ($InitSubmodules) {
         } else {
             $Tls = "openssl"
         }
+    }
 
-        if ($Tls -eq "openssl") {
-            Write-Host "Initializing openssl submodule"
-            git submodule update --remote submodules/openssl
-        } elseif ($Tls -eq "mitls") {
-            Write-Host "Initializing everest submodule"
-            git submodule update --remote submodules/everest
-        }
+    if ($Tls -eq "openssl") {
+        Write-Host "Initializing openssl submodule"
+        git submodule update --remote submodules/openssl
+    } elseif ($Tls -eq "mitls") {
+        Write-Host "Initializing everest submodule"
+        git submodule update --remote submodules/everest
+    }
 
-        if (!$Extra.Contains("-DisableTest")) {
-            Write-Host "Initializing googletest submodule"
-            git submodule update --remote submodules/googletest
-        }
+    if (!$Extra.Contains("-DisableTest")) {
+        Write-Host "Initializing googletest submodule"
+        git submodule update --remote submodules/googletest
     }
 }
 

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -71,19 +71,23 @@ if ($InitSubmodules) {
 
     if ($Tls -eq "openssl") {
         Write-Host "Initializing openssl submodule"
-        git submodule update --remote submodules/openssl
+        git submodule init openssl
+        git submodule update
     } elseif ($Tls -eq "mitls") {
         Write-Host "Initializing everest submodule"
-        git submodule update --remote submodules/everest
+        git submodule init everest
+        git submodule update
     }
 
     if (!$Extra.Contains("-DisableTest")) {
         Write-Host "Initializing googletest submodule"
-        git submodule update --remote submodules/googletest
+        git submodule init googletest
+        git submodule update
 
         if ($Kernel) {
             Write-Host "Initializing wil submodule"
-            git submodule update --remote submodules/wil
+            git submodule init wil
+            git submodule update
         }
     }
 }

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -36,10 +36,10 @@ param (
     [string]$Tls = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$Extra = ""
+    [string]$Extra = "",
 
     [Parameter(Mandatory = $false)]
-    [switch]$Kernel,
+    [switch]$Kernel
 )
 
 #Requires -RunAsAdministrator

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -18,7 +18,16 @@ on the provided configuration.
 param (
     [Parameter(Mandatory = $true)]
     [ValidateSet("Build", "Test", "Dev")]
-    [string]$Configuration
+    [string]$Configuration,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$InitSubmodules,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Tls,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Extra
 )
 
 #Requires -RunAsAdministrator
@@ -36,6 +45,31 @@ $ClogVersion = "0.1.8"
 $ClogDownloadUrl = "https://github.com/microsoft/CLOG/releases/download/v$ClogVersion"
 
 $MessagesAtEnd = New-Object Collections.Generic.List[string]
+
+if ($InitSubmodules) {
+
+    # Default TLS based on current platform.
+    if ("" -eq $Tls) {
+        if ($IsWindows) {
+            $Tls = "schannel"
+        } else {
+            $Tls = "openssl"
+        }
+
+        if ($Tls -eq "openssl") {
+            Write-Host "Initializing openssl submodule"
+            git submodule update --remote submodules/openssl
+        } elseif ($Tls -eq "mitls") {
+            Write-Host "Initializing everest submodule"
+            git submodule update --remote submodules/everest
+        }
+
+        if (!$Extra.Contains("-DisableTest")) {
+            Write-Host "Initializing googletest submodule"
+            git submodule update --remote submodules/googletest
+        }
+    }
+}
 
 function Install-ClogTool {
     param($ToolName)

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -16,6 +16,9 @@ on the provided configuration.
 .PARAMETER Extra
     Any extra build flags being used.
 
+.PARAMETER Kernel
+    Indicates build is for kernel mode.
+
 .EXAMPLE
     prepare-machine.ps1 -Configuration Build
 


### PR DESCRIPTION
- Adds a new wanperf pipeline to manually run wanperf on AZP machines.
- Improves the build pipelines to get only the necessary submodules.
- Fixes a few 'condition' issues with build pipeline yamls.