### PR TITLE
Add a missing dependency: Threads

### DIFF
--- a/src/perf/bin/CMakeLists.txt
+++ b/src/perf/bin/CMakeLists.txt
@@ -12,4 +12,5 @@ add_executable(quicperf ${SOURCES} histogram/hdr_histogram.c)
 
 set_property(TARGET quicperf PROPERTY FOLDER "perf")
 
-target_link_libraries(quicperf inc warnings perflib msquic platform perfbin.clog)
+find_package(Threads)
+target_link_libraries(quicperf inc warnings perflib msquic platform perfbin.clog ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
In a custom kernel (variants of Linux), `quicperf` gave me a following message:

```
/msquic/build/bin/Debug/quicperf: ignoring missing symbol pthread_attr_setschedparam
```
, which was solved by the attached fix.

Despite the running environment differing, I think it is still `msquic`'s responsibility to ensure seamless linking.
On an Ubuntu kernel, there occured no such message; maybe the kernel supplied an appropriate `pthread` library to the executable (maybe by default).

I will leave other possible, lurking dependency issues to others.