### PR TITLE
Fix windows build to build with conformant preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(WIN32)
     endif()
 
     set(QUIC_C_FLAGS ${QUIC_COMMON_FLAGS})
-    set(QUIC_CXX_FLAGS ${QUIC_COMMON_FLAGS} /EHsc)
+    set(QUIC_CXX_FLAGS ${QUIC_COMMON_FLAGS} /EHsc /permissive-)
 
     # These cannot be updated until CMake 3.13
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /GL /Zi")

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -6,7 +6,7 @@
 add_library(inc INTERFACE)
 
 target_compile_options(inc INTERFACE ${QUIC_C_FLAGS})
-target_compile_options(inc INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${QUIC_CXX_FLAGS}> /permissive-)
+target_compile_options(inc INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${QUIC_CXX_FLAGS}>)
 
 target_compile_definitions(inc INTERFACE ${QUIC_COMMON_DEFINES})
 target_include_directories(inc INTERFACE ${QUIC_INCLUDE_DIR})

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -6,16 +6,13 @@
 add_library(inc INTERFACE)
 
 target_compile_options(inc INTERFACE ${QUIC_C_FLAGS})
-target_compile_options(inc INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${QUIC_CXX_FLAGS}>)
+target_compile_options(inc INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${QUIC_CXX_FLAGS}> /permissive-)
 
 target_compile_definitions(inc INTERFACE ${QUIC_COMMON_DEFINES})
 target_include_directories(inc INTERFACE ${QUIC_INCLUDE_DIR})
 
 target_compile_features(inc INTERFACE cxx_std_17)
-
-if (NOT MSVC)
-    target_compile_features(inc INTERFACE c_std_11)
-endif()
+target_compile_features(inc INTERFACE c_std_11)
 
 if (NOT MSVC AND QUIC_ENABLE_SANITIZERS)
     target_link_libraries(inc INTERFACE -fsanitize=address,leak,undefined)

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -157,10 +157,12 @@ QuicPlatformLogAssert(
     _In_z_ const char* Expr
     );
 
+#define QUIC_WIDE_STRING(_str) L##_str
+
 #define QUIC_ASSERT_ACTION(_exp) \
     ((!(_exp)) ? \
         (QuicPlatformLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", L#_exp), \
+         __annotation(L"Debug", L"AssertFail", QUIC_WIDE_STRING(#_exp)), \
          DbgRaiseAssertionFailure(), FALSE) : \
         TRUE)
 

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -37,6 +37,7 @@ Environment:
 #pragma warning(disable:26036)
 #pragma warning(disable:28252)
 #pragma warning(disable:28253)
+#pragma warning(disable:5105) // The conformant preprocessor along with the newest SDK throws this warning for a macro.
 #include <windows.h>
 #include <winsock2.h>
 #include <iphlpapi.h>
@@ -142,10 +143,12 @@ QuicPlatformLogAssert(
     _In_z_ const char* Expr
     );
 
+#define QUIC_WIDE_STRING(_str) L##_str
+
 #define QUIC_ASSERT_ACTION(_exp) \
     ((!(_exp)) ? \
         (QuicPlatformLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", L#_exp), \
+         __annotation(L"Debug", L"AssertFail", QUIC_WIDE_STRING(#_exp)), \
          DbgRaiseAssertionFailure(), FALSE) : \
         TRUE)
 

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -164,8 +164,12 @@ QuicEtwCallback(
 #pragma warning(pop)
 
 #define QuicTraceEventEnabled(Name) EventEnabledQuic##Name()
+#if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
 #define _QuicTraceEvent(Name, Args) EventWriteQuic##Name##Args
 #define QuicTraceEvent(Name, Fmt, ...) _QuicTraceEvent(Name, (__VA_ARGS__))
+#else
+#define QuicTraceEvent(Name, Fmt, ...) EventWriteQuic##Name (__VA_ARGS__)
+#endif
 
 #define CLOG_BYTEARRAY(Len, Data) (uint8_t)(Len), (uint8_t*)(Data)
 


### PR DESCRIPTION
A few changes to macro string and vararg expansion, but the build still works in both conforming and non conforming mode. Necessary for future proofing when MSVC defaults to the conforming preprocessor in a few years