### PR TITLE
Add WanPerf to CI

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -221,6 +221,20 @@ stages:
       remoteTls: openssl
       testTypes: 'Loopback'
 
+- stage: wanperf
+  displayName: WAN Performance Testing
+  dependsOn:
+  - build_windows
+  jobs:
+  - template: ./templates/run-wanperf.yml
+    parameters:
+      iterations: 3
+      durationMs: 10000
+      rateMbps: 100
+      bottleneckQueueRatio: (0.25,1.0)
+      rttMs: (5,50,200)
+      logProfile: Datapath.Light
+
 #
 # Kernel Build Verification Tests
 #


### PR DESCRIPTION
Just runs the tests for now. Next steps include uploading/persisting the results on mainline (like other perf tests) and then adding regression prevention.