### PR TITLE
Use the Same CWND Min for Congestion Events

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -269,7 +269,7 @@ QuicCongestionControlOnCongestionEvent(
     Cc->SlowStartThreshold =
     Cc->CongestionWindow =
         max(
-            (uint32_t)Connection->Paths[0].Mtu * Cc->InitialWindowPackets,
+            (uint32_t)Connection->Paths[0].Mtu * QUIC_PERSISTENT_CONGESTION_WINDOW_PACKETS,
             Cc->CongestionWindow * TEN_TIMES_BETA_CUBIC / 10);
 }
 


### PR DESCRIPTION
In low bandwidth/small-bottleneck-queue scenarios, perf is pretty bad because we never reduce CWND below initial window size. This fixes the "congestion event" code path to use the same min as "persistent congestion event" (which is what the spec says too).