### PR TITLE
Bump openssl cache number (#1069)

### DIFF
--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -26,7 +26,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_3" | .gitmodules'
+      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_4" | .gitmodules'
       path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
     displayName: Cache OpenSSL
     condition: eq('${{ parameters.tls }}', 'openssl')


### PR DESCRIPTION
The CI setup is now fixed, but the build caches are incorrect. Bump the number to force a rebuild.

Cherry picked from main