### PR TITLE
Don't Include Packet Processing Time in RTT

### DIFF
--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -101,6 +101,7 @@ void
 QuicAckTrackerAckPacket(
     _Inout_ QUIC_ACK_TRACKER* Tracker,
     _In_ uint64_t PacketNumber,
+    _In_ uint64_t RecvTimeUs,
     _In_ QUIC_ECN_TYPE ECN,
     _In_ BOOLEAN AckElicitingPayload
     )
@@ -143,7 +144,7 @@ QuicAckTrackerAckPacket(
     BOOLEAN NewLargestPacketNumber =
         PacketNumber == QuicRangeGetMax(&Tracker->PacketNumbersToAck);
     if (NewLargestPacketNumber) {
-        Tracker->LargestPacketNumberRecvTime = QuicTimeUs64();
+        Tracker->LargestPacketNumberRecvTime = RecvTimeUs;
     }
 
     switch (ECN) {

--- a/src/core/ack_tracker.h
+++ b/src/core/ack_tracker.h
@@ -99,6 +99,7 @@ void
 QuicAckTrackerAckPacket(
     _Inout_ QUIC_ACK_TRACKER* Tracker,
     _In_ uint64_t PacketNumber,
+    _In_ uint64_t RecvTimeUs,
     _In_ QUIC_ECN_TYPE ECN,
     _In_ BOOLEAN AckElicitingPayload
     );

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3699,6 +3699,7 @@ QuicConnRecvFrames(
     BOOLEAN Closed = Connection->State.ClosedLocally || Connection->State.ClosedRemotely;
     const uint8_t* Payload = Packet->Buffer + Packet->HeaderLength;
     uint16_t PayloadLength = Packet->PayloadLength;
+    uint64_t RecvTime = QuicTimeUs64();
 
     uint16_t Offset = 0;
     while (Offset < PayloadLength) {
@@ -4464,6 +4465,7 @@ Done:
         QuicAckTrackerAckPacket(
             &Connection->Packets[EncryptLevel]->AckTracker,
             Packet->PacketNumber,
+            RecvTime,
             ECN,
             AckPacketImmediately);
     }


### PR DESCRIPTION
Fix #1077. Include packet processing time in ACK delay (and therefor not in RTT measurement) by grabbing `Now()` before we process the frames instead of after.