### PR TITLE
Cherry Pick: Fix nullptr deref in test stream creation on connection failure. (#1080)

### DIFF
--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -126,6 +126,11 @@ TestConnection::NewStream(
 {
     auto Stream = TestStream::FromConnectionHandle(QuicConnection, StreamShutdownHandler, Flags);
 
+    if (Stream == nullptr) {
+        // Failure reason has already been logged by FromConnectionHandle
+        return nullptr;
+    }
+
     if (StartType != NEW_STREAM_START_NONE) {
         QUIC_STATUS Status =
             Stream->Start(

--- a/src/test/lib/TestStream.cpp
+++ b/src/test/lib/TestStream.cpp
@@ -75,6 +75,9 @@ TestStream::FromConnectionHandle(
     auto Stream = new(std::nothrow) TestStream(QuicStreamHandle, StreamShutdownHandler, IsUnidirectionalStream, true);
     if (Stream == nullptr || !Stream->IsValid()) {
         TEST_FAILURE("Failed to create new TestStream.");
+        if (Stream == nullptr) {
+            MsQuic->StreamClose(QuicStreamHandle);
+        }
         delete Stream;
         return nullptr;
     }


### PR DESCRIPTION
If the stream in FromConnectionHandle returns null, that was never checked, and a bugcheck would occur.

Also fixes a memory leak in FromConnectionHandle when an OOM occurs.

Cherry picked from main.