### PR TITLE
Replace Output Directory with Path

### DIFF
--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -219,7 +219,7 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
                 $TestLogDir = Join-Path $LogDir "$ThisRttMs.$ThisBottleneckMbps.$ThisBottleneckBufferPackets.$ThisRandomLossDenominator.$ThisRandomReorderDenominator.$ThisReorderDelayDeltaMs.$ThisDurationMs.$ThisPacing.$i.$Rate"
                 mkdir $TestLogDir | Out-Null
                 try {
-                    & $LogScript -Stop -OutputDirectory $TestLogDir -RawLogOnly | Out-Null
+                    & $LogScript -Stop -OutputPath $TestLogDir -RawLogOnly | Out-Null
                 } catch {
                     Write-Debug "Logging exception"
                 }

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -216,10 +216,9 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
             $Results.Add($Rate) | Out-Null
 
             if ($LogProfile -ne "None") {
-                $TestLogDir = Join-Path $LogDir "$ThisRttMs.$ThisBottleneckMbps.$ThisBottleneckBufferPackets.$ThisRandomLossDenominator.$ThisRandomReorderDenominator.$ThisReorderDelayDeltaMs.$ThisDurationMs.$ThisPacing.$i.$Rate"
-                mkdir $TestLogDir | Out-Null
+                $TestLogPath = Join-Path $LogDir "$ThisRttMs.$ThisBottleneckMbps.$ThisBottleneckBufferPackets.$ThisRandomLossDenominator.$ThisRandomReorderDenominator.$ThisReorderDelayDeltaMs.$ThisDurationMs.$ThisPacing.$i.$Rate"
                 try {
-                    & $LogScript -Stop -OutputPath $TestLogDir -RawLogOnly | Out-Null
+                    & $LogScript -Stop -OutputPath $TestLogPath -RawLogOnly | Out-Null
                 } catch {
                     Write-Debug "Logging exception"
                 }

--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -173,7 +173,7 @@ function Log-Stop {
         Invoke-Expression "lttng stop $InstanceName" | Write-Debug
 
         $LTTNGTarFile = $OutputPath + ".tgz"
-        $BableTraceFile = $OutputPath ".babel.txt"
+        $BableTraceFile = $OutputPath + ".babel.txt"
 
         Write-Host "tar/gzip LTTng log files: $LTTNGTarFile"
         tar -cvzf $LTTNGTarFile $TempDir | Write-Debug

--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -53,7 +53,7 @@ param (
     [switch]$Stop = $false,
 
     [Parameter(Mandatory = $true, ParameterSetName='Stop')]
-    [string]$OutputDirectory = "",
+    [string]$OutputPath = "",
 
     [Parameter(Mandatory = $false, ParameterSetName='Stop')]
     [switch]$RawLogOnly = $false,
@@ -149,10 +149,10 @@ function Log-Cancel {
 # Stops log collection, keeping the logs.
 function Log-Stop {
     if ($IsWindows) {
-        $EtlPath = Join-Path $OutputDirectory "quic.etl"
+        $EtlPath = $OutputPath + ".etl"
         wpr.exe -stop $EtlPath -instancename $InstanceName 2>&1
         if (!$RawLogOnly) {
-            $LogPath = Join-Path $OutputDirectory "quic.log"
+            $LogPath = $OutputPath + ".log"
             $Command = "netsh trace convert $($EtlPath) output=$($LogPath) overwrite=yes report=no"
             if ($TmfPath -ne "" -and (Test-Path $TmfPath)) {
                 $Command += " tmfpath=$TmfPath"
@@ -160,10 +160,10 @@ function Log-Stop {
             Invoke-Expression $Command
         }
     } else {
-        $ClogOutputDecodeFile = Join-Path $OutputDirectory "quic.log"
+        $ClogOutputDecodeFile = $OutputPath + ".log"
 
-        if (!(Test-Path $OutputDirectory)) {
-            New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
+        if (!(Test-Path $OutputPath)) {
+            New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
         }
 
         if (!(Test-Path $TempDir)) {
@@ -172,8 +172,8 @@ function Log-Stop {
 
         Invoke-Expression "lttng stop $InstanceName" | Write-Debug
 
-        $LTTNGTarFile = Join-Path $OutputDirectory "lttng_trace.tgz"
-        $BableTraceFile = Join-Path $OutputDirectory "babeltrace.txt"
+        $LTTNGTarFile = $OutputPath + ".tgz"
+        $BableTraceFile = $OutputPath ".babel.txt"
 
         Write-Host "tar/gzip LTTng log files: $LTTNGTarFile"
         tar -cvzf $LTTNGTarFile $TempDir | Write-Debug

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -109,7 +109,7 @@ $LogScript = Join-Path $RootDir "scripts" "log.ps1"
 $ExeName = Split-Path $Path -Leaf
 $CoverageName = "$(Split-Path $Path -LeafBase).cov"
 
-# Folder for log files.
+# Path for log files.
 $LogDir = Join-Path $RootDir "artifacts" "logs" $ExeName (Get-Date -UFormat "%m.%d.%Y.%T").Replace(':','.')
 New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
 
@@ -318,7 +318,7 @@ function Wait-Executable($Exe) {
                 if ($CodeCoverage) {
                     & $LogScript -Cancel | Out-Null
                 } else {
-                    & $LogScript -Stop -OutputPath $LogDir -Tmfpath (Join-Path $RootDir "artifacts" "tmf")
+                    & $LogScript -Stop -OutputPath (Join-Path $LogDir "quic") -Tmfpath (Join-Path $RootDir "artifacts" "tmf")
                 }
             }
 

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -318,7 +318,7 @@ function Wait-Executable($Exe) {
                 if ($CodeCoverage) {
                     & $LogScript -Cancel | Out-Null
                 } else {
-                    & $LogScript -Stop -OutputDirectory $LogDir -Tmfpath (Join-Path $RootDir "artifacts" "tmf")
+                    & $LogScript -Stop -OutputPath $LogDir -Tmfpath (Join-Path $RootDir "artifacts" "tmf")
                 }
             }
 

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -466,7 +466,7 @@ function Wait-TestCase($TestCase) {
         if ($KeepOutputOnSuccess -or $ProcessCrashed -or $AnyTestFailed) {
 
             if ($LogProfile -ne "None") {
-                & $LogScript -Stop -OutputDirectory $TestCase.LogDir
+                & $LogScript -Stop -OutputPath $TestCase.LogDir
             }
 
             if ($stdout) {

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -466,7 +466,7 @@ function Wait-TestCase($TestCase) {
         if ($KeepOutputOnSuccess -or $ProcessCrashed -or $AnyTestFailed) {
 
             if ($LogProfile -ne "None") {
-                & $LogScript -Stop -OutputPath $TestCase.LogDir
+                & $LogScript -Stop -OutputPath (Join-Path $TestCase.LogDir "quic")
             }
 
             if ($stdout) {

--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -32,8 +32,8 @@ if ($Clean) {
 }
 
 foreach ($File in $Files) {
-    clog -p windows --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
-    clog -p windows_kernel --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
-    clog -p stubs --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
-    clog -p linux --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
+    clog -p windows --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
+    clog -p windows_kernel --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
+    clog -p stubs --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
+    clog -p linux --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
 }


### PR DESCRIPTION
Removes the extra directory level for logging. It's unnecessary, IMO.