### PR TITLE
TCP WAN Perf Support via netput

### DIFF
--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -86,6 +86,9 @@ param (
     [Int32]$NumIterations = 1,
 
     [Parameter(Mandatory = $false)]
+    [Int32[]]$UseTcp = 0,
+
+    [Parameter(Mandatory = $false)]
     [ValidateSet("None", "Datapath.Light", "Datapath.Verbose", "Performance.Light", "Performance.Verbose")]
     [string]$LogProfile = "None"
 )
@@ -128,21 +131,50 @@ if ($IsWindows) {
     $QuicPerf = Join-Path $RootDir "/artifacts/bin/linux/$($Arch)_$($Config)_$($Tls)/quicperf"
 }
 
+# Path to the netput exectuable.
+$NetPut = "C:\Windows\System32\netput.exe"
+
 Get-NetAdapter | Write-Debug
 ipconfig -all | Write-Debug
 
-# Start the perf server listening.
-$pinfo = New-Object System.Diagnostics.ProcessStartInfo
-$pinfo.FileName = $QuicPerf
-$pinfo.Arguments = "-selfsign:1"
-$pinfo.UseShellExecute = $false
-$p = New-Object System.Diagnostics.Process
-$p.StartInfo = $pinfo
-$p.Start() | Out-Null
+# Start the perf server(s) listening.
+if ($UseTcp.Contains(0)) {
+    Write-Debug "Starting QUIC server..."
+    if (!(Test-Path -Path $QuicPerf)) {
+        Write-Error "Missing file: $QuicPerf"
+    }
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = $QuicPerf
+    $pinfo.Arguments = "-selfsign:1"
+    $pinfo.UseShellExecute = $false
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.RedirectStandardError = $true
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $pinfo
+    $p.Start() | Out-Null
+}
+
+if ($UseTcp.Contains(1)) {
+    Write-Debug "Starting TCP server..."
+    if (!(Test-Path -Path $NetPut)) {
+        Write-Error "Missing file: $NetPut"
+    }
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = $NetPut
+    $pinfo.Arguments = "-s"
+    $pinfo.UseShellExecute = $false
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.RedirectStandardError = $true
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $pinfo
+    $p.Start() | Out-Null
+}
+
+# Wait for the server(s) to come up.
 Sleep -Seconds 1
 
 # CSV header
-$Header = "RttMs, BottleneckMbps, BottleneckBufferPackets, RandomLossDenominator, RandomReorderDenominator, ReorderDelayDeltaMs, DurationMs, Pacing, RateKbps"
+$Header = "RttMs, BottleneckMbps, BottleneckBufferPackets, RandomLossDenominator, RandomReorderDenominator, ReorderDelayDeltaMs, Tcp, DurationMs, Pacing, RateKbps"
 for ($i = 0; $i -lt $NumIterations; $i++) {
     $Header += ", RawRateKbps$($i+1)"
 }
@@ -183,6 +215,7 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
     Start-Sleep 5 # (wait for duonic to restart)
 
     # Loop over all the test configurations.
+    foreach ($ThisUseTcp in $UseTcp) {
     foreach ($ThisDurationMs in $DurationMs) {
     foreach ($ThisPacing in $Pacing) {
 
@@ -201,22 +234,49 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
 
             # Run the throughput upload test with the current configuration.
             Write-Debug "Run upload test: Iteration=$($i + 1)"
-            $Output = iex "$QuicPerf -test:tput -bind:192.168.1.12 -target:192.168.1.11 -sendbuf:0 -upload:$ThisDurationMs -timed:1 -pacing:$ThisPacing"
-            if (!$Output.Contains("App Main returning status 0") -or $Output.Contains("Error:")) {
-                if ($LogProfile -ne "None") {
-                    & $LogScript -Cancel | Out-Null
+
+            $Rate = 0
+            if ($ThisUseTcp -eq 0) {
+                $Command = "$QuicPerf -test:tput -bind:192.168.1.12 -target:192.168.1.11 -sendbuf:0 -upload:$ThisDurationMs -timed:1 -pacing:$ThisPacing"
+                Write-Debug $Command
+                $Output = [string](iex $Command)
+                Write-Debug $Output
+                if (!$Output.Contains("App Main returning status 0") -or $Output.Contains("Error:")) {
+                    if ($LogProfile -ne "None") {
+                        & $LogScript -Cancel | Out-Null
+                    }
+                    Write-Error $Output
                 }
-                Write-Error $Output
+
+                # Grab the rate from the output text. Example:
+                #   Started!  Result: 23068672 bytes @ 18066 kbps (10215.203 ms). App Main returning status 0
+                $Rate = [int]$Output.Split(" ")[6]
+
+            } else {
+                $EstimatedLength = ($ThisBottleneckMbps * $ThisDurationMs * 1000) / 8;
+                $IoSize = 50000 # netput default
+                $IoCount = 1 + ($EstimatedLength / $IoSize)
+                $Command = "$NetPut -c 192.168.1.11 -b 192.168.1.12 -tx -ss $IoSize -n $IoCount"
+                Write-Debug $Command
+                $Output = [string](iex $Command)
+                Write-Debug $Output
+                if ($Output.Contains("connect failed")) {
+                    if ($LogProfile -ne "None") {
+                        & $LogScript -Cancel | Out-Null
+                    }
+                    Write-Error $Output
+                }
+
+                # Grab the rate from the output text. Example:
+                #   Connection established TCP TX 25050000 bytes, 501 calls, 10.813 sec, 2.32 MBps, 18.53 Mbps
+                $Rate = [int](([double]$Output.Split(" ")[-2]) * 1000.0)
             }
 
-            # Grab the result from the output text.
-            $Result = $Output.Split([Environment]::NewLine)[-2]
-            Write-Debug $Result
-            $Rate = [int]$Result.Split(" ")[4]
+            Write-Debug "$Rate Kbps"
             $Results.Add($Rate) | Out-Null
 
             if ($LogProfile -ne "None") {
-                $TestLogPath = Join-Path $LogDir "$ThisRttMs.$ThisBottleneckMbps.$ThisBottleneckBufferPackets.$ThisRandomLossDenominator.$ThisRandomReorderDenominator.$ThisReorderDelayDeltaMs.$ThisDurationMs.$ThisPacing.$i.$Rate"
+                $TestLogPath = Join-Path $LogDir "$ThisRttMs.$ThisBottleneckMbps.$ThisBottleneckBufferPackets.$ThisRandomLossDenominator.$ThisRandomReorderDenominator.$ThisReorderDelayDeltaMs.$ThisUseTcp.$ThisDurationMs.$ThisPacing.$i.$Rate"
                 try {
                     & $LogScript -Stop -OutputPath $TestLogPath -RawLogOnly | Out-Null
                 } catch {
@@ -227,11 +287,11 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
 
         # Grab the average result and write the CSV output.
         $RateKbps = [int]($Results | Measure-Object -Average).Average
-        $Row = "$ThisRttMs, $ThisBottleneckMbps, $ThisBottleneckBufferPackets, $ThisRandomLossDenominator, $ThisRandomReorderDenominator, $ThisReorderDelayDeltaMs, $ThisDurationMs, $ThisPacing, $RateKbps"
+        $Row = "$ThisRttMs, $ThisBottleneckMbps, $ThisBottleneckBufferPackets, $ThisRandomLossDenominator, $ThisRandomReorderDenominator, $ThisReorderDelayDeltaMs, $ThisUseTcp, $ThisDurationMs, $ThisPacing, $RateKbps"
         for ($i = 0; $i -lt $NumIterations; $i++) {
             $Row += ", $($Results[$i])"
         }
         Write-Host $Row
-    }}
+    }}}
 
 }}}}}}


### PR DESCRIPTION
Adds `netput.exe` support to our WAN perf script.

Currently, netput is an unencrypted TCP app that doesn't quite produce an apples to apples comparison. My short term goal will be to add TLS encryption support to netput. My long term goal will be to produce a cross-platform TLS/TCP platform datapath abstraction layer to use for more accurate (secured) TCP performance comparisons.