### PR TITLE
Update CLOG to clean up sidecar

### DIFF
--- a/scripts/install-powershell-docker.sh
+++ b/scripts/install-powershell-docker.sh
@@ -12,10 +12,10 @@ dotnet tool install -g powershell
 
 mkdir nuget
 
-wget https://github.com/microsoft/CLOG/releases/download/v0.1.9/Microsoft.Logging.CLOG.0.1.9.nupkg
-mv Microsoft.Logging.CLOG.0.1.9.nupkg nuget/Microsoft.Logging.CLOG.0.1.9.nupkg
+wget https://github.com/microsoft/CLOG/releases/download/v0.2.0/Microsoft.Logging.CLOG.0.2.0.nupkg
+mv Microsoft.Logging.CLOG.0.2.0.nupkg nuget/Microsoft.Logging.CLOG.0.2.0.nupkg
 dotnet tool install --global --add-source nuget Microsoft.Logging.CLOG
 
-wget https://github.com/microsoft/CLOG/releases/download/v0.1.9/Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg
-mv Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg nuget/Microsoft.Logging.CLOG2Text.Lttng.0.1.9.nupkg
+wget https://github.com/microsoft/CLOG/releases/download/v0.2.0/Microsoft.Logging.CLOG2Text.Lttng.0.2.0.nupkg
+mv Microsoft.Logging.CLOG2Text.Lttng.0.2.0.nupkg nuget/Microsoft.Logging.CLOG2Text.Lttng.0.2.0.nupkg
 dotnet tool install --global --add-source nuget Microsoft.Logging.CLOG2Text.Lttng

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -56,7 +56,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $NuGetPath = Join-Path $RootDir "nuget"
 
 # Well-known location for clog packages.
-$ClogVersion = "0.1.9"
+$ClogVersion = "0.2.0"
 $ClogDownloadUrl = "https://github.com/microsoft/CLOG/releases/download/v$ClogVersion"
 
 $MessagesAtEnd = New-Object Collections.Generic.List[string]

--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -28,12 +28,12 @@ $OutputDir = Join-Path $RootDir "build" "tmp"
 New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
 if ($Clean) {
-    Remove-Item $Sidecar -Force | Out-Null
+    Remove-Item $Sidecar -Force -ErrorAction Ignore | Out-Null
 }
 
 foreach ($File in $Files) {
-    clog -p windows --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
-    clog -p windows_kernel --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
-    clog -p stubs --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
-    clog -p linux --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --OutputPath "$OutputDir"
+    clog -p windows --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
+    clog -p windows_kernel --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
+    clog -p stubs --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
+    clog -p linux --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"
 }

--- a/src/inc/quic_driver_helpers.h
+++ b/src/inc/quic_driver_helpers.h
@@ -298,7 +298,7 @@ public:
             return false;
         }
         QuicTraceLogVerbose(
-            TestSendIoctl,
+            TestReadIoctl,
             "[test] Sending Read IOCTL %u.",
             IoGetFunctionCodeFromCtlCode(IoControlCode));
         if (!DeviceIoControl(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -7,34 +7,15 @@
       "UniqueId": "LibraryErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"WdfDriverCreate\"",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "PacketRxMarkedForAck": {
       "ModuleProperites": {},
@@ -42,42 +23,19 @@
       "UniqueId": "PacketRxMarkedForAck",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ECN",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "ApiEnter": {
       "ModuleProperites": {},
@@ -85,34 +43,15 @@
       "UniqueId": "ApiEnter",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QUIC_TRACE_API_CONNECTION_OPEN",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "RegistrationHandle",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ApiExitStatus": {
       "ModuleProperites": {},
@@ -120,62 +59,25 @@
       "UniqueId": "ApiExitStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ApiWaitOperation": {
       "ModuleProperites": {},
       "TraceString": "[ api] Waiting on operation",
       "UniqueId": "ApiWaitOperation",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ApiExit": {
       "ModuleProperites": {},
       "TraceString": "[ api] Exit",
       "UniqueId": "ApiExit",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "AllocFailure": {
       "ModuleProperites": {},
@@ -183,34 +85,15 @@
       "UniqueId": "AllocFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Server name\"",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ServerNameLength + 1",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "StreamError": {
       "ModuleProperites": {},
@@ -218,34 +101,15 @@
       "UniqueId": "StreamError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Send request total length exceeds max\"",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnError": {
       "ModuleProperites": {},
@@ -253,34 +117,15 @@
       "UniqueId": "ConnError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Send request total length exceeds max\"",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingListenerAlreadyRegistered": {
       "ModuleProperites": {},
@@ -288,34 +133,15 @@
       "UniqueId": "BindingListenerAlreadyRegistered",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ExistingListener",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "BindingSendFailed": {
       "ModuleProperites": {},
@@ -323,52 +149,22 @@
       "UniqueId": "BindingSendFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "PacketTxVersionNegotiation": {
       "ModuleProperites": {},
       "TraceString": "[S][TX][-] VN",
       "UniqueId": "PacketTxVersionNegotiation",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxStatelessReset": {
       "ModuleProperites": {},
@@ -376,26 +172,11 @@
       "UniqueId": "PacketTxStatelessReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                SendDatagram->Buffer + PacketLength - QUIC_STATELESS_RESET_TOKEN_LENGTH,\r\n                QUIC_STATELESS_RESET_TOKEN_LENGTH\r\n            ).Buffer",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxRetry": {
       "ModuleProperites": {},
@@ -403,58 +184,27 @@
       "UniqueId": "PacketTxRetry",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "RecvPacket->LH->Version",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)sizeof(Token)",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "BindingSendTestDrop": {
       "ModuleProperites": {},
@@ -462,26 +212,11 @@
       "UniqueId": "BindingSendTestDrop",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "BindingErrorStatus": {
       "ModuleProperites": {},
@@ -489,42 +224,19 @@
       "UniqueId": "BindingErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Create reset token hash\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingCreated": {
       "ModuleProperites": {},
@@ -532,50 +244,23 @@
       "UniqueId": "BindingCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding->DatapathBinding",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(DatapathLocalAddr), &DatapathLocalAddr)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(DatapathRemoteAddr), &DatapathRemoteAddr)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingCleanup": {
       "ModuleProperites": {},
@@ -583,26 +268,11 @@
       "UniqueId": "BindingCleanup",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingDestroyed": {
       "ModuleProperites": {},
@@ -610,26 +280,11 @@
       "UniqueId": "BindingDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingRundown": {
       "ModuleProperites": {},
@@ -637,50 +292,23 @@
       "UniqueId": "BindingRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding->DatapathBinding",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(DatapathLocalAddr), &DatapathLocalAddr)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(DatapathRemoteAddr), &DatapathRemoteAddr)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "BindingExecOper": {
       "ModuleProperites": {},
@@ -688,34 +316,15 @@
       "UniqueId": "BindingExecOper",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "OperationType",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConfigurationOpenStorageFailed": {
       "ModuleProperites": {},
@@ -723,34 +332,15 @@
       "UniqueId": "ConfigurationOpenStorageFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "ConfigurationOpenAppStorageFailed": {
       "ModuleProperites": {},
@@ -758,34 +348,15 @@
       "UniqueId": "ConfigurationOpenAppStorageFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "ConfigurationSettingsUpdated": {
       "ModuleProperites": {},
@@ -793,34 +364,15 @@
       "UniqueId": "ConfigurationSettingsUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "&Configuration->Settings",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "ConfigurationSetSettings": {
       "ModuleProperites": {},
@@ -828,26 +380,11 @@
       "UniqueId": "ConfigurationSetSettings",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "ConfigurationCreated": {
       "ModuleProperites": {},
@@ -855,34 +392,15 @@
       "UniqueId": "ConfigurationCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConfigurationCleanup": {
       "ModuleProperites": {},
@@ -890,26 +408,11 @@
       "UniqueId": "ConfigurationCleanup",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConfigurationDestroyed": {
       "ModuleProperites": {},
@@ -917,26 +420,11 @@
       "UniqueId": "ConfigurationDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConfigurationRundown": {
       "ModuleProperites": {},
@@ -944,34 +432,15 @@
       "UniqueId": "ConfigurationRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration->Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnCubic": {
       "ModuleProperites": {},
@@ -979,58 +448,27 @@
       "UniqueId": "ConnCubic",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.SlowStartThreshold",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.KCubic",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.WindowMax",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.WindowLastMax",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnCongestion": {
       "ModuleProperites": {},
@@ -1038,26 +476,11 @@
       "UniqueId": "ConnCongestion",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnPersistentCongestion": {
       "ModuleProperites": {},
@@ -1065,26 +488,11 @@
       "UniqueId": "ConnPersistentCongestion",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnRecoveryExit": {
       "ModuleProperites": {},
@@ -1092,26 +500,11 @@
       "UniqueId": "ConnRecoveryExit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "PacketRxStatelessReset": {
       "ModuleProperites": {},
@@ -1119,26 +512,11 @@
       "UniqueId": "PacketRxStatelessReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(PacketResetToken, QUIC_STATELESS_RESET_TOKEN_LENGTH).Buffer",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketRxNotAcked": {
       "ModuleProperites": {},
@@ -1146,34 +524,15 @@
       "UniqueId": "PacketRxNotAcked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "RecvVerNegNoMatch": {
       "ModuleProperites": {},
@@ -1181,26 +540,11 @@
       "UniqueId": "RecvVerNegNoMatch",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "ApiEventNoHandler": {
       "ModuleProperites": {},
@@ -1208,26 +552,11 @@
       "UniqueId": "ApiEventNoHandler",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "ApiEventAlreadyClosed": {
       "ModuleProperites": {},
@@ -1235,26 +564,11 @@
       "UniqueId": "ApiEventAlreadyClosed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "NoReplacementCidForRetire": {
       "ModuleProperites": {},
@@ -1262,26 +576,11 @@
       "UniqueId": "NoReplacementCidForRetire",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "NonActivePathCidRetired": {
       "ModuleProperites": {},
@@ -1289,26 +588,11 @@
       "UniqueId": "NonActivePathCidRetired",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "IgnoreUnreachable": {
       "ModuleProperites": {},
@@ -1316,26 +600,11 @@
       "UniqueId": "IgnoreUnreachable",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "IgnoreFrameAfterClose": {
       "ModuleProperites": {},
@@ -1343,42 +612,19 @@
       "UniqueId": "IgnoreFrameAfterClose",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FrameType",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "StreamId",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "InvalidInitialPackets": {
       "ModuleProperites": {},
@@ -1386,26 +632,11 @@
       "UniqueId": "InvalidInitialPackets",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "UnreachableIgnore": {
       "ModuleProperites": {},
@@ -1413,26 +644,11 @@
       "UniqueId": "UnreachableIgnore",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "UnreachableInvalid": {
       "ModuleProperites": {},
@@ -1440,26 +656,11 @@
       "UniqueId": "UnreachableInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "CloseUserCanceled": {
       "ModuleProperites": {},
@@ -1467,26 +668,11 @@
       "UniqueId": "CloseUserCanceled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "CloseComplete": {
       "ModuleProperites": {},
@@ -1494,26 +680,11 @@
       "UniqueId": "CloseComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "Restart": {
       "ModuleProperites": {},
@@ -1521,34 +692,15 @@
       "UniqueId": "Restart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CompleteReset",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "CryptoStateDiscard": {
       "ModuleProperites": {},
@@ -1556,26 +708,11 @@
       "UniqueId": "CryptoStateDiscard",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SetConfiguration": {
       "ModuleProperites": {},
@@ -1583,34 +720,15 @@
       "UniqueId": "SetConfiguration",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Configuration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PeerTPSet": {
       "ModuleProperites": {},
@@ -1618,26 +736,11 @@
       "UniqueId": "PeerTPSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PeerPreferredAddress": {
       "ModuleProperites": {},
@@ -1645,34 +748,15 @@
       "UniqueId": "PeerPreferredAddress",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Connection->PeerTransportParams.PreferredAddress), &Connection->PeerTransportParams.PreferredAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "NegotiatedDisable1RttEncryption": {
       "ModuleProperites": {},
@@ -1680,26 +764,11 @@
       "UniqueId": "NegotiatedDisable1RttEncryption",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "RecvStatelessReset": {
       "ModuleProperites": {},
@@ -1707,26 +776,11 @@
       "UniqueId": "RecvStatelessReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "HandshakeConfirmedFrame": {
       "ModuleProperites": {},
@@ -1734,26 +788,11 @@
       "UniqueId": "HandshakeConfirmedFrame",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "FirstCidUsage": {
       "ModuleProperites": {},
@@ -1761,34 +800,15 @@
       "UniqueId": "FirstCidUsage",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(Packet->DestCid, Packet->DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathDiscarded": {
       "ModuleProperites": {},
@@ -1796,34 +816,15 @@
       "UniqueId": "PathDiscarded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Paths[i].ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "Unreachable": {
       "ModuleProperites": {},
@@ -1831,26 +832,11 @@
       "UniqueId": "Unreachable",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "UpdateShareBinding": {
       "ModuleProperites": {},
@@ -1858,34 +844,15 @@
       "UniqueId": "UpdateShareBinding",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->State.ShareBinding",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "UpdateStreamSchedulingScheme": {
       "ModuleProperites": {},
@@ -1893,34 +860,15 @@
       "UniqueId": "UpdateStreamSchedulingScheme",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Scheme",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "ApplySettings": {
       "ModuleProperites": {},
@@ -1928,26 +876,11 @@
       "UniqueId": "ApplySettings",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "RttUpdated": {
       "ModuleProperites": {},
@@ -1955,58 +888,27 @@
       "UniqueId": "RttUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->SmoothedRtt / 1000",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->SmoothedRtt % 1000",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "03u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->RttVariance / 1000",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->RttVariance % 1000",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "03u",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "NewSrcCidNameCollision": {
       "ModuleProperites": {},
@@ -2014,26 +916,11 @@
       "UniqueId": "NewSrcCidNameCollision",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ZeroLengthCidRetire": {
       "ModuleProperites": {},
@@ -2041,26 +928,11 @@
       "UniqueId": "ZeroLengthCidRetire",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "TimerExpired": {
       "ModuleProperites": {},
@@ -2068,34 +940,15 @@
       "UniqueId": "TimerExpired",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerNames[Temp[j].Type]",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateShutdownByPeer": {
       "ModuleProperites": {},
@@ -2103,34 +956,15 @@
       "UniqueId": "IndicateShutdownByPeer",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.SHUTDOWN_INITIATED_BY_PEER.ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llx",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateShutdownByTransport": {
       "ModuleProperites": {},
@@ -2138,34 +972,15 @@
       "UniqueId": "IndicateShutdownByTransport",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.SHUTDOWN_INITIATED_BY_TRANSPORT.Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateConnectionShutdownComplete": {
       "ModuleProperites": {},
@@ -2173,26 +988,11 @@
       "UniqueId": "IndicateConnectionShutdownComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateResumptionTicketReceived": {
       "ModuleProperites": {},
@@ -2200,26 +1000,11 @@
       "UniqueId": "IndicateResumptionTicketReceived",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "QueueDatagrams": {
       "ModuleProperites": {},
@@ -2227,34 +1012,15 @@
       "UniqueId": "QueueDatagrams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "DatagramChainLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "RecvVerNeg": {
       "ModuleProperites": {},
@@ -2262,26 +1028,11 @@
       "UniqueId": "RecvVerNeg",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "VerNegItem": {
       "ModuleProperites": {},
@@ -2289,42 +1040,19 @@
       "UniqueId": "VerNegItem",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "i",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicByteSwapUint32(ServerVersionList[i])",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DeferDatagram": {
       "ModuleProperites": {},
@@ -2332,34 +1060,15 @@
       "UniqueId": "DeferDatagram",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->KeyType",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecryptOldKey": {
       "ModuleProperites": {},
@@ -2367,26 +1076,11 @@
       "UniqueId": "DecryptOldKey",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "PossiblePeerKeyUpdate": {
       "ModuleProperites": {},
@@ -2394,34 +1088,15 @@
       "UniqueId": "PossiblePeerKeyUpdate",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "UpdateReadKeyPhase": {
       "ModuleProperites": {},
@@ -2429,34 +1104,15 @@
       "UniqueId": "UpdateReadKeyPhase",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "PeerConnFCBlocked": {
       "ModuleProperites": {},
@@ -2464,34 +1120,15 @@
       "UniqueId": "PeerConnFCBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.DataLimit",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "PeerStreamFCBlocked": {
       "ModuleProperites": {},
@@ -2499,42 +1136,19 @@
       "UniqueId": "PeerStreamFCBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.BidirectionalStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamLimit",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicatePeerNeedStreams": {
       "ModuleProperites": {},
@@ -2542,26 +1156,11 @@
       "UniqueId": "IndicatePeerNeedStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicatePeerAddrChanged": {
       "ModuleProperites": {},
@@ -2569,26 +1168,11 @@
       "UniqueId": "IndicatePeerAddrChanged",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "UdpRecvBatch": {
       "ModuleProperites": {},
@@ -2596,34 +1180,15 @@
       "UniqueId": "UdpRecvBatch",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "BatchCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "UdpRecvDeferred": {
       "ModuleProperites": {},
@@ -2631,34 +1196,15 @@
       "UniqueId": "UdpRecvDeferred",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "DatagramChainCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "UdpRecv": {
       "ModuleProperites": {},
@@ -2666,34 +1212,15 @@
       "UniqueId": "UdpRecv",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "DatagramChainCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DatagramReceiveEnableUpdated": {
       "ModuleProperites": {},
@@ -2701,34 +1228,15 @@
       "UniqueId": "DatagramReceiveEnableUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Datagram.ReceiveEnabled",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "Disable1RttEncrytionUpdated": {
       "ModuleProperites": {},
@@ -2736,34 +1244,15 @@
       "UniqueId": "Disable1RttEncrytionUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->State.Disable1RttEncrytion",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ForceKeyUpdate": {
       "ModuleProperites": {},
@@ -2771,26 +1260,11 @@
       "UniqueId": "ForceKeyUpdate",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ForceCidUpdate": {
       "ModuleProperites": {},
@@ -2798,26 +1272,11 @@
       "UniqueId": "ForceCidUpdate",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "TestTPSet": {
       "ModuleProperites": {},
@@ -2825,42 +1284,19 @@
       "UniqueId": "TestTPSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->TestTransportParameter.Type",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->TestTransportParameter.Length",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "AbandonInternallyClosed": {
       "ModuleProperites": {},
@@ -2868,26 +1304,11 @@
       "UniqueId": "AbandonInternallyClosed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ConnCreated": {
       "ModuleProperites": {},
@@ -2895,42 +1316,19 @@
       "UniqueId": "ConnCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "IsServer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.CorrelationId",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnLocalAddrAdded": {
       "ModuleProperites": {},
@@ -2938,34 +1336,15 @@
       "UniqueId": "ConnLocalAddrAdded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnRemoteAddrAdded": {
       "ModuleProperites": {},
@@ -2973,34 +1352,15 @@
       "UniqueId": "ConnRemoteAddrAdded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnDestCidAdded": {
       "ModuleProperites": {},
@@ -3008,42 +1368,19 @@
       "UniqueId": "ConnDestCidAdded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->DestCid->CID.SequenceNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(Path->DestCid->CID.Length, Path->DestCid->CID.Data)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!CID!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnSourceCidAdded": {
       "ModuleProperites": {},
@@ -3051,42 +1388,19 @@
       "UniqueId": "ConnSourceCidAdded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SourceCid->CID.SequenceNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(SourceCid->CID.Length, SourceCid->CID.Data)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!CID!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnInitializeComplete": {
       "ModuleProperites": {},
@@ -3094,26 +1408,11 @@
       "UniqueId": "ConnInitializeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnUnregistered": {
       "ModuleProperites": {},
@@ -3121,34 +1420,15 @@
       "UniqueId": "ConnUnregistered",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnDestroyed": {
       "ModuleProperites": {},
@@ -3156,26 +1436,11 @@
       "UniqueId": "ConnDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnHandleClosed": {
       "ModuleProperites": {},
@@ -3183,26 +1448,11 @@
       "UniqueId": "ConnHandleClosed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnRegistered": {
       "ModuleProperites": {},
@@ -3210,34 +1460,15 @@
       "UniqueId": "ConnRegistered",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnRundown": {
       "ModuleProperites": {},
@@ -3245,42 +1476,19 @@
       "UniqueId": "ConnRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicConnIsServer(Connection)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.CorrelationId",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnAssignWorker": {
       "ModuleProperites": {},
@@ -3288,34 +1496,15 @@
       "UniqueId": "ConnAssignWorker",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Worker",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnVersionSet": {
       "ModuleProperites": {},
@@ -3323,34 +1512,15 @@
       "UniqueId": "ConnVersionSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.QuicVersion",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnHandshakeComplete": {
       "ModuleProperites": {},
@@ -3358,26 +1528,11 @@
       "UniqueId": "ConnHandshakeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnDestCidRemoved": {
       "ModuleProperites": {},
@@ -3385,42 +1540,19 @@
       "UniqueId": "ConnDestCidRemoved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "DestCid->CID.SequenceNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(DestCid->CID.Length, DestCid->CID.Data)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!CID!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnExecTimerOper": {
       "ModuleProperites": {},
@@ -3428,34 +1560,15 @@
       "UniqueId": "ConnExecTimerOper",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QUIC_CONN_TIMER_ACK_DELAY",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnShutdownComplete": {
       "ModuleProperites": {},
@@ -3463,34 +1576,15 @@
       "UniqueId": "ConnShutdownComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->State.ShutdownCompleteTimedOut",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnAppShutdown": {
       "ModuleProperites": {},
@@ -3498,42 +1592,19 @@
       "UniqueId": "ConnAppShutdown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ClosedRemotely",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnTransportShutdown": {
       "ModuleProperites": {},
@@ -3541,50 +1612,23 @@
       "UniqueId": "ConnTransportShutdown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ClosedRemotely",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "!!(Flags & QUIC_CLOSE_QUIC_STATUS)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnErrorStatus": {
       "ModuleProperites": {},
@@ -3592,42 +1636,19 @@
       "UniqueId": "ConnErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Set current compartment Id\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnServerResumeTicket": {
       "ModuleProperites": {},
@@ -3635,26 +1656,11 @@
       "UniqueId": "ConnServerResumeTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnHandshakeStart": {
       "ModuleProperites": {},
@@ -3662,26 +1668,11 @@
       "UniqueId": "ConnHandshakeStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnPacketRecv": {
       "ModuleProperites": {},
@@ -3689,50 +1680,23 @@
       "UniqueId": "ConnPacketRecv",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->IsShortHeader ? QUIC_TRACE_PACKET_ONE_RTT : (Packet->LH->Type + 1)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->HeaderLength + Packet->PayloadLength",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnSourceCidRemoved": {
       "ModuleProperites": {},
@@ -3740,42 +1704,19 @@
       "UniqueId": "ConnSourceCidRemoved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "NextSourceCid->CID.SequenceNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(NextSourceCid->CID.Length, NextSourceCid->CID.Data)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!CID!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnLocalAddrRemoved": {
       "ModuleProperites": {},
@@ -3783,34 +1724,15 @@
       "UniqueId": "ConnLocalAddrRemoved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnOutFlowStats": {
       "ModuleProperites": {},
@@ -3818,98 +1740,47 @@
       "UniqueId": "ConnOutFlowStats",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.TotalBytes",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.BytesInFlight",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.BytesInFlightMax",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.CongestionWindow",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->CongestionControl.SlowStartThreshold",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg7"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent",
-            "SuggestedTelemetryName": "arg8"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg8"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->SendBuffer.IdealBytes",
-            "SuggestedTelemetryName": "arg9"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg9"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->SendBuffer.PostedBytes",
-            "SuggestedTelemetryName": "arg10"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg10"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->GotFirstRttSample ? Path->SmoothedRtt : 0",
-            "SuggestedTelemetryName": "arg11"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg11"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnOutFlowStreamStats": {
       "ModuleProperites": {},
@@ -3917,42 +1788,19 @@
       "UniqueId": "ConnOutFlowStreamStats",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FcAvailable",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendWindow",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnInFlowStats": {
       "ModuleProperites": {},
@@ -3960,34 +1808,15 @@
       "UniqueId": "ConnInFlowStats",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.TotalBytes",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnStats": {
       "ModuleProperites": {},
@@ -3995,66 +1824,31 @@
       "UniqueId": "ConnStats",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->SmoothedRtt",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.CongestionCount",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.PersistentCongestionCount",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.TotalBytes",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.TotalBytes",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnPacketStats": {
       "ModuleProperites": {},
@@ -4062,90 +1856,43 @@
       "UniqueId": "ConnPacketStats",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.TotalPackets",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.SuspectedLostPackets",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Send.SpuriousLostPackets",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.TotalPackets",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.ReorderedPackets",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg7"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.DroppedPackets",
-            "SuggestedTelemetryName": "arg8"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg8"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.DuplicatePackets",
-            "SuggestedTelemetryName": "arg9"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg9"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Stats.Recv.DecryptionFailures",
-            "SuggestedTelemetryName": "arg10"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg10"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnOutFlowBlocked": {
       "ModuleProperites": {},
@@ -4153,774 +1900,15 @@
       "UniqueId": "ConnOutFlowBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->OutFlowBlockedReasons",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "IgnoreCryptoFrame": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Ignoring received crypto after cleanup",
-      "UniqueId": "IgnoreCryptoFrame",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "DiscardKeyType": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Discarding key type = %hhu",
-      "UniqueId": "DiscardKeyType",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "KeyType",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ZeroRttAccepted": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] 0-RTT accepted",
-      "UniqueId": "ZeroRttAccepted",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ZeroRttRejected": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] 0-RTT rejected",
-      "UniqueId": "ZeroRttRejected",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "HandshakeConfirmedServer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Handshake confirmed (server)",
-      "UniqueId": "HandshakeConfirmedServer",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CryptoDump": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] QS:%u MAX:%u UNA:%u NXT:%u RECOV:%u-%u",
-      "UniqueId": "CryptoDump",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->TlsState.BufferTotalLength",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->MaxSentLength",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->UnAckedOffset",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->NextSendOffset",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->InRecovery ? Crypto->RecoveryNextOffset : 0",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg7"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->InRecovery ? Crypto->RecoveryEndOffset : 0",
-            "SuggestedTelemetryName": "arg8"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg8"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CryptoDumpUnacked": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p]   unACKed: [%llu, %llu]",
-      "UniqueId": "CryptoDumpUnacked",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "UnAcked",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Sack->Low",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CryptoDumpUnacked2": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p]   unACKed: [%llu, %u]",
-      "UniqueId": "CryptoDumpUnacked2",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "UnAcked",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->MaxSentLength",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "NoMoreRoomForCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] No room for CRYPTO frame",
-      "UniqueId": "NoMoreRoomForCrypto",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "AddCryptoFrame": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Sending %hu crypto bytes, offset=%u",
-      "UniqueId": "AddCryptoFrame",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CryptoOffset",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "RecoverCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Recovering crypto from %llu up to %llu",
-      "UniqueId": "RecoverCrypto",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Start",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "End",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "AckCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Received ack for %u crypto bytes, offset=%u",
-      "UniqueId": "AckCrypto",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Offset",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "RecvCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Received %hu crypto bytes, offset=%llu Ready=%hhu",
-      "UniqueId": "RecvCrypto",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame->Length",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame->Offset",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*DataReady",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "IndicateConnected": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_CONNECTED (Resume=%hhu)",
-      "UniqueId": "IndicateConnected",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.CONNECTED.SessionResumed",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "DrainCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Draining %u crypto bytes",
-      "UniqueId": "DrainCrypto",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCryptoGetConnection(Crypto)",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "RecvBufferConsumed",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CryptoNotReady": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] No complete TLS messages to process",
-      "UniqueId": "CryptoNotReady",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnWriteKeyUpdated": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Write Key Updated, %hhu.",
-      "UniqueId": "ConnWriteKeyUpdated",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->TlsState.WriteKey",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnReadKeyUpdated": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Read Key Updated, %hhu.",
-      "UniqueId": "ConnReadKeyUpdated",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Crypto->TlsState.ReadKey",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnNewPacketKeys": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] New packet keys created successfully.",
-      "UniqueId": "ConnNewPacketKeys",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnKeyPhaseChange": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Key phase change (locally initiated=%hhu).",
-      "UniqueId": "ConnKeyPhaseChange",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LocalUpdate",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "NoSniPresent": {
       "ModuleProperites": {},
@@ -4928,26 +1916,11 @@
       "UniqueId": "NoSniPresent",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "DecodeTPReserved": {
       "ModuleProperites": {},
@@ -4955,42 +1928,19 @@
       "UniqueId": "DecodeTPReserved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Id",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "DecodeTPUnknown": {
       "ModuleProperites": {},
@@ -4998,42 +1948,19 @@
       "UniqueId": "DecodeTPUnknown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Id",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "EncodeTPStart": {
       "ModuleProperites": {},
@@ -5041,34 +1968,15 @@
       "UniqueId": "EncodeTPStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "IsServerTP",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPOriginalDestinationCID": {
       "ModuleProperites": {},
@@ -5076,34 +1984,15 @@
       "UniqueId": "EncodeTPOriginalDestinationCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                TransportParams->OriginalDestinationConnectionID,\r\n                TransportParams->OriginalDestinationConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPIdleTimeout": {
       "ModuleProperites": {},
@@ -5111,34 +2000,15 @@
       "UniqueId": "EncodeTPIdleTimeout",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->IdleTimeout",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPStatelessResetToken": {
       "ModuleProperites": {},
@@ -5146,34 +2016,15 @@
       "UniqueId": "EncodeTPStatelessResetToken",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                TransportParams->StatelessResetToken,\r\n                QUIC_STATELESS_RESET_TOKEN_LENGTH).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPMaxUdpPayloadSize": {
       "ModuleProperites": {},
@@ -5181,34 +2032,15 @@
       "UniqueId": "EncodeTPMaxUdpPayloadSize",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxUdpPayloadSize",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPInitMaxData": {
       "ModuleProperites": {},
@@ -5216,34 +2048,15 @@
       "UniqueId": "EncodeTPInitMaxData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxData",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPInitMaxStreamDataBidiLocal": {
       "ModuleProperites": {},
@@ -5251,34 +2064,15 @@
       "UniqueId": "EncodeTPInitMaxStreamDataBidiLocal",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataBidiLocal",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPInitMaxStreamDataBidiRemote": {
       "ModuleProperites": {},
@@ -5286,34 +2080,15 @@
       "UniqueId": "EncodeTPInitMaxStreamDataBidiRemote",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataBidiRemote",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPInitMaxStreamUni": {
       "ModuleProperites": {},
@@ -5321,34 +2096,15 @@
       "UniqueId": "EncodeTPInitMaxStreamUni",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataUni",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPMaxBidiStreams": {
       "ModuleProperites": {},
@@ -5356,34 +2112,15 @@
       "UniqueId": "EncodeTPMaxBidiStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxBidiStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPMaxUniStreams": {
       "ModuleProperites": {},
@@ -5391,34 +2128,15 @@
       "UniqueId": "EncodeTPMaxUniStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxUniStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPAckDelayExponent": {
       "ModuleProperites": {},
@@ -5426,34 +2144,15 @@
       "UniqueId": "EncodeTPAckDelayExponent",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->AckDelayExponent",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPMaxAckDelay": {
       "ModuleProperites": {},
@@ -5461,34 +2160,15 @@
       "UniqueId": "EncodeTPMaxAckDelay",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxAckDelay",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPDisableMigration": {
       "ModuleProperites": {},
@@ -5496,26 +2176,11 @@
       "UniqueId": "EncodeTPDisableMigration",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPPreferredAddress": {
       "ModuleProperites": {},
@@ -5523,26 +2188,11 @@
       "UniqueId": "EncodeTPPreferredAddress",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPCIDLimit": {
       "ModuleProperites": {},
@@ -5550,34 +2200,15 @@
       "UniqueId": "EncodeTPCIDLimit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->ActiveConnectionIdLimit",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPOriginalCID": {
       "ModuleProperites": {},
@@ -5585,34 +2216,15 @@
       "UniqueId": "EncodeTPOriginalCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                TransportParams->InitialSourceConnectionID,\r\n                TransportParams->InitialSourceConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPRetrySourceCID": {
       "ModuleProperites": {},
@@ -5620,34 +2232,15 @@
       "UniqueId": "EncodeTPRetrySourceCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                TransportParams->RetrySourceConnectionID,\r\n                TransportParams->RetrySourceConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeMaxDatagramFrameSize": {
       "ModuleProperites": {},
@@ -5655,34 +2248,15 @@
       "UniqueId": "EncodeMaxDatagramFrameSize",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxDatagramFrameSize",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPDisable1RttEncryption": {
       "ModuleProperites": {},
@@ -5690,26 +2264,11 @@
       "UniqueId": "EncodeTPDisable1RttEncryption",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPTest": {
       "ModuleProperites": {},
@@ -5717,42 +2276,19 @@
       "UniqueId": "EncodeTPTest",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestParam->Type",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestParam->Length",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "EncodeTPEnd": {
       "ModuleProperites": {},
@@ -5760,34 +2296,15 @@
       "UniqueId": "EncodeTPEnd",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)FinalTPLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPStart": {
       "ModuleProperites": {},
@@ -5795,42 +2312,19 @@
       "UniqueId": "DecodeTPStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "IsServerTP",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TPLen",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPOriginalDestinationCID": {
       "ModuleProperites": {},
@@ -5838,34 +2332,15 @@
       "UniqueId": "DecodeTPOriginalDestinationCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                    TransportParams->OriginalDestinationConnectionID,\r\n                    TransportParams->OriginalDestinationConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPIdleTimeout": {
       "ModuleProperites": {},
@@ -5873,34 +2348,15 @@
       "UniqueId": "DecodeTPIdleTimeout",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->IdleTimeout",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPStatelessResetToken": {
       "ModuleProperites": {},
@@ -5908,34 +2364,15 @@
       "UniqueId": "DecodeTPStatelessResetToken",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                    TransportParams->StatelessResetToken,\r\n                    QUIC_STATELESS_RESET_TOKEN_LENGTH).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPMaxUdpPayloadSize": {
       "ModuleProperites": {},
@@ -5943,34 +2380,15 @@
       "UniqueId": "DecodeTPMaxUdpPayloadSize",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxUdpPayloadSize",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPInitMaxData": {
       "ModuleProperites": {},
@@ -5978,34 +2396,15 @@
       "UniqueId": "DecodeTPInitMaxData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxData",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPInitMaxStreamDataBidiLocal": {
       "ModuleProperites": {},
@@ -6013,34 +2412,15 @@
       "UniqueId": "DecodeTPInitMaxStreamDataBidiLocal",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataBidiLocal",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPInitMaxStreamDataBidiRemote": {
       "ModuleProperites": {},
@@ -6048,34 +2428,15 @@
       "UniqueId": "DecodeTPInitMaxStreamDataBidiRemote",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataBidiRemote",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPInitMaxStreamDataBidiUni": {
       "ModuleProperites": {},
@@ -6083,34 +2444,15 @@
       "UniqueId": "DecodeTPInitMaxStreamDataBidiUni",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxStreamDataUni",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPMaxBidiStreams": {
       "ModuleProperites": {},
@@ -6118,34 +2460,15 @@
       "UniqueId": "DecodeTPMaxBidiStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxBidiStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPMaxUniStreams": {
       "ModuleProperites": {},
@@ -6153,34 +2476,15 @@
       "UniqueId": "DecodeTPMaxUniStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->InitialMaxUniStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPAckDelayExponent": {
       "ModuleProperites": {},
@@ -6188,34 +2492,15 @@
       "UniqueId": "DecodeTPAckDelayExponent",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->AckDelayExponent",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPMaxAckDelay": {
       "ModuleProperites": {},
@@ -6223,34 +2508,15 @@
       "UniqueId": "DecodeTPMaxAckDelay",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxAckDelay",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPDisableActiveMigration": {
       "ModuleProperites": {},
@@ -6258,26 +2524,11 @@
       "UniqueId": "DecodeTPDisableActiveMigration",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPPreferredAddress": {
       "ModuleProperites": {},
@@ -6285,26 +2536,11 @@
       "UniqueId": "DecodeTPPreferredAddress",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPCIDLimit": {
       "ModuleProperites": {},
@@ -6312,34 +2548,15 @@
       "UniqueId": "DecodeTPCIDLimit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->ActiveConnectionIdLimit",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPInitialSourceCID": {
       "ModuleProperites": {},
@@ -6347,34 +2564,15 @@
       "UniqueId": "DecodeTPInitialSourceCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                    TransportParams->InitialSourceConnectionID,\r\n                    TransportParams->InitialSourceConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPRetrySourceCID": {
       "ModuleProperites": {},
@@ -6382,34 +2580,15 @@
       "UniqueId": "DecodeTPRetrySourceCID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(\r\n                    TransportParams->RetrySourceConnectionID,\r\n                    TransportParams->RetrySourceConnectionIDLength).Buffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPMaxDatagramFrameSize": {
       "ModuleProperites": {},
@@ -6417,34 +2596,15 @@
       "UniqueId": "DecodeTPMaxDatagramFrameSize",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TransportParams->MaxDatagramFrameSize",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DecodeTPDisable1RttEncryption": {
       "ModuleProperites": {},
@@ -6452,26 +2612,351 @@
       "UniqueId": "DecodeTPDisable1RttEncryption",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "IgnoreCryptoFrame": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Ignoring received crypto after cleanup",
+      "UniqueId": "IgnoreCryptoFrame",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnWarning"
+    },
+    "DiscardKeyType": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Discarding key type = %hhu",
+      "UniqueId": "DiscardKeyType",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "ZeroRttAccepted": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] 0-RTT accepted",
+      "UniqueId": "ZeroRttAccepted",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "ZeroRttRejected": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] 0-RTT rejected",
+      "UniqueId": "ZeroRttRejected",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "HandshakeConfirmedServer": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Handshake confirmed (server)",
+      "UniqueId": "HandshakeConfirmedServer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "CryptoDump": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] QS:%u MAX:%u UNA:%u NXT:%u RECOV:%u-%u",
+      "UniqueId": "CryptoDump",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg8"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoDumpUnacked": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p]   unACKed: [%llu, %llu]",
+      "UniqueId": "CryptoDumpUnacked",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoDumpUnacked2": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p]   unACKed: [%llu, %u]",
+      "UniqueId": "CryptoDumpUnacked2",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "NoMoreRoomForCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] No room for CRYPTO frame",
+      "UniqueId": "NoMoreRoomForCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AddCryptoFrame": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Sending %hu crypto bytes, offset=%u",
+      "UniqueId": "AddCryptoFrame",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RecoverCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Recovering crypto from %llu up to %llu",
+      "UniqueId": "RecoverCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AckCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Received ack for %u crypto bytes, offset=%u",
+      "UniqueId": "AckCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RecvCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Received %hu crypto bytes, offset=%llu Ready=%hhu",
+      "UniqueId": "RecvCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "IndicateConnected": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_CONNECTED (Resume=%hhu)",
+      "UniqueId": "IndicateConnected",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "DrainCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Draining %u crypto bytes",
+      "UniqueId": "DrainCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoNotReady": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] No complete TLS messages to process",
+      "UniqueId": "CryptoNotReady",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "ConnWriteKeyUpdated": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Write Key Updated, %hhu.",
+      "UniqueId": "ConnWriteKeyUpdated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnReadKeyUpdated": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Read Key Updated, %hhu.",
+      "UniqueId": "ConnReadKeyUpdated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnNewPacketKeys": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] New packet keys created successfully.",
+      "UniqueId": "ConnNewPacketKeys",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnKeyPhaseChange": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Key phase change (locally initiated=%hhu).",
+      "UniqueId": "ConnKeyPhaseChange",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "DatagramSendStateChanged": {
       "ModuleProperites": {},
@@ -6479,34 +2964,15 @@
       "UniqueId": "DatagramSendStateChanged",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DatagramSendShutdown": {
       "ModuleProperites": {},
@@ -6514,26 +2980,11 @@
       "UniqueId": "DatagramSendShutdown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateDatagramStateChanged": {
       "ModuleProperites": {},
@@ -6541,42 +2992,19 @@
       "UniqueId": "IndicateDatagramStateChanged",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.DATAGRAM_STATE_CHANGED.SendEnabled",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.DATAGRAM_STATE_CHANGED.MaxSendLength",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "DatagramSendQueued": {
       "ModuleProperites": {},
@@ -6584,50 +3012,23 @@
       "UniqueId": "DatagramSendQueued",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest->TotalLength",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest->Flags",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicateDatagramReceived": {
       "ModuleProperites": {},
@@ -6635,34 +3036,15 @@
       "UniqueId": "IndicateDatagramReceived",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "FrameLogUnknownType": {
       "ModuleProperites": {},
@@ -6670,50 +3052,23 @@
       "UniqueId": "FrameLogUnknownType",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FrameType",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPadding": {
       "ModuleProperites": {},
@@ -6721,50 +3076,23 @@
       "UniqueId": "FrameLogPadding",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(*Offset - Start) + 1",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPing": {
       "ModuleProperites": {},
@@ -6772,42 +3100,19 @@
       "UniqueId": "FrameLogPing",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckInvalid": {
       "ModuleProperites": {},
@@ -6815,42 +3120,19 @@
       "UniqueId": "FrameLogAckInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAck": {
       "ModuleProperites": {},
@@ -6858,58 +3140,27 @@
       "UniqueId": "FrameLogAck",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.LargestAcknowledged",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.AckDelay",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckSingleBlock": {
       "ModuleProperites": {},
@@ -6917,50 +3168,23 @@
       "UniqueId": "FrameLogAckSingleBlock",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.LargestAcknowledged",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckMultiBlock": {
       "ModuleProperites": {},
@@ -6968,58 +3192,27 @@
       "UniqueId": "FrameLogAckMultiBlock",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.LargestAcknowledged - Frame.FirstAckBlock",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.LargestAcknowledged",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckInvalidBlock": {
       "ModuleProperites": {},
@@ -7027,42 +3220,19 @@
       "UniqueId": "FrameLogAckInvalidBlock",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckEcnInvalid": {
       "ModuleProperites": {},
@@ -7070,42 +3240,19 @@
       "UniqueId": "FrameLogAckEcnInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogAckEcn": {
       "ModuleProperites": {},
@@ -7113,66 +3260,31 @@
       "UniqueId": "FrameLogAckEcn",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Ecn.ECT_0_Count",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Ecn.ECT_1_Count",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Ecn.CE_Count",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogResetStreamInvalid": {
       "ModuleProperites": {},
@@ -7180,42 +3292,19 @@
       "UniqueId": "FrameLogResetStreamInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogResetStream": {
       "ModuleProperites": {},
@@ -7223,66 +3312,31 @@
       "UniqueId": "FrameLogResetStream",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.ErrorCode",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.FinalSize",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStopSendingInvalid": {
       "ModuleProperites": {},
@@ -7290,42 +3344,19 @@
       "UniqueId": "FrameLogStopSendingInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStopSending": {
       "ModuleProperites": {},
@@ -7333,58 +3364,27 @@
       "UniqueId": "FrameLogStopSending",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.ErrorCode",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogCryptoInvalid": {
       "ModuleProperites": {},
@@ -7392,42 +3392,19 @@
       "UniqueId": "FrameLogCryptoInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogCrypto": {
       "ModuleProperites": {},
@@ -7435,58 +3412,27 @@
       "UniqueId": "FrameLogCrypto",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Offset",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogNewTokenInvalid": {
       "ModuleProperites": {},
@@ -7494,42 +3440,19 @@
       "UniqueId": "FrameLogNewTokenInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogNewToken": {
       "ModuleProperites": {},
@@ -7537,50 +3460,23 @@
       "UniqueId": "FrameLogNewToken",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.TokenLength",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamInvalid": {
       "ModuleProperites": {},
@@ -7588,42 +3484,19 @@
       "UniqueId": "FrameLogStreamInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamFin": {
       "ModuleProperites": {},
@@ -7631,66 +3504,31 @@
       "UniqueId": "FrameLogStreamFin",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Offset",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStream": {
       "ModuleProperites": {},
@@ -7698,66 +3536,31 @@
       "UniqueId": "FrameLogStream",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Offset",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxDataInvalid": {
       "ModuleProperites": {},
@@ -7765,42 +3568,19 @@
       "UniqueId": "FrameLogMaxDataInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxData": {
       "ModuleProperites": {},
@@ -7808,50 +3588,23 @@
       "UniqueId": "FrameLogMaxData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.MaximumData",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxStreamDataInvalid": {
       "ModuleProperites": {},
@@ -7859,42 +3612,19 @@
       "UniqueId": "FrameLogMaxStreamDataInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxStreamData": {
       "ModuleProperites": {},
@@ -7902,58 +3632,27 @@
       "UniqueId": "FrameLogMaxStreamData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.MaximumData",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxStreamsInvalid": {
       "ModuleProperites": {},
@@ -7961,42 +3660,19 @@
       "UniqueId": "FrameLogMaxStreamsInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogMaxStreams": {
       "ModuleProperites": {},
@@ -8004,58 +3680,27 @@
       "UniqueId": "FrameLogMaxStreams",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.BidirectionalStreams",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.MaximumStreams",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogDataBlockedInvalid": {
       "ModuleProperites": {},
@@ -8063,42 +3708,19 @@
       "UniqueId": "FrameLogDataBlockedInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogDataBlocked": {
       "ModuleProperites": {},
@@ -8106,50 +3728,23 @@
       "UniqueId": "FrameLogDataBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.DataLimit",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamDataBlockedInvalid": {
       "ModuleProperites": {},
@@ -8157,42 +3752,19 @@
       "UniqueId": "FrameLogStreamDataBlockedInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamDataBlocked": {
       "ModuleProperites": {},
@@ -8200,58 +3772,27 @@
       "UniqueId": "FrameLogStreamDataBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamID",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamDataLimit",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamsBlockedInvalid": {
       "ModuleProperites": {},
@@ -8259,42 +3800,19 @@
       "UniqueId": "FrameLogStreamsBlockedInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogStreamsBlocked": {
       "ModuleProperites": {},
@@ -8302,58 +3820,27 @@
       "UniqueId": "FrameLogStreamsBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.BidirectionalStreams",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamLimit",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogNewConnectionIDInvalid": {
       "ModuleProperites": {},
@@ -8361,42 +3848,19 @@
       "UniqueId": "FrameLogNewConnectionIDInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogNewConnectionID": {
       "ModuleProperites": {},
@@ -8404,74 +3868,35 @@
       "UniqueId": "FrameLogNewConnectionID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Sequence",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.RetirePriorTo",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(Frame.Buffer, Frame.Length).Buffer",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg7"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(Frame.Buffer + Frame.Length, QUIC_STATELESS_RESET_TOKEN_LENGTH).Buffer",
-            "SuggestedTelemetryName": "arg8"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg8"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogRetireConnectionIDInvalid": {
       "ModuleProperites": {},
@@ -8479,42 +3904,19 @@
       "UniqueId": "FrameLogRetireConnectionIDInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogRetireConnectionID": {
       "ModuleProperites": {},
@@ -8522,50 +3924,23 @@
       "UniqueId": "FrameLogRetireConnectionID",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Sequence",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPathChallengeInvalid": {
       "ModuleProperites": {},
@@ -8573,42 +3948,19 @@
       "UniqueId": "FrameLogPathChallengeInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPathChallenge": {
       "ModuleProperites": {},
@@ -8616,50 +3968,23 @@
       "UniqueId": "FrameLogPathChallenge",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicByteSwapUint64(*(uint64_t*)Frame.Data)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPathResponseInvalid": {
       "ModuleProperites": {},
@@ -8667,42 +3992,19 @@
       "UniqueId": "FrameLogPathResponseInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogPathResponse": {
       "ModuleProperites": {},
@@ -8710,50 +4012,23 @@
       "UniqueId": "FrameLogPathResponse",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicByteSwapUint64(*(uint64_t*)Frame.Data)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogConnectionCloseInvalid": {
       "ModuleProperites": {},
@@ -8761,42 +4036,19 @@
       "UniqueId": "FrameLogConnectionCloseInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogConnectionCloseApp": {
       "ModuleProperites": {},
@@ -8804,50 +4056,23 @@
       "UniqueId": "FrameLogConnectionCloseApp",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.ErrorCode",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogConnectionClose": {
       "ModuleProperites": {},
@@ -8855,58 +4080,27 @@
       "UniqueId": "FrameLogConnectionClose",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.ErrorCode",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.FrameType",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogHandshakeDone": {
       "ModuleProperites": {},
@@ -8914,42 +4108,19 @@
       "UniqueId": "FrameLogHandshakeDone",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogDatagramInvalid": {
       "ModuleProperites": {},
@@ -8957,42 +4128,19 @@
       "UniqueId": "FrameLogDatagramInvalid",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "FrameLogDatagram": {
       "ModuleProperites": {},
@@ -9000,50 +4148,23 @@
       "UniqueId": "FrameLogDatagram",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryStorageOpenFailed": {
       "ModuleProperites": {},
@@ -9051,44 +4172,18 @@
       "UniqueId": "LibraryStorageOpenFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "LibraryTestDatapathHooksSet": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Updated test datapath hooks",
       "UniqueId": "LibraryTestDatapathHooksSet",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "LibrarySettingsUpdated": {
       "ModuleProperites": {},
@@ -9096,62 +4191,25 @@
       "UniqueId": "LibrarySettingsUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "&MsQuicLib.Settings",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryVerifierEnabledPerRegistration": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Verifing enabled, per-registration!",
       "UniqueId": "LibraryVerifierEnabledPerRegistration",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryVerifierEnabled": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Verifing enabled for all!",
       "UniqueId": "LibraryVerifierEnabled",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryCidLengthSet": {
       "ModuleProperites": {},
@@ -9159,26 +4217,11 @@
       "UniqueId": "LibraryCidLengthSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.CidTotalLength",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryRetryMemoryLimitSet": {
       "ModuleProperites": {},
@@ -9186,26 +4229,11 @@
       "UniqueId": "LibraryRetryMemoryLimitSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.Settings.RetryMemoryLimit",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryLoadBalancingModeSet": {
       "ModuleProperites": {},
@@ -9213,116 +4241,46 @@
       "UniqueId": "LibraryLoadBalancingModeSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.Settings.LoadBalancingMode",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibrarySetSettings": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Setting new settings",
       "UniqueId": "LibrarySetSettings",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryInUse": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Now in use.",
       "UniqueId": "LibraryInUse",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryNotInUse": {
       "ModuleProperites": {},
       "TraceString": "[ lib] No longer in use.",
       "UniqueId": "LibraryNotInUse",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "LibraryMsQuicOpenNull": {
       "ModuleProperites": {},
       "TraceString": "[ api] MsQuicOpen, NULL",
       "UniqueId": "LibraryMsQuicOpenNull",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryMsQuicOpenEntry": {
       "ModuleProperites": {},
       "TraceString": "[ api] MsQuicOpen",
       "UniqueId": "LibraryMsQuicOpenEntry",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryMsQuicOpenExit": {
       "ModuleProperites": {},
@@ -9330,62 +4288,25 @@
       "UniqueId": "LibraryMsQuicOpenExit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryMsQuicClose": {
       "ModuleProperites": {},
       "TraceString": "[ api] MsQuicClose",
       "UniqueId": "LibraryMsQuicClose",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryLoadBalancingModeSetAfterInUse": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Tried to change load balancing mode after library in use!",
       "UniqueId": "LibraryLoadBalancingModeSetAfterInUse",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogError",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogError"
     },
     "LibraryInitialized": {
       "ModuleProperites": {},
@@ -9393,106 +4314,43 @@
       "UniqueId": "LibraryInitialized",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.PartitionCount",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicDataPathGetSupportedFeatures(MsQuicLib.Datapath)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibraryUninitialized": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Uninitialized",
       "UniqueId": "LibraryUninitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibraryAddRef": {
       "ModuleProperites": {},
       "TraceString": "[ lib] AddRef",
       "UniqueId": "LibraryAddRef",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibraryRelease": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Release",
       "UniqueId": "LibraryRelease",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibraryServerInit": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Shared server state initializing",
       "UniqueId": "LibraryServerInit",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibraryRundown": {
       "ModuleProperites": {},
@@ -9500,34 +4358,15 @@
       "UniqueId": "LibraryRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.PartitionCount",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicDataPathGetSupportedFeatures(MsQuicLib.Datapath)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LibrarySendRetryStateUpdated": {
       "ModuleProperites": {},
@@ -9535,26 +4374,11 @@
       "UniqueId": "LibrarySendRetryStateUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MsQuicLib.SendRetryEnabled",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "PerfCountersRundown": {
       "ModuleProperites": {},
@@ -9562,26 +4386,11 @@
       "UniqueId": "PerfCountersRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "!CID!",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerIndicateNewConnection": {
       "ModuleProperites": {},
@@ -9589,34 +4398,15 @@
       "UniqueId": "ListenerIndicateNewConnection",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "ListenerCreated": {
       "ModuleProperites": {},
@@ -9624,34 +4414,15 @@
       "UniqueId": "ListenerCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener->Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerDestroyed": {
       "ModuleProperites": {},
@@ -9659,26 +4430,11 @@
       "UniqueId": "ListenerDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerErrorStatus": {
       "ModuleProperites": {},
@@ -9686,42 +4442,19 @@
       "UniqueId": "ListenerErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Get binding\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerError": {
       "ModuleProperites": {},
@@ -9729,34 +4462,15 @@
       "UniqueId": "ListenerError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Register with binding\"",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerStarted": {
       "ModuleProperites": {},
@@ -9764,42 +4478,19 @@
       "UniqueId": "ListenerStarted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener->Binding",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Listener->LocalAddress), &Listener->LocalAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerStopped": {
       "ModuleProperites": {},
@@ -9807,26 +4498,11 @@
       "UniqueId": "ListenerStopped",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ListenerRundown": {
       "ModuleProperites": {},
@@ -9834,34 +4510,15 @@
       "UniqueId": "ListenerRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Listener->Registration",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "LookupCidFound": {
       "ModuleProperites": {},
@@ -9869,42 +4526,19 @@
       "UniqueId": "LookupCidFound",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupCidNotFound": {
       "ModuleProperites": {},
@@ -9912,34 +4546,15 @@
       "UniqueId": "LookupCidNotFound",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupRemoteHashFound": {
       "ModuleProperites": {},
@@ -9947,42 +4562,19 @@
       "UniqueId": "LookupRemoteHashFound",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupRemoteHashNotFound": {
       "ModuleProperites": {},
@@ -9990,34 +4582,15 @@
       "UniqueId": "LookupRemoteHashNotFound",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupCidInsert": {
       "ModuleProperites": {},
@@ -10025,42 +4598,19 @@
       "UniqueId": "LookupCidInsert",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupRemoteHashInsert": {
       "ModuleProperites": {},
@@ -10068,42 +4618,19 @@
       "UniqueId": "LookupRemoteHashInsert",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Hash",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LookupCidRemoved": {
       "ModuleProperites": {},
@@ -10111,34 +4638,15 @@
       "UniqueId": "LookupCidRemoved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Lookup",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SourceCid->Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxDiscarded": {
       "ModuleProperites": {},
@@ -10146,34 +4654,15 @@
       "UniqueId": "PacketTxDiscarded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxLostDiscarded": {
       "ModuleProperites": {},
@@ -10181,34 +4670,15 @@
       "UniqueId": "PacketTxLostDiscarded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxForget": {
       "ModuleProperites": {},
@@ -10216,34 +4686,15 @@
       "UniqueId": "PacketTxForget",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxLostFack": {
       "ModuleProperites": {},
@@ -10251,42 +4702,19 @@
       "UniqueId": "PacketTxLostFack",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LossDetection->LargestAck - Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxLostRack": {
       "ModuleProperites": {},
@@ -10294,42 +4722,19 @@
       "UniqueId": "PacketTxLostRack",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicTimeDiff32(Packet->SentTime, TimeNow)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "lu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxAckedImplicit": {
       "ModuleProperites": {},
@@ -10337,34 +4742,15 @@
       "UniqueId": "PacketTxAckedImplicit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTx0RttRejected": {
       "ModuleProperites": {},
@@ -10372,34 +4758,15 @@
       "UniqueId": "PacketTx0RttRejected",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxSpuriousLoss": {
       "ModuleProperites": {},
@@ -10407,34 +4774,15 @@
       "UniqueId": "PacketTxSpuriousLoss",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(*End)->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxAcked": {
       "ModuleProperites": {},
@@ -10442,50 +4790,23 @@
       "UniqueId": "PacketTxAcked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketRtt / 1000",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketRtt % 1000",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "03u",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "PacketTxProbeRetransmit": {
       "ModuleProperites": {},
@@ -10493,34 +4814,15 @@
       "UniqueId": "PacketTxProbeRetransmit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "c",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "HandshakeConfirmedAck": {
       "ModuleProperites": {},
@@ -10528,26 +4830,11 @@
       "UniqueId": "HandshakeConfirmedAck",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathMinMtuValidated": {
       "ModuleProperites": {},
@@ -10555,34 +4842,15 @@
       "UniqueId": "PathMinMtuValidated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathMtuUpdated": {
       "ModuleProperites": {},
@@ -10590,42 +4858,19 @@
       "UniqueId": "PathMtuUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->Mtu",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathValidationTimeout": {
       "ModuleProperites": {},
@@ -10633,34 +4878,15 @@
       "UniqueId": "PathValidationTimeout",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "ScheduleProbe": {
       "ModuleProperites": {},
@@ -10668,34 +4894,15 @@
       "UniqueId": "ScheduleProbe",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LossDetection->ProbeCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "lu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "KeyChangeConfirmed": {
       "ModuleProperites": {},
@@ -10703,26 +4910,11 @@
       "UniqueId": "KeyChangeConfirmed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ConnLossDetectionTimerCancel": {
       "ModuleProperites": {},
@@ -10730,26 +4922,11 @@
       "UniqueId": "ConnLossDetectionTimerCancel",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnLossDetectionTimerSet": {
       "ModuleProperites": {},
@@ -10757,50 +4934,23 @@
       "UniqueId": "ConnLossDetectionTimerSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimeoutType",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Delay",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LossDetection->ProbeCount",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnPacketLost": {
       "ModuleProperites": {},
@@ -10808,50 +4958,23 @@
       "UniqueId": "ConnPacketLost",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicPacketTraceType(Packet)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QUIC_TRACE_PACKET_LOSS_FACK",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnPacketACKed": {
       "ModuleProperites": {},
@@ -10859,42 +4982,19 @@
       "UniqueId": "ConnPacketACKed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Packet->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicPacketTraceType(Packet)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnExecApiOper": {
       "ModuleProperites": {},
@@ -10902,34 +5002,15 @@
       "UniqueId": "ConnExecApiOper",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Oper->API_CALL.Context->Type",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnExecOper": {
       "ModuleProperites": {},
@@ -10937,731 +5018,15 @@
       "UniqueId": "ConnExecOper",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Oper->Type",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketVersionNegotiation": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][-] VerNeg DestCid:%s SrcCid:%s (Payload %lu bytes)",
-      "UniqueId": "LogPacketVersionNegotiation",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(SourceCid, SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketLength - Offset",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "lu",
-          "MacroVariableName": "arg6"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketVersionNegotiationVersion": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][-]   Ver:0x%x",
-      "UniqueId": "LogPacketVersionNegotiationVersion",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*(uint32_t*)(Packet + Offset)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketRetry": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][-] LH Ver:0x%x DestCid:%s SrcCid:%s Type:R (Token %hu bytes)",
-      "UniqueId": "LogPacketRetry",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LongHdr->Version",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(SourceCid, SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketLength - (Offset + QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1)",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg7"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketLongHeaderInitial": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][%llu] LH Ver:0x%x DestCid:%s SrcCid:%s Type:I (Token %hu bytes) (Payload %hu bytes)",
-      "UniqueId": "LogPacketLongHeaderInitial",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LongHdr->Version",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(SourceCid, SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg7"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)TokenLength",
-            "SuggestedTelemetryName": "arg8"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg8"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Length",
-            "SuggestedTelemetryName": "arg9"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg9"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketLongHeader": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][%llu] LH Ver:0x%x DestCid:%s SrcCid:%s Type:%s (Payload %hu bytes)",
-      "UniqueId": "LogPacketLongHeader",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "LongHdr->Version",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(SourceCid, SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg7"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicLongHeaderTypeToString(LongHdr->Type)",
-            "SuggestedTelemetryName": "arg8"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg8"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Length",
-            "SuggestedTelemetryName": "arg9"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg9"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketLongHeaderUnsupported": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][%llu] LH Ver:[UNSUPPORTED,0x%x] DestCid:%s SrcCid:%s",
-      "UniqueId": "LogPacketLongHeaderUnsupported",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Invariant->LONG_HDR.Version",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(SourceCid, SourceCidLen).Buffer",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg7"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "LogPacketShortHeader": {
-      "ModuleProperites": {},
-      "TraceString": "[%c][%cX][%llu] SH DestCid:%s KP:%hu SB:%hu (Payload %hu bytes)",
-      "UniqueId": "LogPacketShortHeader",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PtkConnPre(Connection)",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PktRxPre(Rx)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "c",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketNumber",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicCidBufToStr(DestCid, DestCidLen).Buffer",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Header->KeyPhase",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Header->SpinBit",
-            "SuggestedTelemetryName": "arg7"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg7"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PacketLength - Offset",
-            "SuggestedTelemetryName": "arg8"
-          },
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg8"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnDropPacket": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
-      "UniqueId": "ConnDropPacket",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "BindingDropPacket": {
-      "ModuleProperites": {},
-      "TraceString": "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
-      "UniqueId": "BindingDropPacket",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnDropPacketEx": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
-      "UniqueId": "ConnDropPacketEx",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Value",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "BindingDropPacketEx": {
-      "ModuleProperites": {},
-      "TraceString": "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
-      "UniqueId": "BindingDropPacketEx",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Value",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg6"
-          },
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg6"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "NoSrcCidAvailable": {
       "ModuleProperites": {},
@@ -11669,26 +5034,11 @@
       "UniqueId": "NoSrcCidAvailable",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "GetPacketTypeFailure": {
       "ModuleProperites": {},
@@ -11696,34 +5046,15 @@
       "UniqueId": "GetPacketTypeFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Builder->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendFlags",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "PacketBuilderSendBatch": {
       "ModuleProperites": {},
@@ -11731,34 +5062,15 @@
       "UniqueId": "PacketBuilderSendBatch",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Builder->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Builder->TotalCountDatagrams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "ConnPacketSent": {
       "ModuleProperites": {},
@@ -11766,50 +5078,355 @@
       "UniqueId": "ConnPacketSent",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Builder->Metadata->PacketNumber",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicPacketTraceType(Builder->Metadata)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Builder->Metadata->PacketLength",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceEvent"
+    },
+    "LogPacketVersionNegotiation": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][-] VerNeg DestCid:%s SrcCid:%s (Payload %lu bytes)",
+      "UniqueId": "LogPacketVersionNegotiation",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "lu",
+          "MacroVariableName": "arg6"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketVersionNegotiationVersion": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][-]   Ver:0x%x",
+      "UniqueId": "LogPacketVersionNegotiationVersion",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketRetry": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][-] LH Ver:0x%x DestCid:%s SrcCid:%s Type:R (Token %hu bytes)",
+      "UniqueId": "LogPacketRetry",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg7"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketLongHeaderInitial": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu] LH Ver:0x%x DestCid:%s SrcCid:%s Type:I (Token %hu bytes) (Payload %hu bytes)",
+      "UniqueId": "LogPacketLongHeaderInitial",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg8"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg9"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketLongHeader": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu] LH Ver:0x%x DestCid:%s SrcCid:%s Type:%s (Payload %hu bytes)",
+      "UniqueId": "LogPacketLongHeader",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg8"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg9"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketLongHeaderUnsupported": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu] LH Ver:[UNSUPPORTED,0x%x] DestCid:%s SrcCid:%s",
+      "UniqueId": "LogPacketLongHeaderUnsupported",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg7"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LogPacketShortHeader": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu] SH DestCid:%s KP:%hu SB:%hu (Payload %hu bytes)",
+      "UniqueId": "LogPacketShortHeader",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg8"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "ConnDropPacket": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "UniqueId": "ConnDropPacket",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "BindingDropPacket": {
+      "ModuleProperites": {},
+      "TraceString": "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "UniqueId": "BindingDropPacket",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnDropPacketEx": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
+      "UniqueId": "ConnDropPacketEx",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "BindingDropPacketEx": {
+      "ModuleProperites": {},
+      "TraceString": "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
+      "UniqueId": "BindingDropPacketEx",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg6"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "PathInitialized": {
       "ModuleProperites": {},
@@ -11817,34 +5434,15 @@
       "UniqueId": "PathInitialized",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathRemoved": {
       "ModuleProperites": {},
@@ -11852,34 +5450,15 @@
       "UniqueId": "PathRemoved",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathValidated": {
       "ModuleProperites": {},
@@ -11887,42 +5466,19 @@
       "UniqueId": "PathValidated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Path->ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ReasonStrings[Reason]",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "PathActive": {
       "ModuleProperites": {},
@@ -11930,42 +5486,19 @@
       "UniqueId": "PathActive",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Paths[0].ID",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "UdpPortChangeOnly",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "RegistrationVerifierEnabled": {
       "ModuleProperites": {},
@@ -11973,26 +5506,11 @@
       "UniqueId": "RegistrationVerifierEnabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "RegistrationCreated": {
       "ModuleProperites": {},
@@ -12000,34 +5518,15 @@
       "UniqueId": "RegistrationCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration->AppName",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "RegistrationCleanup": {
       "ModuleProperites": {},
@@ -12035,26 +5534,11 @@
       "UniqueId": "RegistrationCleanup",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "RegistrationRundown": {
       "ModuleProperites": {},
@@ -12062,419 +5546,15 @@
       "UniqueId": "RegistrationRundown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Registration->AppName",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "SetSendFlag": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Setting flags 0x%x (existing flags: 0x%x)",
-      "UniqueId": "SetSendFlag",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(SendFlags & (uint32_t)(~Stream->SendFlags))",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->SendFlags",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ClearSendFlags": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Removing flags %x",
-      "UniqueId": "ClearSendFlags",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(SendFlags & Stream->SendFlags)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CancelAckDelayTimer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Canceling ACK_DELAY timer",
-      "UniqueId": "CancelAckDelayTimer",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicSendGetConnection(Send)",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ScheduleSendFlags": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Scheduling flags 0x%x to 0x%x",
-      "UniqueId": "ScheduleSendFlags",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendFlags",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Send->SendFlags",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "RemoveSendFlags": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Removing flags %x",
-      "UniqueId": "RemoveSendFlags",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicSendGetConnection(Send)",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(SendFlags & Send->SendFlags)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "FlushSend": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Flushing send. Allowance=%u bytes",
-      "UniqueId": "FlushSend",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Builder.SendAllowance",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "AmplificationProtectionBlocked": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Cannot send any more because of amplification protection",
-      "UniqueId": "AmplificationProtectionBlocked",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "SetPacingTimer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Setting delayed send (PACING) timer for %u ms",
-      "UniqueId": "SetPacingTimer",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QUIC_SEND_PACING_INTERVAL",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "SendFlushComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Flush complete flags=0x%x",
-      "UniqueId": "SendFlushComplete",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Send->SendFlags",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StartAckDelayTimer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Starting ACK_DELAY timer for %u ms",
-      "UniqueId": "StartAckDelayTimer",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection->Settings.MaxAckDelayMs",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "ConnQueueSendFlush": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Queueing send flush, reason=%u",
-      "UniqueId": "ConnQueueSendFlush",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Reason",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "IndicateIdealSendBuffer": {
       "ModuleProperites": {},
@@ -12482,34 +5562,191 @@
       "UniqueId": "IndicateIdealSendBuffer",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.IDEAL_SEND_BUFFER_SIZE.ByteCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "SetSendFlag": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Setting flags 0x%x (existing flags: 0x%x)",
+      "UniqueId": "SetSendFlag",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "ClearSendFlags": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Removing flags %x",
+      "UniqueId": "ClearSendFlags",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "CancelAckDelayTimer": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Canceling ACK_DELAY timer",
+      "UniqueId": "CancelAckDelayTimer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "ScheduleSendFlags": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Scheduling flags 0x%x to 0x%x",
+      "UniqueId": "ScheduleSendFlags",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RemoveSendFlags": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Removing flags %x",
+      "UniqueId": "RemoveSendFlags",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "FlushSend": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Flushing send. Allowance=%u bytes",
+      "UniqueId": "FlushSend",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AmplificationProtectionBlocked": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Cannot send any more because of amplification protection",
+      "UniqueId": "AmplificationProtectionBlocked",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "SetPacingTimer": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Setting delayed send (PACING) timer for %u ms",
+      "UniqueId": "SetPacingTimer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "SendFlushComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Flush complete flags=0x%x",
+      "UniqueId": "SendFlushComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "StartAckDelayTimer": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Starting ACK_DELAY timer for %u ms",
+      "UniqueId": "StartAckDelayTimer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "ConnQueueSendFlush": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Queueing send flush, reason=%u",
+      "UniqueId": "ConnQueueSendFlush",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "SettingDumpSendBufferingEnabled": {
       "ModuleProperites": {},
@@ -12517,26 +5754,11 @@
       "UniqueId": "SettingDumpSendBufferingEnabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->SendBufferingEnabled",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpPacingEnabled": {
       "ModuleProperites": {},
@@ -12544,26 +5766,11 @@
       "UniqueId": "SettingDumpPacingEnabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->PacingEnabled",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMigrationEnabled": {
       "ModuleProperites": {},
@@ -12571,26 +5778,11 @@
       "UniqueId": "SettingDumpMigrationEnabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MigrationEnabled",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpDatagramReceiveEnabled": {
       "ModuleProperites": {},
@@ -12598,26 +5790,11 @@
       "UniqueId": "SettingDumpDatagramReceiveEnabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->DatagramReceiveEnabled",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMaxOperationsPerDrain": {
       "ModuleProperites": {},
@@ -12625,26 +5802,11 @@
       "UniqueId": "SettingDumpMaxOperationsPerDrain",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MaxOperationsPerDrain",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpRetryMemoryLimit": {
       "ModuleProperites": {},
@@ -12652,26 +5814,11 @@
       "UniqueId": "SettingDumpRetryMemoryLimit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->RetryMemoryLimit",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpLoadBalancingMode": {
       "ModuleProperites": {},
@@ -12679,26 +5826,11 @@
       "UniqueId": "SettingDumpLoadBalancingMode",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->LoadBalancingMode",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMaxStatelessOperations": {
       "ModuleProperites": {},
@@ -12706,26 +5838,11 @@
       "UniqueId": "SettingDumpMaxStatelessOperations",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MaxStatelessOperations",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMaxWorkerQueueDelayUs": {
       "ModuleProperites": {},
@@ -12733,26 +5850,11 @@
       "UniqueId": "SettingDumpMaxWorkerQueueDelayUs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MaxWorkerQueueDelayUs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpInitialWindowPackets": {
       "ModuleProperites": {},
@@ -12760,26 +5862,11 @@
       "UniqueId": "SettingDumpInitialWindowPackets",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->InitialWindowPackets",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpSendIdleTimeoutMs": {
       "ModuleProperites": {},
@@ -12787,26 +5874,11 @@
       "UniqueId": "SettingDumpSendIdleTimeoutMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->SendIdleTimeoutMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpInitialRttMs": {
       "ModuleProperites": {},
@@ -12814,26 +5886,11 @@
       "UniqueId": "SettingDumpInitialRttMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->InitialRttMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMaxAckDelayMs": {
       "ModuleProperites": {},
@@ -12841,26 +5898,11 @@
       "UniqueId": "SettingDumpMaxAckDelayMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MaxAckDelayMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpDisconnectTimeoutMs": {
       "ModuleProperites": {},
@@ -12868,26 +5910,11 @@
       "UniqueId": "SettingDumpDisconnectTimeoutMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->DisconnectTimeoutMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpKeepAliveIntervalMs": {
       "ModuleProperites": {},
@@ -12895,26 +5922,11 @@
       "UniqueId": "SettingDumpKeepAliveIntervalMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->KeepAliveIntervalMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpIdleTimeoutMs": {
       "ModuleProperites": {},
@@ -12922,26 +5934,11 @@
       "UniqueId": "SettingDumpIdleTimeoutMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->IdleTimeoutMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpHandshakeIdleTimeoutMs": {
       "ModuleProperites": {},
@@ -12949,26 +5946,11 @@
       "UniqueId": "SettingDumpHandshakeIdleTimeoutMs",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->HandshakeIdleTimeoutMs",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpBidiStreamCount": {
       "ModuleProperites": {},
@@ -12976,26 +5958,11 @@
       "UniqueId": "SettingDumpBidiStreamCount",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->PeerBidiStreamCount",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpUnidiStreamCount": {
       "ModuleProperites": {},
@@ -13003,26 +5970,11 @@
       "UniqueId": "SettingDumpUnidiStreamCount",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->PeerUnidiStreamCount",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpTlsClientMaxSendBuffer": {
       "ModuleProperites": {},
@@ -13030,26 +5982,11 @@
       "UniqueId": "SettingDumpTlsClientMaxSendBuffer",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->TlsClientMaxSendBuffer",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpTlsServerMaxSendBuffer": {
       "ModuleProperites": {},
@@ -13057,26 +5994,11 @@
       "UniqueId": "SettingDumpTlsServerMaxSendBuffer",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->TlsServerMaxSendBuffer",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpStreamRecvWindowDefault": {
       "ModuleProperites": {},
@@ -13084,26 +6006,11 @@
       "UniqueId": "SettingDumpStreamRecvWindowDefault",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->StreamRecvWindowDefault",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpStreamRecvBufferDefault": {
       "ModuleProperites": {},
@@ -13111,26 +6018,11 @@
       "UniqueId": "SettingDumpStreamRecvBufferDefault",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->StreamRecvBufferDefault",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpConnFlowControlWindow": {
       "ModuleProperites": {},
@@ -13138,26 +6030,11 @@
       "UniqueId": "SettingDumpConnFlowControlWindow",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->ConnFlowControlWindow",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpMaxBytesPerKey": {
       "ModuleProperites": {},
@@ -13165,26 +6042,11 @@
       "UniqueId": "SettingDumpMaxBytesPerKey",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->MaxBytesPerKey",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SettingDumpServerResumptionLevel": {
       "ModuleProperites": {},
@@ -13192,376 +6054,11 @@
       "UniqueId": "SettingDumpServerResumptionLevel",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Settings->ServerResumptionLevel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "CloseWithoutShutdown": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Closing handle without fully shutting down",
-      "UniqueId": "CloseWithoutShutdown",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "EventSilentDiscard": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Event silently discarded",
-      "UniqueId": "EventSilentDiscard",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "IndicateStartComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE (0x%x)",
-      "UniqueId": "IndicateStartComplete",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "IndicateStreamShutdownComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE",
-      "UniqueId": "IndicateStreamShutdownComplete",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamDestroyed": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Destroyed",
-      "UniqueId": "StreamDestroyed",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamCreated": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Created, Conn=%p ID=%llu IsLocal=%hhu",
-      "UniqueId": "StreamCreated",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->ID",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "!IsRemoteStream",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamSendState": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Send State: %hhu",
-      "UniqueId": "StreamSendState",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicStreamSendGetState(Stream)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamRecvState": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Recv State: %hhu",
-      "UniqueId": "StreamRecvState",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicStreamRecvGetState(Stream)",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamOutFlowBlocked": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Send Blocked Flags: %hhu",
-      "UniqueId": "StreamOutFlowBlocked",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->OutFlowBlockedReasons",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
-    },
-    "StreamRundown": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Rundown, Conn=%p ID=%llu IsLocal=%hhu",
-      "UniqueId": "StreamRundown",
-      "splitArgs": [
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg2"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->ID",
-            "SuggestedTelemetryName": "arg4"
-          },
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(!QuicConnIsServer(Stream->Connection) ^ (Stream->ID & STREAM_ID_FLAG_IS_SERVER))",
-            "SuggestedTelemetryName": "arg5"
-          },
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "ResetEarly": {
       "ModuleProperites": {},
@@ -13569,26 +6066,11 @@
       "UniqueId": "ResetEarly",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamWarning"
     },
     "ResetTooBig": {
       "ModuleProperites": {},
@@ -13596,26 +6078,11 @@
       "UniqueId": "ResetTooBig",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamWarning"
     },
     "ReceiveTooBig": {
       "ModuleProperites": {},
@@ -13623,26 +6090,11 @@
       "UniqueId": "ReceiveTooBig",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamWarning"
     },
     "ReceiveBeyondFlowControl": {
       "ModuleProperites": {},
@@ -13650,26 +6102,11 @@
       "UniqueId": "ReceiveBeyondFlowControl",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamWarning"
     },
     "RemoteCloseReset": {
       "ModuleProperites": {},
@@ -13677,26 +6114,11 @@
       "UniqueId": "RemoteCloseReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamInfo",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamInfo"
     },
     "LocalCloseStopSending": {
       "ModuleProperites": {},
@@ -13704,26 +6126,11 @@
       "UniqueId": "LocalCloseStopSending",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamInfo",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamInfo"
     },
     "QueueRecvFlush": {
       "ModuleProperites": {},
@@ -13731,26 +6138,11 @@
       "UniqueId": "QueueRecvFlush",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicatePeerSendAbort": {
       "ModuleProperites": {},
@@ -13758,34 +6150,15 @@
       "UniqueId": "IndicatePeerSendAbort",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicatePeerReceiveAborted": {
       "ModuleProperites": {},
@@ -13793,34 +6166,15 @@
       "UniqueId": "IndicatePeerReceiveAborted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llX",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "FlowControlExhausted": {
       "ModuleProperites": {},
@@ -13828,26 +6182,11 @@
       "UniqueId": "FlowControlExhausted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "Receive": {
       "ModuleProperites": {},
@@ -13855,50 +6194,23 @@
       "UniqueId": "Receive",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame->Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame->Offset",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ReadyToDeliver",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "RemoteBlocked": {
       "ModuleProperites": {},
@@ -13906,34 +6218,15 @@
       "UniqueId": "RemoteBlocked",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.StreamDataLimit",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IncreaseRxBuffer": {
       "ModuleProperites": {},
@@ -13941,58 +6234,27 @@
       "UniqueId": "IncreaseRxBuffer",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->RecvBuffer.VirtualBufferLength * 2",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->Connection->Paths[0].MinRtt",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimeNow",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->RecvWindowLastUpdate",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "UpdateFlowControl": {
       "ModuleProperites": {},
@@ -14000,26 +6262,11 @@
       "UniqueId": "UpdateFlowControl",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IgnoreRecvFlush": {
       "ModuleProperites": {},
@@ -14027,26 +6274,11 @@
       "UniqueId": "IgnoreRecvFlush",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicateReceive": {
       "ModuleProperites": {},
@@ -14054,50 +6286,23 @@
       "UniqueId": "IndicateReceive",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.RECEIVE.TotalBufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.RECEIVE.BufferCount",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.RECEIVE.Flags",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "ReceiveComplete": {
       "ModuleProperites": {},
@@ -14105,34 +6310,15 @@
       "UniqueId": "ReceiveComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicatePeerSendShutdown": {
       "ModuleProperites": {},
@@ -14140,26 +6326,27 @@
       "UniqueId": "IndicatePeerSendShutdown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "StreamRecvState": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Recv State: %hhu",
+      "UniqueId": "StreamRecvState",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "IndicateSendShutdownComplete": {
       "ModuleProperites": {},
@@ -14167,26 +6354,11 @@
       "UniqueId": "IndicateSendShutdownComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicateSendCanceled": {
       "ModuleProperites": {},
@@ -14194,34 +6366,15 @@
       "UniqueId": "IndicateSendCanceled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "IndicateSendComplete": {
       "ModuleProperites": {},
@@ -14229,34 +6382,15 @@
       "UniqueId": "IndicateSendComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SendQueued": {
       "ModuleProperites": {},
@@ -14264,58 +6398,27 @@
       "UniqueId": "SendQueued",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest->TotalLength",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest->StreamOffset",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendRequest->Flags",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "NoMoreRoom": {
       "ModuleProperites": {},
@@ -14323,26 +6426,11 @@
       "UniqueId": "NoMoreRoom",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "NoMoreFrames": {
       "ModuleProperites": {},
@@ -14350,26 +6438,11 @@
       "UniqueId": "NoMoreFrames",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "AddFrame": {
       "ModuleProperites": {},
@@ -14377,50 +6450,23 @@
       "UniqueId": "AddFrame",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Offset",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint16_t)Frame.Length",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "lu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Frame.Fin",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "RecoverOpen": {
       "ModuleProperites": {},
@@ -14428,26 +6474,11 @@
       "UniqueId": "RecoverOpen",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "RecoverFin": {
       "ModuleProperites": {},
@@ -14455,26 +6486,11 @@
       "UniqueId": "RecoverFin",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "RecoverRange": {
       "ModuleProperites": {},
@@ -14482,42 +6498,19 @@
       "UniqueId": "RecoverRange",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Start",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "End",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "AckRange": {
       "ModuleProperites": {},
@@ -14525,50 +6518,23 @@
       "UniqueId": "AckRange",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Offset",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FrameMetadata->Flags",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hx",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "Send0RttUpdated": {
       "ModuleProperites": {},
@@ -14576,34 +6542,15 @@
       "UniqueId": "Send0RttUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FollowingOffset",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SendQueueDrained": {
       "ModuleProperites": {},
@@ -14611,26 +6558,11 @@
       "UniqueId": "SendQueueDrained",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SendDump": {
       "ModuleProperites": {},
@@ -14638,90 +6570,43 @@
       "UniqueId": "SendDump",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->SendFlags",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hX",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->MaxAllowedSendOffset",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->QueuedSendOffset",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->MaxSentLength",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->UnAckedOffset",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg7"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->NextSendOffset",
-            "SuggestedTelemetryName": "arg8"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg8"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->Flags.InRecovery ? Stream->RecoveryNextOffset : 0",
-            "SuggestedTelemetryName": "arg9"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg9"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream->Flags.InRecovery ? Stream->RecoveryEndOffset : 0",
-            "SuggestedTelemetryName": "arg10"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg10"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SendDumpAck": {
       "ModuleProperites": {},
@@ -14729,42 +6614,35 @@
       "UniqueId": "SendDumpAck",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "UnAcked",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Sack->Low",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamVerbose",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "StreamSendState": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Send State: %hhu",
+      "UniqueId": "StreamSendState",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "NotAccepted": {
       "ModuleProperites": {},
@@ -14772,34 +6650,15 @@
       "UniqueId": "NotAccepted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Stream",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogStreamWarning",
-        "EncodedPrefix": "[strm][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogStreamWarning"
     },
     "MaxStreamCountUpdated": {
       "ModuleProperites": {},
@@ -14807,42 +6666,19 @@
       "UniqueId": "MaxStreamCountUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Count",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Type",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "IndicateStreamsAvailable": {
       "ModuleProperites": {},
@@ -14850,42 +6686,19 @@
       "UniqueId": "IndicateStreamsAvailable",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.STREAMS_AVAILABLE.BidirectionalCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.STREAMS_AVAILABLE.UnidirectionalCount",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "PeerStreamCountsUpdated": {
       "ModuleProperites": {},
@@ -14893,42 +6706,19 @@
       "UniqueId": "PeerStreamCountsUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "BidirectionalStreams",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MaxStreams",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "IndicatePeerStreamStarted": {
       "ModuleProperites": {},
@@ -14936,42 +6726,147 @@
       "UniqueId": "IndicatePeerStreamStarted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.PEER_STREAM_STARTED.Stream",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Event.PEER_STREAM_STARTED.Flags",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CloseWithoutShutdown": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Closing handle without fully shutting down",
+      "UniqueId": "CloseWithoutShutdown",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamWarning"
+    },
+    "EventSilentDiscard": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Event silently discarded",
+      "UniqueId": "EventSilentDiscard",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamWarning"
+    },
+    "IndicateStartComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE (0x%x)",
+      "UniqueId": "IndicateStartComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
         },
-        "CustomSettings": null
-      }
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "IndicateStreamShutdownComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE",
+      "UniqueId": "IndicateStreamShutdownComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "StreamDestroyed": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Destroyed",
+      "UniqueId": "StreamDestroyed",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamCreated": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Created, Conn=%p ID=%llu IsLocal=%hhu",
+      "UniqueId": "StreamCreated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamOutFlowBlocked": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Send Blocked Flags: %hhu",
+      "UniqueId": "StreamOutFlowBlocked",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamRundown": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Rundown, Conn=%p ID=%llu IsLocal=%hhu",
+      "UniqueId": "StreamRundown",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
     },
     "TimerWheelResize": {
       "ModuleProperites": {},
@@ -14979,34 +6874,15 @@
       "UniqueId": "TimerWheelResize",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "NewSlotCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TimerWheelNextExpirationNull": {
       "ModuleProperites": {},
@@ -15014,26 +6890,11 @@
       "UniqueId": "TimerWheelNextExpirationNull",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TimerWheelNextExpiration": {
       "ModuleProperites": {},
@@ -15041,42 +6902,19 @@
       "UniqueId": "TimerWheelNextExpiration",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel->NextExpirationTime",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel->NextConnection",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TimerWheelRemoveConnection": {
       "ModuleProperites": {},
@@ -15084,34 +6922,15 @@
       "UniqueId": "TimerWheelRemoveConnection",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TimerWheelUpdateConnection": {
       "ModuleProperites": {},
@@ -15119,34 +6938,15 @@
       "UniqueId": "TimerWheelUpdateConnection",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TimerWheel",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "StillInTimerWheel": {
       "ModuleProperites": {},
@@ -15154,26 +6954,11 @@
       "UniqueId": "StillInTimerWheel",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "IndicateIdealProcChanged": {
       "ModuleProperites": {},
@@ -15181,26 +6966,11 @@
       "UniqueId": "IndicateIdealProcChanged",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "AbandonOnLibShutdown": {
       "ModuleProperites": {},
@@ -15208,26 +6978,11 @@
       "UniqueId": "AbandonOnLibShutdown",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "WorkerCreated": {
       "ModuleProperites": {},
@@ -15235,42 +6990,19 @@
       "UniqueId": "WorkerCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "IdealProcessor",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Owner",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerErrorStatus": {
       "ModuleProperites": {},
@@ -15278,42 +7010,19 @@
       "UniqueId": "WorkerErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"QuicThreadCreate\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerCleanup": {
       "ModuleProperites": {},
@@ -15321,26 +7030,11 @@
       "UniqueId": "WorkerCleanup",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerDestroyed": {
       "ModuleProperites": {},
@@ -15348,26 +7042,11 @@
       "UniqueId": "WorkerDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "ConnScheduleState": {
       "ModuleProperites": {},
@@ -15375,34 +7054,15 @@
       "UniqueId": "ConnScheduleState",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QUIC_SCHEDULE_QUEUED",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerActivityStateUpdated": {
       "ModuleProperites": {},
@@ -15410,42 +7070,19 @@
       "UniqueId": "WorkerActivityStateUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker->IsActive",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Arg",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerQueueDelayUpdated": {
       "ModuleProperites": {},
@@ -15453,34 +7090,15 @@
       "UniqueId": "WorkerQueueDelayUpdated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker->AverageQueueDelay",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerStart": {
       "ModuleProperites": {},
@@ -15488,26 +7106,11 @@
       "UniqueId": "WorkerStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WorkerStop": {
       "ModuleProperites": {},
@@ -15515,26 +7118,11 @@
       "UniqueId": "WorkerStop",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Worker",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "CertCapiVerifiedChain": {
       "ModuleProperites": {},
@@ -15542,42 +7130,19 @@
       "UniqueId": "CertCapiVerifiedChain",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ServerName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "S",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "IgnoreFlags",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "CertCapiParsedChain": {
       "ModuleProperites": {},
@@ -15585,26 +7150,11 @@
       "UniqueId": "CertCapiParsedChain",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CertNumber",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "CertCapiFormattedChain": {
       "ModuleProperites": {},
@@ -15612,26 +7162,11 @@
       "UniqueId": "CertCapiFormattedChain",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CertNumber",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "CertCapiSign": {
       "ModuleProperites": {},
@@ -15639,26 +7174,11 @@
       "UniqueId": "CertCapiSign",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SignatureAlgorithm",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "4.4x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "CertCapiVerify": {
       "ModuleProperites": {},
@@ -15666,26 +7186,11 @@
       "UniqueId": "CertCapiVerify",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SignatureAlgorithm",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "4.4x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryError": {
       "ModuleProperites": {},
@@ -15693,26 +7198,11 @@
       "UniqueId": "LibraryError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Not all cert bytes were processed\"",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "CertOpenSslGetProcessAddressFailure": {
       "ModuleProperites": {},
@@ -15720,34 +7210,15 @@
       "UniqueId": "CertOpenSslGetProcessAddressFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FuncName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Error",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "DatapathWorkerThreadStart": {
       "ModuleProperites": {},
@@ -15755,26 +7226,11 @@
       "UniqueId": "DatapathWorkerThreadStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ProcContext",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "DatapathWorkerThreadStop": {
       "ModuleProperites": {},
@@ -15782,26 +7238,11 @@
       "UniqueId": "DatapathWorkerThreadStop",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ProcContext",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "DatapathResolveHostNameFailed": {
       "ModuleProperites": {},
@@ -15809,34 +7250,15 @@
       "UniqueId": "DatapathResolveHostNameFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Datapath",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "HostName",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogError",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogError"
     },
     "DatapathErrorStatus": {
       "ModuleProperites": {},
@@ -15844,42 +7266,19 @@
       "UniqueId": "DatapathErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"eventfd failed\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "DatapathRecv": {
       "ModuleProperites": {},
@@ -15887,58 +7286,27 @@
       "UniqueId": "DatapathRecv",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)BytesTransferred",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)BytesTransferred",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*LocalAddr), LocalAddr)",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*RemoteAddr), RemoteAddr)",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "DatapathCreated": {
       "ModuleProperites": {},
@@ -15946,42 +7314,19 @@
       "UniqueId": "DatapathCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(RemoteAddress ? sizeof(*RemoteAddress) : 0, RemoteAddress)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "DatapathDestroyed": {
       "ModuleProperites": {},
@@ -15989,26 +7334,11 @@
       "UniqueId": "DatapathDestroyed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "DatapathSend": {
       "ModuleProperites": {},
@@ -16016,66 +7346,31 @@
       "UniqueId": "DatapathSend",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TotalSize",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendContext->BufferCount",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SendContext->Buffers[0].Length",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress)",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg6"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress)",
-            "SuggestedTelemetryName": "arg7"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg7"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "DatapathOpenTcpSocketFailed": {
       "ModuleProperites": {},
@@ -16083,26 +7378,11 @@
       "UniqueId": "DatapathOpenTcpSocketFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathOpenTcpSocketFailedAsync": {
       "ModuleProperites": {},
@@ -16110,26 +7390,11 @@
       "UniqueId": "DatapathOpenTcpSocketFailedAsync",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryRssScalabilityInfoFailed": {
       "ModuleProperites": {},
@@ -16137,26 +7402,11 @@
       "UniqueId": "DatapathQueryRssScalabilityInfoFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryRssScalabilityInfoFailedAsync": {
       "ModuleProperites": {},
@@ -16164,26 +7414,11 @@
       "UniqueId": "DatapathQueryRssScalabilityInfoFailedAsync",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathOpenUdpSocketFailed": {
       "ModuleProperites": {},
@@ -16191,26 +7426,11 @@
       "UniqueId": "DatapathOpenUdpSocketFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathOpenUdpSocketFailedAsync": {
       "ModuleProperites": {},
@@ -16218,26 +7438,11 @@
       "UniqueId": "DatapathOpenUdpSocketFailedAsync",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryUdpSendMsgFailed": {
       "ModuleProperites": {},
@@ -16245,26 +7450,11 @@
       "UniqueId": "DatapathQueryUdpSendMsgFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryUdpSendMsgFailedAsync": {
       "ModuleProperites": {},
@@ -16272,26 +7462,11 @@
       "UniqueId": "DatapathQueryUdpSendMsgFailedAsync",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryRecvMaxCoalescedSizeFailed": {
       "ModuleProperites": {},
@@ -16299,26 +7474,11 @@
       "UniqueId": "DatapathQueryRecvMaxCoalescedSizeFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryRecvMaxCoalescedSizeFailedAsync": {
       "ModuleProperites": {},
@@ -16326,26 +7486,11 @@
       "UniqueId": "DatapathQueryRecvMaxCoalescedSizeFailedAsync",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropEmptyMdl": {
       "ModuleProperites": {},
@@ -16353,26 +7498,11 @@
       "UniqueId": "DatapathDropEmptyMdl",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropMissingInfo": {
       "ModuleProperites": {},
@@ -16380,26 +7510,11 @@
       "UniqueId": "DatapathDropMissingInfo",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropTooBig": {
       "ModuleProperites": {},
@@ -16407,34 +7522,15 @@
       "UniqueId": "DatapathDropTooBig",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint64_t)DataLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropMdlMapFailure": {
       "ModuleProperites": {},
@@ -16442,26 +7538,11 @@
       "UniqueId": "DatapathDropMdlMapFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathFragmented": {
       "ModuleProperites": {},
@@ -16469,26 +7550,11 @@
       "UniqueId": "DatapathFragmented",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropAllocRecvContextFailure": {
       "ModuleProperites": {},
@@ -16496,26 +7562,11 @@
       "UniqueId": "DatapathDropAllocRecvContextFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathDropAllocRecvBufferFailure": {
       "ModuleProperites": {},
@@ -16523,26 +7574,11 @@
       "UniqueId": "DatapathDropAllocRecvBufferFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathUroExceeded": {
       "ModuleProperites": {},
@@ -16550,26 +7586,11 @@
       "UniqueId": "DatapathUroExceeded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathUnreachable": {
       "ModuleProperites": {},
@@ -16577,34 +7598,15 @@
       "UniqueId": "DatapathUnreachable",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(RemoteAddr), &RemoteAddr)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "DatapathQueryRssProcessorInfoFailed": {
       "ModuleProperites": {},
@@ -16612,26 +7614,11 @@
       "UniqueId": "DatapathQueryRssProcessorInfoFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "WsaError",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathQueryProcessorAffinityFailed": {
       "ModuleProperites": {},
@@ -16639,34 +7626,15 @@
       "UniqueId": "DatapathQueryProcessorAffinityFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "WsaError",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathMissingInfo": {
       "ModuleProperites": {},
@@ -16674,26 +7642,11 @@
       "UniqueId": "DatapathMissingInfo",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathRecvEmpty": {
       "ModuleProperites": {},
@@ -16701,26 +7654,11 @@
       "UniqueId": "DatapathRecvEmpty",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathUroPreallocExceeded": {
       "ModuleProperites": {},
@@ -16728,26 +7666,11 @@
       "UniqueId": "DatapathUroPreallocExceeded",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "DatapathShutDownReturn": {
       "ModuleProperites": {},
@@ -16755,26 +7678,11 @@
       "UniqueId": "DatapathShutDownReturn",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "DatapathShutDownComplete": {
       "ModuleProperites": {},
@@ -16782,26 +7690,11 @@
       "UniqueId": "DatapathShutDownComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "DatapathUnreachableWithError": {
       "ModuleProperites": {},
@@ -16809,42 +7702,19 @@
       "UniqueId": "DatapathUnreachableWithError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ErrorCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*RemoteAddr), RemoteAddr)",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "DatapathTooLarge": {
       "ModuleProperites": {},
@@ -16852,34 +7722,15 @@
       "UniqueId": "DatapathTooLarge",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SocketContext->Binding",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CLOG_BYTEARRAY(sizeof(*RemoteAddr), RemoteAddr)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "LibraryAssert": {
       "ModuleProperites": {},
@@ -16887,78 +7738,33 @@
       "UniqueId": "LibraryAssert",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Line",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "File",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Expr",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "WindowsKernelLoaded": {
       "ModuleProperites": {},
       "TraceString": "[ sys] Loaded",
       "UniqueId": "WindowsKernelLoaded",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsKernelUnloaded": {
       "ModuleProperites": {},
       "TraceString": "[ sys] Unloaded",
       "UniqueId": "WindowsKernelUnloaded",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsKernelInitialized": {
       "ModuleProperites": {},
@@ -16966,88 +7772,36 @@
       "UniqueId": "WindowsKernelInitialized",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Sbi.PageSize",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicTotalMemory",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsKernelUninitialized": {
       "ModuleProperites": {},
       "TraceString": "[ sys] Uninitialized",
       "UniqueId": "WindowsKernelUninitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsUserLoaded": {
       "ModuleProperites": {},
       "TraceString": "[ dll] Loaded",
       "UniqueId": "WindowsUserLoaded",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsUserUnloaded": {
       "ModuleProperites": {},
       "TraceString": "[ dll] Unloaded",
       "UniqueId": "WindowsUserUnloaded",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsUserProcessorState": {
       "ModuleProperites": {},
@@ -17055,42 +7809,19 @@
       "UniqueId": "WindowsUserProcessorState",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ActiveProcessorCount",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ProcessorGroupCount",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "NumaNodeCount",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "ProcessorInfo": {
       "ModuleProperites": {},
@@ -17098,50 +7829,23 @@
       "UniqueId": "ProcessorInfo",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Index",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicProcessorInfo[Index].Group",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicProcessorInfo[Index].Index",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicProcessorInfo[Index].NumaNode",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsUserInitialized": {
       "ModuleProperites": {},
@@ -17149,44 +7853,18 @@
       "UniqueId": "WindowsUserInitialized",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicTotalMemory",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "WindowsUserUninitialized": {
       "ModuleProperites": {},
       "TraceString": "[ dll] Uninitialized",
       "UniqueId": "WindowsUserUninitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "CertWaitForCreationEvent": {
       "ModuleProperites": {},
@@ -17194,34 +7872,15 @@
       "UniqueId": "CertWaitForCreationEvent",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "WaitResult",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "GetLastError()",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "CertCleanTestCerts": {
       "ModuleProperites": {},
@@ -17229,88 +7888,36 @@
       "UniqueId": "CertCleanTestCerts",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Found",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Deleted",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "CertOpenRsaKeySuccess": {
       "ModuleProperites": {},
       "TraceString": "[cert] Successfully opened RSA key",
       "UniqueId": "CertOpenRsaKeySuccess",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "CertCreateRsaKeySuccess": {
       "ModuleProperites": {},
       "TraceString": "[cert] Successfully created key",
       "UniqueId": "CertCreateRsaKeySuccess",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "CertCreationEventAlreadyCreated": {
       "ModuleProperites": {},
       "TraceString": "[test] CreateEvent opened existing event",
       "UniqueId": "CertCreationEventAlreadyCreated",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "StorageOpenKey": {
       "ModuleProperites": {},
@@ -17318,62 +7925,25 @@
       "UniqueId": "StorageOpenKey",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FullKeyName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "miTlsInitialize": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Initializing miTLS library",
       "UniqueId": "miTlsInitialize",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "miTlsUninitialize": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Cleaning up miTLS library",
       "UniqueId": "miTlsUninitialize",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "miTlsLogSecret": {
       "ModuleProperites": {},
@@ -17381,42 +7951,19 @@
       "UniqueId": "miTlsLogSecret",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Prefix",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SecretStr",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "miTlsFfiProcessFailed": {
       "ModuleProperites": {},
@@ -17424,42 +7971,19 @@
       "UniqueId": "miTlsFfiProcessFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Context.tls_error",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Context.tls_error_desc",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "miTlsFfiGetHelloSummaryFailed": {
       "ModuleProperites": {},
@@ -17467,42 +7991,19 @@
       "UniqueId": "miTlsFfiGetHelloSummaryFailed",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "CookieLen",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "zu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TicketLen",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "zu",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "miTlsCertValidationDisabled": {
       "ModuleProperites": {},
@@ -17510,26 +8011,11 @@
       "UniqueId": "miTlsCertValidationDisabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "miTlsCertSelected": {
       "ModuleProperites": {},
@@ -17537,42 +8023,19 @@
       "UniqueId": "miTlsCertSelected",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->SNI",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*SelectedSignature",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "4.4x",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "miTlsUsing0Rtt": {
       "ModuleProperites": {},
@@ -17580,26 +8043,11 @@
       "UniqueId": "miTlsUsing0Rtt",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsProcess": {
       "ModuleProperites": {},
@@ -17607,34 +8055,15 @@
       "UniqueId": "miTlsProcess",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsSend0RttTicket": {
       "ModuleProperites": {},
@@ -17642,26 +8071,11 @@
       "UniqueId": "miTlsSend0RttTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsFfiProces": {
       "ModuleProperites": {},
@@ -17669,34 +8083,15 @@
       "UniqueId": "miTlsFfiProces",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Context.input_len",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsFfiProcessResult": {
       "ModuleProperites": {},
@@ -17704,42 +8099,19 @@
       "UniqueId": "miTlsFfiProcessResult",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Context.consumed_bytes",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Context.output_len",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsHandshakeComplete": {
       "ModuleProperites": {},
@@ -17747,26 +8119,11 @@
       "UniqueId": "miTlsHandshakeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsEarlyDataRejected": {
       "ModuleProperites": {},
@@ -17774,26 +8131,11 @@
       "UniqueId": "miTlsEarlyDataRejected",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsEarlyDataAccepted": {
       "ModuleProperites": {},
@@ -17801,26 +8143,11 @@
       "UniqueId": "miTlsEarlyDataAccepted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsEarlyDataNotAttempted": {
       "ModuleProperites": {},
@@ -17828,26 +8155,11 @@
       "UniqueId": "miTlsEarlyDataNotAttempted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsEarlyDataAttempted": {
       "ModuleProperites": {},
@@ -17855,26 +8167,11 @@
       "UniqueId": "miTlsEarlyDataAttempted",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsKeySchedule": {
       "ModuleProperites": {},
@@ -17882,34 +8179,15 @@
       "UniqueId": "miTlsKeySchedule",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->TlsKeySchedule",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTls0RttReadKeyExported": {
       "ModuleProperites": {},
@@ -17917,26 +8195,11 @@
       "UniqueId": "miTls0RttReadKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsHandshakeReadKeyExported": {
       "ModuleProperites": {},
@@ -17944,26 +8207,11 @@
       "UniqueId": "miTlsHandshakeReadKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTls1RttReadKeyExported": {
       "ModuleProperites": {},
@@ -17971,26 +8219,11 @@
       "UniqueId": "miTls1RttReadKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTls0RttWriteKeyExported": {
       "ModuleProperites": {},
@@ -17998,26 +8231,11 @@
       "UniqueId": "miTls0RttWriteKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsHandshakeWriteKeyExported": {
       "ModuleProperites": {},
@@ -18025,26 +8243,11 @@
       "UniqueId": "miTlsHandshakeWriteKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTls1RttWriteKeyExported": {
       "ModuleProperites": {},
@@ -18052,26 +8255,11 @@
       "UniqueId": "miTls1RttWriteKeyExported",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsHandshakeWriteOffsetSet": {
       "ModuleProperites": {},
@@ -18079,34 +8267,15 @@
       "UniqueId": "miTlsHandshakeWriteOffsetSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State->BufferOffsetHandshake",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTls1RttWriteOffsetSet": {
       "ModuleProperites": {},
@@ -18114,34 +8283,15 @@
       "UniqueId": "miTls1RttWriteOffsetSet",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State->BufferOffset1Rtt",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsFfiProcesComplete": {
       "ModuleProperites": {},
@@ -18149,34 +8299,15 @@
       "UniqueId": "miTlsFfiProcesComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "BufferOffset",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsOnCertSelect": {
       "ModuleProperites": {},
@@ -18184,26 +8315,11 @@
       "UniqueId": "miTlsOnCertSelect",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsOnNegotiate": {
       "ModuleProperites": {},
@@ -18211,26 +8327,11 @@
       "UniqueId": "miTlsOnNegotiate",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsProcessServerAlpn": {
       "ModuleProperites": {},
@@ -18238,34 +8339,15 @@
       "UniqueId": "miTlsProcessServerAlpn",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)ExtensionDataLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsOnCertFormat": {
       "ModuleProperites": {},
@@ -18273,26 +8355,11 @@
       "UniqueId": "miTlsOnCertFormat",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsOnCertSign": {
       "ModuleProperites": {},
@@ -18300,26 +8367,11 @@
       "UniqueId": "miTlsOnCertSign",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsOnCertVerify": {
       "ModuleProperites": {},
@@ -18327,26 +8379,11 @@
       "UniqueId": "miTlsOnCertVerify",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "miTlsRecvNewSessionTicket": {
       "ModuleProperites": {},
@@ -18354,50 +8391,23 @@
       "UniqueId": "miTlsRecvNewSessionTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Ticket->ticket_len",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)Ticket->session_len",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ServerNameIndication",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "TlsMessage": {
       "ModuleProperites": {},
@@ -18405,34 +8415,15 @@
       "UniqueId": "TlsMessage",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsGetValue(miTlsCurrentConnectionIndex)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Msg",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "TlsError": {
       "ModuleProperites": {},
@@ -18440,34 +8431,15 @@
       "UniqueId": "TlsError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"SNI Too Long\"",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "OpenSslLogSecret": {
       "ModuleProperites": {},
@@ -18475,42 +8447,19 @@
       "UniqueId": "OpenSslLogSecret",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Prefix",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SecretStr",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "OpenSslAlert": {
       "ModuleProperites": {},
@@ -18518,42 +8467,19 @@
       "UniqueId": "OpenSslAlert",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Alert",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Level",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslHandshakeErrorStr": {
       "ModuleProperites": {},
@@ -18561,34 +8487,15 @@
       "UniqueId": "OpenSslHandshakeErrorStr",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ERR_error_string(ERR_get_error(), NULL)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslHandshakeError": {
       "ModuleProperites": {},
@@ -18596,34 +8503,15 @@
       "UniqueId": "OpenSslHandshakeError",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Err",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslAlpnNegotiationFailure": {
       "ModuleProperites": {},
@@ -18631,26 +8519,11 @@
       "UniqueId": "OpenSslAlpnNegotiationFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslInvalidAlpnLength": {
       "ModuleProperites": {},
@@ -18658,26 +8531,11 @@
       "UniqueId": "OpenSslInvalidAlpnLength",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslNoMatchingAlpn": {
       "ModuleProperites": {},
@@ -18685,26 +8543,11 @@
       "UniqueId": "OpenSslNoMatchingAlpn",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslMissingTransportParameters": {
       "ModuleProperites": {},
@@ -18712,26 +8555,11 @@
       "UniqueId": "OpenSslMissingTransportParameters",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnError",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnError"
     },
     "OpenSslHandshakeDataStart": {
       "ModuleProperites": {},
@@ -18739,34 +8567,15 @@
       "UniqueId": "OpenSslHandshakeDataStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsState->BufferOffsetHandshake",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "OpenSsl1RttDataStart": {
       "ModuleProperites": {},
@@ -18774,34 +8583,15 @@
       "UniqueId": "OpenSsl1RttDataStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsState->BufferOffset1Rtt",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "OpenSslContextReset": {
       "ModuleProperites": {},
@@ -18809,26 +8599,11 @@
       "UniqueId": "OpenSslContextReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "OpenSslHandshakeComplete": {
       "ModuleProperites": {},
@@ -18836,26 +8611,11 @@
       "UniqueId": "OpenSslHandshakeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "OpenSslNewEncryptionSecrets": {
       "ModuleProperites": {},
@@ -18863,34 +8623,15 @@
       "UniqueId": "OpenSslNewEncryptionSecrets",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Level",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "OpenSslAddHandshakeData": {
       "ModuleProperites": {},
@@ -18898,42 +8639,19 @@
       "UniqueId": "OpenSslAddHandshakeData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Level",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "OpenSslContextCreated": {
       "ModuleProperites": {},
@@ -18941,26 +8659,11 @@
       "UniqueId": "OpenSslContextCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "OpenSslContextCleaningUp": {
       "ModuleProperites": {},
@@ -18968,26 +8671,11 @@
       "UniqueId": "OpenSslContextCleaningUp",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "OpenSsslIgnoringTicket": {
       "ModuleProperites": {},
@@ -18995,34 +8683,15 @@
       "UniqueId": "OpenSsslIgnoringTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "OpenSslProcessData": {
       "ModuleProperites": {},
@@ -19030,124 +8699,50 @@
       "UniqueId": "OpenSslProcessData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "SchannelInitialized": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Library initialized",
       "UniqueId": "SchannelInitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelUninitialized": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Library uninitialized",
       "UniqueId": "SchannelUninitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelAchAsync": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Calling SspiAcquireCredentialsHandleAsyncW",
       "UniqueId": "SchannelAchAsync",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelAchWorkerStart": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Starting ACH worker",
       "UniqueId": "SchannelAchWorkerStart",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelAch": {
       "ModuleProperites": {},
       "TraceString": "[ tls] Calling AcquireCredentialsHandleW",
       "UniqueId": "SchannelAch",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelAchCompleteInline": {
       "ModuleProperites": {},
@@ -19155,26 +8750,11 @@
       "UniqueId": "SchannelAchCompleteInline",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelLogSecret": {
       "ModuleProperites": {},
@@ -19182,42 +8762,19 @@
       "UniqueId": "SchannelLogSecret",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Prefix",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Length",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "SecretStr",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "SchannelContextReset": {
       "ModuleProperites": {},
@@ -19225,26 +8782,11 @@
       "UniqueId": "SchannelContextReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelHandshakeComplete": {
       "ModuleProperites": {},
@@ -19252,34 +8794,15 @@
       "UniqueId": "SchannelHandshakeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State->SessionResumed",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelConsumedBytes": {
       "ModuleProperites": {},
@@ -19287,34 +8810,15 @@
       "UniqueId": "SchannelConsumedBytes",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*InBufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelReadHandshakeStart": {
       "ModuleProperites": {},
@@ -19322,26 +8826,11 @@
       "UniqueId": "SchannelReadHandshakeStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelRead1RttStart": {
       "ModuleProperites": {},
@@ -19349,26 +8838,11 @@
       "UniqueId": "SchannelRead1RttStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelWriteHandshakeStart": {
       "ModuleProperites": {},
@@ -19376,34 +8850,15 @@
       "UniqueId": "SchannelWriteHandshakeStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State->BufferOffsetHandshake",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelWrite1RttStart": {
       "ModuleProperites": {},
@@ -19411,34 +8866,15 @@
       "UniqueId": "SchannelWrite1RttStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "State->BufferOffset1Rtt",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelProducedData": {
       "ModuleProperites": {},
@@ -19446,34 +8882,15 @@
       "UniqueId": "SchannelProducedData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "OutputTokenBuffer->cbBuffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelMissingData": {
       "ModuleProperites": {},
@@ -19481,34 +8898,15 @@
       "UniqueId": "SchannelMissingData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "MissingBuffer->cbBuffer",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelContextCreated": {
       "ModuleProperites": {},
@@ -19516,26 +8914,11 @@
       "UniqueId": "SchannelContextCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "SchannelContextCleaningUp": {
       "ModuleProperites": {},
@@ -19543,26 +8926,11 @@
       "UniqueId": "SchannelContextCleaningUp",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "SchannelKeyReady": {
       "ModuleProperites": {},
@@ -19570,50 +8938,23 @@
       "UniqueId": "SchannelKeyReady",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TrafficSecret->TrafficSecretType",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TrafficSecret->MsgSequenceStart",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TrafficSecret->MsgSequenceEnd",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg5"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "SchannelIgnoringTicket": {
       "ModuleProperites": {},
@@ -19621,34 +8962,15 @@
       "UniqueId": "SchannelIgnoringTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "SchannelProcessingData": {
       "ModuleProperites": {},
@@ -19656,34 +8978,15 @@
       "UniqueId": "SchannelProcessingData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "TlsErrorStatus": {
       "ModuleProperites": {},
@@ -19691,42 +8994,19 @@
       "UniqueId": "TlsErrorStatus",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "\"Convert SNI to unicode\"",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceEvent",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceEvent"
     },
     "StubTlsCertValidationDisabled": {
       "ModuleProperites": {},
@@ -19734,26 +9014,11 @@
       "UniqueId": "StubTlsCertValidationDisabled",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnWarning",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnWarning"
     },
     "StubTlsContextReset": {
       "ModuleProperites": {},
@@ -19761,26 +9026,11 @@
       "UniqueId": "StubTlsContextReset",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "StubTlsHandshakeComplete": {
       "ModuleProperites": {},
@@ -19788,26 +9038,11 @@
       "UniqueId": "StubTlsHandshakeComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "StubTlsConsumedData": {
       "ModuleProperites": {},
@@ -19815,34 +9050,15 @@
       "UniqueId": "StubTlsConsumedData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "StubTlsProducedData": {
       "ModuleProperites": {},
@@ -19850,34 +9066,15 @@
       "UniqueId": "StubTlsProducedData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(State->BufferLength - PrevBufferLength)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnInfo",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnInfo"
     },
     "StubTlsContextCreated": {
       "ModuleProperites": {},
@@ -19885,26 +9082,11 @@
       "UniqueId": "StubTlsContextCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "StubTlsUsing0Rtt": {
       "ModuleProperites": {},
@@ -19912,26 +9094,11 @@
       "UniqueId": "StubTlsUsing0Rtt",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "StubTlsContextCleaningUp": {
       "ModuleProperites": {},
@@ -19939,26 +9106,11 @@
       "UniqueId": "StubTlsContextCleaningUp",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "StubTlsRecvNewSessionTicket": {
       "ModuleProperites": {},
@@ -19966,42 +9118,19 @@
       "UniqueId": "StubTlsRecvNewSessionTicket",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ServerMessageLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->SNI",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "StubTlsProcessData": {
       "ModuleProperites": {},
@@ -20009,34 +9138,15 @@
       "UniqueId": "StubTlsProcessData",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TlsContext->Connection",
-            "SuggestedTelemetryName": "arg1"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "*BufferLength",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogConnVerbose",
-        "EncodedPrefix": "[conn][%p] ",
-        "EncodedArgNumber": 2,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogConnVerbose"
     },
     "TestControlClientCanceledRequest": {
       "ModuleProperites": {},
@@ -20044,34 +9154,15 @@
       "UniqueId": "TestControlClientCanceledRequest",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Client",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Request",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogWarning",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogWarning"
     },
     "TestControlClientCreated": {
       "ModuleProperites": {},
@@ -20079,26 +9170,11 @@
       "UniqueId": "TestControlClientCreated",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Client",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestControlClientCleaningUp": {
       "ModuleProperites": {},
@@ -20106,26 +9182,11 @@
       "UniqueId": "TestControlClientCleaningUp",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Client",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestControlClientIoctl": {
       "ModuleProperites": {},
@@ -20133,34 +9194,15 @@
       "UniqueId": "TestControlClientIoctl",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Client",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "FunctionCode",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestControlClientIoctlComplete": {
       "ModuleProperites": {},
@@ -20168,88 +9210,36 @@
       "UniqueId": "TestControlClientIoctlComplete",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Client",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "p",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Status",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestControlInitialized": {
       "ModuleProperites": {},
       "TraceString": "[test] Control interface initialized",
       "UniqueId": "TestControlInitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestControlUninitializing": {
       "ModuleProperites": {},
       "TraceString": "[test] Control interface uninitializing",
       "UniqueId": "TestControlUninitializing",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestControlUninitialized": {
       "ModuleProperites": {},
       "TraceString": "[test] Control interface uninitialized",
       "UniqueId": "TestControlUninitialized",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestDriverFailureLocation": {
       "ModuleProperites": {},
@@ -20257,42 +9247,19 @@
       "UniqueId": "TestDriverFailureLocation",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "File",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Function",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Line",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogError",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogError"
     },
     "TestDriverFailure": {
       "ModuleProperites": {},
@@ -20300,62 +9267,25 @@
       "UniqueId": "TestDriverFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Buffer",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogError",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogError"
     },
     "TestDriverStarted": {
       "ModuleProperites": {},
       "TraceString": "[test] Started",
       "UniqueId": "TestDriverStarted",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestDriverStopped": {
       "ModuleProperites": {},
       "TraceString": "[test] Stopped",
       "UniqueId": "TestDriverStopped",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestCaseStart": {
       "ModuleProperites": {},
@@ -20363,26 +9293,11 @@
       "UniqueId": "TestCaseStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestCaseEnd": {
       "ModuleProperites": {},
@@ -20390,26 +9305,11 @@
       "UniqueId": "TestCaseEnd",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestCaseTStart": {
       "ModuleProperites": {},
@@ -20417,34 +9317,15 @@
       "UniqueId": "TestCaseTStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "stream.str().c_str()",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestCaseTEnd": {
       "ModuleProperites": {},
@@ -20452,26 +9333,11 @@
       "UniqueId": "TestCaseTEnd",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestLogFailure": {
       "ModuleProperites": {},
@@ -20479,60 +9345,26 @@
       "UniqueId": "TestLogFailure",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "File",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Line",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "d",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Buffer",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogError",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogError"
     },
     "TestIgnoreConnectionTimeout": {
       "ModuleProperites": {},
       "TraceString": "[test] Ignoring timeout unexpected status because of random loss",
       "UniqueId": "TestIgnoreConnectionTimeout",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestScopeEntry": {
       "ModuleProperites": {},
@@ -20540,26 +9372,11 @@
       "UniqueId": "TestScopeEntry",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Name",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestScopeExit": {
       "ModuleProperites": {},
@@ -20567,116 +9384,46 @@
       "UniqueId": "TestScopeExit",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Name",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestHookRegister": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Registering",
       "UniqueId": "TestHookRegister",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestHookUnregistering": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Unregistering",
       "UniqueId": "TestHookUnregistering",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestHookUnregistered": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Unregistered",
       "UniqueId": "TestHookUnregistered",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "TestHookDropPacketRandom": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Random packet drop",
       "UniqueId": "TestHookDropPacketRandom",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookDropPacketSelective": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Selective packet drop",
       "UniqueId": "TestHookDropPacketSelective",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookReplaceAddrRecv": {
       "ModuleProperites": {},
@@ -20684,34 +9431,15 @@
       "UniqueId": "TestHookReplaceAddrRecv",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicAddrGetPort(&Original)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicAddrGetPort(&New)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookReplaceAddrSend": {
       "ModuleProperites": {},
@@ -20719,88 +9447,36 @@
       "UniqueId": "TestHookReplaceAddrSend",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicAddrGetPort(&New)",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "QuicAddrGetPort(&Original)",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookDropOldAddrSend": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Dropping send to old addr",
       "UniqueId": "TestHookDropOldAddrSend",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookDropLimitAddrRecv": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Dropping recv over limit to new addr",
       "UniqueId": "TestHookDropLimitAddrRecv",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "TestHookDropLimitAddrSend": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Dropping send over limit to new addr",
       "UniqueId": "TestHookDropLimitAddrSend",
       "splitArgs": [],
-      "macro": {
-        "MacroName": "QuicTraceLogVerbose",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogVerbose"
     },
     "InteropTestStart": {
       "ModuleProperites": {},
@@ -20808,42 +9484,19 @@
       "UniqueId": "InteropTestStart",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PublicEndpoints[EndpointIndex].ServerName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestContext->Port",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)TestContext->Feature",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     },
     "InteropTestStop": {
       "ModuleProperites": {},
@@ -20851,58 +9504,27 @@
       "UniqueId": "InteropTestStop",
       "splitArgs": [
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "PublicEndpoints[EndpointIndex].ServerName",
-            "SuggestedTelemetryName": "arg2"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "TestContext->Port",
-            "SuggestedTelemetryName": "arg3"
-          },
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg3"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "(uint32_t)TestContext->Feature",
-            "SuggestedTelemetryName": "arg4"
-          },
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "Alpn",
-            "SuggestedTelemetryName": "arg5"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg5"
         },
         {
-          "VariableInfo": {
-            "UserSuppliedTrimmed": "ThisTestFailed ? \"false\" : \"true\"",
-            "SuggestedTelemetryName": "arg6"
-          },
           "DefinationEncoding": "s",
           "MacroVariableName": "arg6"
         }
       ],
-      "macro": {
-        "MacroName": "QuicTraceLogInfo",
-        "EncodedPrefix": null,
-        "EncodedArgNumber": 1,
-        "MacroConfiguration": {
-          "linux": "lttng_plus",
-          "stubs": "stubs",
-          "windows_kernel": "empty",
-          "windows": "empty"
-        },
-        "CustomSettings": null
-      }
+      "macroName": "QuicTraceLogInfo"
     }
   },
   "Version": 1,
@@ -21826,86 +10448,6 @@
         "TraceID": "ConnOutFlowBlocked"
       },
       {
-        "UniquenessHash": "60d753ab-6710-fe16-e47d-37f046f5973c",
-        "TraceID": "IgnoreCryptoFrame"
-      },
-      {
-        "UniquenessHash": "6501738d-0b97-8289-8e1d-54274fae4f1d",
-        "TraceID": "DiscardKeyType"
-      },
-      {
-        "UniquenessHash": "7add7bc7-5514-83ea-44ca-8acc7e6643b2",
-        "TraceID": "ZeroRttAccepted"
-      },
-      {
-        "UniquenessHash": "bb841825-a52e-8ecf-243e-1a65d10a3e75",
-        "TraceID": "ZeroRttRejected"
-      },
-      {
-        "UniquenessHash": "fba5c72f-0c3d-f668-a88b-39e5e3e62cbd",
-        "TraceID": "HandshakeConfirmedServer"
-      },
-      {
-        "UniquenessHash": "4e785757-b1de-e65c-a7b1-7ac868748434",
-        "TraceID": "CryptoDump"
-      },
-      {
-        "UniquenessHash": "c2f15df5-6ae8-de48-4875-35d291565d96",
-        "TraceID": "CryptoDumpUnacked"
-      },
-      {
-        "UniquenessHash": "e6984e8e-3408-1b5f-b0a0-7d8f293c6623",
-        "TraceID": "CryptoDumpUnacked2"
-      },
-      {
-        "UniquenessHash": "a2080700-161b-68e4-457e-40e07275acf5",
-        "TraceID": "NoMoreRoomForCrypto"
-      },
-      {
-        "UniquenessHash": "cef32e9a-1355-7a31-bd2d-a458b02e214d",
-        "TraceID": "AddCryptoFrame"
-      },
-      {
-        "UniquenessHash": "94b619d7-6b5a-e1b4-d3ee-1b66a383ebbc",
-        "TraceID": "RecoverCrypto"
-      },
-      {
-        "UniquenessHash": "60f13d90-f6b5-d1e2-41fd-0a5662d602e6",
-        "TraceID": "AckCrypto"
-      },
-      {
-        "UniquenessHash": "e5c3a539-ac41-94df-060d-bd4dc2ef4b82",
-        "TraceID": "RecvCrypto"
-      },
-      {
-        "UniquenessHash": "9ed40f87-2b63-8343-5e37-2640d0a40e27",
-        "TraceID": "IndicateConnected"
-      },
-      {
-        "UniquenessHash": "c53376e2-b465-d6a1-047c-4e5e64c263af",
-        "TraceID": "DrainCrypto"
-      },
-      {
-        "UniquenessHash": "fe4d4428-c697-f073-1d9e-e0441b1a8f45",
-        "TraceID": "CryptoNotReady"
-      },
-      {
-        "UniquenessHash": "15379a50-c581-3086-043e-53167a6b3fd6",
-        "TraceID": "ConnWriteKeyUpdated"
-      },
-      {
-        "UniquenessHash": "252598af-99d8-c9ea-9f14-dd07630a45b4",
-        "TraceID": "ConnReadKeyUpdated"
-      },
-      {
-        "UniquenessHash": "12872365-4c5b-bfd4-dc5f-83f6aae048cf",
-        "TraceID": "ConnNewPacketKeys"
-      },
-      {
-        "UniquenessHash": "ec54e332-0990-e91f-5fc1-9a09441bf8a4",
-        "TraceID": "ConnKeyPhaseChange"
-      },
-      {
         "UniquenessHash": "e1f61a3e-5405-efd7-d585-f3a10ab0b6d1",
         "TraceID": "NoSniPresent"
       },
@@ -22084,6 +10626,86 @@
       {
         "UniquenessHash": "bf16a511-be08-e9ca-915f-5e5c834d5ca6",
         "TraceID": "DecodeTPDisable1RttEncryption"
+      },
+      {
+        "UniquenessHash": "60d753ab-6710-fe16-e47d-37f046f5973c",
+        "TraceID": "IgnoreCryptoFrame"
+      },
+      {
+        "UniquenessHash": "6501738d-0b97-8289-8e1d-54274fae4f1d",
+        "TraceID": "DiscardKeyType"
+      },
+      {
+        "UniquenessHash": "7add7bc7-5514-83ea-44ca-8acc7e6643b2",
+        "TraceID": "ZeroRttAccepted"
+      },
+      {
+        "UniquenessHash": "bb841825-a52e-8ecf-243e-1a65d10a3e75",
+        "TraceID": "ZeroRttRejected"
+      },
+      {
+        "UniquenessHash": "fba5c72f-0c3d-f668-a88b-39e5e3e62cbd",
+        "TraceID": "HandshakeConfirmedServer"
+      },
+      {
+        "UniquenessHash": "4e785757-b1de-e65c-a7b1-7ac868748434",
+        "TraceID": "CryptoDump"
+      },
+      {
+        "UniquenessHash": "c2f15df5-6ae8-de48-4875-35d291565d96",
+        "TraceID": "CryptoDumpUnacked"
+      },
+      {
+        "UniquenessHash": "e6984e8e-3408-1b5f-b0a0-7d8f293c6623",
+        "TraceID": "CryptoDumpUnacked2"
+      },
+      {
+        "UniquenessHash": "a2080700-161b-68e4-457e-40e07275acf5",
+        "TraceID": "NoMoreRoomForCrypto"
+      },
+      {
+        "UniquenessHash": "cef32e9a-1355-7a31-bd2d-a458b02e214d",
+        "TraceID": "AddCryptoFrame"
+      },
+      {
+        "UniquenessHash": "94b619d7-6b5a-e1b4-d3ee-1b66a383ebbc",
+        "TraceID": "RecoverCrypto"
+      },
+      {
+        "UniquenessHash": "60f13d90-f6b5-d1e2-41fd-0a5662d602e6",
+        "TraceID": "AckCrypto"
+      },
+      {
+        "UniquenessHash": "e5c3a539-ac41-94df-060d-bd4dc2ef4b82",
+        "TraceID": "RecvCrypto"
+      },
+      {
+        "UniquenessHash": "9ed40f87-2b63-8343-5e37-2640d0a40e27",
+        "TraceID": "IndicateConnected"
+      },
+      {
+        "UniquenessHash": "c53376e2-b465-d6a1-047c-4e5e64c263af",
+        "TraceID": "DrainCrypto"
+      },
+      {
+        "UniquenessHash": "fe4d4428-c697-f073-1d9e-e0441b1a8f45",
+        "TraceID": "CryptoNotReady"
+      },
+      {
+        "UniquenessHash": "15379a50-c581-3086-043e-53167a6b3fd6",
+        "TraceID": "ConnWriteKeyUpdated"
+      },
+      {
+        "UniquenessHash": "252598af-99d8-c9ea-9f14-dd07630a45b4",
+        "TraceID": "ConnReadKeyUpdated"
+      },
+      {
+        "UniquenessHash": "12872365-4c5b-bfd4-dc5f-83f6aae048cf",
+        "TraceID": "ConnNewPacketKeys"
+      },
+      {
+        "UniquenessHash": "ec54e332-0990-e91f-5fc1-9a09441bf8a4",
+        "TraceID": "ConnKeyPhaseChange"
       },
       {
         "UniquenessHash": "152723b4-2b46-a936-ffaf-9cc429e8e66f",
@@ -22538,6 +11160,22 @@
         "TraceID": "ConnExecOper"
       },
       {
+        "UniquenessHash": "91e6e3a1-830d-6ed9-b737-a6481ac8eb55",
+        "TraceID": "NoSrcCidAvailable"
+      },
+      {
+        "UniquenessHash": "03e79f57-89b7-b2d2-b13f-cb2f995b47cd",
+        "TraceID": "GetPacketTypeFailure"
+      },
+      {
+        "UniquenessHash": "f2859068-aa3b-758e-45b8-db7e1bf4063f",
+        "TraceID": "PacketBuilderSendBatch"
+      },
+      {
+        "UniquenessHash": "8acd91f1-3c17-7458-fb5b-e3453f2825d3",
+        "TraceID": "ConnPacketSent"
+      },
+      {
         "UniquenessHash": "05679666-5021-56bf-0a98-5c02ef0f0bff",
         "TraceID": "LogPacketVersionNegotiation"
       },
@@ -22582,22 +11220,6 @@
         "TraceID": "BindingDropPacketEx"
       },
       {
-        "UniquenessHash": "91e6e3a1-830d-6ed9-b737-a6481ac8eb55",
-        "TraceID": "NoSrcCidAvailable"
-      },
-      {
-        "UniquenessHash": "03e79f57-89b7-b2d2-b13f-cb2f995b47cd",
-        "TraceID": "GetPacketTypeFailure"
-      },
-      {
-        "UniquenessHash": "f2859068-aa3b-758e-45b8-db7e1bf4063f",
-        "TraceID": "PacketBuilderSendBatch"
-      },
-      {
-        "UniquenessHash": "8acd91f1-3c17-7458-fb5b-e3453f2825d3",
-        "TraceID": "ConnPacketSent"
-      },
-      {
         "UniquenessHash": "607e449d-59a9-9d66-fcd1-b0a2e12f1dc1",
         "TraceID": "PathInitialized"
       },
@@ -22628,6 +11250,10 @@
       {
         "UniquenessHash": "6f6956ec-af60-d54a-176e-c9db6ac7a50a",
         "TraceID": "RegistrationRundown"
+      },
+      {
+        "UniquenessHash": "537b9c54-10f5-965c-b3e5-6e6e5c66dc85",
+        "TraceID": "IndicateIdealSendBuffer"
       },
       {
         "UniquenessHash": "c8982d54-5957-078c-2db7-dcfc5ff92003",
@@ -22672,10 +11298,6 @@
       {
         "UniquenessHash": "1774df63-d849-a89c-4a88-bf2ff1002e15",
         "TraceID": "ConnQueueSendFlush"
-      },
-      {
-        "UniquenessHash": "537b9c54-10f5-965c-b3e5-6e6e5c66dc85",
-        "TraceID": "IndicateIdealSendBuffer"
       },
       {
         "UniquenessHash": "a0905196-8b7e-fdd3-5369-0c6ffcc3707f",
@@ -22782,46 +11404,6 @@
         "TraceID": "SettingDumpServerResumptionLevel"
       },
       {
-        "UniquenessHash": "f96b231c-aa1b-08a4-7036-a60927e3eadd",
-        "TraceID": "CloseWithoutShutdown"
-      },
-      {
-        "UniquenessHash": "21a2e517-42a5-1d18-885f-8b57b79a2fba",
-        "TraceID": "EventSilentDiscard"
-      },
-      {
-        "UniquenessHash": "f6a10aa5-a444-631e-8d6f-de27fd8a5565",
-        "TraceID": "IndicateStartComplete"
-      },
-      {
-        "UniquenessHash": "0640b2d1-a929-3d01-b4c9-08733e3f0196",
-        "TraceID": "IndicateStreamShutdownComplete"
-      },
-      {
-        "UniquenessHash": "cfaab7b3-b77b-3a94-a433-4c9b57907696",
-        "TraceID": "StreamDestroyed"
-      },
-      {
-        "UniquenessHash": "ba0612b6-86a7-d764-ac9e-bbd12eeb0dca",
-        "TraceID": "StreamCreated"
-      },
-      {
-        "UniquenessHash": "0a4d4b4f-3622-3e1b-99be-acf0719d1bdf",
-        "TraceID": "StreamSendState"
-      },
-      {
-        "UniquenessHash": "89b5a6dc-7445-0b70-6a73-ff28d3f78246",
-        "TraceID": "StreamRecvState"
-      },
-      {
-        "UniquenessHash": "638251a8-14f3-2929-34e2-e69cfdab2277",
-        "TraceID": "StreamOutFlowBlocked"
-      },
-      {
-        "UniquenessHash": "c91c925c-07e9-3204-5459-5d3b19d137d8",
-        "TraceID": "StreamRundown"
-      },
-      {
         "UniquenessHash": "1f2558ac-412e-da8c-33d7-7c45995dbcf9",
         "TraceID": "ResetEarly"
       },
@@ -22894,6 +11476,10 @@
         "TraceID": "IndicatePeerSendShutdown"
       },
       {
+        "UniquenessHash": "89b5a6dc-7445-0b70-6a73-ff28d3f78246",
+        "TraceID": "StreamRecvState"
+      },
+      {
         "UniquenessHash": "e7d79111-7d5f-45a3-50b8-e4ca6de3c081",
         "TraceID": "IndicateSendShutdownComplete"
       },
@@ -22954,6 +11540,10 @@
         "TraceID": "SendDumpAck"
       },
       {
+        "UniquenessHash": "0a4d4b4f-3622-3e1b-99be-acf0719d1bdf",
+        "TraceID": "StreamSendState"
+      },
+      {
         "UniquenessHash": "48b0b691-89c1-4bb2-1ba4-5bc91586b2b3",
         "TraceID": "NotAccepted"
       },
@@ -22972,6 +11562,38 @@
       {
         "UniquenessHash": "c5a168ed-97fa-1cb7-3c3f-15762d9e402a",
         "TraceID": "IndicatePeerStreamStarted"
+      },
+      {
+        "UniquenessHash": "f96b231c-aa1b-08a4-7036-a60927e3eadd",
+        "TraceID": "CloseWithoutShutdown"
+      },
+      {
+        "UniquenessHash": "21a2e517-42a5-1d18-885f-8b57b79a2fba",
+        "TraceID": "EventSilentDiscard"
+      },
+      {
+        "UniquenessHash": "f6a10aa5-a444-631e-8d6f-de27fd8a5565",
+        "TraceID": "IndicateStartComplete"
+      },
+      {
+        "UniquenessHash": "0640b2d1-a929-3d01-b4c9-08733e3f0196",
+        "TraceID": "IndicateStreamShutdownComplete"
+      },
+      {
+        "UniquenessHash": "cfaab7b3-b77b-3a94-a433-4c9b57907696",
+        "TraceID": "StreamDestroyed"
+      },
+      {
+        "UniquenessHash": "ba0612b6-86a7-d764-ac9e-bbd12eeb0dca",
+        "TraceID": "StreamCreated"
+      },
+      {
+        "UniquenessHash": "638251a8-14f3-2929-34e2-e69cfdab2277",
+        "TraceID": "StreamOutFlowBlocked"
+      },
+      {
+        "UniquenessHash": "c91c925c-07e9-3204-5459-5d3b19d137d8",
+        "TraceID": "StreamRundown"
       },
       {
         "UniquenessHash": "f1df9958-6255-24ce-540f-df464661f666",


### PR DESCRIPTION
Removes both the macro definition and the user code line for each trace. Makes it so file is half the number of lines, and updates to the caller variables will not require a sidecar update