### PR TITLE
Wait on Separate Client Deleted Event

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -615,6 +615,8 @@ QuicTestClientDisconnect(
     PingStats ClientStats(UINT64_MAX - 1, 1, 1, TRUE, TRUE, FALSE, FALSE, TRUE,
         StopListenerFirst ? QUIC_STATUS_CONNECTION_TIMEOUT : QUIC_STATUS_ABORTED);
 
+    EventScope EventClientDeleted(true);
+
     MsQuicRegistration Registration;
     TEST_TRUE(Registration.IsValid());
 
@@ -640,7 +642,6 @@ QuicTestClientDisconnect(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         TestConnection* Client;
-        EventScope EventClientDeleted(true);
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -641,13 +641,12 @@ QuicTestClientDisconnect(
         QuicAddr ServerLocalAddr;
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-        TestConnection* Client;
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
             Listener.Context = &ServerAcceptCtx;
 
-            Client =
+            TestConnection* Client =
                 NewPingConnection(
                     Registration,
                     &ClientStats,

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -690,8 +690,6 @@ QuicTestClientDisconnect(
 
             Server->Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
         }
-
-        (void)Client->WaitForShutdownComplete();
     }
 }
 

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -26,7 +26,7 @@ TestConnection::TestConnection(
     ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
-    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr)
+    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr), EventDeleted(nullptr)
 {
     QuicEventInitialize(&EventConnectionComplete, TRUE, FALSE);
     QuicEventInitialize(&EventPeerClosed, TRUE, FALSE);
@@ -52,7 +52,7 @@ TestConnection::TestConnection(
     ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
-    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr)
+    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr), EventDeleted(nullptr)
 {
     QuicEventInitialize(&EventConnectionComplete, TRUE, FALSE);
     QuicEventInitialize(&EventPeerClosed, TRUE, FALSE);
@@ -80,6 +80,9 @@ TestConnection::~TestConnection()
     QuicEventUninitialize(EventConnectionComplete);
     if (ResumptionTicket) {
         QUIC_FREE(ResumptionTicket, QUIC_POOL_TEST);
+    }
+    if (EventDeleted) {
+        QuicEventSet(*EventDeleted);
     }
 }
 

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -23,10 +23,10 @@ TestConnection::TestConnection(
     PeerAddrChanged(false), PeerClosed(false), TransportClosed(false),
     IsShutdown(false), ShutdownTimedOut(false), AutoDelete(false),
     ExpectedResumed(false), ExpectedTransportCloseStatus(QUIC_STATUS_SUCCESS),
-    ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
+    ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR), EventDeleted(nullptr),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
-    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr), EventDeleted(nullptr)
+    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr)
 {
     QuicEventInitialize(&EventConnectionComplete, TRUE, FALSE);
     QuicEventInitialize(&EventPeerClosed, TRUE, FALSE);
@@ -49,10 +49,10 @@ TestConnection::TestConnection(
     PeerAddrChanged(false), PeerClosed(false), TransportClosed(false),
     IsShutdown(false), ShutdownTimedOut(false), AutoDelete(false),
     ExpectedResumed(false), ExpectedTransportCloseStatus(QUIC_STATUS_SUCCESS),
-    ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
+    ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR), EventDeleted(nullptr),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
-    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr), EventDeleted(nullptr)
+    DatagramsLost(0), DatagramsAcknowledged(0), Context(nullptr)
 {
     QuicEventInitialize(&EventConnectionComplete, TRUE, FALSE);
     QuicEventInitialize(&EventPeerClosed, TRUE, FALSE);

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -73,6 +73,7 @@ class TestConnection
     QUIC_EVENT EventPeerClosed;
     QUIC_EVENT EventShutdownComplete;
     QUIC_EVENT EventResumptionTicketReceived;
+    QUIC_EVENT* EventDeleted;
 
     NEW_STREAM_CALLBACK_HANDLER NewStreamCallback;
     CONN_SHUTDOWN_COMPLETE_CALLBACK_HANDLER ShutdownCompleteCallback;
@@ -122,6 +123,8 @@ public:
     bool IsValid() const { return QuicConnection != nullptr; }
 
     void SetAutoDelete() { AutoDelete = true; }
+
+    void SetDeletedEvent(QUIC_EVENT* Event) { EventDeleted = Event; }
 
     QUIC_STATUS
     Start(


### PR DESCRIPTION
Fixes #1100. Add a new event to wait for the client to be deleted to avoid race condition.