### PR TITLE
Move perf tracking to branch on repo

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -271,6 +271,7 @@ stages:
 
 - stage: perf_post_process
   displayName: Perf Post Processing
+  condition: succeededOrFailed()
   dependsOn:
   - performance
   jobs:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -269,6 +269,13 @@ stages:
       rttMs: (5,50,200)
       logProfile: Datapath.Light
 
+- stage: perf_post_process
+  displayName: Perf Post Processing
+  dependsOn:
+  - performance
+  jobs:
+  - template: ./templates/post-process-performance.yml
+
 #
 # Kernel Build Verification Tests
 #

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -25,10 +25,20 @@ jobs:
       downloadPath: msquic/artifacts/PerfDataResults
 
   - task: Powershell@2
-    displayName: Merge coverage
+    displayName: Merge coverage (Release)
+    condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
     inputs:
       pwsh: true
-      filePath: msquic/merge-performance.ps1
+      filePath: msquic/merge-performance.ps1 -Branch $(Build.SourceBranch) -PublishResults
+    env:
+      MAPPED_DEPLOYMENT_KEY: $(GitHubDeploymentKey)
+
+  - task: Powershell@2
+    displayName: Merge coverage (PR/Feature)
+    condition: not(and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))))
+    inputs:
+      pwsh: true
+      filePath: msquic/merge-performance.ps1 -Branch $(Build.SourceBranch)
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -29,7 +29,8 @@ jobs:
     condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
     inputs:
       pwsh: true
-      filePath: msquic/merge-performance.ps1 -Branch $(Build.SourceBranch) -PublishResults
+      filePath: msquic/merge-performance.ps1
+      arguments: -Branch $(Build.SourceBranch) -PublishResults
     env:
       MAPPED_DEPLOYMENT_KEY: $(GitHubDeploymentKey)
 
@@ -38,7 +39,8 @@ jobs:
     condition: not(and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))))
     inputs:
       pwsh: true
-      filePath: msquic/merge-performance.ps1 -Branch $(Build.SourceBranch)
+      filePath: msquic/merge-performance.ps1
+      arguments: -Branch $(Build.SourceBranch)
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -14,6 +14,7 @@ jobs:
   - task: PowerShell@2
     displayName: Prepare Test Machine
     inputs:
+      targetType: inline
       pwsh: true
       script: git clone --single-branch --branch performance https://github.com/microsoft/msquic
 

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -28,7 +28,7 @@ jobs:
     displayName: Merge coverage
     inputs:
       pwsh: true
-      filePath: merge-performance.ps1
+      filePath: msquic/merge-performance.ps1
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -34,13 +34,13 @@ jobs:
     displayName: Move Performance Results
     condition: succeededOrFailed()
     inputs:
-      sourceFolder: artifacts/PerfDataResults
+      sourceFolder: artifacts/mergedPerfResults
       targetFolder: $(Build.ArtifactStagingDirectory)
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Performance Results
     condition: succeededOrFailed()
     inputs:
-      artifactName: performance
+      artifactName: performance_merged
       pathToPublish: $(Build.ArtifactStagingDirectory)
       parallel: true

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -1,0 +1,46 @@
+# This template does post processing on the performance data files.
+
+jobs:
+- job: post_process_perf
+  displayName: Post Process Performance
+  condition: or(succeeded(), failed())
+  pool:
+    vmImage: ubuntu-latest
+  variables:
+    runCodesignValidationInjection: false
+  steps:
+  - checkout: none
+
+  - task: PowerShell@2
+    displayName: Prepare Test Machine
+    inputs:
+      pwsh: true
+      filePath: git
+      arguments: clone --single-branch --branch performance https://github.com/microsoft/msquic
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download Perf Artifacts
+    inputs:
+      artifactName: performance
+      downloadPath: artifacts/PerfDataResults
+
+  - task: Powershell@2
+    displayName: Merge coverage
+    inputs:
+      pwsh: true
+      filePath: merge-performance.ps1
+
+  - task: CopyFiles@2
+    displayName: Move Performance Results
+    condition: succeededOrFailed()
+    inputs:
+      sourceFolder: artifacts/PerfDataResults
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    displayName: Upload Performance Results
+    condition: succeededOrFailed()
+    inputs:
+      artifactName: performance
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      parallel: true

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -3,7 +3,7 @@
 jobs:
 - job: post_process_perf
   displayName: Post Process Performance
-  condition: or(succeeded(), failed())
+  condition: succeededOrFailed()
   pool:
     vmImage: ubuntu-latest
   variables:

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -15,14 +15,13 @@ jobs:
     displayName: Prepare Test Machine
     inputs:
       pwsh: true
-      filePath: git
-      arguments: clone --single-branch --branch performance https://github.com/microsoft/msquic
+      script: git clone --single-branch --branch performance https://github.com/microsoft/msquic
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Perf Artifacts
     inputs:
       artifactName: performance
-      downloadPath: artifacts/PerfDataResults
+      downloadPath: msquic/artifacts/PerfDataResults
 
   - task: Powershell@2
     displayName: Merge coverage
@@ -34,7 +33,7 @@ jobs:
     displayName: Move Performance Results
     condition: succeededOrFailed()
     inputs:
-      sourceFolder: artifacts/mergedPerfResults
+      sourceFolder: msquic/artifacts/mergedPerfResults
       targetFolder: $(Build.ArtifactStagingDirectory)
 
   - task: PublishBuildArtifacts@1

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -228,6 +228,21 @@ function Get-GitHash {
     return $CurrentCommitHash
 }
 
+function Get-CurrentBranch {
+    param($RepoDir)
+    $CurrentLoc = Get-Location
+    Set-Location -Path $RepoDir | Out-Null
+    $env:GIT_REDIRECT_STDERR = '2>&1'
+    $CurrentBranchName = $null
+    try {
+        $CurrentBranchName = git rev-parse --abbrev-ref HEAD
+    } catch {
+        Write-Debug "Failed to get branch name from git"
+    }
+    Set-Location -Path $CurrentLoc | Out-Null
+    return $CurrentBranchName
+}
+
 function Get-ExePath {
     param ($PathRoot, $Platform, $IsRemote)
     if ($IsRemote) {
@@ -582,7 +597,7 @@ class ThroughputTestPublishResult {
 }
 
 function Publish-ThroughputTestResults {
-    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $OutputDir, $ServerToClient, $ExePath)
+    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $CurrentBranch, $OutputDir, $ServerToClient, $ExePath)
 
     $Request = [ThroughputRequest]::new($Test, $ServerToClient)
 
@@ -623,6 +638,7 @@ function Publish-ThroughputTestResults {
             $MachineName = $env:AGENT_MACHINENAME
         }
         $Results = [ThroughputTestPublishResult]::new($Request, $AllRunsResults, $MachineName, $CurrentCommitHash.Substring(0, 7))
+        $Results.AuthKey = $CurrentBranch;
 
         $ResultFile = Join-Path $OutputDir "results_$Test.json"
         $Results | ConvertTo-Json | Out-File $ResultFile
@@ -694,7 +710,7 @@ class RPSTestPublishResult {
 }
 
 function Publish-RPSTestResults {
-    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $OutputDir, $ExePath)
+    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $CurrentBranch, $OutputDir, $ExePath)
 
     $Request = [RPSRequest]::new($Test)
 
@@ -741,6 +757,7 @@ function Publish-RPSTestResults {
             $MachineName = $env:AGENT_MACHINENAME
         }
         $Results = [RPSTestPublishResult]::new($Request, $AllRunsResults, $MachineName, $CurrentCommitHash.Substring(0, 7))
+        $Results.AuthKey = $CurrentBranch;
 
         $ResultFile = Join-Path $OutputDir "results_$Test.json"
         $Results | ConvertTo-Json | Out-File $ResultFile
@@ -796,7 +813,7 @@ class HPSTestPublishResult {
 }
 
 function Publish-HPSTestResults {
-    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $OutputDir, $ExePath)
+    param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $CurrentBranch, $OutputDir, $ExePath)
 
     $Request = [HPSRequest]::new($Test)
 
@@ -834,6 +851,7 @@ function Publish-HPSTestResults {
             $MachineName = $env:AGENT_MACHINENAME
         }
         $Results = [HPSTestPublishResult]::new($Request, $AllRunsResults, $MachineName, $CurrentCommitHash.Substring(0, 7))
+        $Results.AuthKey = $CurrentBranch;
 
         $ResultFile = Join-Path $OutputDir "results_$Test.json"
         $Results | ConvertTo-Json | Out-File $ResultFile
@@ -845,16 +863,16 @@ function Publish-HPSTestResults {
 #endregion
 
 function Publish-TestResults {
-    param ([TestRunDefinition]$Test, $AllRunsResults, $CurrentCommitHash, $OutputDir, $ExePath)
+    param ([TestRunDefinition]$Test, $AllRunsResults, $CurrentCommitHash, $CurrentBranch, $OutputDir, $ExePath)
 
     if ($Test.TestName -eq "ThroughputUp") {
-        Publish-ThroughputTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -OutputDir $OutputDir -ServerToClient $false -ExePath $ExePath
+        Publish-ThroughputTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -CurrentBranch $CurrentBranch -OutputDir $OutputDir -ServerToClient $false -ExePath $ExePath
     } elseif ($Test.TestName -eq "ThroughputDown") {
-        Publish-ThroughputTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -OutputDir $OutputDir -ServerToClient $true -ExePath $ExePath
+        Publish-ThroughputTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -CurrentBranch $CurrentBranch -OutputDir $OutputDir -ServerToClient $true -ExePath $ExePath
     } elseif ($Test.TestName -eq "RPS") {
-        Publish-RPSTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -OutputDir $OutputDir -ExePath $ExePath
+        Publish-RPSTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -CurrentBranch $CurrentBranch -OutputDir $OutputDir -ExePath $ExePath
     } elseif ($Test.TestName -eq "HPS") {
-        Publish-HPSTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -OutputDir $OutputDir -ExePath $ExePath
+        Publish-HPSTestResults -Test $Test -AllRunsFullResults $AllRunsResults -CurrentCommitHash $CurrentCommitHash -CurrentBranch $CurrentBranch -OutputDir $OutputDir -ExePath $ExePath
     } else {
         Write-Host "Unknown Test Type"
     }

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -241,6 +241,7 @@ if ($Local) {
 }
 
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
+$CurrentBranch = Get-CurrentBranch -RepoDir $RootDir
 
 if ($PGO -and $Local) {
     # PGO needs the server and client executing out of separate directories.
@@ -390,6 +391,7 @@ function Invoke-Test {
     Publish-TestResults -Test $Test `
                         -AllRunsResults $AllRunsResults `
                         -CurrentCommitHash $CurrentCommitHash `
+                        -CurrentBranch $CurrentBranch `
                         -OutputDir $OutputDir `
                         -ExePath $LocalExe
 }


### PR DESCRIPTION
Currently, all performance data gets uploaded to a database, and then displayed using PowerBi. The PowerBi dashboard is problematic, as is  adding anything new to the database. This setup will make storing arbitrary data easier, especially across branches.

This PR adds a new post perf step, that will grab all the perf results from each run, and merge them together. It does not currently publish to the new perf branch, but it will check that the configuration for doing that is correct.