### PR TITLE
Update CodeQL per the GitHub notice, which said:

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,11 +28,6 @@ jobs:
           fetch-depth: 2
           submodules: 'recursive'
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
-
       # Install dependencies and build submodules before starting analysis.
       - run: |
          sudo apt-add-repository ppa:lttng/stable-2.11


### PR DESCRIPTION
> 1 issue was detected with this workflow: git checkout HEAD^2 is no longer
> necessary. Please remove this step as Code Scanning recommends analyzing the
> merge commit for best results.