### PR TITLE
Split release and debug into separate builds on AZP

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -218,6 +218,8 @@ stages:
 
 - stage: build_linux_release
   displayName: Build Linux - Release
+  dependsOn: []
+  jobs:
   - template: ./templates/build-config-user.yml
     parameters:
       image: ubuntu-latest
@@ -228,6 +230,8 @@ stages:
 
 - stage: build_linux_debug
   displayName: Build Linux - Debug
+  dependsOn: []
+  jobs:
   - template: ./templates/build-config-user.yml
     parameters:
       image: ubuntu-latest

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -71,13 +71,28 @@ stages:
       clients: [ 'msquic' ]
       servers: [ 'quant', 'quic-go' ]
 
-- stage: build_winkernel
-  displayName: Build Windows Drivers
+- stage: build_winkernel_release
+  displayName: Build Windows Drivers - Release
   dependsOn: []
   jobs:
   - template: ./templates/build-config-winkernel.yml
     parameters:
       arch: x64
+      config: Release
+
+- stage: build_winkernel_debug
+  displayName: Build Windows Drivers - Debug
+  dependsOn: []
+  jobs:
+  - template: ./templates/build-config-winkernel.yml
+    parameters:
+      arch: x64
+      config: Debug
+
+- stage: build_winkernel_nontest
+  displayName: Build Windows Drivers - Non Tested
+  dependsOn: []
+  jobs:
   - template: ./templates/build-config-winkernel.yml
     parameters:
       arch: x86
@@ -88,10 +103,80 @@ stages:
     parameters:
       arch: arm64
 
-- stage: build_windows
-  displayName: Build Windows
+- stage: build_windows_release
+  displayName: Build Windows - Release
   dependsOn: []
   jobs:
+  # Officially supported configurations.
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: schannel
+      config: Release
+  # Other configurations.
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: openssl
+      config: Release
+
+- stage: build_windows_debug
+  displayName: Build Windows - Debug
+  dependsOn: []
+  jobs:
+  # Officially supported configurations.
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: schannel
+      config: Debug
+  # Other configurations.
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: stub
+      config: Debug
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: mitls
+      config: Debug
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: openssl
+      config: Debug
+
+- stage: build_windows_nontest
+  displayName: Build Windows - Non Tested
+  dependsOn: []
+  jobs:
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: stub
+      config: Release
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: mitls
+      config: Release
   # Officially supported configurations.
   - template: ./templates/build-config-user.yml
     parameters:
@@ -103,12 +188,6 @@ stages:
     parameters:
       image: windows-latest
       platform: windows
-      arch: x64
-      tls: schannel
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
       arch: arm
       tls: schannel
   - template: ./templates/build-config-user.yml
@@ -117,19 +196,6 @@ stages:
       platform: windows
       arch: arm64
       tls: schannel
-  # Other configurations.
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
-      arch: x64
-      tls: stub
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
-      arch: x64
-      tls: mitls
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
@@ -141,12 +207,6 @@ stages:
     parameters:
       image: windows-latest
       platform: windows
-      arch: x64
-      tls: openssl
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
       arch: arm64
       tls: openssl
   - template: ./templates/build-config-user.yml
@@ -156,17 +216,38 @@ stages:
       arch: x86
       tls: openssl
 
-- stage: build_linux
-  displayName: Build Linux
-  dependsOn: []
-  jobs:
-  # Officially supported configurations.
+- stage: build_linux_release
+  displayName: Build Linux - Release
   - template: ./templates/build-config-user.yml
     parameters:
       image: ubuntu-latest
       platform: linux
       arch: x64
       tls: openssl
+      config: Release
+
+- stage: build_linux_debug
+  displayName: Build Linux - Debug
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: ubuntu-latest
+      platform: linux
+      arch: x64
+      tls: openssl
+      config: Debug
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: ubuntu-latest
+      platform: linux
+      arch: x64
+      tls: stub
+      extraBuildArgs: -SanitizeAddress
+      config: Debug
+
+- stage: build_linux_nontest
+  displayName: Build Linux - Non Tested
+  dependsOn: []
+  jobs:
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
@@ -175,6 +256,7 @@ stages:
       arch: x64
       tls: stub
       extraBuildArgs: -SanitizeAddress
+      config: Release
   - template: ./templates/build-config-user.yml
     parameters:
       image: ubuntu-latest
@@ -200,9 +282,9 @@ stages:
 - stage: performance
   displayName: Performance Testing
   dependsOn:
-  - build_windows
-  - build_linux
-  - build_winkernel
+  - build_windows_release
+  - build_linux_release
+  - build_winkernel_release
   jobs:
   - template: ./templates/run-performance.yml
     parameters:
@@ -236,7 +318,7 @@ stages:
 - stage: wanperf
   displayName: WAN Performance Testing
   dependsOn:
-  - build_windows
+  - build_windows_release
   jobs:
   - template: ./templates/run-wanperf.yml
     parameters:
@@ -284,8 +366,8 @@ stages:
 - stage: test_bvt_kernel
   displayName: BVT Kernel
   dependsOn:
-  - build_winkernel
-  - build_windows
+  - build_winkernel_debug
+  - build_windows_debug
   jobs:
   - template: ./templates/run-bvt.yml
     parameters:
@@ -303,8 +385,8 @@ stages:
 - stage: test_bvt
   displayName: BVT
   dependsOn:
-  - build_windows
-  - build_linux
+  - build_windows_debug
+  - build_linux_debug
   jobs:
   - template: ./templates/run-bvt.yml
     parameters:
@@ -346,8 +428,8 @@ stages:
 - stage: spinquic
   displayName: SpinQuic
   dependsOn:
-  - build_windows
-  - build_linux
+  - build_windows_debug
+  - build_linux_debug
   jobs:
   - template: ./templates/run-spinquic.yml
     parameters:
@@ -382,7 +464,7 @@ stages:
 - stage: codecoverage
   displayName: Code Coverage
   dependsOn:
-  - build_windows
+  - build_windows_debug
   jobs:
   - template: ./templates/run-bvt.yml
     parameters:
@@ -411,8 +493,8 @@ stages:
 - stage: quicinterop
   displayName: QuicInterop
   dependsOn:
-  - build_windows
-  - build_linux
+  - build_windows_debug
+  - build_linux_debug
   jobs:
   - template: ./templates/run-quicinterop.yml
     parameters:
@@ -442,9 +524,15 @@ stages:
 - stage: mirror
   displayName: Mirror Branch
   dependsOn:
-  - build_windows
-  - build_winkernel
-  - build_linux
+  - build_windows_release
+  - build_winkernel_release
+  - build_linux_release
+  - build_windows_debug
+  - build_winkernel_debug
+  - build_linux_debug
+  - build_windows_nontest
+  - build_winkernel_nontest
+  - build_linux_nontest
   condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')), succeeded())
   jobs:
   - job: mirror
@@ -470,8 +558,12 @@ stages:
 - stage: distribution
   displayName: Distribution
   dependsOn:
-  - build_windows
-  - build_linux
+  - build_windows_release
+  - build_linux_release
+  - build_windows_debug
+  - build_linux_debug
+  - build_windows_nontest
+  - build_linux_nontest
   condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')), succeeded())
   jobs:
   - template: ./templates/build-distribution.yml

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -177,7 +177,6 @@ stages:
       arch: x64
       tls: mitls
       config: Release
-  # Officially supported configurations.
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest


### PR DESCRIPTION
Will mean that getting to testing happens quicker, which should be a good 10-15 minute speedup in the pipeline