### PR TITLE
Fix interop runner using the incorrect builds

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -496,8 +496,8 @@ stages:
 - stage: quicinterop
   displayName: QuicInterop
   dependsOn:
-  - build_windows_debug
-  - build_linux_debug
+  - build_windows_release
+  - build_linux_release
   jobs:
   - template: ./templates/run-quicinterop.yml
     parameters:


### PR DESCRIPTION
They were using debug, when they should be depending on release. Sometimes this would work, but other times not.