### PR TITLE
Move wanperf artifacts to separate log folder

### DIFF
--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -63,4 +63,5 @@ jobs:
         config: ${{ parameters.config }}
         arch: ${{ parameters.arch }}
         tls: ${{ parameters.tls }}
+        artifactName: wanperflogs
         publishTest: false

--- a/.azure/templates/upload-test-artifacts.yml
+++ b/.azure/templates/upload-test-artifacts.yml
@@ -5,6 +5,7 @@ parameters:
   config: ''
   arch: ''
   tls: ''
+  artifactName: 'logs'
   publishTest: true
   codeCoverage: false
 
@@ -52,7 +53,7 @@ steps:
       ${{ if eq(parameters.publishTest, true) }}:
         condition: failed()
       inputs:
-        artifactName: logs
+        artifactName: ${{ parameters.artifactName }}
         pathToPublish: $(Build.ArtifactStagingDirectory)
         parallel: true
 


### PR DESCRIPTION
Logs folder should only be for failure cases, which allows scripting the failures