### PR TITLE
Add mitls release to release build configuration

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -101,6 +101,13 @@ stages:
       arch: x64
       tls: openssl
       config: Release
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
+      platform: windows
+      arch: x64
+      tls: mitls
+      config: Release
 
 - stage: build_windows_debug
   displayName: Build Windows - Debug
@@ -147,13 +154,6 @@ stages:
       platform: windows
       arch: x64
       tls: stub
-      config: Release
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-latest
-      platform: windows
-      arch: x64
-      tls: mitls
       config: Release
   - template: ./templates/build-config-user.yml
     parameters:


### PR DESCRIPTION
interop depends on it, when it wasn't getting built previously in this block