### PR TITLE
Refactor TLS Callback Abstraction Layer

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -336,6 +336,7 @@ MsQuicConfigurationLoadCredential(
         Status =
             QuicTlsSecConfigCreate(
                 CredConfig,
+                &QuicTlsCallbacks,
                 Configuration,
                 MsQuicConfigurationLoadCredentialComplete);
         if (!(CredConfig->Flags & QUIC_CREDENTIAL_FLAG_LOAD_ASYNCHRONOUS) ||

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -27,6 +27,12 @@ QUIC_TLS_PROCESS_COMPLETE_CALLBACK QuicTlsProcessDataCompleteCallback;
 QUIC_TLS_RECEIVE_TP_CALLBACK QuicConnReceiveTP;
 QUIC_TLS_RECEIVE_TICKET_CALLBACK QuicConnRecvResumptionTicket;
 
+QUIC_TLS_CALLBACKS QuicTlsCallbacks = {
+    QuicTlsProcessDataCompleteCallback,
+    QuicConnReceiveTP,
+    QuicConnRecvResumptionTicket
+};
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicCryptoDumpSendState(
@@ -292,9 +298,6 @@ QuicCryptoInitializeTls(
     TlsConfig.Connection = Connection;
     TlsConfig.ResumptionTicketBuffer = Crypto->ResumptionTicket;
     TlsConfig.ResumptionTicketLength = Crypto->ResumptionTicketLength;
-    TlsConfig.ProcessCompleteCallback = QuicTlsProcessDataCompleteCallback;
-    TlsConfig.ReceiveTPCallback = QuicConnReceiveTP;
-    TlsConfig.ReceiveResumptionCallback = QuicConnRecvResumptionTicket;
     if (!QuicConnIsServer(Connection)) {
         TlsConfig.ServerName = Connection->RemoteServerName;
     }

--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -11,6 +11,11 @@ Abstract:
 --*/
 
 //
+// Set of callbacks for TLS.
+//
+extern QUIC_TLS_CALLBACKS QuicTlsCallbacks;
+
+//
 // Stream of TLS data.
 //
 typedef struct QUIC_CRYPTO {

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -77,6 +77,25 @@ BOOLEAN
 
 typedef QUIC_TLS_RECEIVE_TICKET_CALLBACK *QUIC_TLS_RECEIVE_TICKET_CALLBACK_HANDLER;
 
+typedef struct QUIC_TLS_CALLBACKS {
+
+    //
+    // Invoked for the completion of process calls that were pending.
+    //
+    QUIC_TLS_PROCESS_COMPLETE_CALLBACK_HANDLER ProcessComplete;
+
+    //
+    // Invoked when QUIC transport parameters are received.
+    //
+    QUIC_TLS_RECEIVE_TP_CALLBACK_HANDLER ReceiveTP;
+
+    //
+    // Invoked when a resumption ticket is received.
+    //
+    QUIC_TLS_RECEIVE_TICKET_CALLBACK_HANDLER ReceiveTicket;
+
+} QUIC_TLS_CALLBACKS;
+
 //
 // The input configuration for creation of a TLS context.
 //
@@ -125,21 +144,6 @@ typedef struct QUIC_TLS_CONFIG {
     //
     const uint8_t* LocalTPBuffer;
     uint32_t LocalTPLength;
-
-    //
-    // Invoked for the completion of process calls that were pending.
-    //
-    QUIC_TLS_PROCESS_COMPLETE_CALLBACK_HANDLER ProcessCompleteCallback;
-
-    //
-    // Invoked when QUIC transport parameters are received.
-    //
-    QUIC_TLS_RECEIVE_TP_CALLBACK_HANDLER ReceiveTPCallback;
-
-    //
-    // Invoked when a resumption ticket is received.
-    //
-    QUIC_TLS_RECEIVE_TICKET_CALLBACK_HANDLER ReceiveResumptionCallback;
 
 #ifdef QUIC_TLS_SECRETS_SUPPORT
     //
@@ -293,6 +297,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicTlsSecConfigCreate(
     _In_ const QUIC_CREDENTIAL_CONFIG* CredConfig,
+    _In_ const QUIC_TLS_CALLBACKS* TlsCallbacks,
     _In_opt_ void* Context,
     _In_ QUIC_SEC_CONFIG_CREATE_COMPLETE_HANDLER CompletionHandler
     );

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -1012,7 +1012,7 @@ QuicTlsClientProcess(
 
         QUIC_FRE_ASSERT(ServerMessageLength < UINT16_MAX);
 
-        (void)TlsContext-SecConfig->Callbacks.>ReceiveTicket(
+        (void)TlsContext->SecConfig->Callbacks.ReceiveTicket(
             TlsContext->Connection,
             ServerMessageLength,
             ServerMessage->TICKET.Ticket);

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -77,7 +77,7 @@ protected:
         VERIFY_QUIC_SUCCESS(
             QuicTlsSecConfigCreate(
                 SelfSignedCertParams,
-                &TlsContext::TlsCallbacks,
+                &TlsContext::TlsServerCallbacks,
                 &ServerSecConfig,
                 OnSecConfigCreateComplete));
         ASSERT_NE(nullptr, ServerSecConfig);
@@ -91,7 +91,7 @@ protected:
         VERIFY_QUIC_SUCCESS(
             QuicTlsSecConfigCreate(
                 &ClientCredConfig,
-                &TlsContext::TlsCallbacks,
+                &TlsContext::TlsClientCallbacks,
                 &ClientSecConfig,
                 OnSecConfigCreateComplete));
         ASSERT_NE(nullptr, ClientSecConfig);
@@ -100,7 +100,7 @@ protected:
         VERIFY_QUIC_SUCCESS(
             QuicTlsSecConfigCreate(
                 &ClientCredConfig,
-                &TlsContext::TlsCallbacks,
+                &TlsContext::TlsClientCallbacks,
                 &ClientSecConfigNoCertValidation,
                 OnSecConfigCreateComplete));
         ASSERT_NE(nullptr, ClientSecConfigNoCertValidation);
@@ -130,7 +130,8 @@ protected:
 
         QUIC_TLS_PROCESS_STATE State;
 
-        static QUIC_TLS_CALLBACKS TlsCallbacks;
+        static const QUIC_TLS_CALLBACKS TlsServerCallbacks;
+        static const QUIC_TLS_CALLBACKS TlsClientCallbacks;
 
         bool Connected;
         bool Key0RttReady;
@@ -644,10 +645,16 @@ protected:
     }
 };
 
-QUIC_TLS_CALLBACKS TlsTest::TlsContext::TlsCallbacks = {
+const QUIC_TLS_CALLBACKS TlsTest::TlsContext::TlsServerCallbacks = {
     TlsTest::TlsContext::OnProcessComplete,
     TlsTest::TlsContext::OnRecvQuicTP,
     TlsTest::TlsContext::OnRecvTicketServer
+};
+
+const QUIC_TLS_CALLBACKS TlsTest::TlsContext::TlsClientCallbacks = {
+    TlsTest::TlsContext::OnProcessComplete,
+    TlsTest::TlsContext::OnRecvQuicTP,
+    TlsTest::TlsContext::OnRecvTicketClient
 };
 
 const QUIC_CREDENTIAL_CONFIG* TlsTest::SelfSignedCertParams = nullptr;

--- a/src/tools/attack/packet_writer.cpp
+++ b/src/tools/attack/packet_writer.cpp
@@ -43,9 +43,14 @@ struct TlsContext
             QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION,
             NULL, NULL, NULL, NULL
         };
+        QUIC_TLS_CALLBACKS TlsCallbacks = {
+            OnProcessComplete,
+            OnRecvQuicTP,
+            NULL
+        };
         VERIFY_QUIC_SUCCESS(
             QuicTlsSecConfigCreate(
-                &CredConfig, &SecConfig, OnSecConfigCreateComplete));
+                &CredConfig, &TlsCallbacks, &SecConfig, OnSecConfigCreateComplete));
 
         QUIC_CONNECTION Connection = {0};
 
@@ -75,8 +80,6 @@ struct TlsContext
             printf("Failed to encode transport parameters!\n");
         }
         Config.Connection = (QUIC_CONNECTION*)this;
-        Config.ProcessCompleteCallback = OnProcessComplete;
-        Config.ReceiveTPCallback = OnRecvQuicTP;
         Config.ServerName = Sni;
 
         VERIFY_QUIC_SUCCESS(


### PR DESCRIPTION
Moves the callback functions from per-connection to per-secconfig.