### PR TITLE
Cleanup perf scripts

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -1,308 +1,188 @@
-[
-    {
-        "TestName": "ThroughputUp",
-        "Remote": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Local": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Variables": [
-            {
-                "Name": "Encryption",
-                "Local": {
-                    "On": "",
-                    "Off": "-encrypt:0"
-                },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "On"
+{
+    "Remote": {
+        "Exe": "quicperf",
+        "Arguments": "-selfsign:1"
+    },
+    "FullMatrix": false,
+    "Tests": [
+        {
+            "TestName": "ThroughputUp",
+            "Local": {
+                "Platform": "Windows",
+                "Tls": ["stub", "schannel", "openssl", "mitls"],
+                "Arch": ["x64", "x86", "arm", "arm64"],
+                "Exe": "quicperf",
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000"
             },
-            {
-                "Name": "SendBuffering",
-                "Local": {
-                    "On": "",
-                    "Off": "-sendbuf:0"
+            "Variables": [
+                {
+                    "Name": "Encryption",
+                    "Local": {
+                        "On": "",
+                        "Off": "-encrypt:0"
+                    },
+                    "Default": "On"
                 },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "Off"
-            }
-        ],
-        "AllowLoopback": true,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-8.0"
-    },
-    {
-        "TestName": "ThroughputUp",
-        "Remote" : {
-            "Platform": "Linux",
-            "Tls": ["stub", "openssl"],
-            "Arch": ["x64", "arm"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
+                {
+                    "Name": "SendBuffering",
+                    "Local": {
+                        "On": "",
+                        "Off": "-sendbuf:0"
+                    },
+                    "Default": "Off"
+                }
+            ],
+            "AllowLoopback": true,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": ".*@ (.*) kbps.*",
+            "Formats": ["{0} kbps"],
+            "RegressionThreshold": "-8.0"
         },
-        "Local" : {
-            "Platform": "linux",
-            "Tls": ["stub", "openssl"],
-            "Arch": ["x64", "arm"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -uni:1 -upload:2000000000",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Variables": [
-            {
-                "Name": "Encryption",
-                "Local": {
-                    "On": "",
-                    "Off": "-encrypt:0"
-                },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "On"
+        {
+            "TestName": "ThroughputUp",
+            "Local" : {
+                "Platform": "linux",
+                "Tls": ["stub", "openssl"],
+                "Arch": ["x64", "arm"],
+                "Exe": "quicperf",
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -upload:2000000000"
             },
-            {
-                "Name": "SendBuffering",
-                "Local": {
-                    "On": "",
-                    "Off": "-sendbuf:0"
+            "Variables": [
+                {
+                    "Name": "Encryption",
+                    "Local": {
+                        "On": "",
+                        "Off": "-encrypt:0"
+                    },
+                    "Default": "On"
                 },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "Off"
-            }
-        ],
-        "AllowLoopback": true,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-10.0"
-    },
-    {
-        "TestName": "ThroughputDown",
-        "Remote": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
+                {
+                    "Name": "SendBuffering",
+                    "Local": {
+                        "On": "",
+                        "Off": "-sendbuf:0"
+                    },
+                    "Default": "Off"
+                }
+            ],
+            "AllowLoopback": true,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": ".*@ (.*) kbps.*",
+            "Formats": ["{0} kbps"],
+            "RegressionThreshold": "-10.0"
         },
-        "Local": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Variables": [
-            {
-                "Name": "Encryption",
-                "Local": {
-                    "On": "",
-                    "Off": "-encrypt:0"
-                },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "On"
-            }
-        ],
-        "AllowLoopback": true,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-8.0"
-    },
-    {
-        "TestName": "ThroughputDown",
-        "Remote" : {
-            "Platform": "Linux",
-            "Tls": ["stub", "openssl"],
-            "Arch": ["x64", "arm"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Local" : {
-            "Platform": "linux",
-            "Tls": ["stub", "openssl"],
-            "Arch": ["x64", "arm"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:Throughput -target:$RemoteAddress -uni:1 -download:2000000000",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Variables": [
-            {
-                "Name": "Encryption",
-                "Local": {
-                    "On": "",
-                    "Off": "-encrypt:0"
-                },
-                "Remote": {
-                    "On": "",
-                    "Off": ""
-                },
-                "Default": "On"
-            }
-        ],
-        "AllowLoopback": true,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": ".*@ (.*) kbps.*",
-        "Formats": ["{0} kbps"],
-        "RegressionThreshold": "-10.0"
-    },
-    {
-        "TestName": "RPS",
-        "Remote": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Local": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:RPS -target:$RemoteAddress",
-                "Loopback": "",
-                "Remote": ""
-            }
-        },
-        "Variables": [
-            {
-                "Name": "ConnectionCount",
-                "Local": {
-                    "250": "-conns:250 -requests:7500"
-                },
-                "Remote": {
-                    "250": ""
-                },
-                "Default": "250"
+        {
+            "TestName": "ThroughputDown",
+            "Local": {
+                "Platform": "Windows",
+                "Tls": ["stub", "schannel", "openssl", "mitls"],
+                "Arch": ["x64", "x86", "arm", "arm64"],
+                "Exe": "quicperf",
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000"
             },
-            {
-                "Name": "RequestSize",
-                "Local": {
-                    "0": "-request:0"
-                },
-                "Remote": {
-                    "0": ""
-                },
-
-                "Default": "0"
+            "Variables": [
+                {
+                    "Name": "Encryption",
+                    "Local": {
+                        "On": "",
+                        "Off": "-encrypt:0"
+                    },
+                    "Default": "On"
+                }
+            ],
+            "AllowLoopback": true,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": ".*@ (.*) kbps.*",
+            "Formats": ["{0} kbps"],
+            "RegressionThreshold": "-8.0"
+        },
+        {
+            "TestName": "ThroughputDown",
+            "Local" : {
+                "Platform": "linux",
+                "Tls": ["stub", "openssl"],
+                "Arch": ["x64", "arm"],
+                "Exe": "quicperf",
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -download:2000000000"
             },
-            {
-                "Name": "ResponseSize",
-                "Local": {
-                    "0": "-response:0",
-                    "512": "-response:512",
-                    "4096": "-response:4096",
-                    "16384": "-response:16384"
-                },
-                "Remote": {
-                    "0": "",
-                    "512": "",
-                    "4096": "",
-                    "16384": ""
-                },
-                "Default": "4096"
-            }
-        ],
-        "AllowLoopback": false,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": "Result: (.*) RPS, Min: (.*), Max: (.*), 50th: (.*), 90th: (.*), 99th: (.*), 99.9th: (.*), 99.99th: (.*), 99.999th: (.*), 99.9999th: (.*), StdErr: (.*)",
-        "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"],
-        "RegressionThreshold": "-50.0"
-    },
-    {
-        "TestName": "HPS",
-        "Remote": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-selfsign:1",
-                "Loopback": "",
-                "Remote": ""
-            }
+            "Variables": [
+                {
+                    "Name": "Encryption",
+                    "Local": {
+                        "On": "",
+                        "Off": "-encrypt:0"
+                    },
+                    "Default": "On"
+                }
+            ],
+            "AllowLoopback": true,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": ".*@ (.*) kbps.*",
+            "Formats": ["{0} kbps"],
+            "RegressionThreshold": "-10.0"
         },
-        "Local": {
-            "Platform": "Windows",
-            "Tls": ["stub", "schannel", "openssl", "mitls"],
-            "Arch": ["x64", "x86", "arm", "arm64"],
-            "Exe": "quicperf",
-            "Arguments": {
-                "All": "-test:HPS -target:$RemoteAddress",
-                "Loopback": "",
-                "Remote": ""
-            }
+        {
+            "TestName": "RPS",
+            "Local": {
+                "Platform": "Windows",
+                "Tls": ["stub", "schannel", "openssl", "mitls"],
+                "Arch": ["x64", "x86", "arm", "arm64"],
+                "Exe": "quicperf",
+                "Arguments": "-test:RPS -target:$RemoteAddress"
+            },
+            "Variables": [
+                {
+                    "Name": "ConnectionCount",
+                    "Local": {
+                        "250": "-conns:250 -requests:7500"
+                    },
+                    "Default": "250"
+                },
+                {
+                    "Name": "RequestSize",
+                    "Local": {
+                        "0": "-request:0"
+                    },
+                    "Default": "0"
+                },
+                {
+                    "Name": "ResponseSize",
+                    "Local": {
+                        "0": "-response:0",
+                        "512": "-response:512",
+                        "4096": "-response:4096",
+                        "16384": "-response:16384"
+                    },
+                    "Default": "4096"
+                }
+            ],
+            "AllowLoopback": false,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": "Result: (.*) RPS, Min: (.*), Max: (.*), 50th: (.*), 90th: (.*), 99th: (.*), 99.9th: (.*), 99.99th: (.*), 99.999th: (.*), 99.9999th: (.*), StdErr: (.*)",
+            "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"],
+            "RegressionThreshold": "-50.0"
         },
-        "Variables": [],
-        "AllowLoopback": false,
-        "Iterations": 5,
-        "RemoteReadyMatcher": "Started!",
-        "ResultsMatcher": "Result: (.*) HPS.*",
-        "Formats": ["{0} HPS"],
-        "RegressionThreshold": "-40.0"
-    }
-]
+        {
+            "TestName": "HPS",
+            "Local": {
+                "Platform": "Windows",
+                "Tls": ["stub", "schannel", "openssl", "mitls"],
+                "Arch": ["x64", "x86", "arm", "arm64"],
+                "Exe": "quicperf",
+                "Arguments": "-test:HPS -target:$RemoteAddress"
+            },
+            "Variables": [],
+            "AllowLoopback": false,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": "Result: (.*) HPS.*",
+            "Formats": ["{0} HPS"],
+            "RegressionThreshold": "-40.0"
+        }
+    ]
+}

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -2,6 +2,7 @@
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 
 #region Stack Walk Profiles
 

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -127,6 +127,7 @@ param (
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 
 # Validate the the kernel switch.
 if ($Kernel -and !$IsWindows) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -56,6 +56,8 @@ This script runs performance tests locally for a period of time.
 
 #>
 
+Using module .\performance-helper.psm1
+
 param (
     [Parameter(Mandatory = $false)]
     [ValidateSet("Debug", "Release")]
@@ -176,8 +178,6 @@ if (!$IsWindows) {
 if ($TestsFile -eq "") {
     $TestsFile = Join-Path $PSScriptRoot "RemoteTests.json"
 }
-
-Import-Module (Join-Path $PSScriptRoot 'performance-helper.psm1') -Force
 
 if ($Local) {
     $RemoteAddress = "localhost"
@@ -316,11 +316,11 @@ $LastCommitHash = Get-LatestCommitHash -Branch $BranchName
 $PreviousResults = Get-LatestCpuTestResult -Branch $BranchName -CommitHash $LastCommitHash
 
 function Invoke-Test {
-    param ($Test)
+    param ([TestRunDefinition]$Test, [RemoteConfig]$RemoteConfig)
 
     Write-Output "Running Test $Test"
 
-    $RemoteExe = Get-ExeName -PathRoot $RemoteDirectory -Platform $RemotePlatform -IsRemote $true -TestPlat $Test.Remote
+    $RemoteExe = Get-ExeName -PathRoot $RemoteDirectory -Platform $RemotePlatform -IsRemote $true -TestPlat $RemoteConfig
     $LocalExe = Get-ExeName -PathRoot $LocalDirectory -Platform $LocalPlatform -IsRemote $false -TestPlat $Test.Local
 
     # Check both Exes
@@ -344,11 +344,7 @@ function Invoke-Test {
     $LocalArguments = $Test.Local.Arguments.Replace('$RemoteAddress', $RemoteAddress)
     $LocalArguments = $LocalArguments.Replace('$LocalAddress', $LocalAddress)
 
-    $CertThumbprint = Invoke-TestCommand -Session $Session -ScriptBlock {
-        return $env:QUICCERT
-    }
-
-    $RemoteArguments = $Test.Remote.Arguments.Replace('$Thumbprint', $CertThumbprint)
+    $RemoteArguments = $RemoteConfig.Arguments
 
     Write-Debug "Running Remote: $RemoteExe Args: $RemoteArguments"
 
@@ -440,7 +436,7 @@ if ($Record -and $IsWindows) {
 }
 
 try {
-    $Tests = Get-Tests -Path $TestsFile -RemotePlatform $RemotePlatform -LocalPlatform $LocalPlatform
+    [TestRunConfig]$Tests = Get-Tests -Path $TestsFile -RemotePlatform $RemotePlatform -LocalPlatform $LocalPlatform
 
     if ($null -eq $Tests) {
         Write-Error "Tests are not valid"
@@ -448,28 +444,25 @@ try {
 
     # Find All Remote processes, and kill them
     if (!$Local) {
-        foreach ($Test in $Tests) {
-            $ExeName = $Test.Remote.Exe
-            Invoke-TestCommand -Session $Session -ScriptBlock {
-                param ($ExeName)
-                try {
-                    Stop-Process -Name $ExeName -Force
-                } catch {
-                }
-            } -ArgumentList $ExeName
-        }
-
+        $ExeName = $Tests.Remote.Exe
+        Invoke-TestCommand -Session $Session -ScriptBlock {
+            param ($ExeName)
+            try {
+                Stop-Process -Name $ExeName -Force
+            } catch {
+            }
+        } -ArgumentList $ExeName
     }
 
     if (!$SkipDeploy -and !$Local) {
         Copy-Artifacts -From $LocalDirectory -To $RemoteDirectory
     }
 
-    foreach ($Test in $Tests) {
+    foreach ($Test in $Tests.Tests) {
         if ($TestToRun -ne "" -and $Test.TestName -ne $TestToRun) {
             continue
         }
-        Invoke-Test -Test $Test
+        Invoke-Test -Test $Test -RemoteConfig $Tests.Remote
     }
 
     if ($PGO) {


### PR DESCRIPTION
This removes a lot of what was generic about the remotes, and instead moves remote to a common root context.

This makes new tests much easier to add, especially once we get the full matrix RPS