### PR TITLE
Replace NtClose with ZwClose

### DIFF
--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -55,6 +55,14 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
 NTSTATUS
 NTAPI
+ZwClose(
+    _In_ HANDLE Handle
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSYSAPI
+NTSTATUS
+NTAPI
 ZwQueryInformationThread (
     _In_ HANDLE ThreadHandle,
     _In_ THREADINFOCLASS ThreadInformationClass,
@@ -839,7 +847,7 @@ QuicThreadCreate(
         Status = QUIC_STATUS_SUCCESS;
     }
 Cleanup:
-    NtClose(ThreadHandle);
+    ZwClose(ThreadHandle);
 Error:
     return Status;
 }

--- a/src/platform/storage_winkernel.c
+++ b/src/platform/storage_winkernel.c
@@ -54,17 +54,6 @@ ZwQueryValueKey(
     );
 
 //
-// Copied from wdm.h
-//
-_IRQL_requires_max_(PASSIVE_LEVEL)
-NTSYSAPI
-NTSTATUS
-NTAPI
-ZwClose(
-    _In_ HANDLE Handle
-    );
-
-//
 // Copied from zwapi_x.h
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1340,7 +1340,7 @@ QuicTlsSecConfigCreate(
                 KernelMode,
                 &Thread,
                 NULL);
-        NtClose(ThreadHandle);
+        ZwClose(ThreadHandle);
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 LibraryErrorStatus,


### PR DESCRIPTION
Fixes an issue when user mode threads are used to call into kernel MsQuic code.