### PR TITLE
Initial TCP Support

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -395,13 +395,13 @@ stages:
       image: ubuntu-latest
       platform: linux
       tls: openssl
-      extraArgs: -Filter -*TlsTest.CertificateError
+      extraArgs: -Filter -*TlsTest.CertificateError:*.Tcp*
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest
       platform: linux
       tls: stub
-      extraArgs: -Filter -*TlsTest.CertificateError
+      extraArgs: -Filter -*TlsTest.CertificateError:*.Tcp*
 
 #
 # SpinQuic Tests

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -128,6 +128,7 @@ QuicBindingInitialize(
     Status =
         QuicDataPathBindingCreate(
             MsQuicLib.Datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             LocalAddress,
             RemoteAddress,
             Binding,

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -568,7 +568,7 @@ QUIC_STATELESS_CONTEXT*
 QuicBindingCreateStatelessOperation(
     _In_ QUIC_BINDING* Binding,
     _In_ QUIC_WORKER* Worker,
-    _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ QUIC_RECV_DATA* Datagram
     )
 {
     uint32_t TimeMs = QuicTimeMs32();
@@ -688,7 +688,7 @@ BOOLEAN
 QuicBindingQueueStatelessOperation(
     _In_ QUIC_BINDING* Binding,
     _In_ QUIC_OPERATION_TYPE OperType,
-    _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ QUIC_RECV_DATA* Datagram
     )
 {
     if (MsQuicLib.StatelessRegistration == NULL) {
@@ -739,7 +739,7 @@ QuicBindingProcessStatelessOperation(
     )
 {
     QUIC_BINDING* Binding = StatelessCtx->Binding;
-    QUIC_RECV_DATAGRAM* RecvDatagram = StatelessCtx->Datagram;
+    QUIC_RECV_DATA* RecvDatagram = StatelessCtx->Datagram;
     QUIC_RECV_PACKET* RecvPacket =
         QuicDataPathRecvDatagramToRecvPacket(RecvDatagram);
     QUIC_BUFFER* SendDatagram = NULL;
@@ -1030,7 +1030,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicBindingQueueStatelessReset(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ QUIC_RECV_DATA* Datagram
     )
 {
     QUIC_DBG_ASSERT(!Binding->Exclusive);
@@ -1062,7 +1062,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicBindingPreprocessDatagram(
     _In_ QUIC_BINDING* Binding,
-    _Inout_ QUIC_RECV_DATAGRAM* Datagram,
+    _Inout_ QUIC_RECV_DATA* Datagram,
     _Out_ BOOLEAN* ReleaseDatagram
     )
 {
@@ -1159,7 +1159,7 @@ QuicBindingValidateRetryToken(
         return FALSE;
     }
 
-    const QUIC_RECV_DATAGRAM* Datagram =
+    const QUIC_RECV_DATA* Datagram =
         QuicDataPathRecvPacketToRecvDatagram(Packet);
     if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Datagram->Tuple->RemoteAddress)) {
         QuicPacketLogDrop(Binding, Packet, "Retry Token Addr Mismatch");
@@ -1214,7 +1214,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_CONNECTION*
 QuicBindingCreateConnection(
     _In_ QUIC_BINDING* Binding,
-    _In_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_ const QUIC_RECV_DATA* const Datagram
     )
 {
     //
@@ -1338,7 +1338,7 @@ _Function_class_(QUIC_DATAPATH_RECEIVE_CALLBACK)
 BOOLEAN
 QuicBindingDeliverDatagrams(
     _In_ QUIC_BINDING* Binding,
-    _In_ QUIC_RECV_DATAGRAM* DatagramChain,
+    _In_ QUIC_RECV_DATA* DatagramChain,
     _In_ uint32_t DatagramChainLength
     )
 {
@@ -1492,7 +1492,7 @@ void
 QuicBindingReceive(
     _In_ QUIC_DATAPATH_BINDING* DatapathBinding,
     _In_ void* RecvCallbackContext,
-    _In_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_ QUIC_RECV_DATA* DatagramChain
     )
 {
     UNREFERENCED_PARAMETER(DatapathBinding);
@@ -1500,11 +1500,11 @@ QuicBindingReceive(
     QUIC_DBG_ASSERT(DatagramChain != NULL);
 
     QUIC_BINDING* Binding = (QUIC_BINDING*)RecvCallbackContext;
-    QUIC_RECV_DATAGRAM* ReleaseChain = NULL;
-    QUIC_RECV_DATAGRAM** ReleaseChainTail = &ReleaseChain;
-    QUIC_RECV_DATAGRAM* SubChain = NULL;
-    QUIC_RECV_DATAGRAM** SubChainTail = &SubChain;
-    QUIC_RECV_DATAGRAM** SubChainDataTail = &SubChain;
+    QUIC_RECV_DATA* ReleaseChain = NULL;
+    QUIC_RECV_DATA** ReleaseChainTail = &ReleaseChain;
+    QUIC_RECV_DATA* SubChain = NULL;
+    QUIC_RECV_DATA** SubChainTail = &SubChain;
+    QUIC_RECV_DATA** SubChainDataTail = &SubChain;
     uint32_t SubChainLength = 0;
     uint32_t TotalChainLength = 0;
     uint32_t TotalDatagramBytes = 0;
@@ -1519,7 +1519,7 @@ QuicBindingReceive(
     // connection it was delivered to.
     //
 
-    QUIC_RECV_DATAGRAM* Datagram;
+    QUIC_RECV_DATA* Datagram;
     while ((Datagram = DatagramChain) != NULL) {
         TotalChainLength++;
         TotalDatagramBytes += Datagram->BufferLength;

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -126,9 +126,8 @@ QuicBindingInitialize(
 #endif
 
     Status =
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             MsQuicLib.Datapath,
-            QUIC_SOCKET_UDP,
             LocalAddress,
             RemoteAddress,
             Binding,

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -205,7 +205,7 @@ typedef struct QUIC_BINDING {
     //
     // The datapath binding.
     //
-    QUIC_DATAPATH_BINDING* DatapathBinding;
+    QUIC_SOCKET* Socket;
 
     //
     // Lock for accessing the listeners.

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -416,7 +416,7 @@ QuicBindingSend(
     _In_ QUIC_BINDING* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext,
+    _In_ QUIC_SEND_DATA* SendContext,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend
     );

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1832,8 +1832,8 @@ QuicConnStart(
     }
 
     Connection->State.LocalAddressSet = TRUE;
-    QuicDataPathBindingGetLocalAddress(
-        Path->Binding->DatapathBinding,
+    QuicSocketGetLocalAddress(
+        Path->Binding->Socket,
         &Path->LocalAddress);
     QuicTraceEvent(
         ConnLocalAddrAdded,
@@ -2165,8 +2165,8 @@ QuicConnGenerateLocalTransportParameters(
     LocalTP->InitialMaxStreamDataUni = Connection->Settings.StreamRecvWindowDefault;
     LocalTP->MaxUdpPayloadSize =
         MaxUdpPayloadSizeFromMTU(
-            QuicDataPathBindingGetLocalMtu(
-                Connection->Paths[0].Binding->DatapathBinding));
+            QuicSocketGetLocalMtu(
+                Connection->Paths[0].Binding->Socket));
     LocalTP->MaxAckDelay =
         Connection->Settings.MaxAckDelayMs + MsQuicLib.TimerResolutionMs;
     LocalTP->ActiveConnectionIdLimit = QUIC_ACTIVE_CONNECTION_ID_LIMIT;
@@ -5255,8 +5255,8 @@ QuicConnParamSet(
                 Connection,
                 CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
 
-            QuicDataPathBindingGetLocalAddress(
-                Connection->Paths[0].Binding->DatapathBinding,
+            QuicSocketGetLocalAddress(
+                Connection->Paths[0].Binding->Socket,
                 &Connection->Paths[0].LocalAddress);
 
             QuicTraceEvent(

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -423,8 +423,8 @@ typedef struct QUIC_CONNECTION {
     // Receive packet queue.
     //
     uint32_t ReceiveQueueCount;
-    QUIC_RECV_DATAGRAM* ReceiveQueue;
-    QUIC_RECV_DATAGRAM** ReceiveQueueTail;
+    QUIC_RECV_DATA* ReceiveQueue;
+    QUIC_RECV_DATA** ReceiveQueueTail;
     QUIC_DISPATCH_LOCK ReceiveQueueLock;
 
     //
@@ -824,7 +824,7 @@ _Success_(return != NULL)
 QUIC_CONNECTION*
 QuicConnAlloc(
     _In_ QUIC_REGISTRATION* Registration,
-    _In_opt_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_opt_ const QUIC_RECV_DATA* const Datagram
     );
 
 //
@@ -1323,7 +1323,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicConnQueueRecvDatagrams(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_RECV_DATAGRAM* DatagramChain,
+    _In_ QUIC_RECV_DATA* DatagramChain,
     _In_ uint32_t DatagramChainLength
     );
 

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -191,6 +191,11 @@ MsQuicLibraryInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     BOOLEAN PlatformInitialized = FALSE;
     uint32_t DefaultMaxPartitionCount = QUIC_MAX_PARTITION_COUNT;
+    const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
+        NULL,
+        QuicBindingReceive,
+        QuicBindingUnreachable
+    };
 
     Status = QuicPlatformInitialize();
     if (QUIC_FAILED(Status)) {
@@ -283,8 +288,7 @@ MsQuicLibraryInitialize(
     Status =
         QuicDataPathInitialize(
             sizeof(QUIC_RECV_PACKET),
-            QuicBindingReceive,
-            QuicBindingUnreachable,
+            &DatapathCallbacks,
             &MsQuicLib.Datapath);
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1493,7 +1493,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_WORKER*
 QUIC_NO_SANITIZE("implicit-conversion")
 QuicLibraryGetWorker(
-    _In_ const _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ const _In_ QUIC_RECV_DATA* Datagram
     )
 {
     QUIC_DBG_ASSERT(MsQuicLib.StatelessRegistration != NULL);

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -191,8 +191,7 @@ MsQuicLibraryInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     BOOLEAN PlatformInitialized = FALSE;
     uint32_t DefaultMaxPartitionCount = QUIC_MAX_PARTITION_COUNT;
-    const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
-        NULL,
+    const QUIC_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
         QuicBindingReceive,
         QuicBindingUnreachable
     };
@@ -289,6 +288,7 @@ MsQuicLibraryInitialize(
         QuicDataPathInitialize(
             sizeof(QUIC_RECV_PACKET),
             &DatapathCallbacks,
+            NULL,                   // TcpCallbacks
             &MsQuicLib.Datapath);
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1226,7 +1226,7 @@ QuicLibraryLookupBinding(
 #endif
 
         QUIC_ADDR BindingLocalAddr;
-        QuicDataPathBindingGetLocalAddress(Binding->DatapathBinding, &BindingLocalAddr);
+        QuicSocketGetLocalAddress(Binding->Socket, &BindingLocalAddr);
 
         if (!QuicAddrCompare(LocalAddress, &BindingLocalAddr)) {
             continue;
@@ -1238,7 +1238,7 @@ QuicLibraryLookupBinding(
             }
 
             QUIC_ADDR BindingRemoteAddr;
-            QuicDataPathBindingGetRemoteAddress(Binding->DatapathBinding, &BindingRemoteAddr);
+            QuicSocketGetRemoteAddress(Binding->Socket, &BindingRemoteAddr);
             if (!QuicAddrCompare(RemoteAddress, &BindingRemoteAddr)) {
                 continue;
             }
@@ -1336,7 +1336,7 @@ NewBinding:
         goto Exit;
     }
 
-    QuicDataPathBindingGetLocalAddress((*NewBinding)->DatapathBinding, &NewLocalAddress);
+    QuicSocketGetLocalAddress((*NewBinding)->Socket, &NewLocalAddress);
 
     QuicDispatchLockAcquire(&MsQuicLib.DatapathLock);
 

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -476,7 +476,7 @@ QuicLibraryOnListenerRegistered(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_WORKER*
 QuicLibraryGetWorker(
-    _In_ const _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ const _In_ QUIC_RECV_DATA* Datagram
     );
 
 //

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -290,8 +290,8 @@ MsQuicListenerStart(
     }
 
     if (PortUnspecified) {
-        QuicDataPathBindingGetLocalAddress(
-            Listener->Binding->DatapathBinding,
+        QuicSocketGetLocalAddress(
+            Listener->Binding->Socket,
             &BindingLocalAddress);
         QuicAddrSetPort(
             &Listener->LocalAddress,

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -179,7 +179,7 @@ typedef struct QUIC_STATELESS_CONTEXT {
     QUIC_ADDR RemoteAddress;
     QUIC_LIST_ENTRY ListEntry;
     QUIC_HASHTABLE_ENTRY TableEntry;
-    QUIC_RECV_DATAGRAM* Datagram;
+    QUIC_RECV_DATA* Datagram;
     uint32_t CreationTimeMs;
     uint8_t HasBindingRef : 1;
     uint8_t IsProcessed : 1;

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -702,7 +702,7 @@ QuicPacketLogDrop(
     _In_z_ const char* Reason
     )
 {
-    const QUIC_RECV_DATAGRAM* Datagram = // cppcheck-suppress unreadVariable; NOLINT
+    const QUIC_RECV_DATA* Datagram = // cppcheck-suppress unreadVariable; NOLINT
         QuicDataPathRecvPacketToRecvDatagram(Packet);
 
     if (Packet->AssignedToConnection) {
@@ -736,7 +736,7 @@ QuicPacketLogDropWithValue(
     _In_ uint64_t Value
     )
 {
-    const QUIC_RECV_DATAGRAM* Datagram = // cppcheck-suppress unreadVariable; NOLINT
+    const QUIC_RECV_DATA* Datagram = // cppcheck-suppress unreadVariable; NOLINT
         QuicDataPathRecvPacketToRecvDatagram(Packet);
 
     if (Packet->AssignedToConnection) {

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -703,7 +703,7 @@ QuicPacketLogDrop(
     )
 {
     const QUIC_RECV_DATA* Datagram = // cppcheck-suppress unreadVariable; NOLINT
-        QuicDataPathRecvPacketToRecvDatagram(Packet);
+        QuicDataPathRecvPacketToRecvData(Packet);
 
     if (Packet->AssignedToConnection) {
         InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
@@ -737,7 +737,7 @@ QuicPacketLogDropWithValue(
     )
 {
     const QUIC_RECV_DATA* Datagram = // cppcheck-suppress unreadVariable; NOLINT
-        QuicDataPathRecvPacketToRecvDatagram(Packet);
+        QuicDataPathRecvPacketToRecvData(Packet);
 
     if (Packet->AssignedToConnection) {
         InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -184,7 +184,7 @@ QuicPacketBuilderPrepare(
         if (Builder->SendContext == NULL) {
             Builder->SendContext =
                 QuicSendDataAlloc(
-                    Builder->Path->Binding->DatapathBinding,
+                    Builder->Path->Binding->Socket,
                     QUIC_ECN_NON_ECT,
                     IsPathMtuDiscovery ?
                         0 :

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -183,7 +183,7 @@ QuicPacketBuilderPrepare(
 
         if (Builder->SendContext == NULL) {
             Builder->SendContext =
-                QuicDataPathBindingAllocSendContext(
+                QuicSendDataAlloc(
                     Builder->Path->Binding->DatapathBinding,
                     QUIC_ECN_NON_ECT,
                     IsPathMtuDiscovery ?
@@ -211,7 +211,7 @@ QuicPacketBuilderPrepare(
         }
 
         Builder->Datagram =
-            QuicDataPathBindingAllocSendDatagram(
+            QuicSendDataAllocBuffer(
                 Builder->SendContext,
                 NewDatagramLength);
         if (Builder->Datagram == NULL) {
@@ -585,7 +585,7 @@ QuicPacketBuilderFinalize(
             Builder->DatagramLength -= Builder->HeaderLength;
 
             if (Builder->DatagramLength == 0) {
-                QuicDataPathBindingFreeSendDatagram(Builder->SendContext, Builder->Datagram);
+                QuicSendDataFreeBuffer(Builder->SendContext, Builder->Datagram);
                 Builder->Datagram = NULL;
             }
         }
@@ -859,7 +859,7 @@ Exit:
             Builder->TotalDatagramsLength += Builder->DatagramLength;
         }
 
-        if (FlushBatchedDatagrams || QuicDataPathBindingIsSendContextFull(Builder->SendContext)) {
+        if (FlushBatchedDatagrams || QuicSendDataIsFull(Builder->SendContext)) {
             if (Builder->BatchCount != 0) {
                 QuicPacketBuilderFinalizeHeaderProtection(Builder);
             }

--- a/src/core/packet_builder.h
+++ b/src/core/packet_builder.h
@@ -28,7 +28,7 @@ typedef struct QUIC_PACKET_BUILDER {
     //
     // Represents a set of UDP datagrams.
     //
-    QUIC_DATAPATH_SEND_CONTEXT* SendContext;
+    QUIC_SEND_DATA* SendContext;
 
     //
     // Represents a single UDP payload. Can contain multiple coalesced QUIC

--- a/src/core/packet_space.c
+++ b/src/core/packet_space.c
@@ -58,7 +58,7 @@ QuicPacketSpaceUninitialize(
         do {
             Datagram->QueuedOnConnection = FALSE;
         } while ((Datagram = Datagram->Next) != NULL);
-        QuicDataPathBindingReturnRecvDatagrams(Packets->DeferredDatagrams);
+        QuicRecvDataReturn(Packets->DeferredDatagrams);
     }
 
     QuicAckTrackerUninitialize(&Packets->AckTracker);

--- a/src/core/packet_space.c
+++ b/src/core/packet_space.c
@@ -54,7 +54,7 @@ QuicPacketSpaceUninitialize(
     // Release any pending packets back to the binding.
     //
     if (Packets->DeferredDatagrams != NULL) {
-        QUIC_RECV_DATAGRAM* Datagram = Packets->DeferredDatagrams;
+        QUIC_RECV_DATA* Datagram = Packets->DeferredDatagrams;
         do {
             Datagram->QueuedOnConnection = FALSE;
         } while ((Datagram = Datagram->Next) != NULL);

--- a/src/core/packet_space.h
+++ b/src/core/packet_space.h
@@ -71,7 +71,7 @@ typedef struct QUIC_PACKET_SPACE {
     // List of received QUIC_RECV_DATAGRAMs that we don't have the key
     // for yet.
     //
-    QUIC_RECV_DATAGRAM* DeferredDatagrams;
+    QUIC_RECV_DATA* DeferredDatagrams;
 
     //
     // Information related to packets that have been received and need to be

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -165,7 +165,7 @@ _Ret_maybenull_
 QUIC_PATH*
 QuicConnGetPathForDatagram(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ const QUIC_RECV_DATAGRAM* Datagram
+    _In_ const QUIC_RECV_DATA* Datagram
     )
 {
     for (uint8_t i = 0; i < Connection->PathsCount; ++i) {

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -215,5 +215,5 @@ _Ret_maybenull_
 QUIC_PATH*
 QuicConnGetPathForDatagram(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ const QUIC_RECV_DATAGRAM* Datagram
+    _In_ const QUIC_RECV_DATA* Datagram
     );

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -234,7 +234,7 @@ QUIC_STATIC_ASSERT(IS_POWER_OF_TWO(QUIC_MAX_RANGE_DECODE_ACKS), L"Must be power 
 // Path MTU discovery will always start with/initialize with the smallest
 // allowable MTU for QUIC (1280 bytes).
 //
-#define QUIC_DEFAULT_PATH_MTU                   QUIC_MIN_MTU
+#define QUIC_DEFAULT_PATH_MTU                   1280    // TODO - Use 1200 instead
 
 //
 // The maximum time an app callback can take before we log a warning.

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -272,7 +272,7 @@ QuicWorkerQueueOperation(
     if (Operation != NULL) {
         const QUIC_BINDING* Binding = Operation->STATELESS.Context->Binding;
         const QUIC_RECV_PACKET* Packet =
-            QuicDataPathRecvDatagramToRecvPacket(
+            QuicDataPathRecvDataToRecvPacket(
                 Operation->STATELESS.Context->Datagram);
         QuicPacketLogDrop(Binding, Packet, "Worker operation limit reached");
         QuicOperationFree(Worker, Operation);

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 typedef struct QUIC_RECV_DATA QUIC_RECV_DATA;
-typedef struct QUIC_DATAPATH_SEND_CONTEXT QUIC_DATAPATH_SEND_CONTEXT;
+typedef struct QUIC_SEND_DATA QUIC_SEND_DATA;
 
 //
 // Returns TRUE to drop the packet.
@@ -42,7 +42,7 @@ BOOLEAN
 (QUIC_API * QUIC_TEST_DATAPATH_SEND_HOOK)(
     _Inout_ QUIC_ADDR* RemoteAddress,
     _Inout_opt_ QUIC_ADDR* LocalAddress,
-    _Inout_ QUIC_DATAPATH_SEND_CONTEXT* SendContext
+    _Inout_ QUIC_SEND_DATA* SendContext
     );
 
 typedef struct QUIC_TEST_DATAPATH_HOOKS {

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -20,7 +20,7 @@ Abstract:
 extern "C" {
 #endif
 
-typedef struct QUIC_RECV_DATAGRAM QUIC_RECV_DATAGRAM;
+typedef struct QUIC_RECV_DATA QUIC_RECV_DATA;
 typedef struct QUIC_DATAPATH_SEND_CONTEXT QUIC_DATAPATH_SEND_CONTEXT;
 
 //
@@ -30,7 +30,7 @@ typedef
 _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 (QUIC_API * QUIC_TEST_DATAPATH_RECEIVE_HOOK)(
-    _Inout_ QUIC_RECV_DATAGRAM* Datagram
+    _Inout_ QUIC_RECV_DATA* Datagram
     );
 
 //

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -313,14 +313,14 @@ QuicDataPathResolveAddress(
 //
 
 typedef enum QUIC_SOCKET_TYPE {
-    QUIC_SOCKET_UDP   = 0,
-    QUIC_SOCKET_TCP   = 1
+    QUIC_SOCKET_UDP             = 0,
+    QUIC_SOCKET_TCP             = 1,
+    QUIC_SOCKET_TCP_LISTENER    = 2
 } QUIC_SOCKET_TYPE;
 
 //
 // Creates a datapath socket handle for the given local address and/or remote
-// address. This function immediately registers for receive upcalls from the
-// layer below.
+// address. This function immediately registers for upcalls from the layer below.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -225,6 +225,21 @@ void
 typedef QUIC_DATAPATH_ACCEPT_CALLBACK *QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER;
 
 //
+// Function pointer type for datapath TCP connect/disconnect callbacks.
+//
+typedef
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Function_class_(QUIC_DATAPATH_CONNECT_CALLBACK)
+void
+(QUIC_DATAPATH_CONNECT_CALLBACK)(
+    _In_ QUIC_SOCKET* Socket,
+    _In_ void* Context,
+    _In_ BOOLEAN Connected
+    );
+
+typedef QUIC_DATAPATH_CONNECT_CALLBACK *QUIC_DATAPATH_CONNECT_CALLBACK_HANDLER;
+
+//
 // Function pointer type for datapath receive callbacks.
 //
 typedef
@@ -255,15 +270,25 @@ void
 typedef QUIC_DATAPATH_UNREACHABLE_CALLBACK *QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER;
 
 //
-// Callback function pointers used by the datapath.
+// UDP Callback function pointers used by the datapath.
 //
-typedef struct QUIC_DATAPATH_CALLBACKS {
+typedef struct QUIC_UDP_DATAPATH_CALLBACKS {
 
-    QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER Accept;
     QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER Receive;
     QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER Unreachable;
 
-} QUIC_DATAPATH_CALLBACKS;
+} QUIC_UDP_DATAPATH_CALLBACKS;
+
+//
+// TCP Callback function pointers used by the datapath.
+//
+typedef struct QUIC_TCP_DATAPATH_CALLBACKS {
+
+    QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER Accept;
+    QUIC_DATAPATH_CONNECT_CALLBACK_HANDLER Connect;
+    QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER Receive;
+
+} QUIC_TCP_DATAPATH_CALLBACKS;
 
 //
 // Function pointer type for send complete callbacks.
@@ -288,7 +313,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicDataPathInitialize(
     _In_ uint32_t ClientRecvContextLength,
-    _In_ const QUIC_DATAPATH_CALLBACKS* Callbacks,
+    _In_opt_ const QUIC_UDP_DATAPATH_CALLBACKS* UdpCallbacks,
+    _In_opt_ const QUIC_TCP_DATAPATH_CALLBACKS* TcpCallbacks,
     _Out_ QUIC_DATAPATH** NewDatapath
     );
 

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -365,8 +365,9 @@ QuicDataPathResolveAddress(
 //
 
 //
-// Creates a UDP socket for the given local address and/or remote address. This
-// function immediately registers for receive upcalls from the layer below.
+// Creates a UDP socket for the given (optional) local address and/or (optional)
+// remote address. This function immediately registers for receive upcalls from
+// the layer below.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
@@ -379,7 +380,7 @@ QuicSocketCreateUdp(
     );
 
 //
-// Creates a TCP socket for the (optional) (optional) given local address and
+// Creates a TCP socket for the given (optional) local address and (required)
 // remote address. This function immediately registers for upcalls from the
 // layer below.
 //
@@ -394,7 +395,7 @@ QuicSocketCreateTcp(
     );
 
 //
-// Creates a TCP listener socket for the (optional) given local address. This
+// Creates a TCP listener socket for the given (optional) local address. This
 // function immediately registers for accept upcalls from the layer below.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -209,6 +209,22 @@ QuicDataPathRecvDataToRecvPacket(
     );
 
 //
+// Function pointer type for datapath TCP accept callbacks.
+//
+typedef
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Function_class_(QUIC_DATAPATH_ACCEPT_CALLBACK)
+void
+(QUIC_DATAPATH_ACCEPT_CALLBACK)(
+    _In_ QUIC_SOCKET* ListenerSocket,
+    _In_ void* ListenerContext,
+    _In_ QUIC_SOCKET* ClientSocket,
+    _Out_ void** ClientContext
+    );
+
+typedef QUIC_DATAPATH_ACCEPT_CALLBACK *QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER;
+
+//
 // Function pointer type for datapath receive callbacks.
 //
 typedef
@@ -239,6 +255,17 @@ void
 typedef QUIC_DATAPATH_UNREACHABLE_CALLBACK *QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER;
 
 //
+// Callback function pointers used by the datapath.
+//
+typedef struct QUIC_DATAPATH_CALLBACKS {
+
+    QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER Accept;
+    QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER Receive;
+    QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER Unreachable;
+
+} QUIC_DATAPATH_CALLBACKS;
+
+//
 // Function pointer type for send complete callbacks.
 //
 typedef
@@ -261,8 +288,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicDataPathInitialize(
     _In_ uint32_t ClientRecvContextLength,
-    _In_ QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER RecvCallback,
-    _In_ QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER UnreachableCallback,
+    _In_ const QUIC_DATAPATH_CALLBACKS* Callbacks,
     _Out_ QUIC_DATAPATH** NewDatapath
     );
 
@@ -314,8 +340,9 @@ QuicDataPathResolveAddress(
 
 typedef enum QUIC_SOCKET_TYPE {
     QUIC_SOCKET_UDP             = 0,
-    QUIC_SOCKET_TCP             = 1,
-    QUIC_SOCKET_TCP_LISTENER    = 2
+    QUIC_SOCKET_TCP_LISTENER    = 1,
+    QUIC_SOCKET_TCP             = 2,
+    QUIC_SOCKET_TCP_SERVER      = 3     // Used internally only!
 } QUIC_SOCKET_TYPE;
 
 //

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -338,24 +338,44 @@ QuicDataPathResolveAddress(
 // The following APIs are specific to a single UDP or TCP socket abstraction.
 //
 
-typedef enum QUIC_SOCKET_TYPE {
-    QUIC_SOCKET_UDP             = 0,
-    QUIC_SOCKET_TCP_LISTENER    = 1,
-    QUIC_SOCKET_TCP             = 2,
-    QUIC_SOCKET_TCP_SERVER      = 3     // Used internally only!
-} QUIC_SOCKET_TYPE;
-
 //
-// Creates a datapath socket handle for the given local address and/or remote
-// address. This function immediately registers for upcalls from the layer below.
+// Creates a UDP socket for the given local address and/or remote address. This
+// function immediately registers for receive upcalls from the layer below.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
-QuicSocketCreate(
+QuicSocketCreateUdp(
     _In_ QUIC_DATAPATH* Datapath,
-    _In_ QUIC_SOCKET_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
+    _In_opt_ void* CallbackContext,
+    _Out_ QUIC_SOCKET** Socket
+    );
+
+//
+// Creates a TCP socket for the (optional) (optional) given local address and
+// remote address. This function immediately registers for upcalls from the
+// layer below.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicSocketCreateTcp(
+    _In_ QUIC_DATAPATH* Datapath,
+    _In_opt_ const QUIC_ADDR* LocalAddress,
+    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_opt_ void* CallbackContext,
+    _Out_ QUIC_SOCKET** Socket
+    );
+
+//
+// Creates a TCP listener socket for the (optional) given local address. This
+// function immediately registers for accept upcalls from the layer below.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicSocketCreateTcpListener(
+    _In_ QUIC_DATAPATH* Datapath,
+    _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ void* CallbackContext,
     _Out_ QUIC_SOCKET** Socket
     );

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -218,8 +218,8 @@ void
 (QUIC_DATAPATH_ACCEPT_CALLBACK)(
     _In_ QUIC_SOCKET* ListenerSocket,
     _In_ void* ListenerContext,
-    _In_ QUIC_SOCKET* ClientSocket,
-    _Out_ void** ClientContext
+    _In_ QUIC_SOCKET* AcceptSocket,
+    _Out_ void** AcceptClientContext
     );
 
 typedef QUIC_DATAPATH_ACCEPT_CALLBACK *QUIC_DATAPATH_ACCEPT_CALLBACK_HANDLER;
@@ -356,7 +356,7 @@ QuicSocketCreate(
     _In_ QUIC_SOCKET_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
-    _In_opt_ void* RecvCallbackContext,
+    _In_opt_ void* CallbackContext,
     _Out_ QUIC_SOCKET** Socket
     );
 

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -139,14 +139,14 @@ typedef struct QUIC_TUPLE {
 } QUIC_TUPLE;
 
 //
-// Structure to represent received UDP datagrams.
+// Structure to represent received UDP datagrams or TCP data.
 //
-typedef struct QUIC_RECV_DATAGRAM {
+typedef struct QUIC_RECV_DATA {
 
     //
     // The next receive datagram in the chain.
     //
-    struct QUIC_RECV_DATAGRAM* Next;
+    struct QUIC_RECV_DATA* Next;
 
     //
     // Contains the 4 tuple.
@@ -181,12 +181,12 @@ typedef struct QUIC_RECV_DATAGRAM {
     uint8_t Allocated : 1;          // Used for debugging. Set to FALSE on free.
     uint8_t QueuedOnConnection : 1; // Used for debugging.
 
-} QUIC_RECV_DATAGRAM;
+} QUIC_RECV_DATA;
 
 //
 // Gets the corresponding recv datagram from its context pointer.
 //
-QUIC_RECV_DATAGRAM*
+QUIC_RECV_DATA*
 QuicDataPathRecvPacketToRecvDatagram(
     _In_ const QUIC_RECV_PACKET* const Packet
     );
@@ -196,7 +196,7 @@ QuicDataPathRecvPacketToRecvDatagram(
 //
 QUIC_RECV_PACKET*
 QuicDataPathRecvDatagramToRecvPacket(
-    _In_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_ const QUIC_RECV_DATA* const Datagram
     );
 
 //
@@ -209,7 +209,7 @@ void
 (QUIC_DATAPATH_RECEIVE_CALLBACK)(
     _In_ QUIC_DATAPATH_BINDING* Binding,
     _In_ void* Context,
-    _In_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_ QUIC_RECV_DATA* DatagramChain
     );
 
 typedef QUIC_DATAPATH_RECEIVE_CALLBACK *QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER;
@@ -373,7 +373,7 @@ QuicDataPathBindingGetRemoteAddress(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicDataPathBindingReturnRecvDatagrams(
-    _In_opt_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_opt_ QUIC_RECV_DATA* DatagramChain
     );
 
 //

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -105,7 +105,7 @@ typedef struct QUIC_SINGLE_LIST_ENTRY {
 #define QUIC_POOL_PLATFORM_PROC             '92cQ' // Qc29 - QUIC Platform Processor info
 #define QUIC_POOL_PLATFORM_GENERIC          'A2cQ' // Qc2A - QUIC Platform generic
 #define QUIC_POOL_DATAPATH                  'B2cQ' // Qc2B - QUIC Platform datapath
-#define QUIC_POOL_SOCKET          'C2cQ' // Qc2C - QUIC Platform datapath binding
+#define QUIC_POOL_SOCKET                    'C2cQ' // Qc2C - QUIC Platform socket
 #define QUIC_POOL_STORAGE                   'D2cQ' // Qc2D - QUIC Platform storage
 #define QUIC_POOL_HASHTABLE                 'E2cQ' // Qc2E - QUIC Platform hashtable
 #define QUIC_POOL_HASHTABLE_MEMBER          'F2cQ' // Qc2F - QUIC Platform hashtable member lists

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -105,7 +105,7 @@ typedef struct QUIC_SINGLE_LIST_ENTRY {
 #define QUIC_POOL_PLATFORM_PROC             '92cQ' // Qc29 - QUIC Platform Processor info
 #define QUIC_POOL_PLATFORM_GENERIC          'A2cQ' // Qc2A - QUIC Platform generic
 #define QUIC_POOL_DATAPATH                  'B2cQ' // Qc2B - QUIC Platform datapath
-#define QUIC_POOL_DATAPATH_BINDING          'C2cQ' // Qc2C - QUIC Platform datapath binding
+#define QUIC_POOL_SOCKET          'C2cQ' // Qc2C - QUIC Platform datapath binding
 #define QUIC_POOL_STORAGE                   'D2cQ' // Qc2D - QUIC Platform storage
 #define QUIC_POOL_HASHTABLE                 'E2cQ' // Qc2E - QUIC Platform hashtable
 #define QUIC_POOL_HASHTABLE_MEMBER          'F2cQ' // Qc2F - QUIC Platform hashtable member lists

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -130,7 +130,7 @@ void
 
 typedef
 uint16_t
-(*QUIC_DATPATH_Socket_GET_LOCAL_MTU)(
+(*QUIC_DATPATH_SOCKET_GET_LOCAL_MTU)(
     _In_ QUIC_SOCKET* Socket
     );
 
@@ -242,15 +242,15 @@ typedef struct QUIC_PLATFORM_DISPATCH {
     QUIC_DATAPATH_RESOLVE_ADDRESS DatapathResolveAddress;
     QUIC_SOCKET_CREATE SocketCreate;
     QUIC_SOCKET_DELETE SocketDelete;
-    QUIC_DATPATH_Socket_GET_LOCAL_MTU SocketGetLocalMtu;
+    QUIC_DATPATH_SOCKET_GET_LOCAL_MTU SocketGetLocalMtu;
     QUIC_SOCKET_GET_LOCAL_ADDRESS SocketGetLocalAddress;
     QUIC_SOCKET_GET_REMOTE_ADDRESS SocketGetRemoteAddress;
     QUIC_RECV_DATA_RETURN RecvDataReturn;
-    QUIC_SEND_DATA_ALLOC QuicSendDataAlloc;
-    QUIC_SEND_DATA_FREE QuicSendDataFree;
-    QUIC_SEND_DATA_IS_FULL QuicSendDataIsFull;
-    QUIC_SEND_DATA_ALLOC_BUFFER QuicSendDataAllocBuffer;
-    QUIC_SEND_DATA_FREE_BUFFER QuicSendDataFreeBuffer;
+    QUIC_SEND_DATA_ALLOC SendDataAlloc;
+    QUIC_SEND_DATA_FREE SendDataFree;
+    QUIC_SEND_DATA_IS_FULL SendDataIsFull;
+    QUIC_SEND_DATA_ALLOC_BUFFER SendDataAllocBuffer;
+    QUIC_SEND_DATA_FREE_BUFFER SendDataFreeBuffer;
     QUIC_SOCKET_SEND SocketSend;
     QUIC_SOCKET_SET_PARAM SocketSetParam;
     QUIC_SOCKET_GET_PARAM SocketGetParam;

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -87,9 +87,8 @@ typedef
 QUIC_STATUS
 (*QUIC_DATAPATH_INITIALIZE)(
     _In_ uint32_t ClientRecvContextLength,
-    _In_ QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER RecvCallback,
-    _In_ QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER UnreachableCallback,
-    _Out_ QUIC_DATAPATH* *NewDatapath
+    _In_ const QUIC_DATAPATH_CALLBACKS* Callback,
+    _Out_ QUIC_DATAPATH** NewDatapath
     );
 
 typedef

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -72,7 +72,7 @@ void
     );
 
 typedef
-QUIC_RECV_DATAGRAM*
+QUIC_RECV_DATA*
 (*QUIC_DATAPATH_RECVCONTEXT_TO_RECVBUFFER)(
     _In_ const QUIC_RECV_PACKET* const RecvPacket
     );
@@ -80,7 +80,7 @@ QUIC_RECV_DATAGRAM*
 typedef
 QUIC_RECV_PACKET*
 (*QUIC_DATAPATH_RECVBUFFER_TO_RECVCONTEXT)(
-    _In_ const QUIC_RECV_DATAGRAM* const RecvDatagram
+    _In_ const QUIC_RECV_DATA* const RecvDatagram
     );
 
 typedef
@@ -151,7 +151,7 @@ void
 typedef
 void
 (*QUIC_DATAPATH_BINDING_RETURN_RECV_BUFFER)(
-    _In_ QUIC_RECV_DATAGRAM* RecvPacketChain
+    _In_ QUIC_RECV_DATA* RecvPacketChain
     );
 
 typedef

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -155,7 +155,7 @@ void
     );
 
 typedef
-QUIC_DATAPATH_SEND_CONTEXT*
+QUIC_SEND_DATA*
 (*QUIC_DATAPATH_BINDING_ALLOC_SEND_CONTEXT)(
     _In_ QUIC_DATAPATH_BINDING* Binding,
     _In_ uint16_t MaxPacketSize
@@ -164,27 +164,27 @@ QUIC_DATAPATH_SEND_CONTEXT*
 typedef
 void
 (*QUIC_DATAPATH_BINDING_FREE_SEND_CONTEXT)(
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext
+    _In_ QUIC_SEND_DATA* SendContext
     );
 
 typedef
 QUIC_BUFFER*
 (*QUIC_DATAPATH_BINDING_ALLOC_SEND_BUFFER)(
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext,
+    _In_ QUIC_SEND_DATA* SendContext,
     _In_ uint16_t MaxBufferLength
     );
 
 typedef
 void
 (*QUIC_DATAPATH_BINDING_FREE_SEND_BUFFER)(
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext,
+    _In_ QUIC_SEND_DATA* SendContext,
     _In_ QUIC_BUFFER* SendBuffer
     );
 
 typedef
 BOOLEAN
 (*QUIC_DATAPATH_BINDING_IS_SEND_CONTEXT_FULL)(
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext
+    _In_ QUIC_SEND_DATA* SendContext
     );
 
 typedef
@@ -193,7 +193,7 @@ QUIC_STATUS
     _In_ QUIC_DATAPATH_BINDING* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ QUIC_DATAPATH_SEND_CONTEXT* SendContext
+    _In_ QUIC_SEND_DATA* SendContext
     );
 
 typedef

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -114,92 +114,94 @@ QUIC_STATUS
 
 typedef
 QUIC_STATUS
-(*QUIC_DATAPATH_BINDING_CREATE)(
+(*QUIC_SOCKET_CREATE)(
     _In_ QUIC_DATAPATH* Datapath,
+    _In_ QUIC_SOCKET_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
-    _Out_ QUIC_DATAPATH_BINDING** Binding
+    _Out_ QUIC_SOCKET** Socket
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_DELETE)(
-    _In_ QUIC_DATAPATH_BINDING* Binding
+(*QUIC_SOCKET_DELETE)(
+    _In_ QUIC_SOCKET* Socket
     );
 
 typedef
 uint16_t
-(*QUIC_DATPATH_BINDING_GET_LOCAL_MTU)(
-    _In_ QUIC_DATAPATH_BINDING* Binding
+(*QUIC_DATPATH_Socket_GET_LOCAL_MTU)(
+    _In_ QUIC_SOCKET* Socket
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_GET_LOCAL_ADDRESS)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SOCKET_GET_LOCAL_ADDRESS)(
+    _In_ QUIC_SOCKET* Socket,
     _Out_ QUIC_ADDR* Address
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_GET_REMOTE_ADDRESS)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SOCKET_GET_REMOTE_ADDRESS)(
+    _In_ QUIC_SOCKET* Socket,
     _Out_ QUIC_ADDR* Address
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_RETURN_RECV_BUFFER)(
-    _In_ QUIC_RECV_DATA* RecvPacketChain
+(*QUIC_RECV_DATA_RETURN)(
+    _In_ QUIC_RECV_DATA* RecvDataChain
     );
 
 typedef
 QUIC_SEND_DATA*
-(*QUIC_DATAPATH_BINDING_ALLOC_SEND_CONTEXT)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SEND_DATA_ALLOC)(
+    _In_ QUIC_SOCKET* Socket,
+    _In_ QUIC_ECN_TYPE ECN,
     _In_ uint16_t MaxPacketSize
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_FREE_SEND_CONTEXT)(
-    _In_ QUIC_SEND_DATA* SendContext
+(*QUIC_SEND_DATA_FREE)(
+    _In_ QUIC_SEND_DATA* SendData
     );
 
 typedef
 QUIC_BUFFER*
-(*QUIC_DATAPATH_BINDING_ALLOC_SEND_BUFFER)(
-    _In_ QUIC_SEND_DATA* SendContext,
+(*QUIC_SEND_DATA_ALLOC_BUFFER)(
+    _In_ QUIC_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     );
 
 typedef
 void
-(*QUIC_DATAPATH_BINDING_FREE_SEND_BUFFER)(
-    _In_ QUIC_SEND_DATA* SendContext,
-    _In_ QUIC_BUFFER* SendBuffer
+(*QUIC_SEND_DATA_FREE_BUFFER)(
+    _In_ QUIC_SEND_DATA* SendData,
+    _In_ QUIC_BUFFER* Buffer
     );
 
 typedef
 BOOLEAN
-(*QUIC_DATAPATH_BINDING_IS_SEND_CONTEXT_FULL)(
-    _In_ QUIC_SEND_DATA* SendContext
+(*QUIC_SEND_DATA_IS_FULL)(
+    _In_ QUIC_SEND_DATA* SendData
     );
 
 typedef
 QUIC_STATUS
-(*QUIC_DATAPATH_BINDING_SEND)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SOCKET_SEND)(
+    _In_ QUIC_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ QUIC_SEND_DATA* SendContext
+    _In_ QUIC_SEND_DATA* SendData
     );
 
 typedef
 QUIC_STATUS
-(*QUIC_DATAPATH_BINDING_SET_PARAM)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SOCKET_SET_PARAM)(
+    _In_ QUIC_SOCKET* Socket,
     _In_ uint32_t Param,
     _In_ uint32_t BufferLength,
     _In_reads_bytes_(BufferLength) const uint8_t * Buffer
@@ -207,8 +209,8 @@ QUIC_STATUS
 
 typedef
 QUIC_STATUS
-(*QUIC_DATAPATH_BINDING_GET_PARAM)(
-    _In_ QUIC_DATAPATH_BINDING* Binding,
+(*QUIC_SOCKET_GET_PARAM)(
+    _In_ QUIC_SOCKET* Socket,
     _In_ uint32_t Param,
     _Inout_ uint32_t* BufferLength,
     _Out_writes_bytes_opt_(*BufferLength) uint8_t * Buffer
@@ -220,7 +222,6 @@ QUIC_STATUS
     _In_ uint32_t BufferLen,
     _Out_writes_bytes_(BufferLen) void* Buffer
     );
-
 
 typedef struct QUIC_PLATFORM_DISPATCH {
     QUIC_ALLOC Alloc;
@@ -240,20 +241,20 @@ typedef struct QUIC_PLATFORM_DISPATCH {
     QUIC_DATAPATH_RECVBUFFER_TO_RECVCONTEXT DatapathRecvPacketToRecvContext;
     QUIC_DATAPATH_IS_PADDING_PREFERRED DatapathIsPaddingPreferred;
     QUIC_DATAPATH_RESOLVE_ADDRESS DatapathResolveAddress;
-    QUIC_DATAPATH_BINDING_CREATE DatapathBindingCreate;
-    QUIC_DATAPATH_BINDING_DELETE DatapathBindingDelete;
-    QUIC_DATPATH_BINDING_GET_LOCAL_MTU DatapathBindingGetLocalMtu;
-    QUIC_DATAPATH_BINDING_GET_LOCAL_ADDRESS DatapathBindingGetLocalAddress;
-    QUIC_DATAPATH_BINDING_GET_REMOTE_ADDRESS DatapathBindingGetRemoteAddress;
-    QUIC_DATAPATH_BINDING_RETURN_RECV_BUFFER DatapathBindingReturnRecvPacket;
-    QUIC_DATAPATH_BINDING_ALLOC_SEND_CONTEXT DatapathBindingAllocSendContext;
-    QUIC_DATAPATH_BINDING_FREE_SEND_CONTEXT DatapathBindingFreeSendContext;
-    QUIC_DATAPATH_BINDING_IS_SEND_CONTEXT_FULL DatapathBindingIsSendContextFull;
-    QUIC_DATAPATH_BINDING_ALLOC_SEND_BUFFER DatapathBindingAllocSendBuffer;
-    QUIC_DATAPATH_BINDING_FREE_SEND_BUFFER DatapathBindingFreeSendBuffer;
-    QUIC_DATAPATH_BINDING_SEND DatapathBindingSend;
-    QUIC_DATAPATH_BINDING_SET_PARAM DatapathBindingSetParam;
-    QUIC_DATAPATH_BINDING_GET_PARAM DatapathBindingGetParam;
+    QUIC_SOCKET_CREATE SocketCreate;
+    QUIC_SOCKET_DELETE SocketDelete;
+    QUIC_DATPATH_Socket_GET_LOCAL_MTU SocketGetLocalMtu;
+    QUIC_SOCKET_GET_LOCAL_ADDRESS SocketGetLocalAddress;
+    QUIC_SOCKET_GET_REMOTE_ADDRESS SocketGetRemoteAddress;
+    QUIC_RECV_DATA_RETURN RecvDataReturn;
+    QUIC_SEND_DATA_ALLOC QuicSendDataAlloc;
+    QUIC_SEND_DATA_FREE QuicSendDataFree;
+    QUIC_SEND_DATA_IS_FULL QuicSendDataIsFull;
+    QUIC_SEND_DATA_ALLOC_BUFFER QuicSendDataAllocBuffer;
+    QUIC_SEND_DATA_FREE_BUFFER QuicSendDataFreeBuffer;
+    QUIC_SOCKET_SEND SocketSend;
+    QUIC_SOCKET_SET_PARAM SocketSetParam;
+    QUIC_SOCKET_GET_PARAM SocketGetParam;
 
 } QUIC_PLATFORM_DISPATCH;
 

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -1353,7 +1353,7 @@
                 />
             <data
                 inType="win:Pointer"
-                name="DatapathBinding"
+                name="Socket"
                 />
             <data
                 inType="win:UInt8"

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -88,7 +88,7 @@ QuicMainStart(
         }
 
         QuicAddr LocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
-        Status = QuicDataPathBindingCreate(Datapath, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
+        Status = QuicDataPathBindingCreate(Datapath, QUIC_DATAPATH_BINDING_UDP, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
         if (QUIC_FAILED(Status)) {
             QuicDataPathUninitialize(Datapath);
             Datapath = nullptr;

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -81,12 +81,11 @@ QuicMainStart(
     if (ServerMode) {
         Datapath = nullptr;
         Binding = nullptr;
-        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
-            NULL,
+        const QUIC_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
             DatapathReceive,
             DatapathUnreachable
         };
-        Status = QuicDataPathInitialize(0, &DatapathCallbacks, &Datapath);
+        Status = QuicDataPathInitialize(0, &DatapathCallbacks, NULL, &Datapath);
         if (QUIC_FAILED(Status)) {
             WriteOutput("Datapath for shutdown failed to initialize: %d\n", Status);
             return Status;

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -93,7 +93,7 @@ QuicMainStart(
         }
 
         QuicAddr LocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
-        Status = QuicSocketCreate(Datapath, QUIC_SOCKET_UDP, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
+        Status = QuicSocketCreateUdp(Datapath, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
         if (QUIC_FAILED(Status)) {
             QuicDataPathUninitialize(Datapath);
             Datapath = nullptr;

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -212,7 +212,7 @@ void
 DatapathReceive(
     _In_ QUIC_DATAPATH_BINDING*,
     _In_ void* Context,
-    _In_ QUIC_RECV_DATAGRAM*
+    _In_ QUIC_RECV_DATA*
     )
 {
     QUIC_EVENT* Event = static_cast<QUIC_EVENT*>(Context);

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -30,7 +30,7 @@ PerfBase* TestToRun;
 QUIC_DATAPATH_RECEIVE_CALLBACK DatapathReceive;
 QUIC_DATAPATH_UNREACHABLE_CALLBACK DatapathUnreachable;
 QUIC_DATAPATH* Datapath;
-QUIC_DATAPATH_BINDING* Binding;
+QUIC_SOCKET* Binding;
 bool ServerMode = false;
 
 static
@@ -88,7 +88,7 @@ QuicMainStart(
         }
 
         QuicAddr LocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
-        Status = QuicDataPathBindingCreate(Datapath, QUIC_DATAPATH_BINDING_UDP, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
+        Status = QuicSocketCreate(Datapath, QUIC_SOCKET_UDP, &LocalAddress.SockAddr, nullptr, StopEvent, &Binding);
         if (QUIC_FAILED(Status)) {
             QuicDataPathUninitialize(Datapath);
             Datapath = nullptr;
@@ -172,7 +172,7 @@ QuicMainFree(
     MsQuic = nullptr;
 
     if (Binding) {
-        QuicDataPathBindingDelete(Binding);
+        QuicSocketDelete(Binding);
         Binding = nullptr;
     }
     if (Datapath) {
@@ -210,7 +210,7 @@ QuicMainGetExtraData(
 
 void
 DatapathReceive(
-    _In_ QUIC_DATAPATH_BINDING*,
+    _In_ QUIC_SOCKET*,
     _In_ void* Context,
     _In_ QUIC_RECV_DATA*
     )
@@ -221,7 +221,7 @@ DatapathReceive(
 
 void
 DatapathUnreachable(
-    _In_ QUIC_DATAPATH_BINDING*,
+    _In_ QUIC_SOCKET*,
     _In_ void*,
     _In_ const QUIC_ADDR*
     )

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -81,7 +81,12 @@ QuicMainStart(
     if (ServerMode) {
         Datapath = nullptr;
         Binding = nullptr;
-        Status = QuicDataPathInitialize(0, DatapathReceive, DatapathUnreachable, &Datapath);
+        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
+            NULL,
+            DatapathReceive,
+            DatapathUnreachable
+        };
+        Status = QuicDataPathInitialize(0, &DatapathCallbacks, &Datapath);
         if (QUIC_FAILED(Status)) {
             WriteOutput("Datapath for shutdown failed to initialize: %d\n", Status);
             return Status;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -485,21 +485,20 @@ QuicProcessorContextUninitialize(
 QUIC_STATUS
 QuicDataPathInitialize(
     _In_ uint32_t ClientRecvContextLength,
-    _In_ QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER RecvCallback,
-    _In_ QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER UnreachableCallback,
-    _Out_ QUIC_DATAPATH* *NewDataPath
+    _In_ const QUIC_DATAPATH_CALLBACKS* Callback,
+    _Out_ QUIC_DATAPATH** NewDataPath
     )
 {
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->DatapathInitialize(
             ClientRecvContextLength,
-            RecvCallback,
-            UnreachableCallback,
+            Callback,
             NewDataPath);
 #else
-    if (RecvCallback == NULL ||
-        UnreachableCallback == NULL ||
+    if (Callback == NULL ||
+        Callback->Receive == NULL ||
+        Callback->Unreachable == NULL ||
         NewDataPath == NULL) {
         return QUIC_STATUS_INVALID_PARAMETER;
     }
@@ -522,8 +521,8 @@ QuicDataPathInitialize(
     }
 
     QuicZeroMemory(Datapath, DatapathLength);
-    Datapath->RecvHandler = RecvCallback;
-    Datapath->UnreachHandler = UnreachableCallback;
+    Datapath->RecvHandler = Callback->Receive;
+    Datapath->UnreachHandler = Callback->Unreachable;
     Datapath->ClientRecvContextLength = ClientRecvContextLength;
     Datapath->ProcCount = QuicProcMaxCount();
     Datapath->MaxSendBatchSize = QUIC_MAX_BATCH_SEND;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1566,7 +1566,6 @@ QuicSocketCreate(
     _Out_ QUIC_SOCKET** NewBinding
     )
 {
-    UNREFERENCED_PARAMETER(Type);
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->SocketCreate(
@@ -1578,6 +1577,10 @@ QuicSocketCreate(
             NewBinding);
 #else
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+
+    if (Type != QUIC_SOCKET_UDP) {
+        return QUIC_STATUS_NOT_SUPPORTED;
+    }
 
     uint32_t SocketCount = Datapath->ProcCount; // TODO - Only use 1 for client (RemoteAddress != NULL) bindings?
     size_t BindingLength =

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1559,12 +1559,14 @@ QuicSocketContextProcessEvents(
 QUIC_STATUS
 QuicDataPathBindingCreate(
     _In_ QUIC_DATAPATH* Datapath,
+    _In_ QUIC_DATAPATH_BINDING_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
     _Out_ QUIC_DATAPATH_BINDING** NewBinding
     )
 {
+    UNREFERENCED_PARAMETER(Type);
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->DatapathBindingCreate(

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -1556,9 +1556,8 @@ QuicSocketContextProcessEvents(
 //
 
 QUIC_STATUS
-QuicSocketCreate(
+QuicSocketCreateUdp(
     _In_ QUIC_DATAPATH* Datapath,
-    _In_ QUIC_SOCKET_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
@@ -1576,10 +1575,6 @@ QuicSocketCreate(
             NewBinding);
 #else
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
-
-    if (Type != QUIC_SOCKET_UDP) {
-        return QUIC_STATUS_NOT_SUPPORTED;
-    }
 
     uint32_t SocketCount = Datapath->ProcCount; // TODO - Only use 1 for client (RemoteAddress != NULL) bindings?
     size_t BindingLength =

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -44,7 +44,7 @@ typedef struct QUIC_DATAPATH_RECV_BLOCK {
     //
     // The recv buffer used by MsQuic.
     //
-    QUIC_RECV_DATAGRAM RecvPacket;
+    QUIC_RECV_DATA RecvPacket;
 
     //
     // Represents the address (source and destination) information of the
@@ -1243,7 +1243,7 @@ QuicSocketContextRecvComplete(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
 
     QUIC_DBG_ASSERT(SocketContext->CurrentRecvBlock != NULL);
-    QUIC_RECV_DATAGRAM* RecvPacket = &SocketContext->CurrentRecvBlock->RecvPacket;
+    QUIC_RECV_DATA* RecvPacket = &SocketContext->CurrentRecvBlock->RecvPacket;
     SocketContext->CurrentRecvBlock = NULL;
 
     BOOLEAN FoundLocalAddr = FALSE;
@@ -1794,7 +1794,7 @@ QuicDataPathBindingGetParam(
 #endif
 }
 
-QUIC_RECV_DATAGRAM*
+QUIC_RECV_DATA*
 QuicDataPathRecvPacketToRecvDatagram(
     _In_ const QUIC_RECV_PACKET* const Packet
     )
@@ -1812,7 +1812,7 @@ QuicDataPathRecvPacketToRecvDatagram(
 
 QUIC_RECV_PACKET*
 QuicDataPathRecvDatagramToRecvPacket(
-    _In_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_ const QUIC_RECV_DATA* const Datagram
     )
 {
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
@@ -1827,7 +1827,7 @@ QuicDataPathRecvDatagramToRecvPacket(
 
 void
 QuicDataPathBindingReturnRecvDatagrams(
-    _In_opt_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_opt_ QUIC_RECV_DATA* DatagramChain
     )
 {
 #ifdef QUIC_PLATFORM_DISPATCH_TABLE
@@ -1835,7 +1835,7 @@ QuicDataPathBindingReturnRecvDatagrams(
         PlatDispatch->DatapathBindingReturnRecvPacket(DatagramChain);
     }
 #else
-    QUIC_RECV_DATAGRAM* Datagram;
+    QUIC_RECV_DATA* Datagram;
     while ((Datagram = DatagramChain) != NULL) {
         DatagramChain = DatagramChain->Next;
         QUIC_DATAPATH_RECV_BLOCK* RecvBlock =

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -823,8 +823,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicDataPathInitialize(
     _In_ uint32_t ClientRecvContextLength,
-    _In_ QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER RecvCallback,
-    _In_ QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER UnreachableCallback,
+    _In_ const QUIC_DATAPATH_CALLBACKS* Callback,
     _Out_ QUIC_DATAPATH* *NewDataPath
     )
 {
@@ -839,7 +838,10 @@ QuicDataPathInitialize(
         WSK_EVENT_RECEIVE_FROM
     };
 
-    if (RecvCallback == NULL || UnreachableCallback == NULL || NewDataPath == NULL) {
+    if (Callback == NULL ||
+        Callback->Receive == NULL ||
+        Callback->Unreachable == NULL ||
+        NewDataPath == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         Datapath = NULL;
         goto Exit;
@@ -861,8 +863,8 @@ QuicDataPathInitialize(
     }
 
     RtlZeroMemory(Datapath, DatapathLength);
-    Datapath->RecvHandler = RecvCallback;
-    Datapath->UnreachableHandler = UnreachableCallback;
+    Datapath->RecvHandler = Callback->Receive;
+    Datapath->UnreachableHandler = Callback->Unreachable;
     Datapath->ClientRecvContextLength = ClientRecvContextLength;
     Datapath->ProcCount = (uint32_t)QuicProcMaxCount();
     Datapath->WskDispatch.WskReceiveFromEvent = QuicDataPathSocketReceive;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -447,35 +447,35 @@ QuicSendBufferPoolAlloc(
         Tag, \
         0)
 
-QUIC_RECV_DATAGRAM*
+QUIC_RECV_DATA*
 QuicDataPathRecvPacketToRecvDatagram(
     _In_ const QUIC_RECV_PACKET* const Context
     )
 {
-    return (QUIC_RECV_DATAGRAM*)
+    return (QUIC_RECV_DATA*)
         (((PUCHAR)Context) -
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) -
-            sizeof(QUIC_RECV_DATAGRAM));
+            sizeof(QUIC_RECV_DATA));
 }
 
 QUIC_RECV_PACKET*
 QuicDataPathRecvDatagramToRecvPacket(
-    _In_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_ const QUIC_RECV_DATA* const Datagram
     )
 {
     return (QUIC_RECV_PACKET*)
         (((PUCHAR)Datagram) +
-            sizeof(QUIC_RECV_DATAGRAM) +
+            sizeof(QUIC_RECV_DATA) +
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT));
 }
 
 QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*
 QuicDataPathDatagramToInternalDatagramContext(
-    _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ QUIC_RECV_DATA* Datagram
     )
 {
     return (QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*)
-        (((PUCHAR)Datagram) + sizeof(QUIC_RECV_DATAGRAM));
+        (((PUCHAR)Datagram) + sizeof(QUIC_RECV_DATA));
 }
 
 IO_COMPLETION_ROUTINE QuicDataPathIoCompletion;
@@ -868,7 +868,7 @@ QuicDataPathInitialize(
     Datapath->WskDispatch.WskReceiveFromEvent = QuicDataPathSocketReceive;
     Datapath->DatagramStride =
         ALIGN_UP(
-            sizeof(QUIC_RECV_DATAGRAM) +
+            sizeof(QUIC_RECV_DATA) +
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) +
             ClientRecvContextLength,
             PVOID);
@@ -1923,8 +1923,8 @@ QuicDataPathSocketReceive(
 
     PWSK_DATAGRAM_INDICATION ReleaseChain = NULL;
     PWSK_DATAGRAM_INDICATION* ReleaseChainTail = &ReleaseChain;
-    QUIC_RECV_DATAGRAM* DatagramChain = NULL;
-    QUIC_RECV_DATAGRAM** DatagramChainTail = &DatagramChain;
+    QUIC_RECV_DATA* DatagramChain = NULL;
+    QUIC_RECV_DATA** DatagramChainTail = &DatagramChain;
 
     UNREFERENCED_PARAMETER(Flags);
 
@@ -1939,7 +1939,7 @@ QuicDataPathSocketReceive(
 
         QUIC_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext = NULL;
         QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalDatagramContext;
-        QUIC_RECV_DATAGRAM* Datagram = NULL;
+        QUIC_RECV_DATA* Datagram = NULL;
 
         if (DataIndication->Buffer.Mdl == NULL ||
             DataIndication->Buffer.Length == 0) {
@@ -2154,7 +2154,7 @@ QuicDataPathSocketReceive(
                 RecvContext->ReferenceCount = 0;
                 RecvContext->Tuple.LocalAddress = LocalAddr;
                 RecvContext->Tuple.RemoteAddress = RemoteAddr;
-                Datagram = (QUIC_RECV_DATAGRAM*)(RecvContext + 1);
+                Datagram = (QUIC_RECV_DATA*)(RecvContext + 1);
             }
 
             QUIC_DBG_ASSERT(Datagram != NULL);
@@ -2204,7 +2204,7 @@ QuicDataPathSocketReceive(
                 MdlOffset = 0;
             }
 
-            Datagram = (QUIC_RECV_DATAGRAM*)
+            Datagram = (QUIC_RECV_DATA*)
                 (((PUCHAR)Datagram) +
                     Binding->Datapath->DatagramStride);
         }
@@ -2256,7 +2256,7 @@ QuicDataPathSocketReceive(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicDataPathBindingReturnRecvDatagrams(
-    _In_opt_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_opt_ QUIC_RECV_DATA* DatagramChain
     )
 {
     QUIC_DATAPATH_BINDING* Binding = NULL;
@@ -2267,7 +2267,7 @@ QuicDataPathBindingReturnRecvDatagrams(
     LONG BatchedBufferCount = 0;
     QUIC_DATAPATH_INTERNAL_RECV_CONTEXT* BatchedInternalContext = NULL;
 
-    QUIC_RECV_DATAGRAM* Datagram;
+    QUIC_RECV_DATA* Datagram;
     while ((Datagram = DatagramChain) != NULL) {
 
         QUIC_DBG_ASSERT(Datagram->Allocated);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1278,9 +1278,8 @@ QuicDataPathSetControlSocket(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
-QuicSocketCreate(
+QuicSocketCreateUdp(
     _In_ QUIC_DATAPATH* Datapath,
-    _In_ QUIC_SOCKET_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
@@ -1291,11 +1290,6 @@ QuicSocketCreate(
     size_t BindingSize;
     QUIC_SOCKET* Binding = NULL;
     uint32_t Option;
-
-    if (Type != QUIC_SOCKET_UDP) {
-        Status = QUIC_STATUS_NOT_SUPPORTED;
-        goto Error;
-    }
 
     if (Datapath == NULL || NewBinding == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1290,7 +1290,10 @@ QuicSocketCreate(
     QUIC_SOCKET* Binding = NULL;
     uint32_t Option;
 
-    UNREFERENCED_PARAMETER(Type);
+    if (Type != QUIC_SOCKET_UDP) {
+        Status = QUIC_STATUS_NOT_SUPPORTED;
+        goto Error;
+    }
 
     if (Datapath == NULL || NewBinding == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1278,6 +1278,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicDataPathBindingCreate(
     _In_ QUIC_DATAPATH* Datapath,
+    _In_ QUIC_DATAPATH_BINDING_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
@@ -1288,6 +1289,8 @@ QuicDataPathBindingCreate(
     size_t BindingSize;
     QUIC_DATAPATH_BINDING* Binding = NULL;
     uint32_t Option;
+
+    UNREFERENCED_PARAMETER(Type);
 
     if (Datapath == NULL || NewBinding == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -1002,6 +1002,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicDataPathBindingCreate(
     _In_ QUIC_DATAPATH* Datapath,
+    _In_ QUIC_DATAPATH_BINDING_TYPE Type,
     _In_opt_ const QUIC_ADDR* LocalAddress,
     _In_opt_ const QUIC_ADDR* RemoteAddress,
     _In_opt_ void* RecvCallbackContext,
@@ -1014,6 +1015,8 @@ QuicDataPathBindingCreate(
     uint16_t SocketCount = (RemoteAddress == NULL) ? Datapath->ProcCount : 1;
     int Result;
     int Option;
+
+    UNREFERENCED_PARAMETER(Type);
 
     BindingLength =
         sizeof(QUIC_DATAPATH_BINDING) +

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -392,35 +392,35 @@ typedef struct QUIC_DATAPATH {
 
 } QUIC_DATAPATH;
 
-QUIC_RECV_DATAGRAM*
+QUIC_RECV_DATA*
 QuicDataPathRecvPacketToRecvDatagram(
     _In_ const QUIC_RECV_PACKET* const Context
     )
 {
-    return (QUIC_RECV_DATAGRAM*)
+    return (QUIC_RECV_DATA*)
         (((PUCHAR)Context) -
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) -
-            sizeof(QUIC_RECV_DATAGRAM));
+            sizeof(QUIC_RECV_DATA));
 }
 
 QUIC_RECV_PACKET*
 QuicDataPathRecvDatagramToRecvPacket(
-    _In_ const QUIC_RECV_DATAGRAM* const Datagram
+    _In_ const QUIC_RECV_DATA* const Datagram
     )
 {
     return (QUIC_RECV_PACKET*)
         (((PUCHAR)Datagram) +
-            sizeof(QUIC_RECV_DATAGRAM) +
+            sizeof(QUIC_RECV_DATA) +
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT));
 }
 
 QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*
 QuicDataPathDatagramToInternalDatagramContext(
-    _In_ QUIC_RECV_DATAGRAM* Datagram
+    _In_ QUIC_RECV_DATA* Datagram
     )
 {
     return (QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*)
-        (((PUCHAR)Datagram) + sizeof(QUIC_RECV_DATAGRAM));
+        (((PUCHAR)Datagram) + sizeof(QUIC_RECV_DATA));
 }
 
 //
@@ -634,7 +634,7 @@ QuicDataPathInitialize(
 
     Datapath->DatagramStride =
         ALIGN_UP(
-            sizeof(QUIC_RECV_DATAGRAM) +
+            sizeof(QUIC_RECV_DATA) +
             sizeof(QUIC_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) +
             ClientRecvContextLength,
             PVOID);
@@ -1962,11 +1962,11 @@ QuicDataPathRecvComplete(
 
     } else if (IoResult == QUIC_STATUS_SUCCESS) {
 
-        QUIC_RECV_DATAGRAM* DatagramChain = NULL;
-        QUIC_RECV_DATAGRAM** DatagramChainTail = &DatagramChain;
+        QUIC_RECV_DATA* DatagramChain = NULL;
+        QUIC_RECV_DATA** DatagramChainTail = &DatagramChain;
 
         QUIC_DATAPATH* Datapath = SocketContext->Binding->Datapath;
-        QUIC_RECV_DATAGRAM* Datagram;
+        QUIC_RECV_DATA* Datagram;
         PUCHAR RecvPayload = ((PUCHAR)RecvContext) + Datapath->RecvPayloadOffset;
 
         BOOLEAN FoundLocalAddr = FALSE;
@@ -2048,7 +2048,7 @@ QuicDataPathRecvComplete(
 
         QUIC_DBG_ASSERT(NumberOfBytesTransferred <= SocketContext->RecvWsaBuf.len);
 
-        Datagram = (QUIC_RECV_DATAGRAM*)(RecvContext + 1);
+        Datagram = (QUIC_RECV_DATA*)(RecvContext + 1);
 
         for ( ;
             NumberOfBytesTransferred != 0;
@@ -2083,7 +2083,7 @@ QuicDataPathRecvComplete(
             DatagramChainTail = &Datagram->Next;
             RecvContext->ReferenceCount++;
 
-            Datagram = (QUIC_RECV_DATAGRAM*)
+            Datagram = (QUIC_RECV_DATA*)
                 (((PUCHAR)Datagram) +
                     SocketContext->Binding->Datapath->DatagramStride);
 
@@ -2101,7 +2101,7 @@ QuicDataPathRecvComplete(
 
 #ifdef QUIC_FUZZER
         if (MsQuicFuzzerContext.RecvCallback) {
-            QUIC_RECV_DATAGRAM *_DatagramIter = DatagramChain;
+            QUIC_RECV_DATA *_DatagramIter = DatagramChain;
 
             while (_DatagramIter) {
                 MsQuicFuzzerContext.RecvCallback(
@@ -2137,10 +2137,10 @@ Drop:
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicDataPathBindingReturnRecvDatagrams(
-    _In_opt_ QUIC_RECV_DATAGRAM* DatagramChain
+    _In_opt_ QUIC_RECV_DATA* DatagramChain
     )
 {
-    QUIC_RECV_DATAGRAM* Datagram;
+    QUIC_RECV_DATA* Datagram;
 
     LONG BatchedBufferCount = 0;
     QUIC_DATAPATH_INTERNAL_RECV_CONTEXT* BatchedInternalContext = NULL;
@@ -2808,7 +2808,7 @@ QuicFuzzerReceiveInject(
 
     RecvContext->Tuple.RemoteAddress = *SourceAddress;
 
-    QUIC_RECV_DATAGRAM* Datagram = (QUIC_RECV_DATAGRAM*)(RecvContext + 1);
+    QUIC_RECV_DATA* Datagram = (QUIC_RECV_DATA*)(RecvContext + 1);
 
     Datagram->Next = NULL;
     Datagram->BufferLength = PacketLength;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -840,9 +840,7 @@ QuicDataPathInitialize(
         MessageCount * Datapath->DatagramStride;
 
     uint32_t RecvDatagramLength =
-        Datapath->RecvPayloadOffset +
-            ((Datapath->Features & QUIC_DATAPATH_FEATURE_RECV_COALESCING) ?
-                MAX_URO_PAYLOAD_LENGTH : MAX_UDP_PAYLOAD_LENGTH);
+        Datapath->RecvPayloadOffset + MAX_URO_PAYLOAD_LENGTH;
 
     for (uint16_t i = 0; i < Datapath->ProcCount; i++) {
 
@@ -3138,7 +3136,7 @@ QuicDataPathTcpRecvComplete(
             "[ udp][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             IoResult,
-            "WSARecvMsg completion");
+            "WSARecv completion");
     }
 
 Drop:

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -156,7 +156,7 @@ protected:
     EmptyReceiveCallback(
         _In_ QUIC_DATAPATH_BINDING* /* Binding */,
         _In_ void * /* RecvContext */,
-        _In_ QUIC_RECV_DATAGRAM* /* RecvPacketChain */
+        _In_ QUIC_RECV_DATA* /* RecvPacketChain */
         )
     {
     }
@@ -174,13 +174,13 @@ protected:
     DataRecvCallback(
         _In_ QUIC_DATAPATH_BINDING* binding,
         _In_ void * recvContext,
-        _In_ QUIC_RECV_DATAGRAM* recvBufferChain
+        _In_ QUIC_RECV_DATA* recvBufferChain
         )
     {
         DataRecvContext* RecvContext = (DataRecvContext*)recvContext;
         ASSERT_NE(nullptr, RecvContext);
 
-        QUIC_RECV_DATAGRAM* recvBuffer = recvBufferChain;
+        QUIC_RECV_DATA* recvBuffer = recvBufferChain;
 
         while (recvBuffer != NULL) {
             ASSERT_EQ(recvBuffer->BufferLength, ExpectedDataSize);
@@ -220,13 +220,13 @@ protected:
     DataRecvCallbackECT0(
         _In_ QUIC_DATAPATH_BINDING* binding,
         _In_ void * recvContext,
-        _In_ QUIC_RECV_DATAGRAM* recvBufferChain
+        _In_ QUIC_RECV_DATA* recvBufferChain
         )
     {
         DataRecvContext* RecvContext = (DataRecvContext*)recvContext;
         ASSERT_NE(nullptr, RecvContext);
 
-        QUIC_RECV_DATAGRAM* recvBuffer = recvBufferChain;
+        QUIC_RECV_DATA* recvBuffer = recvBufferChain;
 
         while (recvBuffer != NULL) {
             ASSERT_EQ(recvBuffer->BufferLength, ExpectedDataSize);

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -395,9 +395,8 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Datapath, nullptr);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -428,9 +427,8 @@ TEST_F(DataPathTest, UdpRebind)
     ASSERT_NE(nullptr, Datapath);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -442,9 +440,8 @@ TEST_F(DataPathTest, UdpRebind)
     ASSERT_NE(Address1.Ipv4.sin_port, (uint16_t)0);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -484,9 +481,8 @@ TEST_P(DataPathTest, UdpData)
     while (Status == QUIC_STATUS_ADDRESS_IN_USE) {
         serverAddress.SockAddr.Ipv4.sin_port = GetNextPort();
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateUdp(
                 Datapath,
-                QUIC_SOCKET_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -506,9 +502,8 @@ TEST_P(DataPathTest, UdpData)
     serverAddress.SetPort(RecvContext.ServerAddress.Ipv4.sin_port);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -568,9 +563,8 @@ TEST_P(DataPathTest, UdpDataRebind)
     while (Status == QUIC_STATUS_ADDRESS_IN_USE) {
         serverAddress.SockAddr.Ipv4.sin_port = GetNextPort();
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateUdp(
                 Datapath,
-                QUIC_SOCKET_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -590,9 +584,8 @@ TEST_P(DataPathTest, UdpDataRebind)
     serverAddress.SetPort(RecvContext.ServerAddress.Ipv4.sin_port);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -626,9 +619,8 @@ TEST_P(DataPathTest, UdpDataRebind)
     QuicEventReset(RecvContext.ClientCompletion);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -687,9 +679,8 @@ TEST_P(DataPathTest, UdpDataECT0)
     while (Status == QUIC_STATUS_ADDRESS_IN_USE) {
         serverAddress.SockAddr.Ipv4.sin_port = GetNextPort();
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateUdp(
                 Datapath,
-                QUIC_SOCKET_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -709,9 +700,8 @@ TEST_P(DataPathTest, UdpDataECT0)
     serverAddress.SetPort(RecvContext.ServerAddress.Ipv4.sin_port);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -762,10 +752,8 @@ TEST_F(DataPathTest, TcpListener)
     ASSERT_NE(Datapath, nullptr);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateTcpListener(
             Datapath,
-            QUIC_SOCKET_TCP_LISTENER,
-            nullptr,
             nullptr,
             nullptr,
             &Socket));
@@ -800,11 +788,9 @@ TEST_P(DataPathTest, TcpConnect)
     while (Status == QUIC_STATUS_ADDRESS_IN_USE) {
         serverAddress.SockAddr.Ipv4.sin_port = GetNextPort();
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateTcpListener(
                 Datapath,
-                QUIC_SOCKET_TCP_LISTENER,
                 &serverAddress.SockAddr,
-                nullptr,
                 &Server,
                 &Listener);
 #ifdef _WIN32
@@ -824,9 +810,8 @@ TEST_P(DataPathTest, TcpConnect)
     serverAddress.SetPort(Address.Ipv4.sin_port);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateTcp(
             Datapath,
-            QUIC_SOCKET_TCP,
             nullptr,
             &serverAddress.SockAddr,
             nullptr,
@@ -865,11 +850,9 @@ TEST_P(DataPathTest, TcpData)
     while (Status == QUIC_STATUS_ADDRESS_IN_USE) {
         serverAddress.SockAddr.Ipv4.sin_port = GetNextPort();
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateTcpListener(
                 Datapath,
-                QUIC_SOCKET_TCP_LISTENER,
                 &serverAddress.SockAddr,
-                nullptr,
                 &Server,
                 &Listener);
 #ifdef _WIN32
@@ -889,9 +872,8 @@ TEST_P(DataPathTest, TcpData)
     serverAddress.SetPort(ServerAddress.Ipv4.sin_port);
 
     VERIFY_QUIC_SUCCESS(
-        QuicSocketCreate(
+        QuicSocketCreateTcp(
             Datapath,
-            QUIC_SOCKET_TCP,
             nullptr,
             &serverAddress.SockAddr,
             nullptr,

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -326,6 +326,7 @@ TEST_F(DataPathTest, Bind)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -359,6 +360,7 @@ TEST_F(DataPathTest, Rebind)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -372,6 +374,7 @@ TEST_F(DataPathTest, Rebind)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             nullptr,
             nullptr,
@@ -414,6 +417,7 @@ TEST_P(DataPathTest, Data)
         Status =
             QuicDataPathBindingCreate(
                 datapath,
+                QUIC_DATAPATH_BINDING_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -435,6 +439,7 @@ TEST_P(DataPathTest, Data)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -497,6 +502,7 @@ TEST_P(DataPathTest, DataRebind)
         Status =
             QuicDataPathBindingCreate(
                 datapath,
+                QUIC_DATAPATH_BINDING_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -518,6 +524,7 @@ TEST_P(DataPathTest, DataRebind)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -553,6 +560,7 @@ TEST_P(DataPathTest, DataRebind)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,
@@ -614,6 +622,7 @@ TEST_P(DataPathTest, DataECT0)
         Status =
             QuicDataPathBindingCreate(
                 datapath,
+                QUIC_DATAPATH_BINDING_UDP,
                 &serverAddress.SockAddr,
                 nullptr,
                 &RecvContext,
@@ -635,6 +644,7 @@ TEST_P(DataPathTest, DataECT0)
     VERIFY_QUIC_SUCCESS(
         QuicDataPathBindingCreate(
             datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             &serverAddress.SockAddr,
             &RecvContext,

--- a/src/plugins/dbg/binding.cpp
+++ b/src/plugins/dbg/binding.cpp
@@ -20,7 +20,7 @@ EXT_COMMAND(
 {
     Binding Binding(GetUnnamedArgU64(0));
     auto Lookup = Binding.GetLookup();
-    auto DatapathBinding = Binding.GetDatapathBinding();
+    auto Socket = Binding.GetSocket();
 
     Dml("\n<b>BINDING</b> (<link cmd=\"dt msquic!QUIC_BINDING 0x%I64X\">raw</link>)\n"
         "\n"
@@ -38,8 +38,8 @@ EXT_COMMAND(
         Binding.RefCount(),
         Lookup.CidCount(),
         Lookup.PartitionCount(),
-        DatapathBinding.GetLocalAddress().IpString,
-        DatapathBinding.GetRemoteAddress().IpString);
+        Socket.GetLocalAddress().IpString,
+        Socket.GetRemoteAddress().IpString);
 
     bool HasAtLeastOne = false;
     auto Listeners = Binding.GetListeners();

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -1395,9 +1395,9 @@ struct Lookup : Struct {
     }
 };
 
-struct DatapathBinding : Struct {
+struct Socket : Struct {
 
-    DatapathBinding(ULONG64 Addr) : Struct("msquic!QUIC_DATAPATH_BINDING", Addr) { }
+    Socket(ULONG64 Addr) : Struct("msquic!QUIC_SOCKET", Addr) { }
 
     IpAddress GetLocalAddress() {
         return IpAddress(AddrOf("LocalAddress"));
@@ -1436,8 +1436,8 @@ struct Binding : Struct {
         return Lookup(AddrOf("Lookup"));
     }
 
-    DatapathBinding GetDatapathBinding() {
-        return DatapathBinding(ReadPointer("DatapathBinding"));
+    Socket GetSocket() {
+        return Socket(ReadPointer("Socket"));
     }
 };
 

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -131,11 +131,15 @@ struct DrillSender {
         _In_ uint16_t NetworkPort
         )
     {
+        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
+            NULL,
+            DrillUdpRecvCallback,
+            DrillUdpUnreachCallback,
+        };
         QUIC_STATUS Status =
             QuicDataPathInitialize(
                 0,
-                DrillUdpRecvCallback,
-                DrillUdpUnreachCallback,
+                &DatapathCallbacks,
                 &Datapath);
         if (QUIC_FAILED(Status)) {
             TEST_FAILURE("Datapath init failed 0x%x", Status);

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -98,7 +98,7 @@ struct DrillSender {
         _In_ QUIC_RECV_DATA* RecvBufferChain
         )
     {
-        QuicDataPathBindingReturnRecvDatagrams(RecvBufferChain);
+        QuicRecvDataReturn(RecvBufferChain);
     }
 
     _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -186,12 +186,12 @@ struct DrillSender {
         QUIC_ADDR LocalAddress;
         QuicDataPathBindingGetLocalAddress(Binding, &LocalAddress);
 
-        QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(
+        QUIC_SEND_DATA* SendContext =
+            QuicSendDataAlloc(
                 Binding, QUIC_ECN_NON_ECT, DatagramLength);
 
         QUIC_BUFFER* SendBuffer =
-            QuicDataPathBindingAllocSendDatagram(SendContext, DatagramLength);
+            QuicSendDataAllocBuffer(SendContext, DatagramLength);
 
         if (SendBuffer == nullptr) {
             TEST_FAILURE("Buffer null");

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -131,8 +131,7 @@ struct DrillSender {
         _In_ uint16_t NetworkPort
         )
     {
-        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
-            NULL,
+        const QUIC_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
             DrillUdpRecvCallback,
             DrillUdpUnreachCallback,
         };
@@ -140,6 +139,7 @@ struct DrillSender {
             QuicDataPathInitialize(
                 0,
                 &DatapathCallbacks,
+                NULL,
                 &Datapath);
         if (QUIC_FAILED(Status)) {
             TEST_FAILURE("Datapath init failed 0x%x", Status);

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -163,6 +163,7 @@ struct DrillSender {
         Status =
             QuicDataPathBindingCreate(
                 Datapath,
+                QUIC_DATAPATH_BINDING_UDP,
                 nullptr,
                 &ServerAddress,
                 this,

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -95,7 +95,7 @@ struct DrillSender {
     DrillUdpRecvCallback(
         _In_ QUIC_DATAPATH_BINDING* /* Binding */,
         _In_ void* /* Context */,
-        _In_ QUIC_RECV_DATAGRAM* RecvBufferChain
+        _In_ QUIC_RECV_DATA* RecvBufferChain
         )
     {
         QuicDataPathBindingReturnRecvDatagrams(RecvBufferChain);

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -165,9 +165,8 @@ struct DrillSender {
         }
 
         Status =
-            QuicSocketCreate(
+            QuicSocketCreateUdp(
                 Datapath,
-                QUIC_SOCKET_UDP,
                 nullptr,
                 &ServerAddress,
                 this,

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -86,14 +86,14 @@ QuicDrillConnectionCallbackHandler(
 
 struct DrillSender {
     QUIC_DATAPATH* Datapath;
-    QUIC_DATAPATH_BINDING* Binding;
+    QUIC_SOCKET* Binding;
     QUIC_ADDR ServerAddress;
 
     _IRQL_requires_max_(DISPATCH_LEVEL)
     _Function_class_(QUIC_DATAPATH_RECEIVE_CALLBACK)
     static void
     DrillUdpRecvCallback(
-        _In_ QUIC_DATAPATH_BINDING* /* Binding */,
+        _In_ QUIC_SOCKET* /* Binding */,
         _In_ void* /* Context */,
         _In_ QUIC_RECV_DATA* RecvBufferChain
         )
@@ -105,7 +105,7 @@ struct DrillSender {
     _Function_class_(QUIC_DATAPATH_UNREACHABLE_CALLBACK)
     static void
     DrillUdpUnreachCallback(
-        _In_ QUIC_DATAPATH_BINDING* /* Binding */,
+        _In_ QUIC_SOCKET* /* Binding */,
         _In_ void* /* Context */,
         _In_ const QUIC_ADDR* /* RemoteAddress */
         )
@@ -116,7 +116,7 @@ struct DrillSender {
 
     ~DrillSender() {
         if (Binding != nullptr) {
-            QuicDataPathBindingDelete(Binding);
+            QuicSocketDelete(Binding);
         }
 
         if (Datapath != nullptr) {
@@ -161,9 +161,9 @@ struct DrillSender {
         }
 
         Status =
-            QuicDataPathBindingCreate(
+            QuicSocketCreate(
                 Datapath,
-                QUIC_DATAPATH_BINDING_UDP,
+                QUIC_SOCKET_UDP,
                 nullptr,
                 &ServerAddress,
                 this,
@@ -184,7 +184,7 @@ struct DrillSender {
         const uint16_t DatagramLength = (uint16_t) PacketBuffer->size();
 
         QUIC_ADDR LocalAddress;
-        QuicDataPathBindingGetLocalAddress(Binding, &LocalAddress);
+        QuicSocketGetLocalAddress(Binding, &LocalAddress);
 
         QUIC_SEND_DATA* SendContext =
             QuicSendDataAlloc(
@@ -205,7 +205,7 @@ struct DrillSender {
         memcpy(SendBuffer->Buffer, PacketBuffer->data(), DatagramLength);
 
         Status =
-            QuicDataPathBindingSend(
+            QuicSocketSend(
                 Binding,
                 &LocalAddress,
                 &ServerAddress,

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -127,7 +127,7 @@ struct DatapathHook
     _IRQL_requires_max_(DISPATCH_LEVEL)
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* /* Datagram */
+        _Inout_ struct QUIC_RECV_DATA* /* Datagram */
         ) {
         return FALSE; // Don't drop by default
     }
@@ -156,7 +156,7 @@ class DatapathHooks
     BOOLEAN
     QUIC_API
     ReceiveCallback(
-        _Inout_ struct QUIC_RECV_DATAGRAM* Datagram
+        _Inout_ struct QUIC_RECV_DATA* Datagram
         ) {
         return Instance->Receive(Datagram);
     }
@@ -219,7 +219,7 @@ class DatapathHooks
 
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* Datagram
+        _Inout_ struct QUIC_RECV_DATA* Datagram
         ) {
         BOOLEAN Result = FALSE;
         QuicDispatchLockAcquire(&Lock);
@@ -312,7 +312,7 @@ struct RandomLossHelper : public DatapathHook
     _IRQL_requires_max_(DISPATCH_LEVEL)
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* /* Datagram */
+        _Inout_ struct QUIC_RECV_DATA* /* Datagram */
         ) {
         uint8_t RandomValue;
         QuicRandom(sizeof(RandomValue), &RandomValue);
@@ -339,7 +339,7 @@ struct SelectiveLossHelper : public DatapathHook
     _IRQL_requires_max_(DISPATCH_LEVEL)
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* /* Datagram */
+        _Inout_ struct QUIC_RECV_DATA* /* Datagram */
         ) {
         if (DropPacketCount == 0) {
             return FALSE;
@@ -366,7 +366,7 @@ struct ReplaceAddressHelper : public DatapathHook
     _IRQL_requires_max_(DISPATCH_LEVEL)
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* Datagram
+        _Inout_ struct QUIC_RECV_DATA* Datagram
         ) {
         if (QuicAddrCompare(
                 &Datagram->Tuple->RemoteAddress,
@@ -419,7 +419,7 @@ struct ReplaceAddressThenDropHelper : public DatapathHook
     _IRQL_requires_max_(DISPATCH_LEVEL)
     BOOLEAN
     Receive(
-        _Inout_ struct QUIC_RECV_DATAGRAM* Datagram
+        _Inout_ struct QUIC_RECV_DATA* Datagram
         ) {
         if (QuicAddrCompare(
                 &Datagram->Tuple->RemoteAddress,

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -138,7 +138,7 @@ struct DatapathHook
     Send(
         _Inout_ QUIC_ADDR* /* RemoteAddress */,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */
+        _Inout_ struct QUIC_SEND_DATA* /* SendContext */
         ) {
         return FALSE; // Don't drop by default
     }
@@ -168,7 +168,7 @@ class DatapathHooks
     SendCallback(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* LocalAddress,
-        _Inout_ struct QUIC_DATAPATH_SEND_CONTEXT* SendContext
+        _Inout_ struct QUIC_SEND_DATA* SendContext
         ) {
         return Instance->Send(RemoteAddress, LocalAddress, SendContext);
     }
@@ -239,7 +239,7 @@ class DatapathHooks
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* LocalAddress,
-        _Inout_ struct QUIC_DATAPATH_SEND_CONTEXT* SendContext
+        _Inout_ struct QUIC_SEND_DATA* SendContext
         ) {
         BOOLEAN Result = FALSE;
         QuicDispatchLockAcquire(&Lock);
@@ -385,7 +385,7 @@ struct ReplaceAddressHelper : public DatapathHook
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */
+        _Inout_ struct QUIC_SEND_DATA* /* SendContext */
         ) {
         if (QuicAddrCompare(RemoteAddress, &New)) {
             *RemoteAddress = Original;
@@ -445,7 +445,7 @@ struct ReplaceAddressThenDropHelper : public DatapathHook
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */
+        _Inout_ struct QUIC_SEND_DATA* /* SendContext */
         ) {
         if (QuicAddrCompare(RemoteAddress, &New)) {
             if (AllowPacketCount == 0) {

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -374,8 +374,7 @@ main(
     )
 {
     int ErrorCode = -1;
-    const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
-        NULL,
+    const QUIC_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
         UdpRecvCallback,
         UdpUnreachCallback,
     };
@@ -385,6 +384,7 @@ main(
     QuicDataPathInitialize(
         0,
         &DatapathCallbacks,
+        NULL,
         &Datapath);
 
     if (argc < 2) {

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -90,7 +90,7 @@ UdpRecvCallback(
     _In_ QUIC_RECV_DATA* RecvBufferChain
     )
 {
-    QuicDataPathBindingReturnRecvDatagrams(RecvBufferChain);
+    QuicRecvDataReturn(RecvBufferChain);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -114,20 +114,20 @@ void RunAttackRandom(QUIC_DATAPATH_BINDING* Binding, uint16_t Length, bool Valid
 
     while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs) {
 
-        QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(
+        QUIC_SEND_DATA* SendContext =
+            QuicSendDataAlloc(
                 Binding, QUIC_ECN_NON_ECT, Length);
         if (SendContext == nullptr) {
-            printf("QuicDataPathBindingAllocSendContext failed\n");
+            printf("QuicSendDataAlloc failed\n");
             return;
         }
 
-        while (!QuicDataPathBindingIsSendContextFull(SendContext)) {
+        while (!QuicSendDataIsFull(SendContext)) {
             QUIC_BUFFER* SendBuffer =
-                QuicDataPathBindingAllocSendDatagram(SendContext, Length);
+                QuicSendDataAllocBuffer(SendContext, Length);
             if (SendBuffer == nullptr) {
-                printf("QuicDataPathBindingAllocSendDatagram failed\n");
-                QuicDataPathBindingFreeSendContext(SendContext);
+                printf("QuicSendDataAllocBuffer failed\n");
+                QuicSendDataFree(SendContext);
                 return;
             }
 
@@ -217,15 +217,15 @@ void RunAttackValidInitial(QUIC_DATAPATH_BINDING* Binding)
 
     while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs) {
 
-        QUIC_DATAPATH_SEND_CONTEXT* SendContext =
-            QuicDataPathBindingAllocSendContext(
+        QUIC_SEND_DATA* SendContext =
+            QuicSendDataAlloc(
                 Binding, QUIC_ECN_NON_ECT, DatagramLength);
         VERIFY(SendContext);
 
         while (QuicTimeDiff64(TimeStart, QuicTimeMs64()) < TimeoutMs &&
-            !QuicDataPathBindingIsSendContextFull(SendContext)) {
+            !QuicSendDataIsFull(SendContext)) {
             QUIC_BUFFER* SendBuffer =
-                QuicDataPathBindingAllocSendDatagram(SendContext, DatagramLength);
+                QuicSendDataAllocBuffer(SendContext, DatagramLength);
             VERIFY(SendBuffer);
 
             (*DestCid)++; (*SrcCid)++;

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -301,6 +301,7 @@ QUIC_THREAD_CALLBACK(RunAttackThread, /* Context */)
     QUIC_STATUS Status =
         QuicDataPathBindingCreate(
             Datapath,
+            QUIC_DATAPATH_BINDING_UDP,
             nullptr,
             &ServerAddress,
             nullptr,

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -299,15 +299,14 @@ QUIC_THREAD_CALLBACK(RunAttackThread, /* Context */)
 {
     QUIC_SOCKET* Binding;
     QUIC_STATUS Status =
-        QuicSocketCreate(
+        QuicSocketCreateUdp(
             Datapath,
-            QUIC_SOCKET_UDP,
             nullptr,
             &ServerAddress,
             nullptr,
             &Binding);
     if (QUIC_FAILED(Status)) {
-        printf("QuicSocketCreate failed, 0x%x\n", Status);
+        printf("QuicSocketCreateUdp failed, 0x%x\n", Status);
         QUIC_THREAD_RETURN(Status);
     }
 

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -375,13 +375,17 @@ main(
     )
 {
     int ErrorCode = -1;
+    const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
+        NULL,
+        UdpRecvCallback,
+        UdpUnreachCallback,
+    };
 
     QuicPlatformSystemLoad();
     QuicPlatformInitialize();
     QuicDataPathInitialize(
         0,
-        UdpRecvCallback,
-        UdpUnreachCallback,
+        &DatapathCallbacks,
         &Datapath);
 
     if (argc < 2) {

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -87,7 +87,7 @@ void
 UdpRecvCallback(
     _In_ QUIC_DATAPATH_BINDING* /* Binding */,
     _In_ void* /* Context */,
-    _In_ QUIC_RECV_DATAGRAM* RecvBufferChain
+    _In_ QUIC_RECV_DATA* RecvBufferChain
     )
 {
     QuicDataPathBindingReturnRecvDatagrams(RecvBufferChain);

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -85,7 +85,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _Function_class_(QUIC_DATAPATH_RECEIVE_CALLBACK)
 void
 UdpRecvCallback(
-    _In_ QUIC_DATAPATH_BINDING* /* Binding */,
+    _In_ QUIC_SOCKET* /* Binding */,
     _In_ void* /* Context */,
     _In_ QUIC_RECV_DATA* RecvBufferChain
     )
@@ -97,17 +97,17 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _Function_class_(QUIC_DATAPATH_UNREACHABLE_CALLBACK)
 void
 UdpUnreachCallback(
-    _In_ QUIC_DATAPATH_BINDING* /* Binding */,
+    _In_ QUIC_SOCKET* /* Binding */,
     _In_ void* /* Context */,
     _In_ const QUIC_ADDR* /* RemoteAddress */
     )
 {
 }
 
-void RunAttackRandom(QUIC_DATAPATH_BINDING* Binding, uint16_t Length, bool ValidQuic)
+void RunAttackRandom(QUIC_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 {
     QUIC_ADDR LocalAddress;
-    QuicDataPathBindingGetLocalAddress(Binding, &LocalAddress);
+    QuicSocketGetLocalAddress(Binding, &LocalAddress);
 
     uint64_t ConnectionId = 0;
     QuicRandom(sizeof(ConnectionId), &ConnectionId);
@@ -157,7 +157,7 @@ void RunAttackRandom(QUIC_DATAPATH_BINDING* Binding, uint16_t Length, bool Valid
 
         VERIFY(
         QUIC_SUCCEEDED(
-        QuicDataPathBindingSend(
+        QuicSocketSend(
             Binding,
             &LocalAddress,
             &ServerAddress,
@@ -178,14 +178,14 @@ void printf_buf(const char* name, void* buf, uint32_t len)
 #define printf_buf(name, buf, len)
 #endif
 
-void RunAttackValidInitial(QUIC_DATAPATH_BINDING* Binding)
+void RunAttackValidInitial(QUIC_SOCKET* Binding)
 {
     const StrBuffer InitialSalt("afbfec289993d24c9e9786f19c6111e04390a899");
     const uint16_t DatagramLength = QUIC_MIN_INITIAL_LENGTH;
     const uint64_t PacketNumber = 0;
 
     QUIC_ADDR LocalAddress;
-    QuicDataPathBindingGetLocalAddress(Binding, &LocalAddress);
+    QuicSocketGetLocalAddress(Binding, &LocalAddress);
 
     uint8_t Packet[512] = {0};
     uint16_t PacketLength, HeaderLength;
@@ -287,7 +287,7 @@ void RunAttackValidInitial(QUIC_DATAPATH_BINDING* Binding)
 
         VERIFY(
         QUIC_SUCCEEDED(
-        QuicDataPathBindingSend(
+        QuicSocketSend(
             Binding,
             &LocalAddress,
             &ServerAddress,
@@ -297,17 +297,17 @@ void RunAttackValidInitial(QUIC_DATAPATH_BINDING* Binding)
 
 QUIC_THREAD_CALLBACK(RunAttackThread, /* Context */)
 {
-    QUIC_DATAPATH_BINDING* Binding;
+    QUIC_SOCKET* Binding;
     QUIC_STATUS Status =
-        QuicDataPathBindingCreate(
+        QuicSocketCreate(
             Datapath,
-            QUIC_DATAPATH_BINDING_UDP,
+            QUIC_SOCKET_UDP,
             nullptr,
             &ServerAddress,
             nullptr,
             &Binding);
     if (QUIC_FAILED(Status)) {
-        printf("QuicDataPathBindingCreate failed, 0x%x\n", Status);
+        printf("QuicSocketCreate failed, 0x%x\n", Status);
         QUIC_THREAD_RETURN(Status);
     }
 
@@ -328,7 +328,7 @@ QUIC_THREAD_CALLBACK(RunAttackThread, /* Context */)
         break;
     }
 
-    QuicDataPathBindingDelete(Binding);
+    QuicSocketDelete(Binding);
 
     QUIC_THREAD_RETURN(QUIC_STATUS_SUCCESS);
 }

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -146,15 +146,11 @@ main(int argc, char **argv)
 
     if (ServerIp == nullptr) {
         QUIC_DATAPATH* Datapath = nullptr;
-        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
-            NULL,
-            (QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER)(1),
-            (QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER)(1),
-        };
         if (QUIC_FAILED(
             QuicDataPathInitialize(
                 0,
-                &DatapathCallbacks,
+                NULL,
+                NULL,
                 &Datapath))) {
             printf("QuicDataPathInitialize failed.\n");
             exit(1);

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -146,11 +146,15 @@ main(int argc, char **argv)
 
     if (ServerIp == nullptr) {
         QUIC_DATAPATH* Datapath = nullptr;
+        const QUIC_DATAPATH_CALLBACKS DatapathCallbacks = {
+            NULL,
+            (QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER)(1),
+            (QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER)(1),
+        };
         if (QUIC_FAILED(
             QuicDataPathInitialize(
                 0,
-                (QUIC_DATAPATH_RECEIVE_CALLBACK_HANDLER)(1),
-                (QUIC_DATAPATH_UNREACHABLE_CALLBACK_HANDLER)(1),
+                &DatapathCallbacks,
                 &Datapath))) {
             printf("QuicDataPathInitialize failed.\n");
             exit(1);

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -709,7 +709,7 @@ BOOLEAN QUIC_API DatapathHookReceiveCallback(struct QUIC_RECV_DATA* /* Datagram 
     return (RandomValue % 100) < Settings.LossPercent;
 }
 
-BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct QUIC_DATAPATH_SEND_CONTEXT* /* SendContext */)
+BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct QUIC_SEND_DATA* /* SendContext */)
 {
     return FALSE; // Don't drop
 }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -702,7 +702,7 @@ QUIC_THREAD_CALLBACK(ClientSpin, Context)
     QUIC_THREAD_RETURN(0);
 }
 
-BOOLEAN QUIC_API DatapathHookReceiveCallback(struct QUIC_RECV_DATAGRAM* /* Datagram */)
+BOOLEAN QUIC_API DatapathHookReceiveCallback(struct QUIC_RECV_DATA* /* Datagram */)
 {
     uint8_t RandomValue;
     QuicRandom(sizeof(RandomValue), &RandomValue);


### PR DESCRIPTION
Adds TCP support to the data path abstraction layer. This is so that we can add TCP support to our performance tool to compare with QUIC. Only supported on Windows user mode. Because it no longer abstracts just a UDP binding, renames the data path binding to socket.