### PR TITLE
Support using SMB to copy performance artifacts

### DIFF
--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -201,19 +201,18 @@ function Copy-Artifacts {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
     param ([string]$From, [string]$To, [boolean]$SmbCopy)
     Remove-PerfServices
-    Invoke-TestCommand $Session -ScriptBlock {
-        param ($To)
-        try {
-            Remove-Item -Path "$To/*" -Recurse -Force
-        } catch [System.Management.Automation.ItemNotFoundException] {
-            # Ignore Not Found for when the directory does not exist
-            # This will still throw if a file cannot successfuly be deleted
-        }
-
-    } -ArgumentList $To
     if ($SmbCopy) {
-        robocopy $From $To /e
+        robocopy $From $To /e /IS /IT /IM
     } else {
+        Invoke-TestCommand $Session -ScriptBlock {
+            param ($To)
+            try {
+                Remove-Item -Path "$To/*" -Recurse -Force
+            } catch [System.Management.Automation.ItemNotFoundException] {
+                # Ignore Not Found for when the directory does not exist
+                # This will still throw if a file cannot successfuly be deleted
+            }
+        } -ArgumentList $To
         Copy-Item -Path "$From\*" -Destination $To -ToSession $Session  -Recurse -Force
     }
 }

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -209,10 +209,10 @@ function Copy-Artifacts {
             # This will still throw if a file cannot successfuly be deleted
         }
         robocopy $From $SmbDir /e /IS /IT /IM | Out-Null
-        if ($LASTERRORCODE -ne 1) {
-            Write-Error "Robocopy failed: $LASTERRORCODE"
+        if ($LASTEXITCODE -ne 1) {
+            Write-Error "Robocopy failed: $LASTEXITCODE"
         } else {
-            $global:LASTERRORCODE = 0
+            $global:LASTEXITCODE = 0
         }
     } else {
         Invoke-TestCommand $Session -ScriptBlock {

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -199,7 +199,7 @@ function Wait-ForRemote {
 
 function Copy-Artifacts {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
-    param ([string]$From, [string]$To)
+    param ([string]$From, [string]$To, [boolean]$SmbCopy)
     Remove-PerfServices
     Invoke-TestCommand $Session -ScriptBlock {
         param ($To)
@@ -211,7 +211,11 @@ function Copy-Artifacts {
         }
 
     } -ArgumentList $To
-    Copy-Item -Path "$From\*" -Destination $To -ToSession $Session  -Recurse -Force
+    if ($SmbCopy) {
+        robocopy $From $To /e
+    } else {
+        Copy-Item -Path "$From\*" -Destination $To -ToSession $Session  -Recurse -Force
+    }
 }
 
 function Get-GitHash {

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -209,6 +209,11 @@ function Copy-Artifacts {
             # This will still throw if a file cannot successfuly be deleted
         }
         robocopy $From $SmbDir /e /IS /IT /IM | Out-Null
+        if ($LASTERRORCODE -ne 1) {
+            Write-Error "Robocopy failed: $LASTERRORCODE"
+        } else {
+            $global:LASTERRORCODE = 0
+        }
     } else {
         Invoke-TestCommand $Session -ScriptBlock {
             param ($To)
@@ -1004,7 +1009,6 @@ function Publish-HPSTestResults {
 
         $ResultFile = Join-Path $OutputDir "results_$Test.json"
         $Results | ConvertTo-Json | Out-File $ResultFile
-        Write-Output "Finished Writing Publish File"
     } elseif (!$Publish) {
         Write-Debug "Failed to publish because of missing commit hash"
     }

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -1004,6 +1004,7 @@ function Publish-HPSTestResults {
 
         $ResultFile = Join-Path $OutputDir "results_$Test.json"
         $Results | ConvertTo-Json | Out-File $ResultFile
+        Write-Output "Finished Writing Publish File"
     } elseif (!$Publish) {
         Write-Debug "Failed to publish because of missing commit hash"
     }

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -208,7 +208,7 @@ function Copy-Artifacts {
             # Ignore Not Found for when the directory does not exist
             # This will still throw if a file cannot successfuly be deleted
         }
-        robocopy $From $SmbDir /e /IS /IT /IM
+        robocopy $From $SmbDir /e /IS /IT /IM | Out-Null
     } else {
         Invoke-TestCommand $Session -ScriptBlock {
             param ($To)

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -199,10 +199,16 @@ function Wait-ForRemote {
 
 function Copy-Artifacts {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
-    param ([string]$From, [string]$To, [boolean]$SmbCopy)
+    param ([string]$From, [string]$To, [string]$SmbDir)
     Remove-PerfServices
-    if ($SmbCopy) {
-        robocopy $From $To /e /IS /IT /IM
+    if ($null -ne $SmbDir) {
+        try {
+            Remove-Item -Path "$SmbDir/*" -Recurse -Force
+        } catch [System.Management.Automation.ItemNotFoundException] {
+            # Ignore Not Found for when the directory does not exist
+            # This will still throw if a file cannot successfuly be deleted
+        }
+        robocopy $From $SmbDir /e /IS /IT /IM
     } else {
         Invoke-TestCommand $Session -ScriptBlock {
             param ($To)

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -239,15 +239,22 @@ $RemotePlatform = Invoke-TestCommand -Session $Session -ScriptBlock {
 $OutputDir = Join-Path $RootDir "artifacts/PerfDataResults/$RemotePlatform/$($RemoteArch)_$($Config)_$($RemoteTls)"
 New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
-# Join path in script to ensure right platform separator
-$RemoteDirectory = Invoke-TestCommand -Session $Session -ScriptBlock {
-    Join-Path (Get-Location) "Tests"
-}
-
 $LocalDirectory = Join-Path $RootDir "artifacts/bin"
+$UsingSmbPath = $false
 
 if ($Local) {
     $RemoteDirectory = $LocalDirectory
+} else {
+    # See if remote SMB path exists
+    if (Test-Path "\\$ComputerName\Tests") {
+        $UsingSmbPath = $true
+        $RemoteDirectory = "\\$ComputerName\Tests"
+    } else {
+        # Join path in script to ensure right platform separator
+        $RemoteDirectory = Invoke-TestCommand -Session $Session -ScriptBlock {
+            Join-Path (Get-Location) "Tests"
+        }
+    }
 }
 
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
@@ -462,7 +469,7 @@ try {
     }
 
     if (!$SkipDeploy -and !$Local) {
-        Copy-Artifacts -From $LocalDirectory -To $RemoteDirectory
+        Copy-Artifacts -From $LocalDirectory -To $RemoteDirectory -SmbCopy $UsingSmbPath
     }
 
     foreach ($Test in $Tests.Tests) {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -494,4 +494,3 @@ try {
     }
     LocalTeardown($LocalDataCache)
 }
-Write-Host "Finishing"

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -494,3 +494,4 @@ try {
     }
     LocalTeardown($LocalDataCache)
 }
+Write-Host "Finishing"


### PR DESCRIPTION
Copy-Items is very slow over WMI, so use a file share to copy the files with robocopy.