### PR TITLE
Rename quicperf driver to quicperfdrv, add private instance

### DIFF
--- a/msquic.kernel.sln
+++ b/msquic.kernel.sln
@@ -20,11 +20,13 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "manifest.kernel", "src\mani
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "perflib.kernel", "src\perf\lib\perflib.kernel.vcxproj", "{11633785-79CC-4C7D-AB6A-AECDF29A1FA7}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "performance.kernel", "src\perf\bin\performance.kernel.vcxproj", "{2BE64DBF-60E6-4FE8-96B0-5F2526405096}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "quicperfdriverpriv.kernel", "src\perf\bin\quicperfdriverpriv.kernel.vcxproj", "{2BE64DBF-60E6-4FE8-96B0-5F2526405096}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msquicpriv.kernel", "src\bin\winkernel\msquicpriv.kernel.vcxproj", "{E2DDB0A8-594D-424D-9ADD-4EF211F7FC3F}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msquictestpriv.kernel", "src\test\bin\winkernel\msquictestpriv.kernel.vcxproj", "{C8491270-B0BE-440C-B88D-7B441A8CB67E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "quicperfdriver.kernel", "src\perf\bin\quicperfdriver.kernel.vcxproj", "{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -278,6 +280,30 @@ Global
 		{C8491270-B0BE-440C-B88D-7B441A8CB67E}.Release|x86.ActiveCfg = Release|Win32
 		{C8491270-B0BE-440C-B88D-7B441A8CB67E}.Release|x86.Build.0 = Release|Win32
 		{C8491270-B0BE-440C-B88D-7B441A8CB67E}.Release|x86.Deploy.0 = Release|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM.ActiveCfg = Debug|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM.Build.0 = Debug|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM.Deploy.0 = Debug|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM64.Build.0 = Debug|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x64.ActiveCfg = Debug|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x64.Build.0 = Debug|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x64.Deploy.0 = Debug|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x86.ActiveCfg = Debug|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x86.Build.0 = Debug|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Debug|x86.Deploy.0 = Debug|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM.ActiveCfg = Release|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM.Build.0 = Release|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM.Deploy.0 = Release|ARM
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM64.ActiveCfg = Release|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM64.Build.0 = Release|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|ARM64.Deploy.0 = Release|ARM64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x64.ActiveCfg = Release|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x64.Build.0 = Release|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x64.Deploy.0 = Release|x64
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x86.ActiveCfg = Release|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x86.Build.0 = Release|Win32
+		{1862CCD7-31D7-4869-A409-5B9B5EDF19BB}.Release|x86.Deploy.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -342,7 +342,7 @@ function Invoke-RemoteExe {
     } -ArgumentList $Exe
 
     if ($Kernel) {
-        $RunArgs = "--kernel --privateLibrary $RunArgs"
+        $RunArgs = "--kernelPriv $RunArgs"
     }
 
     Write-Debug "Running Remote: $Exe $RunArgs"

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -310,12 +310,12 @@ function Get-ExeName {
 function Remove-PerfServices {
     if ($IsWindows) {
         Invoke-TestCommand -Session $Session -ScriptBlock {
-            if ($null -ne (Get-Service -Name "quicperf" -ErrorAction Ignore)) {
+            if ($null -ne (Get-Service -Name "quicperfdrvpriv" -ErrorAction Ignore)) {
                 try {
-                    net.exe stop quicperf /y | Out-Null
+                    net.exe stop quicperfdrvpriv /y | Out-Null
                 }
                 catch {}
-                sc.exe delete quicperf /y | Out-Null
+                sc.exe delete quicperfdrvpriv /y | Out-Null
             }
             if ($null -ne (Get-Service -Name "msquicpriv" -ErrorAction Ignore)) {
                 try {
@@ -342,7 +342,7 @@ function Invoke-RemoteExe {
     } -ArgumentList $Exe
 
     if ($Kernel) {
-        $RunArgs = "--kernel $RunArgs"
+        $RunArgs = "--kernel --privateLibrary $RunArgs"
     }
 
     Write-Debug "Running Remote: $Exe $RunArgs"
@@ -370,7 +370,7 @@ function Invoke-RemoteExe {
         $KernelDir = Join-Path $RootBinPath "winkernel" $Arch
 
         if ($Kernel) {
-            Copy-Item (Join-Path $KernelDir "quicperf.sys") (Split-Path $Exe -Parent)
+            Copy-Item (Join-Path $KernelDir "quicperfdrvpriv.sys") (Split-Path $Exe -Parent)
             Copy-Item (Join-Path $KernelDir "msquicpriv.sys") (Split-Path $Exe -Parent)
             sc.exe create "msquicpriv" type= kernel binpath= (Join-Path (Split-Path $Exe -Parent) "msquicpriv.sys") start= demand | Out-Null
             net.exe start msquicpriv
@@ -381,7 +381,7 @@ function Invoke-RemoteExe {
         # Uninstall the kernel mode test driver and revert the msquic driver.
         if ($Kernel) {
             net.exe stop msquicpriv /y | Out-Null
-            sc.exe delete quicperf | Out-Null
+            sc.exe delete quicperfdrvpriv | Out-Null
             sc.exe delete msquicpriv | Out-Null
         }
 

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -311,7 +311,7 @@ function Start-TestCase([String]$Name) {
         $Arguments += " --gtest_break_on_failure"
     }
     if ($Kernel -ne "") {
-        $Arguments += " --kernel --privateLibrary"
+        $Arguments += " --kernelPriv"
     }
 
     # Start the test process and return some information about the test case.
@@ -345,7 +345,7 @@ function Start-AllTestCases {
         $Arguments += " --gtest_break_on_failure"
     }
     if ($Kernel -ne "") {
-        $Arguments += " --kernel --privateLibrary"
+        $Arguments += " --kernelPriv"
     }
 
     # Start the test process and return some information about the test case.

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -405,6 +405,7 @@ main(
         printf("Entering kernel mode main\n");
         RetVal = QuicKernelMain(ArgCount, ArgValues.get(), KeyboardWait, SelfSignedCredConfig, PrivateTestLibrary, FileName);
 #else
+        UNREFERENCED_PARAMETER(PrivateTestLibrary);
         QUIC_FRE_ASSERT(FALSE);
 #endif
     } else {

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -368,7 +368,7 @@ main(
     }
 
     for (int i = 0; i < argc; ++i) {
-        if (strcmp("--kernel", argv[i]) == 0) {
+        if (strcmp("--kernel", argv[i]) == 0 || strcmp("--kernelPriv", argv[i]) == 0) {
 #ifdef _WIN32
             TestingKernelMode = true;
             if (strcmp("--kernelPriv", argv[i]) == 0) {

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -23,7 +23,8 @@ Abstract:
 #include "PerfIoctls.h"
 #include "quic_driver_helpers.h"
 
-#define QUIC_DRIVER_NAME   "quicperf"
+#define QUIC_DRIVER_NAME   "quicperfdrv"
+#define QUIC_DRIVER_NAME_PRIVATE    "quicperfdrvpriv"
 
 #endif
 
@@ -171,6 +172,7 @@ QuicKernelMain(
     _In_reads_(argc) _Null_terminated_ char* argv[],
     _In_ bool /*KeyboardWait*/,
     _In_ const QUIC_CREDENTIAL_CONFIG* SelfSignedParams,
+    _In_ bool PrivateTestLibrary,
     _In_opt_z_ const char* FileName
     )
 {
@@ -220,7 +222,17 @@ QuicKernelMain(
     QuicDriverService DriverService;
     QuicDriverClient DriverClient;
 
-    if (!DriverService.Initialize(QUIC_DRIVER_NAME, "msquicpriv\0")) {
+    const char* DriverName;
+    const char* DependentDriverNames;
+    if (PrivateTestLibrary) {
+        DriverName = QUIC_DRIVER_NAME_PRIVATE;
+        DependentDriverNames = "msquicpriv\0";
+    } else {
+        DriverName = QUIC_DRIVER_NAME;
+        DependentDriverNames = "msquic\0";
+    }
+
+    if (!DriverService.Initialize(DriverName, DependentDriverNames)) {
         printf("Failed to initialize driver service\n");
         QUIC_FREE(Data, QUIC_POOL_PERF);
         return QUIC_STATUS_INVALID_STATE;
@@ -232,7 +244,7 @@ QuicKernelMain(
         return QUIC_STATUS_INVALID_STATE;
     }
 
-    if (!DriverClient.Initialize((QUIC_CERTIFICATE_HASH*)(SelfSignedParams + 1), QUIC_DRIVER_NAME)) {
+    if (!DriverClient.Initialize((QUIC_CERTIFICATE_HASH*)(SelfSignedParams + 1), DriverName)) {
         printf("Intializing Driver Client Failed.\n");
         DriverService.Uninitialize();
         QUIC_FREE(Data, QUIC_POOL_PERF);
@@ -340,6 +352,7 @@ main(
     bool TestingKernelMode = false;
     bool KeyboardWait = false;
     const char* FileName = nullptr;
+    bool PrivateTestLibrary = false;
 
     UniquePtr<char*[]> ArgValues = UniquePtr<char*[]>(new char*[argc]);
 
@@ -367,6 +380,8 @@ main(
             KeyboardWait = true;
         } else if (strncmp("--extraOutputFile", argv[i], 17) == 0) {
             FileName = argv[i] + 18;
+        } else if (strcmp("--privateLibrary", argv[i]) == 0) {
+            PrivateTestLibrary = true;
         } else {
             ArgValues[ArgCount] = argv[i];
             ArgCount++;
@@ -387,7 +402,7 @@ main(
     if (TestingKernelMode) {
 #ifdef _WIN32
         printf("Entering kernel mode main\n");
-        RetVal = QuicKernelMain(ArgCount, ArgValues.get(), KeyboardWait, SelfSignedCredConfig, FileName);
+        RetVal = QuicKernelMain(ArgCount, ArgValues.get(), KeyboardWait, SelfSignedCredConfig, PrivateTestLibrary, FileName);
 #else
         QUIC_FRE_ASSERT(FALSE);
 #endif

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -23,7 +23,7 @@ Abstract:
 #include "PerfIoctls.h"
 #include "quic_driver_helpers.h"
 
-#define QUIC_DRIVER_NAME   "quicperfdrv"
+#define QUIC_DRIVER_NAME            "quicperfdrv"
 #define QUIC_DRIVER_NAME_PRIVATE    "quicperfdrvpriv"
 
 #endif
@@ -371,6 +371,9 @@ main(
         if (strcmp("--kernel", argv[i]) == 0) {
 #ifdef _WIN32
             TestingKernelMode = true;
+            if (strcmp("--kernelPriv", argv[i]) == 0) {
+                PrivateTestLibrary = true;
+            }
 #else
             printf("Cannot run kernel mode tests on non windows platforms\n");
             RetVal = QUIC_STATUS_NOT_SUPPORTED;
@@ -380,8 +383,6 @@ main(
             KeyboardWait = true;
         } else if (strncmp("--extraOutputFile", argv[i], 17) == 0) {
             FileName = argv[i] + 18;
-        } else if (strcmp("--privateLibrary", argv[i]) == 0) {
-            PrivateTestLibrary = true;
         } else {
             ArgValues[ArgCount] = argv[i];
             ArgCount++;

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -17,8 +17,13 @@ Abstract:
 #include "drivermain.cpp.clog.h"
 #endif
 
-DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceName, L"\\Device\\quicperf");
-DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceSymLink, L"\\DosDevices\\quicperf");
+#ifdef PRIVATE_LIBRARY
+DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceName, L"\\Device\\quicperfdrv");
+DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
+#else
+DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceName, L"\\Device\\quicperfdrv");
+DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
+#endif
 
 typedef struct QUIC_DEVICE_EXTENSION {
     EX_PUSH_LOCK Lock;
@@ -505,7 +510,7 @@ QuicPerfCtlEvtIoCanceled(
     )
 {
     NTSTATUS Status;
-    
+
 
     WDFFILEOBJECT FileObject = WdfRequestGetFileObject(Request);
     if (FileObject == nullptr) {

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -18,11 +18,11 @@ Abstract:
 #endif
 
 #ifdef PRIVATE_LIBRARY
-DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceName, L"\\Device\\quicperfdrv");
-DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
+DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceName, L"\\Device\\quicperfdrv");
+DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
 #else
-DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceName, L"\\Device\\quicperfdrv");
-DECLARE_CONST_UNICODE_STRING(QuicTestCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
+DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceName, L"\\Device\\quicperfdrv");
+DECLARE_CONST_UNICODE_STRING(QuicPerfCtlDeviceSymLink, L"\\DosDevices\\quicperfdrvpriv");
 #endif
 
 typedef struct QUIC_DEVICE_EXTENSION {

--- a/src/perf/bin/quicperfdriver.kernel.vcxproj
+++ b/src/perf/bin/quicperfdriver.kernel.vcxproj
@@ -49,7 +49,7 @@
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{2be64dbf-60e6-4fe8-96b0-5f2526405096}</ProjectGuid>
+    <ProjectGuid>{1862ccd7-31d7-4869-a409-5b9b5edf19bb}</ProjectGuid>
     <TemplateGuid>{1bc93793-694f-48fe-9372-81e2b05556fd}</TemplateGuid>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
@@ -75,7 +75,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <TargetName>quicperf</TargetName>
+    <TargetName>quicperfdrv</TargetName>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <EnableInf2cat>false</EnableInf2cat>
     <OutDir>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>

--- a/src/perf/bin/quicperfdriverpriv.kernel.vcxproj
+++ b/src/perf/bin/quicperfdriverpriv.kernel.vcxproj
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="drvmain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\platform\platform.kernel.vcxproj">
+      <Project>{5f99f713-bf5f-44eb-90fe-fea03906bba9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\perflib.kernel.vcxproj">
+      <Project>{11633785-79cc-4c7d-ab6a-aecdf29a1fa7}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\bin\winkernel\msquicpriv.kernel.vcxproj">
+      <Project>{e2ddb0a8-594d-424d-9add-4ef211f7fc3f}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2be64dbf-60e6-4fe8-96b0-5f2526405096}</ProjectGuid>
+    <TemplateGuid>{1bc93793-694f-48fe-9372-81e2b05556fd}</TemplateGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>KMDF</DriverType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>quicperfdrvpriv</TargetName>
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <EnableInf2cat>false</EnableInf2cat>
+    <OutDir>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</OutDir>
+    <IntDir>$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\obj\$(ProjectName)\</IntDir>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\lib;..\..;..\..\inc;$(SolutionDir)build\winkernel\$(Platform)_$(Configuration)_schannel\inc;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <AdditionalOptions Condition="'$(Platform)'!='x64'">/Gw /kernel /ZH:SHA_256</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Platform)'=='x64'">/Gw /kernel /ZH:SHA_256 -d2jumptablerdata -d2epilogunwindrequirev2</AdditionalOptions>
+      <DisableSpecificWarnings>4748;5040;4459;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cng.lib;ksecdd.lib;msnetioid.lib;netio.lib;wdmsec.lib;uuid.lib;msquicpriv.lib;ndis.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PreprocessorDefinitions>PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <FilesToPackage Include="$(TargetPath)" />
+  </ItemGroup>
+  <PropertyGroup>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -983,7 +983,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 int main(int argc, char** argv) {
     for (int i = 0; i < argc; ++i) {
-        if (strcmp("--kernel", argv[i]) == 0) {
+        if (strcmp("--kernel", argv[i]) == 0 || strcmp("--kernelPriv", argv[i]) == 0) {
             TestingKernelMode = true;
             if (strcmp("--kernelPriv", argv[i]) == 0) {
                 PrivateTestLibrary = true;

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -985,9 +985,9 @@ int main(int argc, char** argv) {
     for (int i = 0; i < argc; ++i) {
         if (strcmp("--kernel", argv[i]) == 0) {
             TestingKernelMode = true;
-        }
-        if (strcmp("--privateLibrary", argv[i]) == 0) {
-            PrivateTestLibrary = true;
+            if (strcmp("--kernelPriv", argv[i]) == 0) {
+                PrivateTestLibrary = true;
+            }
         }
     }
     ::testing::AddGlobalTestEnvironment(new QuicTestEnvironment);


### PR DESCRIPTION
Changing the name makes symbols not interfere between executable and driver, and we need a version that links into shipping msquic for internel tests