### PR TITLE
Rename Datapath Log Prefix

### DIFF
--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -19,7 +19,7 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 $SrcDir = Join-Path $RootDir "src"
 
-$Files = Get-ChildItem -Path "$SrcDir\*" -Recurse -Include *.c,*.h,*.cpp,*.hpp -File
+$Files = Get-ChildItem -Path "$SrcDir\*" -Recurse -Include *.c,*.h,*.cpp,*.hpp -File | Sort-Object
 
 $Sidecar = Join-Path $SrcDir "manifest" "clog.sidecar"
 $ConfigFile = Join-Path $SrcDir "manifest" "msquic.clog_config"

--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -16,10 +16,18 @@ param (
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
+class SimpleStringComparer:Collections.Generic.IComparer[string] {
+    [Globalization.CompareInfo]$CompareInfo = [Globalization.CompareInfo]::GetCompareInfo([CultureInfo]::InvariantCulture.Name)
+    [int]Compare([string]$x, [string]$y) {
+        return $this.CompareInfo.Compare($x, $y, [Globalization.CompareOptions]::OrdinalIgnoreCase)
+    }
+}
+
 $RootDir = Split-Path $PSScriptRoot -Parent
 $SrcDir = Join-Path $RootDir "src"
 
-$Files = Get-ChildItem -Path "$SrcDir\*" -Recurse -Include *.c,*.h,*.cpp,*.hpp -File | Sort-Object
+$Files = [System.Collections.Generic.List[string]](Get-ChildItem -Path "$SrcDir\*" -Recurse -Include *.c,*.h,*.cpp,*.hpp -File)
+$Files.Sort([SimpleStringComparer]::new())
 
 $Sidecar = Join-Path $SrcDir "manifest" "clog.sidecar"
 $ConfigFile = Join-Path $SrcDir "manifest" "msquic.clog_config"

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -3368,27 +3368,27 @@
             />
         <string
             id="Etw.DatapathSend"
-            value="[ udp][%1] Send %2 bytes in %3 buffers (segment=%4) Dst=%6 Src=%8"
+            value="[data][%1] Send %2 bytes in %3 buffers (segment=%4) Dst=%6 Src=%8"
             />
         <string
             id="Etw.DatapathRecv"
-            value="[ udp][%1] Recv %2 bytes (segment=%3) Src=%5 Dst=%7"
+            value="[data][%1] Recv %2 bytes (segment=%3) Src=%5 Dst=%7"
             />
         <string
             id="Etw.DatapathError"
-            value="[ udp][%1] ERROR, %2."
+            value="[data][%1] ERROR, %2."
             />
         <string
             id="Etw.DatapathErrorStatus"
-            value="[ udp][%1] ERROR, %2, %3."
+            value="[data][%1] ERROR, %2, %3."
             />
         <string
             id="Etw.DatapathCreated"
-            value="[ udp][%1] Created, local=%3, remote=%5"
+            value="[data][%1] Created, local=%3, remote=%5"
             />
         <string
             id="Etw.DatapathDestroyed"
-            value="[ udp][%1] Destroyed"
+            value="[data][%1] Destroyed"
             />
         <string
             id="Etw.ApiEnter"

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1910,6 +1910,346 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "IgnoreCryptoFrame": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Ignoring received crypto after cleanup",
+      "UniqueId": "IgnoreCryptoFrame",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnWarning"
+    },
+    "DiscardKeyType": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Discarding key type = %hhu",
+      "UniqueId": "DiscardKeyType",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "ZeroRttAccepted": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] 0-RTT accepted",
+      "UniqueId": "ZeroRttAccepted",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "ZeroRttRejected": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] 0-RTT rejected",
+      "UniqueId": "ZeroRttRejected",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "HandshakeConfirmedServer": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Handshake confirmed (server)",
+      "UniqueId": "HandshakeConfirmedServer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "CryptoDump": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] QS:%u MAX:%u UNA:%u NXT:%u RECOV:%u-%u",
+      "UniqueId": "CryptoDump",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg8"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoDumpUnacked": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p]   unACKed: [%llu, %llu]",
+      "UniqueId": "CryptoDumpUnacked",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoDumpUnacked2": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p]   unACKed: [%llu, %u]",
+      "UniqueId": "CryptoDumpUnacked2",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "NoMoreRoomForCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] No room for CRYPTO frame",
+      "UniqueId": "NoMoreRoomForCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AddCryptoFrame": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Sending %hu crypto bytes, offset=%u",
+      "UniqueId": "AddCryptoFrame",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RecoverCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Recovering crypto from %llu up to %llu",
+      "UniqueId": "RecoverCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AckCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Received ack for %u crypto bytes, offset=%u",
+      "UniqueId": "AckCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RecvCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Received %hu crypto bytes, offset=%llu Ready=%hhu",
+      "UniqueId": "RecvCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "IndicateConnected": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_CONNECTED (Resume=%hhu)",
+      "UniqueId": "IndicateConnected",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "DrainCrypto": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Draining %u crypto bytes",
+      "UniqueId": "DrainCrypto",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "CryptoNotReady": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] No complete TLS messages to process",
+      "UniqueId": "CryptoNotReady",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "ConnWriteKeyUpdated": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Write Key Updated, %hhu.",
+      "UniqueId": "ConnWriteKeyUpdated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnReadKeyUpdated": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Read Key Updated, %hhu.",
+      "UniqueId": "ConnReadKeyUpdated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnNewPacketKeys": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] New packet keys created successfully.",
+      "UniqueId": "ConnNewPacketKeys",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "ConnKeyPhaseChange": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Key phase change (locally initiated=%hhu).",
+      "UniqueId": "ConnKeyPhaseChange",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "NoSniPresent": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] No SNI extension present",
@@ -2617,346 +2957,6 @@
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
-    },
-    "IgnoreCryptoFrame": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Ignoring received crypto after cleanup",
-      "UniqueId": "IgnoreCryptoFrame",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnWarning"
-    },
-    "DiscardKeyType": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Discarding key type = %hhu",
-      "UniqueId": "DiscardKeyType",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
-    "ZeroRttAccepted": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] 0-RTT accepted",
-      "UniqueId": "ZeroRttAccepted",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
-    "ZeroRttRejected": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] 0-RTT rejected",
-      "UniqueId": "ZeroRttRejected",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
-    "HandshakeConfirmedServer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Handshake confirmed (server)",
-      "UniqueId": "HandshakeConfirmedServer",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
-    "CryptoDump": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] QS:%u MAX:%u UNA:%u NXT:%u RECOV:%u-%u",
-      "UniqueId": "CryptoDump",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg6"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg7"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg8"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "CryptoDumpUnacked": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p]   unACKed: [%llu, %llu]",
-      "UniqueId": "CryptoDumpUnacked",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "CryptoDumpUnacked2": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p]   unACKed: [%llu, %u]",
-      "UniqueId": "CryptoDumpUnacked2",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "NoMoreRoomForCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] No room for CRYPTO frame",
-      "UniqueId": "NoMoreRoomForCrypto",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "AddCryptoFrame": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Sending %hu crypto bytes, offset=%u",
-      "UniqueId": "AddCryptoFrame",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "RecoverCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Recovering crypto from %llu up to %llu",
-      "UniqueId": "RecoverCrypto",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "AckCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Received ack for %u crypto bytes, offset=%u",
-      "UniqueId": "AckCrypto",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "RecvCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Received %hu crypto bytes, offset=%llu Ready=%hhu",
-      "UniqueId": "RecvCrypto",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "IndicateConnected": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_CONNECTED (Resume=%hhu)",
-      "UniqueId": "IndicateConnected",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "DrainCrypto": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Draining %u crypto bytes",
-      "UniqueId": "DrainCrypto",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "CryptoNotReady": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] No complete TLS messages to process",
-      "UniqueId": "CryptoNotReady",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "ConnWriteKeyUpdated": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Write Key Updated, %hhu.",
-      "UniqueId": "ConnWriteKeyUpdated",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "ConnReadKeyUpdated": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Read Key Updated, %hhu.",
-      "UniqueId": "ConnReadKeyUpdated",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "ConnNewPacketKeys": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] New packet keys created successfully.",
-      "UniqueId": "ConnNewPacketKeys",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "ConnKeyPhaseChange": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Key phase change (locally initiated=%hhu).",
-      "UniqueId": "ConnKeyPhaseChange",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
     },
     "DatagramSendStateChanged": {
       "ModuleProperites": {},
@@ -5028,74 +5028,6 @@
       ],
       "macroName": "QuicTraceEvent"
     },
-    "NoSrcCidAvailable": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] No src CID to send with",
-      "UniqueId": "NoSrcCidAvailable",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnWarning"
-    },
-    "GetPacketTypeFailure": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Failed to get packet type for control frames, 0x%x",
-      "UniqueId": "GetPacketTypeFailure",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnWarning"
-    },
-    "PacketBuilderSendBatch": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Sending batch. %hu datagrams",
-      "UniqueId": "PacketBuilderSendBatch",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "ConnPacketSent": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p][TX][%llu] %hhu (%hu bytes)",
-      "UniqueId": "ConnPacketSent",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "LogPacketVersionNegotiation": {
       "ModuleProperites": {},
       "TraceString": "[%c][%cX][-] VerNeg DestCid:%s SrcCid:%s (Payload %lu bytes)",
@@ -5428,6 +5360,74 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "NoSrcCidAvailable": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] No src CID to send with",
+      "UniqueId": "NoSrcCidAvailable",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnWarning"
+    },
+    "GetPacketTypeFailure": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Failed to get packet type for control frames, 0x%x",
+      "UniqueId": "GetPacketTypeFailure",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnWarning"
+    },
+    "PacketBuilderSendBatch": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Sending batch. %hu datagrams",
+      "UniqueId": "PacketBuilderSendBatch",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "ConnPacketSent": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p][TX][%llu] %hhu (%hu bytes)",
+      "UniqueId": "ConnPacketSent",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "PathInitialized": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Path[%hhu] Initialized",
@@ -5555,22 +5555,6 @@
         }
       ],
       "macroName": "QuicTraceEvent"
-    },
-    "IndicateIdealSendBuffer": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE = %llu",
-      "UniqueId": "IndicateIdealSendBuffer",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SetSendFlag": {
       "ModuleProperites": {},
@@ -5747,6 +5731,22 @@
         }
       ],
       "macroName": "QuicTraceEvent"
+    },
+    "IndicateIdealSendBuffer": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE = %llu",
+      "UniqueId": "IndicateIdealSendBuffer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "SettingDumpSendBufferingEnabled": {
       "ModuleProperites": {},
@@ -6060,6 +6060,166 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
+    "CloseWithoutShutdown": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Closing handle without fully shutting down",
+      "UniqueId": "CloseWithoutShutdown",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamWarning"
+    },
+    "EventSilentDiscard": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Event silently discarded",
+      "UniqueId": "EventSilentDiscard",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamWarning"
+    },
+    "IndicateStartComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE (0x%x)",
+      "UniqueId": "IndicateStartComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "IndicateStreamShutdownComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE",
+      "UniqueId": "IndicateStreamShutdownComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "StreamDestroyed": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Destroyed",
+      "UniqueId": "StreamDestroyed",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamCreated": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Created, Conn=%p ID=%llu IsLocal=%hhu",
+      "UniqueId": "StreamCreated",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamSendState": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Send State: %hhu",
+      "UniqueId": "StreamSendState",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamRecvState": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Recv State: %hhu",
+      "UniqueId": "StreamRecvState",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamOutFlowBlocked": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Send Blocked Flags: %hhu",
+      "UniqueId": "StreamOutFlowBlocked",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "StreamRundown": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Rundown, Conn=%p ID=%llu IsLocal=%hhu",
+      "UniqueId": "StreamRundown",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "ResetEarly": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] Tried to reset at earlier final size!",
@@ -6331,22 +6491,6 @@
         }
       ],
       "macroName": "QuicTraceLogStreamVerbose"
-    },
-    "StreamRecvState": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Recv State: %hhu",
-      "UniqueId": "StreamRecvState",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
     },
     "IndicateSendShutdownComplete": {
       "ModuleProperites": {},
@@ -6628,22 +6772,6 @@
       ],
       "macroName": "QuicTraceLogStreamVerbose"
     },
-    "StreamSendState": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Send State: %hhu",
-      "UniqueId": "StreamSendState",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "NotAccepted": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] New stream wasn't accepted, 0x%x",
@@ -6739,134 +6867,6 @@
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
-    },
-    "CloseWithoutShutdown": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Closing handle without fully shutting down",
-      "UniqueId": "CloseWithoutShutdown",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamWarning"
-    },
-    "EventSilentDiscard": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Event silently discarded",
-      "UniqueId": "EventSilentDiscard",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamWarning"
-    },
-    "IndicateStartComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE (0x%x)",
-      "UniqueId": "IndicateStartComplete",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamVerbose"
-    },
-    "IndicateStreamShutdownComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE",
-      "UniqueId": "IndicateStreamShutdownComplete",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamVerbose"
-    },
-    "StreamDestroyed": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Destroyed",
-      "UniqueId": "StreamDestroyed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "StreamCreated": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Created, Conn=%p ID=%llu IsLocal=%hhu",
-      "UniqueId": "StreamCreated",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "StreamOutFlowBlocked": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Send Blocked Flags: %hhu",
-      "UniqueId": "StreamOutFlowBlocked",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "StreamRundown": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Rundown, Conn=%p ID=%llu IsLocal=%hhu",
-      "UniqueId": "StreamRundown",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
     },
     "TimerWheelResize": {
       "ModuleProperites": {},
@@ -7222,7 +7222,7 @@
     },
     "DatapathWorkerThreadStart": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Worker start",
+      "TraceString": "[data][%p] Worker start",
       "UniqueId": "DatapathWorkerThreadStart",
       "splitArgs": [
         {
@@ -7234,7 +7234,7 @@
     },
     "DatapathWorkerThreadStop": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Worker stop",
+      "TraceString": "[data][%p] Worker stop",
       "UniqueId": "DatapathWorkerThreadStop",
       "splitArgs": [
         {
@@ -7262,7 +7262,7 @@
     },
     "DatapathErrorStatus": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] ERROR, %u, %s.",
+      "TraceString": "[data][%p] ERROR, %u, %s.",
       "UniqueId": "DatapathErrorStatus",
       "splitArgs": [
         {
@@ -7282,7 +7282,7 @@
     },
     "DatapathRecv": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
+      "TraceString": "[data][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
       "UniqueId": "DatapathRecv",
       "splitArgs": [
         {
@@ -7310,7 +7310,7 @@
     },
     "DatapathCreated": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+      "TraceString": "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
       "UniqueId": "DatapathCreated",
       "splitArgs": [
         {
@@ -7330,7 +7330,7 @@
     },
     "DatapathDestroyed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Destroyed",
+      "TraceString": "[data][%p] Destroyed",
       "UniqueId": "DatapathDestroyed",
       "splitArgs": [
         {
@@ -7342,7 +7342,7 @@
     },
     "DatapathSend": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+      "TraceString": "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
       "UniqueId": "DatapathSend",
       "splitArgs": [
         {
@@ -7374,7 +7374,7 @@
     },
     "DatapathOpenTcpSocketFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] RSS helper socket failed to open, 0x%x",
+      "TraceString": "[data] RSS helper socket failed to open, 0x%x",
       "UniqueId": "DatapathOpenTcpSocketFailed",
       "splitArgs": [
         {
@@ -7386,7 +7386,7 @@
     },
     "DatapathOpenTcpSocketFailedAsync": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] RSS helper socket failed to open (async), 0x%x",
+      "TraceString": "[data] RSS helper socket failed to open (async), 0x%x",
       "UniqueId": "DatapathOpenTcpSocketFailedAsync",
       "splitArgs": [
         {
@@ -7398,7 +7398,7 @@
     },
     "DatapathQueryRssScalabilityInfoFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
+      "TraceString": "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
       "UniqueId": "DatapathQueryRssScalabilityInfoFailed",
       "splitArgs": [
         {
@@ -7410,7 +7410,7 @@
     },
     "DatapathQueryRssScalabilityInfoFailedAsync": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed (async), 0x%x",
+      "TraceString": "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed (async), 0x%x",
       "UniqueId": "DatapathQueryRssScalabilityInfoFailedAsync",
       "splitArgs": [
         {
@@ -7422,7 +7422,7 @@
     },
     "DatapathOpenUdpSocketFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] UDP send segmentation helper socket failed to open, 0x%x",
+      "TraceString": "[data] UDP send segmentation helper socket failed to open, 0x%x",
       "UniqueId": "DatapathOpenUdpSocketFailed",
       "splitArgs": [
         {
@@ -7434,7 +7434,7 @@
     },
     "DatapathOpenUdpSocketFailedAsync": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] UDP send segmentation helper socket failed to open (async), 0x%x",
+      "TraceString": "[data] UDP send segmentation helper socket failed to open (async), 0x%x",
       "UniqueId": "DatapathOpenUdpSocketFailedAsync",
       "splitArgs": [
         {
@@ -7446,7 +7446,7 @@
     },
     "DatapathQueryUdpSendMsgFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
+      "TraceString": "[data] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
       "UniqueId": "DatapathQueryUdpSendMsgFailed",
       "splitArgs": [
         {
@@ -7458,7 +7458,7 @@
     },
     "DatapathQueryUdpSendMsgFailedAsync": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for UDP_SEND_MSG_SIZE failed (async), 0x%x",
+      "TraceString": "[data] Query for UDP_SEND_MSG_SIZE failed (async), 0x%x",
       "UniqueId": "DatapathQueryUdpSendMsgFailedAsync",
       "splitArgs": [
         {
@@ -7470,7 +7470,7 @@
     },
     "DatapathQueryRecvMaxCoalescedSizeFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
+      "TraceString": "[data] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
       "UniqueId": "DatapathQueryRecvMaxCoalescedSizeFailed",
       "splitArgs": [
         {
@@ -7482,7 +7482,7 @@
     },
     "DatapathQueryRecvMaxCoalescedSizeFailedAsync": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for UDP_RECV_MAX_COALESCED_SIZE failed (async), 0x%x",
+      "TraceString": "[data] Query for UDP_RECV_MAX_COALESCED_SIZE failed (async), 0x%x",
       "UniqueId": "DatapathQueryRecvMaxCoalescedSizeFailedAsync",
       "splitArgs": [
         {
@@ -7610,7 +7610,7 @@
     },
     "DatapathQueryRssProcessorInfoFailed": {
       "ModuleProperites": {},
-      "TraceString": "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
+      "TraceString": "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
       "UniqueId": "DatapathQueryRssProcessorInfoFailed",
       "splitArgs": [
         {
@@ -7620,25 +7620,9 @@
       ],
       "macroName": "QuicTraceLogWarning"
     },
-    "DatapathQueryProcessorAffinityFailed": {
-      "ModuleProperites": {},
-      "TraceString": "[ udp][%p] WSAIoctl for SIO_QUERY_RSS_PROCESSOR_INFO failed, 0x%x",
-      "UniqueId": "DatapathQueryProcessorAffinityFailed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogWarning"
-    },
     "DatapathMissingInfo": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] WSARecvMsg completion is missing IP_PKTINFO",
+      "TraceString": "[data][%p] WSARecvMsg completion is missing IP_PKTINFO",
       "UniqueId": "DatapathMissingInfo",
       "splitArgs": [
         {
@@ -7650,7 +7634,7 @@
     },
     "DatapathRecvEmpty": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Dropping datagram with empty payload.",
+      "TraceString": "[data][%p] Dropping datagram with empty payload.",
       "UniqueId": "DatapathRecvEmpty",
       "splitArgs": [
         {
@@ -7662,7 +7646,7 @@
     },
     "DatapathUroPreallocExceeded": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Exceeded URO preallocation capacity.",
+      "TraceString": "[data][%p] Exceeded URO preallocation capacity.",
       "UniqueId": "DatapathUroPreallocExceeded",
       "splitArgs": [
         {
@@ -7674,7 +7658,7 @@
     },
     "DatapathShutDownReturn": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Shut down (return)",
+      "TraceString": "[data][%p] Shut down (return)",
       "UniqueId": "DatapathShutDownReturn",
       "splitArgs": [
         {
@@ -7686,7 +7670,7 @@
     },
     "DatapathShutDownComplete": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Shut down (complete)",
+      "TraceString": "[data][%p] Shut down (complete)",
       "UniqueId": "DatapathShutDownComplete",
       "splitArgs": [
         {
@@ -7698,7 +7682,7 @@
     },
     "DatapathUnreachableWithError": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Received unreachable error (0x%x) from %!ADDR!",
+      "TraceString": "[data][%p] Received unreachable error (0x%x) from %!ADDR!",
       "UniqueId": "DatapathUnreachableWithError",
       "splitArgs": [
         {
@@ -7718,7 +7702,7 @@
     },
     "DatapathTooLarge": {
       "ModuleProperites": {},
-      "TraceString": "[ udp][%p] Received larger than expected datagram from %!ADDR!",
+      "TraceString": "[data][%p] Received larger than expected datagram from %!ADDR!",
       "UniqueId": "DatapathTooLarge",
       "splitArgs": [
         {
@@ -8593,18 +8577,6 @@
       ],
       "macroName": "QuicTraceLogConnInfo"
     },
-    "OpenSslContextReset": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Resetting TLS state",
-      "UniqueId": "OpenSslContextReset",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
     "OpenSslHandshakeComplete": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Handshake complete",
@@ -8775,18 +8747,6 @@
         }
       ],
       "macroName": "QuicTraceLogVerbose"
-    },
-    "SchannelContextReset": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Resetting TLS state",
-      "UniqueId": "SchannelContextReset",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
     },
     "SchannelHandshakeComplete": {
       "ModuleProperites": {},
@@ -9020,18 +8980,6 @@
       ],
       "macroName": "QuicTraceLogConnWarning"
     },
-    "StubTlsContextReset": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Resetting TLS state",
-      "UniqueId": "StubTlsContextReset",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
     "StubTlsHandshakeComplete": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Handshake complete",
@@ -9040,22 +8988,6 @@
         {
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
-    "StubTlsConsumedData": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Consumed %u bytes",
-      "UniqueId": "StubTlsConsumedData",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceLogConnInfo"
@@ -9071,6 +9003,22 @@
         },
         {
           "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
+    "StubTlsConsumedData": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Consumed %u bytes",
+      "UniqueId": "StubTlsConsumedData",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -9147,6 +9095,78 @@
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
+    },
+    "TestCaseStart": {
+      "ModuleProperites": {},
+      "TraceString": "[test] START %s",
+      "UniqueId": "TestCaseStart",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "TestCaseEnd": {
+      "ModuleProperites": {},
+      "TraceString": "[test] END %s",
+      "UniqueId": "TestCaseEnd",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "TestCaseTStart": {
+      "ModuleProperites": {},
+      "TraceString": "[test] START %s, %s",
+      "UniqueId": "TestCaseTStart",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "TestCaseTEnd": {
+      "ModuleProperites": {},
+      "TraceString": "[test] END %s",
+      "UniqueId": "TestCaseTEnd",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "TestLogFailure": {
+      "ModuleProperites": {},
+      "TraceString": "[test] FAILURE - %s:%d - %s",
+      "UniqueId": "TestLogFailure",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogError"
     },
     "TestControlClientCanceledRequest": {
       "ModuleProperites": {},
@@ -9286,78 +9306,6 @@
       "UniqueId": "TestDriverStopped",
       "splitArgs": [],
       "macroName": "QuicTraceLogInfo"
-    },
-    "TestCaseStart": {
-      "ModuleProperites": {},
-      "TraceString": "[test] START %s",
-      "UniqueId": "TestCaseStart",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogInfo"
-    },
-    "TestCaseEnd": {
-      "ModuleProperites": {},
-      "TraceString": "[test] END %s",
-      "UniqueId": "TestCaseEnd",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogInfo"
-    },
-    "TestCaseTStart": {
-      "ModuleProperites": {},
-      "TraceString": "[test] START %s, %s",
-      "UniqueId": "TestCaseTStart",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogInfo"
-    },
-    "TestCaseTEnd": {
-      "ModuleProperites": {},
-      "TraceString": "[test] END %s",
-      "UniqueId": "TestCaseTEnd",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogInfo"
-    },
-    "TestLogFailure": {
-      "ModuleProperites": {},
-      "TraceString": "[test] FAILURE - %s:%d - %s",
-      "UniqueId": "TestLogFailure",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
     },
     "TestIgnoreConnectionTimeout": {
       "ModuleProperites": {},
@@ -10448,6 +10396,86 @@
         "TraceID": "ConnOutFlowBlocked"
       },
       {
+        "UniquenessHash": "60d753ab-6710-fe16-e47d-37f046f5973c",
+        "TraceID": "IgnoreCryptoFrame"
+      },
+      {
+        "UniquenessHash": "6501738d-0b97-8289-8e1d-54274fae4f1d",
+        "TraceID": "DiscardKeyType"
+      },
+      {
+        "UniquenessHash": "7add7bc7-5514-83ea-44ca-8acc7e6643b2",
+        "TraceID": "ZeroRttAccepted"
+      },
+      {
+        "UniquenessHash": "bb841825-a52e-8ecf-243e-1a65d10a3e75",
+        "TraceID": "ZeroRttRejected"
+      },
+      {
+        "UniquenessHash": "fba5c72f-0c3d-f668-a88b-39e5e3e62cbd",
+        "TraceID": "HandshakeConfirmedServer"
+      },
+      {
+        "UniquenessHash": "4e785757-b1de-e65c-a7b1-7ac868748434",
+        "TraceID": "CryptoDump"
+      },
+      {
+        "UniquenessHash": "c2f15df5-6ae8-de48-4875-35d291565d96",
+        "TraceID": "CryptoDumpUnacked"
+      },
+      {
+        "UniquenessHash": "e6984e8e-3408-1b5f-b0a0-7d8f293c6623",
+        "TraceID": "CryptoDumpUnacked2"
+      },
+      {
+        "UniquenessHash": "a2080700-161b-68e4-457e-40e07275acf5",
+        "TraceID": "NoMoreRoomForCrypto"
+      },
+      {
+        "UniquenessHash": "cef32e9a-1355-7a31-bd2d-a458b02e214d",
+        "TraceID": "AddCryptoFrame"
+      },
+      {
+        "UniquenessHash": "94b619d7-6b5a-e1b4-d3ee-1b66a383ebbc",
+        "TraceID": "RecoverCrypto"
+      },
+      {
+        "UniquenessHash": "60f13d90-f6b5-d1e2-41fd-0a5662d602e6",
+        "TraceID": "AckCrypto"
+      },
+      {
+        "UniquenessHash": "e5c3a539-ac41-94df-060d-bd4dc2ef4b82",
+        "TraceID": "RecvCrypto"
+      },
+      {
+        "UniquenessHash": "9ed40f87-2b63-8343-5e37-2640d0a40e27",
+        "TraceID": "IndicateConnected"
+      },
+      {
+        "UniquenessHash": "c53376e2-b465-d6a1-047c-4e5e64c263af",
+        "TraceID": "DrainCrypto"
+      },
+      {
+        "UniquenessHash": "fe4d4428-c697-f073-1d9e-e0441b1a8f45",
+        "TraceID": "CryptoNotReady"
+      },
+      {
+        "UniquenessHash": "15379a50-c581-3086-043e-53167a6b3fd6",
+        "TraceID": "ConnWriteKeyUpdated"
+      },
+      {
+        "UniquenessHash": "252598af-99d8-c9ea-9f14-dd07630a45b4",
+        "TraceID": "ConnReadKeyUpdated"
+      },
+      {
+        "UniquenessHash": "12872365-4c5b-bfd4-dc5f-83f6aae048cf",
+        "TraceID": "ConnNewPacketKeys"
+      },
+      {
+        "UniquenessHash": "ec54e332-0990-e91f-5fc1-9a09441bf8a4",
+        "TraceID": "ConnKeyPhaseChange"
+      },
+      {
         "UniquenessHash": "e1f61a3e-5405-efd7-d585-f3a10ab0b6d1",
         "TraceID": "NoSniPresent"
       },
@@ -10626,86 +10654,6 @@
       {
         "UniquenessHash": "bf16a511-be08-e9ca-915f-5e5c834d5ca6",
         "TraceID": "DecodeTPDisable1RttEncryption"
-      },
-      {
-        "UniquenessHash": "60d753ab-6710-fe16-e47d-37f046f5973c",
-        "TraceID": "IgnoreCryptoFrame"
-      },
-      {
-        "UniquenessHash": "6501738d-0b97-8289-8e1d-54274fae4f1d",
-        "TraceID": "DiscardKeyType"
-      },
-      {
-        "UniquenessHash": "7add7bc7-5514-83ea-44ca-8acc7e6643b2",
-        "TraceID": "ZeroRttAccepted"
-      },
-      {
-        "UniquenessHash": "bb841825-a52e-8ecf-243e-1a65d10a3e75",
-        "TraceID": "ZeroRttRejected"
-      },
-      {
-        "UniquenessHash": "fba5c72f-0c3d-f668-a88b-39e5e3e62cbd",
-        "TraceID": "HandshakeConfirmedServer"
-      },
-      {
-        "UniquenessHash": "4e785757-b1de-e65c-a7b1-7ac868748434",
-        "TraceID": "CryptoDump"
-      },
-      {
-        "UniquenessHash": "c2f15df5-6ae8-de48-4875-35d291565d96",
-        "TraceID": "CryptoDumpUnacked"
-      },
-      {
-        "UniquenessHash": "e6984e8e-3408-1b5f-b0a0-7d8f293c6623",
-        "TraceID": "CryptoDumpUnacked2"
-      },
-      {
-        "UniquenessHash": "a2080700-161b-68e4-457e-40e07275acf5",
-        "TraceID": "NoMoreRoomForCrypto"
-      },
-      {
-        "UniquenessHash": "cef32e9a-1355-7a31-bd2d-a458b02e214d",
-        "TraceID": "AddCryptoFrame"
-      },
-      {
-        "UniquenessHash": "94b619d7-6b5a-e1b4-d3ee-1b66a383ebbc",
-        "TraceID": "RecoverCrypto"
-      },
-      {
-        "UniquenessHash": "60f13d90-f6b5-d1e2-41fd-0a5662d602e6",
-        "TraceID": "AckCrypto"
-      },
-      {
-        "UniquenessHash": "e5c3a539-ac41-94df-060d-bd4dc2ef4b82",
-        "TraceID": "RecvCrypto"
-      },
-      {
-        "UniquenessHash": "9ed40f87-2b63-8343-5e37-2640d0a40e27",
-        "TraceID": "IndicateConnected"
-      },
-      {
-        "UniquenessHash": "c53376e2-b465-d6a1-047c-4e5e64c263af",
-        "TraceID": "DrainCrypto"
-      },
-      {
-        "UniquenessHash": "fe4d4428-c697-f073-1d9e-e0441b1a8f45",
-        "TraceID": "CryptoNotReady"
-      },
-      {
-        "UniquenessHash": "15379a50-c581-3086-043e-53167a6b3fd6",
-        "TraceID": "ConnWriteKeyUpdated"
-      },
-      {
-        "UniquenessHash": "252598af-99d8-c9ea-9f14-dd07630a45b4",
-        "TraceID": "ConnReadKeyUpdated"
-      },
-      {
-        "UniquenessHash": "12872365-4c5b-bfd4-dc5f-83f6aae048cf",
-        "TraceID": "ConnNewPacketKeys"
-      },
-      {
-        "UniquenessHash": "ec54e332-0990-e91f-5fc1-9a09441bf8a4",
-        "TraceID": "ConnKeyPhaseChange"
       },
       {
         "UniquenessHash": "152723b4-2b46-a936-ffaf-9cc429e8e66f",
@@ -11160,22 +11108,6 @@
         "TraceID": "ConnExecOper"
       },
       {
-        "UniquenessHash": "91e6e3a1-830d-6ed9-b737-a6481ac8eb55",
-        "TraceID": "NoSrcCidAvailable"
-      },
-      {
-        "UniquenessHash": "03e79f57-89b7-b2d2-b13f-cb2f995b47cd",
-        "TraceID": "GetPacketTypeFailure"
-      },
-      {
-        "UniquenessHash": "f2859068-aa3b-758e-45b8-db7e1bf4063f",
-        "TraceID": "PacketBuilderSendBatch"
-      },
-      {
-        "UniquenessHash": "8acd91f1-3c17-7458-fb5b-e3453f2825d3",
-        "TraceID": "ConnPacketSent"
-      },
-      {
         "UniquenessHash": "05679666-5021-56bf-0a98-5c02ef0f0bff",
         "TraceID": "LogPacketVersionNegotiation"
       },
@@ -11220,6 +11152,22 @@
         "TraceID": "BindingDropPacketEx"
       },
       {
+        "UniquenessHash": "91e6e3a1-830d-6ed9-b737-a6481ac8eb55",
+        "TraceID": "NoSrcCidAvailable"
+      },
+      {
+        "UniquenessHash": "03e79f57-89b7-b2d2-b13f-cb2f995b47cd",
+        "TraceID": "GetPacketTypeFailure"
+      },
+      {
+        "UniquenessHash": "f2859068-aa3b-758e-45b8-db7e1bf4063f",
+        "TraceID": "PacketBuilderSendBatch"
+      },
+      {
+        "UniquenessHash": "8acd91f1-3c17-7458-fb5b-e3453f2825d3",
+        "TraceID": "ConnPacketSent"
+      },
+      {
         "UniquenessHash": "607e449d-59a9-9d66-fcd1-b0a2e12f1dc1",
         "TraceID": "PathInitialized"
       },
@@ -11250,10 +11198,6 @@
       {
         "UniquenessHash": "6f6956ec-af60-d54a-176e-c9db6ac7a50a",
         "TraceID": "RegistrationRundown"
-      },
-      {
-        "UniquenessHash": "537b9c54-10f5-965c-b3e5-6e6e5c66dc85",
-        "TraceID": "IndicateIdealSendBuffer"
       },
       {
         "UniquenessHash": "c8982d54-5957-078c-2db7-dcfc5ff92003",
@@ -11298,6 +11242,10 @@
       {
         "UniquenessHash": "1774df63-d849-a89c-4a88-bf2ff1002e15",
         "TraceID": "ConnQueueSendFlush"
+      },
+      {
+        "UniquenessHash": "537b9c54-10f5-965c-b3e5-6e6e5c66dc85",
+        "TraceID": "IndicateIdealSendBuffer"
       },
       {
         "UniquenessHash": "a0905196-8b7e-fdd3-5369-0c6ffcc3707f",
@@ -11404,6 +11352,46 @@
         "TraceID": "SettingDumpServerResumptionLevel"
       },
       {
+        "UniquenessHash": "f96b231c-aa1b-08a4-7036-a60927e3eadd",
+        "TraceID": "CloseWithoutShutdown"
+      },
+      {
+        "UniquenessHash": "21a2e517-42a5-1d18-885f-8b57b79a2fba",
+        "TraceID": "EventSilentDiscard"
+      },
+      {
+        "UniquenessHash": "f6a10aa5-a444-631e-8d6f-de27fd8a5565",
+        "TraceID": "IndicateStartComplete"
+      },
+      {
+        "UniquenessHash": "0640b2d1-a929-3d01-b4c9-08733e3f0196",
+        "TraceID": "IndicateStreamShutdownComplete"
+      },
+      {
+        "UniquenessHash": "cfaab7b3-b77b-3a94-a433-4c9b57907696",
+        "TraceID": "StreamDestroyed"
+      },
+      {
+        "UniquenessHash": "ba0612b6-86a7-d764-ac9e-bbd12eeb0dca",
+        "TraceID": "StreamCreated"
+      },
+      {
+        "UniquenessHash": "0a4d4b4f-3622-3e1b-99be-acf0719d1bdf",
+        "TraceID": "StreamSendState"
+      },
+      {
+        "UniquenessHash": "89b5a6dc-7445-0b70-6a73-ff28d3f78246",
+        "TraceID": "StreamRecvState"
+      },
+      {
+        "UniquenessHash": "638251a8-14f3-2929-34e2-e69cfdab2277",
+        "TraceID": "StreamOutFlowBlocked"
+      },
+      {
+        "UniquenessHash": "c91c925c-07e9-3204-5459-5d3b19d137d8",
+        "TraceID": "StreamRundown"
+      },
+      {
         "UniquenessHash": "1f2558ac-412e-da8c-33d7-7c45995dbcf9",
         "TraceID": "ResetEarly"
       },
@@ -11476,10 +11464,6 @@
         "TraceID": "IndicatePeerSendShutdown"
       },
       {
-        "UniquenessHash": "89b5a6dc-7445-0b70-6a73-ff28d3f78246",
-        "TraceID": "StreamRecvState"
-      },
-      {
         "UniquenessHash": "e7d79111-7d5f-45a3-50b8-e4ca6de3c081",
         "TraceID": "IndicateSendShutdownComplete"
       },
@@ -11540,10 +11524,6 @@
         "TraceID": "SendDumpAck"
       },
       {
-        "UniquenessHash": "0a4d4b4f-3622-3e1b-99be-acf0719d1bdf",
-        "TraceID": "StreamSendState"
-      },
-      {
         "UniquenessHash": "48b0b691-89c1-4bb2-1ba4-5bc91586b2b3",
         "TraceID": "NotAccepted"
       },
@@ -11562,38 +11542,6 @@
       {
         "UniquenessHash": "c5a168ed-97fa-1cb7-3c3f-15762d9e402a",
         "TraceID": "IndicatePeerStreamStarted"
-      },
-      {
-        "UniquenessHash": "f96b231c-aa1b-08a4-7036-a60927e3eadd",
-        "TraceID": "CloseWithoutShutdown"
-      },
-      {
-        "UniquenessHash": "21a2e517-42a5-1d18-885f-8b57b79a2fba",
-        "TraceID": "EventSilentDiscard"
-      },
-      {
-        "UniquenessHash": "f6a10aa5-a444-631e-8d6f-de27fd8a5565",
-        "TraceID": "IndicateStartComplete"
-      },
-      {
-        "UniquenessHash": "0640b2d1-a929-3d01-b4c9-08733e3f0196",
-        "TraceID": "IndicateStreamShutdownComplete"
-      },
-      {
-        "UniquenessHash": "cfaab7b3-b77b-3a94-a433-4c9b57907696",
-        "TraceID": "StreamDestroyed"
-      },
-      {
-        "UniquenessHash": "ba0612b6-86a7-d764-ac9e-bbd12eeb0dca",
-        "TraceID": "StreamCreated"
-      },
-      {
-        "UniquenessHash": "638251a8-14f3-2929-34e2-e69cfdab2277",
-        "TraceID": "StreamOutFlowBlocked"
-      },
-      {
-        "UniquenessHash": "c91c925c-07e9-3204-5459-5d3b19d137d8",
-        "TraceID": "StreamRundown"
       },
       {
         "UniquenessHash": "f1df9958-6255-24ce-540f-df464661f666",
@@ -11692,11 +11640,11 @@
         "TraceID": "CertOpenSslGetProcessAddressFailure"
       },
       {
-        "UniquenessHash": "8200b193-6dab-1cc4-e8c0-c7963434388c",
+        "UniquenessHash": "f2af462d-2374-ab88-bb90-5b540254387e",
         "TraceID": "DatapathWorkerThreadStart"
       },
       {
-        "UniquenessHash": "8db9f276-e7e4-a879-8d66-04c080b4ed22",
+        "UniquenessHash": "1033d20d-4c1c-25d6-ee0f-5f449e3ed6d5",
         "TraceID": "DatapathWorkerThreadStop"
       },
       {
@@ -11704,63 +11652,63 @@
         "TraceID": "DatapathResolveHostNameFailed"
       },
       {
-        "UniquenessHash": "0592002f-39b9-c666-727b-d92cd6fb7eeb",
+        "UniquenessHash": "17f0621a-2b85-e04d-3ff1-a2b62cef0bf5",
         "TraceID": "DatapathErrorStatus"
       },
       {
-        "UniquenessHash": "4a17af8c-bd56-a1f2-d3d6-b28b75030213",
+        "UniquenessHash": "3b8a506d-ede0-3c3b-7c31-83127acebfc6",
         "TraceID": "DatapathRecv"
       },
       {
-        "UniquenessHash": "bf892b4a-1e02-799f-587c-a17d05c80159",
+        "UniquenessHash": "1cde4174-4172-15b7-b59b-dcbb6410b43a",
         "TraceID": "DatapathCreated"
       },
       {
-        "UniquenessHash": "cab95979-24b5-0b36-044d-b1ab73d3aa37",
+        "UniquenessHash": "f5328bae-6bcb-72fc-a6fd-89b44261a85b",
         "TraceID": "DatapathDestroyed"
       },
       {
-        "UniquenessHash": "94b78b13-9aec-bd06-569d-6b47607c66be",
+        "UniquenessHash": "20cf52f5-ef36-a45b-6a54-29e5eaac7f19",
         "TraceID": "DatapathSend"
       },
       {
-        "UniquenessHash": "b24b16a3-d334-7fa7-5991-5361737fa9a5",
+        "UniquenessHash": "6eeae539-95db-bea9-7e36-8635006dae40",
         "TraceID": "DatapathOpenTcpSocketFailed"
       },
       {
-        "UniquenessHash": "19716fe5-c9e9-01cf-c8fe-adaa001f1096",
+        "UniquenessHash": "3fa7bab2-3b0c-9bb8-549d-167f35ace387",
         "TraceID": "DatapathOpenTcpSocketFailedAsync"
       },
       {
-        "UniquenessHash": "e199bbc2-944b-b1c2-6013-67e8818f2e13",
+        "UniquenessHash": "89ed61ea-4393-6369-8aeb-35d7b01a2b02",
         "TraceID": "DatapathQueryRssScalabilityInfoFailed"
       },
       {
-        "UniquenessHash": "3d57fa5f-a053-b239-52cb-febd154ffd26",
+        "UniquenessHash": "74f297f4-8e97-b395-7e1b-bf46a620caa1",
         "TraceID": "DatapathQueryRssScalabilityInfoFailedAsync"
       },
       {
-        "UniquenessHash": "71af3614-5dc0-62a2-c723-6f31838c3400",
+        "UniquenessHash": "78b2984b-b937-3b8e-7684-9339d9267135",
         "TraceID": "DatapathOpenUdpSocketFailed"
       },
       {
-        "UniquenessHash": "d1b57f51-d0dc-7fe1-82ba-ccde7926e0cc",
+        "UniquenessHash": "b68b4500-98ad-8200-72d3-788a4f0af3d1",
         "TraceID": "DatapathOpenUdpSocketFailedAsync"
       },
       {
-        "UniquenessHash": "71ede21d-777c-2e7a-9260-26fd3efc8601",
+        "UniquenessHash": "e9dcd981-9b8a-a04f-303a-c3acf58a93eb",
         "TraceID": "DatapathQueryUdpSendMsgFailed"
       },
       {
-        "UniquenessHash": "8703c474-c698-92fe-cb33-28ca924e6b98",
+        "UniquenessHash": "26a5e3a8-910f-4058-923c-97ea977107b0",
         "TraceID": "DatapathQueryUdpSendMsgFailedAsync"
       },
       {
-        "UniquenessHash": "9c74edde-b4c6-c412-a4aa-615ad0321ac3",
+        "UniquenessHash": "1ba702fe-3407-9bab-a2bf-4f694b478ac0",
         "TraceID": "DatapathQueryRecvMaxCoalescedSizeFailed"
       },
       {
-        "UniquenessHash": "8f820ed1-ce50-5793-0bd4-ae115f172b66",
+        "UniquenessHash": "5af86e1e-9f51-cd58-2506-9b88ac659923",
         "TraceID": "DatapathQueryRecvMaxCoalescedSizeFailedAsync"
       },
       {
@@ -11800,39 +11748,35 @@
         "TraceID": "DatapathUnreachable"
       },
       {
-        "UniquenessHash": "73d44c65-66ff-f29f-bb76-28617b93d44b",
+        "UniquenessHash": "86f0cb85-ebae-d293-4103-fb695920b86c",
         "TraceID": "DatapathQueryRssProcessorInfoFailed"
       },
       {
-        "UniquenessHash": "113c84ef-50cb-cb52-931e-bf57bcabe3c4",
-        "TraceID": "DatapathQueryProcessorAffinityFailed"
-      },
-      {
-        "UniquenessHash": "4823f9ea-3d4b-3896-96e5-438ed9e7226d",
+        "UniquenessHash": "379a72cf-af97-5535-180f-f644b7513c0c",
         "TraceID": "DatapathMissingInfo"
       },
       {
-        "UniquenessHash": "e460ace3-ef66-a745-4bc5-76eee2744d3e",
+        "UniquenessHash": "e5973396-4dc6-d94f-5d67-921952ed35a5",
         "TraceID": "DatapathRecvEmpty"
       },
       {
-        "UniquenessHash": "fe61acb5-853e-cb16-5c4a-1e0173785458",
+        "UniquenessHash": "fc873bff-2380-b7f7-a8be-4ff93b6d72d7",
         "TraceID": "DatapathUroPreallocExceeded"
       },
       {
-        "UniquenessHash": "fd58fa11-aba1-7179-7742-223f6d568030",
+        "UniquenessHash": "313a165a-4ec1-9450-6b07-56ed0db4c004",
         "TraceID": "DatapathShutDownReturn"
       },
       {
-        "UniquenessHash": "1c3083a0-c3d9-e546-87d3-006f97a1f0e0",
+        "UniquenessHash": "4f1e0892-0852-480e-71db-5b9bb377aabc",
         "TraceID": "DatapathShutDownComplete"
       },
       {
-        "UniquenessHash": "7a22a16e-f913-2343-79f3-1686b66e5e6c",
+        "UniquenessHash": "381ba642-ea84-5bf3-aeea-543fe5c5e9b5",
         "TraceID": "DatapathUnreachableWithError"
       },
       {
-        "UniquenessHash": "2266b6a6-3223-3a10-348c-e3c811fa0818",
+        "UniquenessHash": "a07c9538-e6d7-3c41-1367-ce58f2df4d9e",
         "TraceID": "DatapathTooLarge"
       },
       {
@@ -12088,10 +12032,6 @@
         "TraceID": "OpenSsl1RttDataStart"
       },
       {
-        "UniquenessHash": "c4429bfe-e7df-7623-090b-4ab09187da8f",
-        "TraceID": "OpenSslContextReset"
-      },
-      {
         "UniquenessHash": "a02a0e9d-57cd-0abf-1cd9-5a46076919b2",
         "TraceID": "OpenSslHandshakeComplete"
       },
@@ -12146,10 +12086,6 @@
       {
         "UniquenessHash": "c04de4b9-64de-c415-dda2-b07f295f9897",
         "TraceID": "SchannelLogSecret"
-      },
-      {
-        "UniquenessHash": "d1939214-2593-326a-34c8-0b05b89e7468",
-        "TraceID": "SchannelContextReset"
       },
       {
         "UniquenessHash": "799852e0-2f39-43d4-6888-98a33178b844",
@@ -12212,20 +12148,16 @@
         "TraceID": "StubTlsCertValidationDisabled"
       },
       {
-        "UniquenessHash": "ae0cc427-609d-ce4f-004d-6ef2c2d6c540",
-        "TraceID": "StubTlsContextReset"
-      },
-      {
         "UniquenessHash": "2ca06c46-059c-c3e2-a6db-dc8f0d6292eb",
         "TraceID": "StubTlsHandshakeComplete"
       },
       {
-        "UniquenessHash": "27a202b6-2090-aed6-26c8-4b193f0cb901",
-        "TraceID": "StubTlsConsumedData"
-      },
-      {
         "UniquenessHash": "8671265f-83a7-8d8f-4fac-ea0d14b9da84",
         "TraceID": "StubTlsProducedData"
+      },
+      {
+        "UniquenessHash": "27a202b6-2090-aed6-26c8-4b193f0cb901",
+        "TraceID": "StubTlsConsumedData"
       },
       {
         "UniquenessHash": "d3788ab1-cacd-d552-e06c-2e7bee8b6da9",
@@ -12246,6 +12178,26 @@
       {
         "UniquenessHash": "9b5f99a0-b1b6-bae7-12fd-89f89d1f1667",
         "TraceID": "StubTlsProcessData"
+      },
+      {
+        "UniquenessHash": "75b94a49-9bfe-7be0-7756-8f014aeeddba",
+        "TraceID": "TestCaseStart"
+      },
+      {
+        "UniquenessHash": "b79cc8df-4d28-f459-11b2-ba8160512a09",
+        "TraceID": "TestCaseEnd"
+      },
+      {
+        "UniquenessHash": "cf26e1f0-583d-ec79-4a49-8e398f9883b0",
+        "TraceID": "TestCaseTStart"
+      },
+      {
+        "UniquenessHash": "36ce89a9-c16e-d08a-4bea-f8e25c22d2ce",
+        "TraceID": "TestCaseTEnd"
+      },
+      {
+        "UniquenessHash": "3928cc2f-84c2-48ac-845b-40781cf8021b",
+        "TraceID": "TestLogFailure"
       },
       {
         "UniquenessHash": "ad38c379-0d77-0135-bf6a-19efa61ee493",
@@ -12294,26 +12246,6 @@
       {
         "UniquenessHash": "4f17ceb1-4af8-424e-18d8-17117328147a",
         "TraceID": "TestDriverStopped"
-      },
-      {
-        "UniquenessHash": "75b94a49-9bfe-7be0-7756-8f014aeeddba",
-        "TraceID": "TestCaseStart"
-      },
-      {
-        "UniquenessHash": "b79cc8df-4d28-f459-11b2-ba8160512a09",
-        "TraceID": "TestCaseEnd"
-      },
-      {
-        "UniquenessHash": "cf26e1f0-583d-ec79-4a49-8e398f9883b0",
-        "TraceID": "TestCaseTStart"
-      },
-      {
-        "UniquenessHash": "36ce89a9-c16e-d08a-4bea-f8e25c22d2ce",
-        "TraceID": "TestCaseTEnd"
-      },
-      {
-        "UniquenessHash": "3928cc2f-84c2-48ac-845b-40781cf8021b",
-        "TraceID": "TestLogFailure"
       },
       {
         "UniquenessHash": "f4248703-23be-e418-2b90-c9670966f154",

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -770,7 +770,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "eventfd failed");
@@ -792,7 +792,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "epoll_ctl(EPOLL_CTL_ADD) failed");
@@ -811,7 +811,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "socket failed");
@@ -833,7 +833,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IPV6_V6ONLY) failed");
@@ -862,7 +862,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IP_MTU_DISCOVER) failed");
@@ -881,7 +881,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IPV6_DONTFRAG) failed");
@@ -910,7 +910,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IPV6_RECVPKTINFO) failed");
@@ -929,7 +929,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IP_PKTINFO) failed");
@@ -952,7 +952,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IPV6_RECVTCLASS) failed");
@@ -971,7 +971,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(IP_RECVTOS) failed");
@@ -994,7 +994,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(SO_RCVBUF) failed");
@@ -1016,7 +1016,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "setsockopt(SO_REUSEADDR) failed");
@@ -1037,7 +1037,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "bind failed");
@@ -1062,7 +1062,7 @@ QuicSocketContextInitialize(
             Status = errno;
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Binding,
                 Status,
                 "connect failed");
@@ -1086,7 +1086,7 @@ QuicSocketContextInitialize(
         Status = errno;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "getsockname failed");
@@ -1215,7 +1215,7 @@ QuicSocketContextStartReceive(
         Status = Ret;
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketContext->Binding,
             Status,
             "epoll_ctl failed");
@@ -1298,7 +1298,7 @@ QuicSocketContextRecvComplete(
 
     QuicTraceEvent(
         DatapathRecv,
-        "[ udp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
+        "[data][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
         SocketContext->Binding,
         (uint32_t)BytesTransferred,
         (uint32_t)BytesTransferred,
@@ -1352,7 +1352,7 @@ QuicSocketContextPendSend(
         if (Ret != 0) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 errno,
                 "epoll_ctl failed");
@@ -1424,7 +1424,7 @@ QuicSocketContextSendComplete(
             Status = Ret;
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 Status,
                 "epoll_ctl failed");
@@ -1495,14 +1495,14 @@ QuicSocketContextProcessEvents(
         if (Ret < 0) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 errno,
                 "getsockopt(SO_ERROR) failed");
         } else {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 ErrNum,
                 "Socket error event");
@@ -1535,7 +1535,7 @@ QuicSocketContextProcessEvents(
                 if (errno != EAGAIN && errno != EWOULDBLOCK) {
                     QuicTraceEvent(
                         DatapathErrorStatus,
-                        "[ udp][%p] ERROR, %u, %s.",
+                        "[data][%p] ERROR, %u, %s.",
                         SocketContext->Binding,
                         errno,
                         "recvmsg failed");
@@ -1597,7 +1597,7 @@ QuicSocketCreateUdp(
 
     QuicTraceEvent(
         DatapathCreated,
-        "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+        "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
         Binding,
         CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress),
         CLOG_BYTEARRAY(RemoteAddress ? sizeof(*RemoteAddress) : 0, RemoteAddress));
@@ -1668,7 +1668,7 @@ Exit:
         if (Binding != NULL) {
             QuicTraceEvent(
                 DatapathDestroyed,
-                "[ udp][%p] Destroyed",
+                "[data][%p] Destroyed",
                 Binding);
             // TODO - Clean up socket contexts
             QuicRundownRelease(&Datapath->BindingsRundown);
@@ -1727,7 +1727,7 @@ QuicSocketDelete(
     QUIC_DBG_ASSERT(Binding != NULL);
     QuicTraceEvent(
         DatapathDestroyed,
-        "[ udp][%p] Destroyed",
+        "[data][%p] Destroyed",
         Binding);
 
     //
@@ -2053,7 +2053,7 @@ QuicSocketSend(
 
     QuicTraceEvent(
         DatapathSend,
-        "[ udp][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Binding,
         TotalSize,
         SendContext->BufferCount,
@@ -2130,7 +2130,7 @@ QuicSocketSend(
             Status = errno;
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 Status,
                 "sendmsg failed");
@@ -2184,7 +2184,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceLogInfo(
         DatapathWorkerThreadStart,
-        "[ udp][%p] Worker start",
+        "[data][%p] Worker start",
         ProcContext);
 
     const size_t EpollEventCtMax = 16; // TODO: Experiment.
@@ -2219,7 +2219,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceLogInfo(
         DatapathWorkerThreadStop,
-        "[ udp][%p] Worker stop",
+        "[data][%p] Worker stop",
         ProcContext);
 
     return NO_ERROR;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -550,7 +550,7 @@ QuicDataPathQueryRssScalabilityInfo(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathOpenTcpSocketFailed,
-            "[ udp] RSS helper socket failed to open, 0x%x",
+            "[data] RSS helper socket failed to open, 0x%x",
             Status);
         goto Error;
     }
@@ -560,7 +560,7 @@ QuicDataPathQueryRssScalabilityInfo(
     if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathOpenTcpSocketFailedAsync,
-            "[ udp] RSS helper socket failed to open (async), 0x%x",
+            "[data] RSS helper socket failed to open (async), 0x%x",
             Status);
         goto Error;
     }
@@ -595,7 +595,7 @@ QuicDataPathQueryRssScalabilityInfo(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathQueryRssScalabilityInfoFailed,
-            "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
+            "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
             Status);
         goto Error;
     }
@@ -605,7 +605,7 @@ QuicDataPathQueryRssScalabilityInfo(
     if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathQueryRssScalabilityInfoFailedAsync,
-            "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed (async), 0x%x",
+            "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed (async), 0x%x",
             Status);
         goto Error;
     }
@@ -682,7 +682,7 @@ QuicDataPathQuerySockoptSupport(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathOpenUdpSocketFailed,
-            "[ udp] UDP send segmentation helper socket failed to open, 0x%x",
+            "[data] UDP send segmentation helper socket failed to open, 0x%x",
             Status);
         goto Error;
     }
@@ -692,7 +692,7 @@ QuicDataPathQuerySockoptSupport(
     if (QUIC_FAILED(Status)) {
         QuicTraceLogWarning(
             DatapathOpenUdpSocketFailedAsync,
-            "[ udp] UDP send segmentation helper socket failed to open (async), 0x%x",
+            "[data] UDP send segmentation helper socket failed to open (async), 0x%x",
             Status);
         goto Error;
     }
@@ -730,7 +730,7 @@ QuicDataPathQuerySockoptSupport(
         } else if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 DatapathQueryUdpSendMsgFailed,
-                "[ udp] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
+                "[data] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
                 Status);
             break;
         }
@@ -739,7 +739,7 @@ QuicDataPathQuerySockoptSupport(
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 DatapathQueryUdpSendMsgFailedAsync,
-                "[ udp] Query for UDP_SEND_MSG_SIZE failed (async), 0x%x",
+                "[data] Query for UDP_SEND_MSG_SIZE failed (async), 0x%x",
                 Status);
             break;
         }
@@ -778,7 +778,7 @@ QuicDataPathQuerySockoptSupport(
         } else if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 DatapathQueryRecvMaxCoalescedSizeFailed,
-                "[ udp] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
+                "[data] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
                 Status);
             break;
         }
@@ -787,7 +787,7 @@ QuicDataPathQuerySockoptSupport(
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 DatapathQueryRecvMaxCoalescedSizeFailedAsync,
-                "[ udp] Query for UDP_RECV_MAX_COALESCED_SIZE failed (async), 0x%x",
+                "[data] Query for UDP_RECV_MAX_COALESCED_SIZE failed (async), 0x%x",
                 Status);
             break;
         }
@@ -1325,7 +1325,7 @@ QuicSocketCreateUdp(
 
     QuicTraceEvent(
         DatapathCreated,
-        "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+        "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
         Binding,
         CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress),
         CLOG_BYTEARRAY(RemoteAddress ? sizeof(*RemoteAddress) : 0, RemoteAddress));
@@ -1376,7 +1376,7 @@ QuicSocketCreateUdp(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskSocket");
@@ -1388,7 +1388,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskSocket completion");
@@ -1412,7 +1412,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IPV6_V6ONLY");
@@ -1431,7 +1431,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IP_DONTFRAGMENT");
@@ -1450,7 +1450,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IPV6_DONTFRAG");
@@ -1469,7 +1469,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IPV6_PKTINFO");
@@ -1488,7 +1488,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IP_PKTINFO");
@@ -1507,7 +1507,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IPV6_RECVERR");
@@ -1526,7 +1526,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "Set IP_RECVERR");
@@ -1546,7 +1546,7 @@ QuicSocketCreateUdp(
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Binding,
                 Status,
                 "Set UDP_RECV_MAX_COALESCED_SIZE");
@@ -1577,7 +1577,7 @@ QuicSocketCreateUdp(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskBind");
@@ -1589,7 +1589,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskBind completion");
@@ -1611,7 +1611,7 @@ QuicSocketCreateUdp(
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Binding,
                 Status,
                 "Set SIO_WSK_SET_REMOTE_ADDRESS");
@@ -1646,7 +1646,7 @@ QuicSocketCreateUdp(
     } else if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskGetLocalAddress");
@@ -1658,7 +1658,7 @@ QuicSocketCreateUdp(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskGetLocalAddress completion");
@@ -1758,7 +1758,7 @@ QuicDataPathCloseSocketIoCompletion(
         if (QUIC_FAILED(Binding->Irp.IoStatus.Status)) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Binding,
                 Binding->Irp.IoStatus.Status,
                 "WskCloseSocket completion");
@@ -1783,7 +1783,7 @@ QuicSocketDelete(
     QUIC_DBG_ASSERT(Binding != NULL);
     QuicTraceEvent(
         DatapathDestroyed,
-        "[ udp][%p] Destroyed",
+        "[data][%p] Destroyed",
         Binding);
 
     if (Binding->Socket != NULL) {
@@ -1814,7 +1814,7 @@ QuicSocketDelete(
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Binding,
                 Status,
                 "WskCloseSocket");
@@ -2117,7 +2117,7 @@ QuicDataPathSocketReceive(
 
         QuicTraceEvent(
             DatapathRecv,
-            "[ udp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
+            "[data][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
             Binding,
             (uint32_t)DataLength,
             MessageLength,
@@ -2756,7 +2756,7 @@ QuicDataPathSendComplete(
     if (!NT_SUCCESS(Irp->IoStatus.Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Irp->IoStatus.Status,
             "WskSendMessages completion");
@@ -2817,7 +2817,7 @@ QuicSocketSend(
 
     QuicTraceEvent(
         DatapathSend,
-        "[ udp][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Binding,
         SendContext->TotalSize,
         SendContext->WskBufferCount,
@@ -2893,7 +2893,7 @@ QuicSocketSend(
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Binding,
             Status,
             "WskSendMessages");

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -516,7 +516,7 @@ QuicDataPathQueryRssScalabilityInfo(
         int WsaError = WSAGetLastError();
         QuicTraceLogWarning(
             DatapathOpenTcpSocketFailed,
-            "[ udp] RSS helper socket failed to open, 0x%x",
+            "[data] RSS helper socket failed to open, 0x%x",
             WsaError);
         goto Error;
     }
@@ -536,7 +536,7 @@ QuicDataPathQueryRssScalabilityInfo(
         int WsaError = WSAGetLastError();
         QuicTraceLogWarning(
             DatapathQueryRssProcessorInfoFailed,
-            "[ udp] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
+            "[data] Query for SIO_QUERY_RSS_SCALABILITY_INFO failed, 0x%x",
             WsaError);
         goto Error;
     }
@@ -571,7 +571,7 @@ QuicDataPathQuerySockoptSupport(
         int WsaError = WSAGetLastError();
         QuicTraceLogWarning(
             DatapathOpenUdpSocketFailed,
-            "[ udp] UDP send segmentation helper socket failed to open, 0x%x",
+            "[data] UDP send segmentation helper socket failed to open, 0x%x",
             WsaError);
         goto Error;
     }
@@ -686,7 +686,7 @@ QuicDataPathQuerySockoptSupport(
         int WsaError = WSAGetLastError();
         QuicTraceLogWarning(
             DatapathQueryUdpSendMsgFailed,
-            "[ udp] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
+            "[data] Query for UDP_SEND_MSG_SIZE failed, 0x%x",
             WsaError);
     } else {
         Datapath->Features |= QUIC_DATAPATH_FEATURE_SEND_SEGMENTATION;
@@ -709,7 +709,7 @@ QuicDataPathQuerySockoptSupport(
         int WsaError = WSAGetLastError();
         QuicTraceLogWarning(
             DatapathQueryRecvMaxCoalescedSizeFailed,
-            "[ udp] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
+            "[data] Query for UDP_RECV_MAX_COALESCED_SIZE failed, 0x%x",
             WsaError);
     } else {
         Datapath->Features |= QUIC_DATAPATH_FEATURE_RECV_COALESCING;
@@ -1220,7 +1220,7 @@ QuicSocketCreateUdp(
 
     QuicTraceEvent(
         DatapathCreated,
-        "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+        "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
         Socket,
         CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress),
         CLOG_BYTEARRAY(RemoteAddress ? sizeof(*RemoteAddress) : 0, RemoteAddress));
@@ -1267,7 +1267,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "WSASocketW");
@@ -1291,7 +1291,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IPV6_V6ONLY");
@@ -1316,7 +1316,7 @@ QuicSocketCreateUdp(
                 int WsaError = WSAGetLastError();
                 QuicTraceEvent(
                     DatapathErrorStatus,
-                    "[ udp][%p] ERROR, %u, %s.",
+                    "[data][%p] ERROR, %u, %s.",
                     Socket,
                     WsaError,
                     "SIO_CPU_AFFINITY");
@@ -1337,7 +1337,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IP_DONTFRAGMENT");
@@ -1357,7 +1357,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IPV6_DONTFRAG");
@@ -1377,7 +1377,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IPV6_PKTINFO");
@@ -1397,7 +1397,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IP_PKTINFO");
@@ -1417,7 +1417,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IPV6_ECN");
@@ -1437,7 +1437,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set IP_ECN");
@@ -1461,7 +1461,7 @@ QuicSocketCreateUdp(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "Set SO_RCVBUF");
@@ -1483,7 +1483,7 @@ QuicSocketCreateUdp(
                 int WsaError = WSAGetLastError();
                 QuicTraceEvent(
                     DatapathErrorStatus,
-                    "[ udp][%p] ERROR, %u, %s.",
+                    "[data][%p] ERROR, %u, %s.",
                     Socket,
                     WsaError,
                     "Set UDP_RECV_MAX_COALESCED_SIZE");
@@ -1504,7 +1504,7 @@ QuicSocketCreateUdp(
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 LastError,
                 "SetFileCompletionNotificationModes");
@@ -1529,7 +1529,7 @@ QUIC_DISABLED_BY_FUZZER_START;
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 LastError,
                 "CreateIoCompletionPort");
@@ -1546,7 +1546,7 @@ QUIC_DISABLED_BY_FUZZER_START;
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "bind");
@@ -1567,7 +1567,7 @@ QUIC_DISABLED_BY_FUZZER_START;
                 int WsaError = WSAGetLastError();
                 QuicTraceEvent(
                     DatapathErrorStatus,
-                    "[ udp][%p] ERROR, %u, %s.",
+                    "[data][%p] ERROR, %u, %s.",
                     Socket,
                     WsaError,
                     "connect");
@@ -1594,7 +1594,7 @@ QUIC_DISABLED_BY_FUZZER_START;
                 int WsaError = WSAGetLastError();
                 QuicTraceEvent(
                     DatapathErrorStatus,
-                    "[ udp][%p] ERROR, %u, %s.",
+                    "[data][%p] ERROR, %u, %s.",
                     Socket,
                     WsaError,
                     "getsockaddress");
@@ -1648,7 +1648,7 @@ Error:
         if (Socket != NULL) {
             QuicTraceEvent(
                 DatapathDestroyed,
-                "[ udp][%p] Destroyed",
+                "[data][%p] Destroyed",
                 Socket);
             if (Socket->ProcsOutstanding != 0) {
                 for (uint16_t i = 0; i < SocketCount; i++) {
@@ -1728,7 +1728,7 @@ QuicSocketCreateTcpInternal(
 
     QuicTraceEvent(
         DatapathCreated,
-        "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+        "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
         Socket,
         CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress),
         CLOG_BYTEARRAY(RemoteAddress ? sizeof(*RemoteAddress) : 0, RemoteAddress));
@@ -1769,7 +1769,7 @@ QuicSocketCreateTcpInternal(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "WSASocketW");
@@ -1789,7 +1789,7 @@ QuicSocketCreateTcpInternal(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "Set IPV6_V6ONLY");
@@ -1808,7 +1808,7 @@ QuicSocketCreateTcpInternal(
         DWORD LastError = GetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             LastError,
             "SetFileCompletionNotificationModes");
@@ -1827,7 +1827,7 @@ QuicSocketCreateTcpInternal(
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 LastError,
                 "CreateIoCompletionPort");
@@ -1844,7 +1844,7 @@ QuicSocketCreateTcpInternal(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "bind");
@@ -1870,7 +1870,7 @@ QuicSocketCreateTcpInternal(
                 if (WsaError != WSA_IO_PENDING) {
                     QuicTraceEvent(
                         DatapathErrorStatus,
-                        "[ udp][%p] ERROR, %u, %s.",
+                        "[data][%p] ERROR, %u, %s.",
                         Socket,
                         WsaError,
                         "AcceptEx");
@@ -1889,7 +1889,7 @@ QuicSocketCreateTcpInternal(
                     DWORD LastError = GetLastError();
                     QuicTraceEvent(
                         DatapathErrorStatus,
-                        "[ udp][%p] ERROR, %u, %s.",
+                        "[data][%p] ERROR, %u, %s.",
                         Socket,
                         LastError,
                         "PostQueuedCompletionStatus");
@@ -1915,7 +1915,7 @@ QuicSocketCreateTcpInternal(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "getsockaddress");
@@ -1948,7 +1948,7 @@ Error:
         if (Socket != NULL) {
             QuicTraceEvent(
                 DatapathDestroyed,
-                "[ udp][%p] Destroyed",
+                "[data][%p] Destroyed",
                 Socket);
             if (Socket->ProcsOutstanding != 0) {
 
@@ -2029,7 +2029,7 @@ QuicSocketCreateTcpListener(
 
     QuicTraceEvent(
         DatapathCreated,
-        "[ udp][%p] Created, local=%!ADDR!, remote=%!ADDR!",
+        "[data][%p] Created, local=%!ADDR!, remote=%!ADDR!",
         Socket,
         CLOG_BYTEARRAY(LocalAddress ? sizeof(*LocalAddress) : 0, LocalAddress),
         CLOG_BYTEARRAY(0, NULL));
@@ -2065,7 +2065,7 @@ QuicSocketCreateTcpListener(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "WSASocketW");
@@ -2085,7 +2085,7 @@ QuicSocketCreateTcpListener(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "Set IPV6_V6ONLY");
@@ -2104,7 +2104,7 @@ QuicSocketCreateTcpListener(
         DWORD LastError = GetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             LastError,
             "SetFileCompletionNotificationModes");
@@ -2121,7 +2121,7 @@ QuicSocketCreateTcpListener(
         DWORD LastError = GetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             LastError,
             "CreateIoCompletionPort");
@@ -2138,7 +2138,7 @@ QuicSocketCreateTcpListener(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "bind");
@@ -2162,7 +2162,7 @@ QuicSocketCreateTcpListener(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "getsockaddress");
@@ -2184,7 +2184,7 @@ QuicSocketCreateTcpListener(
         int WsaError = WSAGetLastError();
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Socket,
             WsaError,
             "listen");
@@ -2211,7 +2211,7 @@ Error:
         if (Socket != NULL) {
             QuicTraceEvent(
                 DatapathDestroyed,
-                "[ udp][%p] Destroyed",
+                "[data][%p] Destroyed",
                 Socket);
             if (Socket->ProcsOutstanding != 0) {
                 CancelIo((HANDLE)SocketProc->Socket);
@@ -2256,7 +2256,7 @@ QuicSocketDelete(
     QUIC_DBG_ASSERT(Socket != NULL);
     QuicTraceEvent(
         DatapathDestroyed,
-        "[ udp][%p] Destroyed",
+        "[data][%p] Destroyed",
         Socket);
 
     //
@@ -2274,7 +2274,7 @@ QuicSocketDelete(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "closesocket");
@@ -2294,7 +2294,7 @@ QuicSocketDelete(
                 if (WsaError != WSAENOTCONN) {
                     QuicTraceEvent(
                         DatapathErrorStatus,
-                        "[ udp][%p] ERROR, %u, %s.",
+                        "[data][%p] ERROR, %u, %s.",
                         Socket,
                         WsaError,
                         "shutdown");
@@ -2310,7 +2310,7 @@ QUIC_DISABLED_BY_FUZZER_START;
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 Socket,
                 WsaError,
                 "closesocket");
@@ -2352,7 +2352,7 @@ QUIC_DISABLED_BY_FUZZER_END;
 
     QuicTraceLogVerbose(
         DatapathShutDownReturn,
-        "[ udp][%p] Shut down (return)",
+        "[data][%p] Shut down (return)",
         Socket);
 }
 
@@ -2385,7 +2385,7 @@ QuicDataPathSocketContextShutdown(
         QuicRundownRelease(&SocketProc->Parent->Datapath->SocketsRundown);
         QuicTraceLogVerbose(
             DatapathShutDownComplete,
-            "[ udp][%p] Shut down (complete)",
+            "[data][%p] Shut down (complete)",
             SocketProc->Parent);
         QUIC_FREE(SocketProc->Parent, QUIC_POOL_SOCKET);
     }
@@ -2488,7 +2488,7 @@ QuicSocketStartAccept(
         if (WsaError != WSA_IO_PENDING) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 ListenerSocketProc->Parent,
                 WsaError,
                 "AcceptEx");
@@ -2507,7 +2507,7 @@ QuicSocketStartAccept(
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 ListenerSocketProc->Parent,
                 LastError,
                 "PostQueuedCompletionStatus");
@@ -2549,7 +2549,7 @@ QuicDataPathAcceptComplete(
 
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             ListenerSocketProc->Parent,
             0,
             "AcceptEx Completed!");
@@ -2565,7 +2565,7 @@ QuicDataPathAcceptComplete(
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 ListenerSocketProc->AcceptSocket,
                 WsaError,
                 "Set UPDATE_ACCEPT_CONTEXT");
@@ -2581,7 +2581,7 @@ QuicDataPathAcceptComplete(
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 ListenerSocketProc->AcceptSocket,
                 LastError,
                 "CreateIoCompletionPort (accepted)");
@@ -2606,7 +2606,7 @@ QuicDataPathAcceptComplete(
     } else {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             ListenerSocketProc->Parent,
             IoResult,
             "AcceptEx completion");
@@ -2646,7 +2646,7 @@ QuicDataPathConnectComplete(
 
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             0,
             "ConnectEx Completed!");
@@ -2665,7 +2665,7 @@ QuicDataPathConnectComplete(
     } else {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             IoResult,
             "ConnectEx completion");
@@ -2692,7 +2692,7 @@ QuicSocketHandleUnreachableError(
 #if QUIC_CLOG
     QuicTraceLogVerbose(
         DatapathUnreachableWithError,
-        "[ udp][%p] Received unreachable error (0x%x) from %!ADDR!",
+        "[data][%p] Received unreachable error (0x%x) from %!ADDR!",
         SocketProc->Parent,
         ErrorCode,
         CLOG_BYTEARRAY(sizeof(*RemoteAddr), RemoteAddr));
@@ -2785,7 +2785,7 @@ Retry_recv:
             } else {
                 QuicTraceEvent(
                     DatapathErrorStatus,
-                    "[ udp][%p] ERROR, %u, %s.",
+                    "[data][%p] ERROR, %u, %s.",
                     SocketProc->Parent,
                     WsaError,
                     "WSARecvMsg");
@@ -2805,7 +2805,7 @@ Retry_recv:
             DWORD LastError = GetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketProc->Parent,
                 LastError,
                 "PostQueuedCompletionStatus");
@@ -2863,7 +2863,7 @@ QuicDataPathUdpRecvComplete(
 #if QUIC_CLOG
         QuicTraceLogVerbose(
             DatapathTooLarge,
-            "[ udp][%p] Received larger than expected datagram from %!ADDR!",
+            "[data][%p] Received larger than expected datagram from %!ADDR!",
             SocketProc->Parent,
             CLOG_BYTEARRAY(sizeof(*RemoteAddr), RemoteAddr));
 #endif
@@ -2934,7 +2934,7 @@ QuicDataPathUdpRecvComplete(
             //
             QuicTraceLogWarning(
                 DatapathMissingInfo,
-                "[ udp][%p] WSARecvMsg completion is missing IP_PKTINFO",
+                "[data][%p] WSARecvMsg completion is missing IP_PKTINFO",
                 SocketProc->Parent);
             goto Drop;
         }
@@ -2942,7 +2942,7 @@ QuicDataPathUdpRecvComplete(
         if (NumberOfBytesTransferred == 0) {
             QuicTraceLogWarning(
                 DatapathRecvEmpty,
-                "[ udp][%p] Dropping datagram with empty payload.",
+                "[data][%p] Dropping datagram with empty payload.",
                 SocketProc->Parent);
             goto Drop;
         }
@@ -2951,7 +2951,7 @@ QuicDataPathUdpRecvComplete(
 
         QuicTraceEvent(
             DatapathRecv,
-            "[ udp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
+            "[data][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
             SocketProc->Parent,
             NumberOfBytesTransferred,
             MessageLength,
@@ -3002,7 +3002,7 @@ QuicDataPathUdpRecvComplete(
             if (IsCoalesced && ++MessageCount == URO_MAX_DATAGRAMS_PER_INDICATION) {
                 QuicTraceLogWarning(
                     DatapathUroPreallocExceeded,
-                    "[ udp][%p] Exceeded URO preallocation capacity.",
+                    "[data][%p] Exceeded URO preallocation capacity.",
                     SocketProc->Parent);
                 break;
             }
@@ -3032,7 +3032,7 @@ QuicDataPathUdpRecvComplete(
     } else {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             IoResult,
             "WSARecvMsg completion");
@@ -3099,7 +3099,7 @@ QuicDataPathTcpRecvComplete(
 
         QuicTraceEvent(
             DatapathRecv,
-            "[ udp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
+            "[data][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
             SocketProc->Parent,
             NumberOfBytesTransferred,
             NumberOfBytesTransferred,
@@ -3133,7 +3133,7 @@ QuicDataPathTcpRecvComplete(
     } else {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             IoResult,
             "WSARecv completion");
@@ -3477,7 +3477,7 @@ QuicSendContextComplete(
     if (IoResult != QUIC_STATUS_SUCCESS) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[ udp][%p] ERROR, %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             SocketProc->Parent,
             IoResult,
             "WSASendMsg completion");
@@ -3517,7 +3517,7 @@ QuicSocketSend(
 
     QuicTraceEvent(
         DatapathSend,
-        "[ udp][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Socket,
         SendContext->TotalSize,
         SendContext->WsaBufferCount,
@@ -3639,7 +3639,7 @@ QuicSocketSend(
         if (WsaError != WSA_IO_PENDING) {
             QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketProc->Parent,
                 WsaError,
                 "WSASendMsg");
@@ -3677,7 +3677,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceLogInfo(
         DatapathWorkerThreadStart,
-        "[ udp][%p] Worker start",
+        "[data][%p] Worker start",
         DatapathProc);
 
     QUIC_DBG_ASSERT(DatapathProc != NULL);
@@ -3717,7 +3717,7 @@ QuicDataPathWorkerThread(
 
             /*QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketProc->Parent,
                 IoResult,
                 "Overlapped Complete");*/
@@ -3787,7 +3787,7 @@ QuicDataPathWorkerThread(
 
             /*QuicTraceEvent(
                 DatapathErrorStatus,
-                "[ udp][%p] ERROR, %u, %s.",
+                "[data][%p] ERROR, %u, %s.",
                 SocketProc->Parent,
                 IoResult,
                 "Overlapped Complete (send)");*/
@@ -3807,7 +3807,7 @@ QuicDataPathWorkerThread(
 
     QuicTraceLogInfo(
         DatapathWorkerThreadStop,
-        "[ udp][%p] Worker stop",
+        "[data][%p] Worker stop",
         DatapathProc);
 
     return NO_ERROR;

--- a/src/tools/etw/trace.c
+++ b/src/tools/etw/trace.c
@@ -1163,7 +1163,7 @@ const char* TracePrefix[EventType_Count] = {
     "[strm][%.5u] ",
     "[bind][%.5u] ",
     "[ tls][%.5u] ",
-    "[ udp][%.5u] ",
+    "[data][%.5u] ",
     NULL
 };
 


### PR DESCRIPTION
Now that the datapath include TCP, it makes little sense to use `[ udp]` as the log prefix.