### PR TITLE
Make pool allocators on linux actually use pool

### DIFF
--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -137,30 +137,6 @@ typedef enum CXPLAT_THREAD_FLAGS {
 DEFINE_ENUM_FLAG_OPERATORS(CXPLAT_THREAD_FLAGS);
 #endif
 
-FORCEINLINE
-void
-CxPlatListPushEntry(
-    _Inout_ CXPLAT_SLIST_ENTRY* ListHead,
-    _Inout_ __drv_aliasesMem CXPLAT_SLIST_ENTRY* Entry
-    )
-{
-    Entry->Next = ListHead->Next;
-    ListHead->Next = Entry;
-}
-
-FORCEINLINE
-CXPLAT_SLIST_ENTRY*
-CxPlatListPopEntry(
-    _Inout_ CXPLAT_SLIST_ENTRY* ListHead
-    )
-{
-    CXPLAT_SLIST_ENTRY* FirstEntry = ListHead->Next;
-    if (FirstEntry != NULL) {
-        ListHead->Next = FirstEntry->Next;
-    }
-    return FirstEntry;
-}
-
 #ifdef _KERNEL_MODE
 #define CX_PLATFORM_TYPE 1
 #include <quic_platform_winkernel.h>
@@ -304,6 +280,30 @@ CxPlatListMoveItems(
         //
         CxPlatListInitializeHead(Source);
     }
+}
+
+FORCEINLINE
+void
+CxPlatListPushEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead,
+    _Inout_ __drv_aliasesMem CXPLAT_SLIST_ENTRY* Entry
+    )
+{
+    Entry->Next = ListHead->Next;
+    ListHead->Next = Entry;
+}
+
+FORCEINLINE
+CXPLAT_SLIST_ENTRY*
+CxPlatListPopEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead
+    )
+{
+    CXPLAT_SLIST_ENTRY* FirstEntry = ListHead->Next;
+    if (FirstEntry != NULL) {
+        ListHead->Next = FirstEntry->Next;
+    }
+    return FirstEntry;
 }
 
 #include "quic_hashtable.h"

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -137,6 +137,30 @@ typedef enum CXPLAT_THREAD_FLAGS {
 DEFINE_ENUM_FLAG_OPERATORS(CXPLAT_THREAD_FLAGS);
 #endif
 
+FORCEINLINE
+void
+CxPlatListPushEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead,
+    _Inout_ __drv_aliasesMem CXPLAT_SLIST_ENTRY* Entry
+    )
+{
+    Entry->Next = ListHead->Next;
+    ListHead->Next = Entry;
+}
+
+FORCEINLINE
+CXPLAT_SLIST_ENTRY*
+CxPlatListPopEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead
+    )
+{
+    CXPLAT_SLIST_ENTRY* FirstEntry = ListHead->Next;
+    if (FirstEntry != NULL) {
+        ListHead->Next = FirstEntry->Next;
+    }
+    return FirstEntry;
+}
+
 #ifdef _KERNEL_MODE
 #define CX_PLATFORM_TYPE 1
 #include <quic_platform_winkernel.h>
@@ -280,30 +304,6 @@ CxPlatListMoveItems(
         //
         CxPlatListInitializeHead(Source);
     }
-}
-
-FORCEINLINE
-void
-CxPlatListPushEntry(
-    _Inout_ CXPLAT_SLIST_ENTRY* ListHead,
-    _Inout_ __drv_aliasesMem CXPLAT_SLIST_ENTRY* Entry
-    )
-{
-    Entry->Next = ListHead->Next;
-    ListHead->Next = Entry;
-}
-
-FORCEINLINE
-CXPLAT_SLIST_ENTRY*
-CxPlatListPopEntry(
-    _Inout_ CXPLAT_SLIST_ENTRY* ListHead
-    )
-{
-    CXPLAT_SLIST_ENTRY* FirstEntry = ListHead->Next;
-    if (FirstEntry != NULL) {
-        ListHead->Next = FirstEntry->Next;
-    }
-    return FirstEntry;
 }
 
 #include "quic_hashtable.h"

--- a/src/inc/quic_platform_dispatch.h
+++ b/src/inc/quic_platform_dispatch.h
@@ -39,33 +39,6 @@ void
 
 typedef
 void
-(*CXPLAT_POOL_INITIALIZE)(
-    _In_ BOOLEAN IsPaged,
-    _In_ uint32_t Size,
-    _Inout_ CXPLAT_POOL* Pool
-    );
-
-typedef
-void
-(*CXPLAT_POOL_UNINITIALIZE)(
-    _Inout_ CXPLAT_POOL* Pool
-    );
-
-typedef
-void*
-(*CXPLAT_POOL_ALLOC)(
-    _Inout_ CXPLAT_POOL* Pool
-    );
-
-typedef
-void
-(*CXPLAT_POOL_FREE)(
-    _Inout_ CXPLAT_POOL* Pool,
-    _In_ void* Entry
-    );
-
-typedef
-void
 (*CXPLAT_LOG)(
     _In_ const char* Fmt,
     _In_ va_list args
@@ -225,10 +198,6 @@ QUIC_STATUS
 typedef struct CX_PLATFORM_DISPATCH {
     CXPLAT_ALLOC Alloc;
     CXPLAT_FREE Free;
-    CXPLAT_POOL_INITIALIZE PoolInitialize;
-    CXPLAT_POOL_UNINITIALIZE PoolUninitialize;
-    CXPLAT_POOL_ALLOC PoolAlloc;
-    CXPLAT_POOL_FREE PoolFree;
 
     CXPLAT_LOG Log;
 

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -367,7 +367,7 @@ typedef struct CXPLAT_POOL {
     // LINUX_TODO: Check how to make this lock free?
     //
 
-    pthread_mutex_t Lock;
+    CXPLAT_LOCK Lock;
 
     //
     // Size of entries.

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -454,7 +454,7 @@ CxPlatPoolAlloc(
     CxPlatLockAcquire(&Pool->Lock);
     void* Entry = CxPlatListPopEntry(&Pool->ListHead);
     if (Entry != NULL) {
-        QUIC_FRE_ASSERT(Pool->ListDepth > 0);
+        CXPLAT_FRE_ASSERT(Pool->ListDepth > 0);
         Pool->ListDepth--;
     }
     CxPlatLockRelease(&Pool->Lock);

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -348,6 +348,19 @@ typedef CXPLAT_RW_LOCK CXPLAT_DISPATCH_RW_LOCK;
 // This must be below the lock definitions.
 //
 
+FORCEINLINE
+void
+CxPlatListPushEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead,
+    _Inout_ __drv_aliasesMem CXPLAT_SLIST_ENTRY* Entry
+    );
+
+FORCEINLINE
+CXPLAT_SLIST_ENTRY*
+CxPlatListPopEntry(
+    _Inout_ CXPLAT_SLIST_ENTRY* ListHead
+    );
+
 typedef struct CXPLAT_POOL {
 
     //

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -408,7 +408,7 @@ CxPlatPoolInitialize(
     Pool->Tag = Tag;
     CxPlatLockInitialize(&Pool->Lock);
     Pool->ListDepth = 0;
-    CxPlatZeroMemory(&Pool->ListHead);
+    CxPlatZeroMemory(&Pool->ListHead, sizeof(Pool->ListHead));
     UNREFERENCED_PARAMETER(IsPaged);
 }
 

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -433,7 +433,7 @@ CxPlatPoolUninitialize(
     void* Entry;
     CxPlatLockAcquire(&Pool->Lock);
     while ((Entry = CxPlatListPopEntry(&Pool->ListHead)) != NULL) {
-        QUIC_FRE_ASSERT(Pool->ListDepth > 0);
+        CXPLAT_FRE_ASSERT(Pool->ListDepth > 0);
         Pool->ListDepth--;
         CxPlatLockRelease(&Pool->Lock);
         CxPlatFree(Entry, Pool->Tag);

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -406,6 +406,7 @@ typedef struct CXPLAT_POOL_ENTRY {
 #define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAA
 #endif
 
+inline
 void
 CxPlatPoolInitialize(
     _In_ BOOLEAN IsPaged,
@@ -425,6 +426,7 @@ CxPlatPoolInitialize(
     UNREFERENCED_PARAMETER(IsPaged);
 }
 
+inline
 void
 CxPlatPoolUninitialize(
     _Inout_ CXPLAT_POOL* Pool
@@ -443,6 +445,7 @@ CxPlatPoolUninitialize(
     CxPlatLockUninitialize(&Pool->Lock);
 }
 
+inline
 void*
 CxPlatPoolAlloc(
     _Inout_ CXPLAT_POOL* Pool
@@ -470,6 +473,7 @@ CxPlatPoolAlloc(
 #endif
 }
 
+inline
 void
 CxPlatPoolFree(
     _Inout_ CXPLAT_POOL* Pool,

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -269,14 +269,14 @@ typedef struct CXPLAT_POOL {
     uint32_t Tag;
 } CXPLAT_POOL;
 
-#define QUIC_POOL_MAXIMUM_DEPTH   256 // Copied from EX_MAXIMUM_LOOKASIDE_DEPTH_BASE
+#define CXPLAT_POOL_MAXIMUM_DEPTH   256 // Copied from EX_MAXIMUM_LOOKASIDE_DEPTH_BASE
 
 #if DEBUG
-typedef struct QUIC_POOL_ENTRY {
+typedef struct CXPLAT_POOL_ENTRY {
     SLIST_ENTRY ListHead;
     uint32_t SpecialFlag;
-} QUIC_POOL_ENTRY;
-#define QUIC_POOL_SPECIAL_FLAG    0xAAAAAAAA
+} CXPLAT_POOL_ENTRY;
+#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAA
 #endif
 
 inline
@@ -289,7 +289,7 @@ CxPlatPoolInitialize(
     )
 {
 #if DEBUG
-    CXPLAT_DBG_ASSERT(Size >= sizeof(QUIC_POOL_ENTRY));
+    CXPLAT_DBG_ASSERT(Size >= sizeof(CXPLAT_POOL_ENTRY));
 #endif
     Pool->Size = Size;
     Pool->Tag = Tag;
@@ -324,7 +324,7 @@ CxPlatPoolAlloc(
     }
 #if DEBUG
     if (Entry != NULL) {
-        ((QUIC_POOL_ENTRY*)Entry)->SpecialFlag = 0;
+        ((CXPLAT_POOL_ENTRY*)Entry)->SpecialFlag = 0;
     }
 #endif
     return Entry;
@@ -344,10 +344,10 @@ CxPlatPoolFree(
     return;
 #else
 #if DEBUG
-    CXPLAT_DBG_ASSERT(((QUIC_POOL_ENTRY*)Entry)->SpecialFlag != QUIC_POOL_SPECIAL_FLAG);
-    ((QUIC_POOL_ENTRY*)Entry)->SpecialFlag = QUIC_POOL_SPECIAL_FLAG;
+    CXPLAT_DBG_ASSERT(((CXPLAT_POOL_ENTRY*)Entry)->SpecialFlag != CXPLAT_POOL_SPECIAL_FLAG);
+    ((CXPLAT_POOL_ENTRY*)Entry)->SpecialFlag = CXPLAT_POOL_SPECIAL_FLAG;
 #endif
-    if (QueryDepthSList(&Pool->ListHead) >= QUIC_POOL_MAXIMUM_DEPTH) {
+    if (QueryDepthSList(&Pool->ListHead) >= CXPLAT_POOL_MAXIMUM_DEPTH) {
         CxPlatFree(Entry, Pool->Tag);
     } else {
         InterlockedPushEntrySList(&Pool->ListHead, (PSLIST_ENTRY)Entry);

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -32,6 +32,30 @@ MaxUdpPayloadSizeForFamily(
     );
 
 void
+CxPlatPoolInitialize(
+    _In_ BOOLEAN IsPaged,
+    _In_ uint32_t Size,
+    _In_ uint32_t Tag,
+    _Inout_ CXPLAT_POOL* Pool
+    );
+
+void
+CxPlatPoolUninitialize(
+    _Inout_ CXPLAT_POOL* Pool
+    );
+
+void*
+CxPlatPoolAlloc(
+    _Inout_ CXPLAT_POOL* Pool
+    );
+
+void
+CxPlatPoolFree(
+    _Inout_ CXPLAT_POOL* Pool,
+    _In_ void* Entry
+    );
+
+void
 CxPlatListInitializeHead(
     _Out_ CXPLAT_LIST_ENTRY* ListHead
     );

--- a/src/platform/platform_linux.c
+++ b/src/platform/platform_linux.c
@@ -200,67 +200,6 @@ CxPlatFree(
 }
 
 void
-CxPlatPoolInitialize(
-    _In_ BOOLEAN IsPaged,
-    _In_ uint32_t Size,
-    _In_ uint32_t Tag,
-    _Inout_ CXPLAT_POOL* Pool
-    )
-{
-#ifdef CX_PLATFORM_DISPATCH_TABLE
-    PlatDispatch->PoolInitialize(IsPaged, Size, Pool);
-#else
-    UNREFERENCED_PARAMETER(IsPaged);
-    Pool->Size = Size;
-    Pool->MemTag = Tag;
-#endif
-}
-
-void
-CxPlatPoolUninitialize(
-    _Inout_ CXPLAT_POOL* Pool
-    )
-{
-#ifdef CX_PLATFORM_DISPATCH_TABLE
-    PlatDispatch->PoolUninitialize(Pool);
-#else
-    UNREFERENCED_PARAMETER(Pool);
-#endif
-}
-
-void*
-CxPlatPoolAlloc(
-    _Inout_ CXPLAT_POOL* Pool
-    )
-{
-#ifdef CX_PLATFORM_DISPATCH_TABLE
-    return PlatDispatch->PoolAlloc(Pool);
-#else
-    void*Entry = CxPlatAlloc(Pool->Size, Pool->MemTag);
-
-    if (Entry != NULL) {
-        CxPlatZeroMemory(Entry, Pool->Size);
-    }
-
-    return Entry;
-#endif
-}
-
-void
-CxPlatPoolFree(
-    _Inout_ CXPLAT_POOL* Pool,
-    _In_ void* Entry
-    )
-{
-#ifdef CX_PLATFORM_DISPATCH_TABLE
-    PlatDispatch->PoolFree(Pool, Entry);
-#else
-    UNREFERENCED_PARAMETER(Pool);
-    CxPlatFree(Entry, Pool->MemTag);
-#endif
-}
-
-void
 CxPlatRefInitialize(
     _Inout_ CXPLAT_REF_COUNT* RefCount
     )


### PR DESCRIPTION
Previously, just malloc was being used. Switches the allocation to both be inlined, and to use a pool allocator.

On Windows, calling CxPlatPoolFree after CxPlatPoolUninitalize will result in a memory leak (assuming the pool still has memory), however in Linux it will crash. However, both of these are bugs, so I don't believe the difference will matter.