### PR TITLE
Switch linux to using windows values for address family

### DIFF
--- a/src/inc/msquic_linux.h
+++ b/src/inc/msquic_linux.h
@@ -153,9 +153,9 @@ typedef sa_family_t QUIC_ADDRESS_FAMILY;
 //
 // Defines match windows values.
 //
-#define QUIC_ADDRESS_FAMILY_UNSPEC AF_UNSPEC
-#define QUIC_ADDRESS_FAMILY_INET AF_INET
-#define QUIC_ADDRESS_FAMILY_INET6 AF_INET6
+#define QUIC_ADDRESS_FAMILY_UNSPEC 0
+#define QUIC_ADDRESS_FAMILY_INET 2
+#define QUIC_ADDRESS_FAMILY_INET6 23
 
 typedef union QUIC_ADDR {
     struct sockaddr Ip;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -665,6 +665,7 @@ CxPlatDataPathPopulateTargetAddress(
             return;
         }
         Address->Ipv6 = *SockAddrIn6;
+        Address->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
         return;
     }
 
@@ -672,6 +673,7 @@ CxPlatDataPathPopulateTargetAddress(
         CXPLAT_DBG_ASSERT(sizeof(struct sockaddr_in) == AddrInfo->ai_addrlen);
         SockAddrIn = (struct sockaddr_in*)AddrInfo->ai_addr;
         Address->Ipv4 = *SockAddrIn;
+        Address->Ipv4.sin_family = QUIC_ADDRESS_FAMILY_INET;
         return;
     }
 

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -700,6 +700,9 @@ CxPlatDataPathResolveAddress(
     // Prepopulate hint with input family. It might be unspecified.
     //
     Hints.ai_family = Address->Ip.sa_family;
+    if (Hints.ai_family == QUIC_ADDRESS_FAMILY_INET6) {
+        Hints.ai_family = AF_INET6;
+    }
 
     //
     // Try numeric name first.


### PR DESCRIPTION
Will make high level wrappers much easier to implement. Closes #404 

Note that this is an ABI breaking change, so cannot be done as part of a 1.x release.