### PR TITLE
TCP Perf: Support Abort Stream

### DIFF
--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -52,7 +52,7 @@ parameters:
 - name: extraArgs
   type: string
   displayName: Extra Args
-  default: ''
+  default: 'none'
 
 stages:
 
@@ -96,4 +96,5 @@ stages:
       rttMs: ${{ parameters.rttMs }}
       pacing: ${{ parameters.pacing }}
       logProfile: ${{ parameters.logProfile }}
-      extraArgs: ${{ parameters.extraArgs }}
+      ${{ if ne(parameters.extraArgs, 'none') }}:
+        extraArgs: ${{ parameters.extraArgs }}

--- a/.azure/azure-pipelines.wanperf.yml
+++ b/.azure/azure-pipelines.wanperf.yml
@@ -49,6 +49,10 @@ parameters:
   - None
   - Datapath.Light
   - Performance.Light
+- name: extraArgs
+  type: string
+  displayName: Extra Args
+  default: ''
 
 stages:
 
@@ -92,3 +96,4 @@ stages:
       rttMs: ${{ parameters.rttMs }}
       pacing: ${{ parameters.pacing }}
       logProfile: ${{ parameters.logProfile }}
+      extraArgs: ${{ parameters.extraArgs }}

--- a/.azure/templates/run-wanperf.yml
+++ b/.azure/templates/run-wanperf.yml
@@ -17,6 +17,7 @@ parameters:
   rttMs: '50'
   pacing: '(0,1)'
   logProfile: 'None'
+  extraArgs: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -55,7 +56,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/emulated-performance.ps1
-      arguments: -Protocol ${{ parameters.protocol }} -NumIterations ${{ parameters.iterations }} -BottleneckMbps ${{ parameters.rateMbps }} -BottleneckQueueRatio ${{ parameters.bottleneckQueueRatio }} -DurationMs ${{ parameters.durationMs }} -RttMs ${{ parameters.rttMs }} -Pacing ${{ parameters.pacing }} -LogProfile ${{ parameters.logProfile }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -Protocol ${{ parameters.protocol }} -NumIterations ${{ parameters.iterations }} -BottleneckMbps ${{ parameters.rateMbps }} -BottleneckQueueRatio ${{ parameters.bottleneckQueueRatio }} -DurationMs ${{ parameters.durationMs }} -RttMs ${{ parameters.rttMs }} -Pacing ${{ parameters.pacing }} -LogProfile ${{ parameters.logProfile }} -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }} ${{ parameters.extraArgs }}
 
   - task: CopyFiles@2
     displayName: Move Performance Results

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -319,3 +319,6 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
 }}}}}}
 
 $RunResults | ConvertTo-Json -Depth 100 | Out-File $OutputFile
+
+# Kill any leftovers.
+try { Stop-Process -Name quicperf } catch { }

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -96,66 +96,6 @@ param (
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
-# Default TLS based on current platform.
-if ("" -eq $Tls) {
-    if ($IsWindows) {
-        $Tls = "schannel"
-    } else {
-        $Tls = "openssl"
-    }
-}
-
-# Root directory of the project.
-$RootDir = Split-Path $PSScriptRoot -Parent
-
-# Script for controlling loggings.
-$LogScript = Join-Path $RootDir "scripts" "log.ps1"
-
-# Folder for log files.
-$LogDir = Join-Path $RootDir "artifacts" "logs" "wanperf" (Get-Date -UFormat "%m.%d.%Y.%T").Replace(':','.')
-if ($LogProfile -ne "None") {
-    try {
-        Write-Debug "Canceling any already running logs"
-        & $LogScript -Cancel
-    } catch {
-    }
-    New-Item -Path $LogDir -ItemType Directory -Force | Write-Debug
-    dir $LogScript | Write-Debug
-}
-
-$Platform = $IsWindows ? "windows" : "linux"
-$ExeName = $IsWindows ? "quicperf.exe" : "quicperf"
-# Path to the quicperf exectuable.
-$QuicPerf = Join-Path $RootDir "artifacts" "bin" $Platform "$($Arch)_$($Config)_$($Tls)" $ExeName
-
-# Path to the netput exectuable.
-$NetPut = "C:\Windows\System32\netput.exe"
-
-Get-NetAdapter | Write-Debug
-ipconfig -all | Write-Debug
-
-# Start the perf server listening.
-Write-Debug "Starting server..."
-if (!(Test-Path -Path $QuicPerf)) {
-    Write-Error "Missing file: $QuicPerf"
-}
-$pinfo = New-Object System.Diagnostics.ProcessStartInfo
-$pinfo.FileName = $QuicPerf
-$pinfo.UseShellExecute = $false
-$pinfo.RedirectStandardOutput = $true
-$pinfo.RedirectStandardError = $true
-$p = New-Object System.Diagnostics.Process
-$p.StartInfo = $pinfo
-$p.Start() | Out-Null
-
-# Wait for the server(s) to come up.
-Sleep -Seconds 1
-
-$OutputDir = Join-Path $RootDir "artifacts" "PerfDataResults" $Platform "$($Arch)_$($Config)_$($Tls)" "WAN"
-New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
-$UniqueId = New-Guid
-$OutputFile = Join-Path $OutputDir "WANPerf_$($UniqueId.ToString("N")).json"
-
 class TestResult {
     [int]$RttMs;
     [int]$BottleneckMbps;
@@ -206,9 +146,67 @@ class Results {
     }
 }
 
-$PlatformName = (($IsWindows ? "Windows" : "Linux") + "_$($Arch)_$($Tls)")
-$RunResults = [Results]::new($PlatformName)
+# Default TLS based on current platform.
+if ("" -eq $Tls) {
+    if ($IsWindows) {
+        $Tls = "schannel"
+    } else {
+        $Tls = "openssl"
+    }
+}
 
+# Root directory of the project.
+$RootDir = Split-Path $PSScriptRoot -Parent
+
+# Script for controlling loggings.
+$LogScript = Join-Path $RootDir "scripts" "log.ps1"
+
+# Folder for log files.
+$LogDir = Join-Path $RootDir "artifacts" "logs" "wanperf" (Get-Date -UFormat "%m.%d.%Y.%T").Replace(':','.')
+if ($LogProfile -ne "None") {
+    try {
+        Write-Debug "Canceling any already running logs"
+        & $LogScript -Cancel
+    } catch {
+    }
+    New-Item -Path $LogDir -ItemType Directory -Force | Write-Debug
+    dir $LogScript | Write-Debug
+}
+
+$Platform = $IsWindows ? "windows" : "linux"
+$PlatformName = (($IsWindows ? "Windows" : "Linux") + "_$($Arch)_$($Tls)")
+
+# Path to the quicperf exectuable.
+$ExeName = $IsWindows ? "quicperf.exe" : "quicperf"
+$QuicPerf = Join-Path $RootDir "artifacts" "bin" $Platform "$($Arch)_$($Config)_$($Tls)" $ExeName
+
+Get-NetAdapter | Write-Debug
+ipconfig -all | Write-Debug
+
+# Make sure to kill any old processes
+try { Stop-Process -Name quicperf } catch { }
+
+# Start the perf server listening.
+Write-Debug "Starting server..."
+if (!(Test-Path -Path $QuicPerf)) {
+    Write-Error "Missing file: $QuicPerf"
+}
+$pinfo = New-Object System.Diagnostics.ProcessStartInfo
+$pinfo.FileName = $QuicPerf
+$pinfo.UseShellExecute = $false
+$pinfo.RedirectStandardOutput = $true
+$pinfo.RedirectStandardError = $true
+$p = New-Object System.Diagnostics.Process
+$p.StartInfo = $pinfo
+$p.Start() | Out-Null
+
+# Wait for the server(s) to come up.
+Sleep -Seconds 1
+
+$OutputDir = Join-Path $RootDir "artifacts" "PerfDataResults" $Platform "$($Arch)_$($Config)_$($Tls)" "WAN"
+New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+$UniqueId = New-Guid
+$OutputFile = Join-Path $OutputDir "WANPerf_$($UniqueId.ToString("N")).json"
 # CSV header
 $Header = "RttMs, BottleneckMbps, BottleneckBufferPackets, RandomLossDenominator, RandomReorderDenominator, ReorderDelayDeltaMs, Tcp, DurationMs, Pacing, RateKbps"
 for ($i = 0; $i -lt $NumIterations; $i++) {
@@ -224,6 +222,8 @@ Set-NetAdapterAdvancedProperty duo? -DisplayName RdqEnabled -RegistryValue 1 -No
 # network (such a middlebox would only see packets after LSO sends are split
 # into MTU-sized packets).
 Set-NetAdapterLso duo? -IPv4Enabled $false -IPv6Enabled $false -NoRestart
+
+$RunResults = [Results]::new($PlatformName)
 
 # Loop over all the network emulation configurations.
 foreach ($ThisRttMs in $RttMs) {

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -390,7 +390,7 @@ PerfServer::TcpSendCompleteCallback(
             auto Stream = CXPLAT_CONTAINING_RECORD(Entry, StreamContext, Entry);
             Stream->OutstandingBytes -= Data->Length;
             This->SendTcpResponse(Stream, Connection);
-            if (Data->Fin) {
+            if ((Data->Fin || Data->Abort) && !Stream->SendShutdown) {
                 Stream->SendShutdown = true;
                 if (Stream->RecvShutdown) {
                     This->StreamTable.Remove(&Stream->Entry);

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -320,6 +320,7 @@ PerfServer::TcpReceiveCallback(
     uint32_t StreamID,
     bool Open,
     bool Fin,
+    bool Abort,
     uint32_t Length,
     uint8_t* Buffer
     )
@@ -343,7 +344,17 @@ PerfServer::TcpReceiveCallback(
         Stream->ResponseSize = CxPlatByteSwapUint64(Stream->ResponseSize);
         Stream->ResponseSizeSet = true;
     }
-    if (Fin) {
+    if (Abort) {
+        Stream->ResponseSize = 0; // Reset to make sure we stop sending more
+        auto SendData = new TcpSendData();
+        SendData->StreamId = StreamID;
+        SendData->Open = Open ? TRUE : FALSE;
+        SendData->Abort = TRUE;
+        SendData->Buffer = This->DataBuffer->Buffer;
+        SendData->Length = 0;
+        Connection->Send(SendData);
+
+    } else if (Fin) {
         if (Stream->ResponseSizeSet && Stream->ResponseSize != 0) {
             This->SendTcpResponse(Stream, Connection);
         } else {

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -164,6 +164,7 @@ private:
         uint32_t StreamID,
         bool Open,
         bool Fin,
+        bool Abort,
         uint32_t Length,
         uint8_t* Buffer
         );

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -30,9 +30,10 @@ struct TcpFrame {
     // uint8_t Tag[CXPLAT_ENCRYPTION_OVERHEAD];
 };
 struct TcpStreamFrame {
-    uint32_t Id : 30;
+    uint32_t Id : 29;
     uint32_t Open : 1;
     uint32_t Fin : 1;
+    uint32_t Abort : 1;
     uint8_t Data[0];
 };
 #pragma pack(pop)
@@ -724,6 +725,7 @@ bool TcpConnection::ProcessReceiveFrame(TcpFrame* Frame)
             StreamFrame->Id,
             StreamFrame->Open,
             StreamFrame->Fin,
+            StreamFrame->Abort,
             Frame->Length - sizeof(TcpStreamFrame),
             StreamFrame->Data);
         break;
@@ -771,6 +773,7 @@ void TcpConnection::ProcessSend()
             StreamFrame->Id = NextSendData->StreamId;
             StreamFrame->Open = Offset == 0 ? NextSendData->Open : FALSE;
             StreamFrame->Fin = Offset + StreamLength == NextSendData->Length ? NextSendData->Fin : FALSE;
+            StreamFrame->Abort = Offset + StreamLength == NextSendData->Length ? NextSendData->Abort : FALSE;
             CxPlatCopyMemory(StreamFrame->Data, NextSendData->Buffer + Offset, StreamLength);
             Offset += StreamLength;
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -471,10 +471,12 @@ void TcpConnection::Process()
         TcpServer* Server = (TcpServer*)Context;
         Context = nullptr;
         Engine->AcceptHandler(Server, this);
+        StartTls = true;
     }
     if (IndicateConnect) {
         IndicateConnect = false;
         Engine->ConnectHandler(this, true);
+        StartTls = true;
     }
     if (StartTls) {
         StartTls = false;

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -308,6 +308,9 @@ TcpConnection::TcpConnection(
     if ((SecConfig = Helper.Load(CredConfig)) == nullptr) {
         return;
     }
+    if (LocalAddress) {
+        Family = QuicAddrGetFamily(LocalAddress);
+    }
     QuicAddrSetFamily(&RemoteAddress, Family);
     if (QUIC_FAILED(
         CxPlatDataPathResolveAddress(

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -458,12 +458,6 @@ TcpConnection::TlsReceiveTicketCallback(
     return TRUE;
 }
 
-void TcpConnection::Fatal()
-{
-    WriteOutput("Fatal\n");
-    // TODO - Disconnect
-}
-
 void TcpConnection::Process()
 {
     if (IndicateAccept) {
@@ -481,17 +475,24 @@ void TcpConnection::Process()
     if (StartTls) {
         StartTls = false;
         if (!InitializeTls()) {
-            Fatal();
+            IndicateDisconnect = true;
         }
     }
     if (ReceiveData) {
-        ProcessReceive();
+        if (!ProcessReceive()) {
+            IndicateDisconnect = true;
+        }
     }
     if (TlsState.WriteKey >= QUIC_PACKET_KEY_1_RTT && SendData) {
-        ProcessSend();
+        if (!ProcessSend()) {
+            IndicateDisconnect = true;
+        }
     }
     if (BatchedSendData) {
-        CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData);
+        if (QUIC_FAILED(
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
+            IndicateDisconnect = true;
+        }
         BatchedSendData = nullptr;
     }
     if (IndicateSendComplete) {
@@ -549,6 +550,7 @@ bool TcpConnection::ProcessTls(const uint8_t* Buffer, uint32_t BufferLength)
             &TlsState);
     if (Results & CXPLAT_TLS_RESULT_PENDING) {
         // TODO - Not supported yet
+        WriteOutput("CxPlatTlsProcessData PENDING (not supported)\n");
         return false;
     }
     if (Results & CXPLAT_TLS_RESULT_ERROR) {
@@ -597,6 +599,7 @@ bool TcpConnection::SendTlsData(const uint8_t* Buffer, uint16_t BufferLength, ui
 {
     auto SendBuffer = NewSendBuffer();
     if (!SendBuffer) {
+        WriteOutput("NewSendBuffer FAILED\n");
         return false;
     }
 
@@ -607,26 +610,27 @@ bool TcpConnection::SendTlsData(const uint8_t* Buffer, uint16_t BufferLength, ui
     CxPlatCopyMemory(Frame->Data, Buffer, BufferLength);
 
     if (!EncryptFrame(Frame)) {
+        WriteOutput("EncryptFrame FAILED\n");
         FreeSendBuffer(SendBuffer);
         return false;
     }
 
     SendBuffer->Length = sizeof(TcpFrame) + Frame->Length + CXPLAT_ENCRYPTION_OVERHEAD;
-    FinalizeSendBuffer(SendBuffer);
-
-    return true;
+    return FinalizeSendBuffer(SendBuffer);
 }
 
-void TcpConnection::ProcessReceive()
+bool TcpConnection::ProcessReceive()
 {
     CxPlatDispatchLockAcquire(&Lock);
     CXPLAT_RECV_DATA* RecvDataChain = ReceiveData;
     ReceiveData = nullptr;
     CxPlatDispatchLockRelease(&Lock);
 
+    bool Result = true;
     auto NextRecvData = RecvDataChain;
     while (NextRecvData) {
         if (!ProcessReceiveData(NextRecvData->Buffer, NextRecvData->BufferLength)) {
+            Result = false;
             goto Exit;
         }
         NextRecvData = NextRecvData->Next;
@@ -635,6 +639,8 @@ void TcpConnection::ProcessReceive()
 Exit:
 
     CxPlatRecvDataReturn(RecvDataChain);
+
+    return Result;
 }
 
 bool TcpConnection::ProcessReceiveData(const uint8_t* Buffer, uint32_t BufferLength)
@@ -709,7 +715,7 @@ bool TcpConnection::ProcessReceiveFrame(TcpFrame* Frame)
                 (uint8_t*)Frame,
                 Frame->Length + CXPLAT_ENCRYPTION_OVERHEAD,
                 Frame->Data))) {
-            WriteOutput("Decrypt failed\n");
+            WriteOutput("CxPlatDecrypt FAILED\n");
             return false;
         }
     }
@@ -742,7 +748,7 @@ bool TcpConnection::ProcessReceiveFrame(TcpFrame* Frame)
     return true;
 }
 
-void TcpConnection::ProcessSend()
+bool TcpConnection::ProcessSend()
 {
     CxPlatDispatchLockAcquire(&Lock);
     TcpSendData* SendDataChain = SendData;
@@ -761,7 +767,8 @@ void TcpConnection::ProcessSend()
         do {
             auto SendBuffer = NewSendBuffer();
             if (!SendBuffer) {
-                return;
+                WriteOutput("NewSendBuffer FAILED\n");
+                return false;
             }
 
             uint32_t StreamLength = TLS_BLOCK_SIZE - sizeof(TcpFrame) - sizeof(TcpStreamFrame) - CXPLAT_ENCRYPTION_OVERHEAD;
@@ -783,18 +790,23 @@ void TcpConnection::ProcessSend()
             Offset += StreamLength;
 
             if (!EncryptFrame(Frame)) {
+                WriteOutput("EncryptFrame FAILED\n");
                 FreeSendBuffer(SendBuffer);
-                return;
+                return false;
             }
 
             SendBuffer->Length = sizeof(TcpFrame) + Frame->Length + CXPLAT_ENCRYPTION_OVERHEAD;
-            FinalizeSendBuffer(SendBuffer);
+            if (!FinalizeSendBuffer(SendBuffer)) {
+                return false;
+            }
 
         } while (NextSendData->Length > Offset);
 
         NextSendData->Offset = TotalSendOffset;
         NextSendData = NextSendData->Next;
     }
+
+    return true;
 }
 
 void TcpConnection::ProcessSendComplete()
@@ -838,25 +850,23 @@ void TcpConnection::FreeSendBuffer(QUIC_BUFFER* SendBuffer)
     CxPlatSendDataFreeBuffer(BatchedSendData, SendBuffer);
 }
 
-void TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
+bool TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
 {
-    //auto Frame = (TcpFrame*)SendBuffer->Buffer;
-    //printf("[SEND] Frame %hu bytes (key=%hhu) (type=%hhu)\n", Frame->Length, Frame->KeyType, Frame->FrameType);
-
     TotalSendOffset += SendBuffer->Length;
     if (SendBuffer->Length != TLS_BLOCK_SIZE ||
         CxPlatSendDataIsFull(BatchedSendData)) {
         if (QUIC_FAILED(
             CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
-            // FATAL
+            WriteOutput("CxPlatSocketSend FAILED\n");
+            return false;
         }
         BatchedSendData = nullptr;
     }
+    return true;
 }
 
 void TcpConnection::Send(TcpSendData* Data)
 {
-    //printf("[SEND] App %u bytes, Id=%u, Open=%hhu, Fin=%hhu\n", Data->Length, Data->StreamId, Data->Open, Data->Fin);
     CxPlatDispatchLockAcquire(&Lock);
     TcpSendData** Tail = &SendData;
     while (*Tail) {

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -243,20 +243,19 @@ class TcpConnection {
         );
     ~TcpConnection();
     void Queue() { Worker->QueueConnection(this); }
-    void Fatal();
     void Process();
     bool InitializeTls();
     bool ProcessTls(const uint8_t* Buffer, uint32_t BufferLength);
     bool SendTlsData(const uint8_t* Buffer, uint16_t BufferLength, uint8_t KeyType);
-    void ProcessReceive();
+    bool ProcessReceive();
     bool ProcessReceiveData(const uint8_t* Buffer, uint32_t BufferLength);
     bool ProcessReceiveFrame(TcpFrame* Frame);
-    void ProcessSend();
+    bool ProcessSend();
     void ProcessSendComplete();
     bool EncryptFrame(TcpFrame* Frame);
     QUIC_BUFFER* NewSendBuffer();
     void FreeSendBuffer(QUIC_BUFFER* SendBuffer);
-    void FinalizeSendBuffer(QUIC_BUFFER* SendBuffer);
+    bool FinalizeSendBuffer(QUIC_BUFFER* SendBuffer);
     void AddRef() { CxPlatRefIncrement(&Ref); }
     void Release() { if (CxPlatRefDecrement(&Ref)) delete this; }
 public:

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -24,9 +24,10 @@ struct TcpFrame;
 
 struct TcpSendData {
     TcpSendData* Next;
-    uint32_t StreamId : 30;
+    uint32_t StreamId : 29;
     uint32_t Open : 1;
     uint32_t Fin : 1;
+    uint32_t Abort : 1;
     uint32_t Length;
     uint8_t* Buffer;
     uint64_t Offset; // Used internally only
@@ -62,6 +63,7 @@ void
     uint32_t StreamID,
     bool Open,
     bool Fin,
+    bool Abort,
     uint32_t Length,
     uint8_t* Buffer
     );

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -165,7 +165,7 @@ class TcpConnection {
     bool Initialized{false};
     bool ClosedByApp{false};
     bool QueuedOnWorker{false};
-    bool StartTls{true};
+    bool StartTls{false};
     bool IndicateAccept{false};
     bool IndicateConnect{false};
     bool IndicateDisconnect{false};

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -554,6 +554,10 @@ ThroughputClient::TcpConnectCallback(
 {
     auto This = (ThroughputClient*)Connection->Context;
     if (!IsConnected) {
+        if (This->TcpStrmContext) {
+            This->OnStreamShutdownComplete(This->TcpStrmContext);
+            This->TcpStrmContext = nullptr;
+        }
         Connection->Close();
         CxPlatEventSet(*This->StopEvent);
     }

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -150,6 +150,7 @@ private:
         uint32_t StreamID,
         bool Open,
         bool Fin,
+        bool Abort,
         uint32_t Length,
         uint8_t* Buffer
         );

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3097,7 +3097,8 @@ CxPlatDataPathTcpRecvComplete(
 
     if (IoResult == WSAENOTSOCK ||
         IoResult == WSA_OPERATION_ABORTED ||
-        IoResult == ERROR_NETNAME_DELETED) {
+        IoResult == ERROR_NETNAME_DELETED ||
+        IoResult == WSAECONNRESET) {
         //
         // Error from shutdown, silently ignore. Return immediately so the
         // receive doesn't get reposted.


### PR DESCRIPTION
Adds the ability to abort a stream to the TCP logic. This is required for "timed` performance testing, which is what wanperf uses. Also fixes a few other TCP bugs found while debugging WAN perf.