### PR TITLE
Custom Commit Filtering

### DIFF
--- a/assets/summary/dataTemplate.js
+++ b/assets/summary/dataTemplate.js
@@ -107,23 +107,6 @@ var timeAxis = {
     scaleLabel: createScaleLabel('Latest Commits')
 };
 
-var summaryTimeAxis = {
-    type: 'linear',
-    offset: true,
-    ticks: {
-        maxTicksLimit: summaryChartCommits + 10,
-        stepSize: 1,
-        callback: function(value) {
-            if (value % 1 !== 0) {
-                return "";
-            } else {
-                return maxIndex - 1 - value;
-            }
-        }
-    },
-    scaleLabel: createScaleLabel('Latest Commits')
-};
-
 var pluginObject = {
     zoom: {
         pan: {
@@ -159,7 +142,7 @@ function createSummaryChartOptions(title, yName) {
         },
         tooltips: tooltipsSummaryObject,
         scales: {
-            xAxes: [summaryTimeAxis],
+            xAxes: [timeAxis],
             yAxes: [{
                 scaleLabel: createScaleLabel(yName),
                 ticks: { min: 0 }


### PR DESCRIPTION
Updates the JS code to support a custom commit count filtering for the commit data generated by the CI pipeline. This theoretically allows us to update the CI pipeline to generate data files with all (or probably capped to a larger number of commits) data and then have our JS filter (possibly dynamically controlled by the user) to a smaller number of commits to actually display.

Practically, this change introduces two variables (`summaryChartCommits` and `detailChartCommits`) that control the current number of commits to actually display in the respective charts.