### PR TITLE
Add MaxRuntime Support to QuicPerf

### DIFF
--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -260,6 +260,8 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
             $UseTcp = 1
         }
 
+        $MaxRuntimeMs = $ThisDurationMs + 5000
+
         # Run through all the iterations and keep track of the results.
         $Results = [System.Collections.Generic.List[int]]::new()
         Write-Debug "Run upload test: Duration=$ThisDurationMs ms, Pacing=$ThisPacing"
@@ -277,7 +279,7 @@ foreach ($ThisReorderDelayDeltaMs in $ReorderDelayDeltaMs) {
             Write-Debug "Run upload test: Iteration=$($i + 1)"
 
             $Rate = 0
-            $Command = "$QuicPerf -test:tput -tcp:$UseTcp -bind:192.168.1.12 -target:192.168.1.11 -sendbuf:0 -upload:$ThisDurationMs -timed:1 -pacing:$ThisPacing"
+            $Command = "$QuicPerf -test:tput -tcp:$UseTcp -maxruntime:$MaxRuntimeMs -bind:192.168.1.12 -target:192.168.1.11 -sendbuf:0 -upload:$ThisDurationMs -timed:1 -pacing:$ThisPacing"
             Write-Debug $Command
             $Output = [string](iex $Command)
             Write-Debug $Output

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -129,7 +129,7 @@ QuicUserMain(
         CxPlatEventSet(StopEvent);
     }
 
-    Status = QuicMainStop(0);
+    Status = QuicMainStop();
     if (QUIC_FAILED(Status)) {
         printf("Stop failed with status %d\n", Status);
         QuicMainFree();

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -605,8 +605,7 @@ CXPLAT_THREAD_CALLBACK(PerformanceWaitForStopThreadCb, Context)
     QUIC_STATUS StopStatus;
     NTSTATUS Status;
 
-    StopStatus =
-        QuicMainStop(0);
+    StopStatus = QuicMainStop();
 
     if (Client->Canceled) {
         QuicTraceLogInfo(

--- a/src/perf/lib/PerfHelpers.h
+++ b/src/perf/lib/PerfHelpers.h
@@ -51,7 +51,6 @@ QuicMainStart(
 extern
 QUIC_STATUS
 QuicMainStop(
-    _In_ int Timeout
     );
 
 extern

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -130,7 +130,14 @@ private:
     uint32_t IoSize {0};
 
     TcpEngine Engine;
+    TcpConnection* TcpConn{nullptr};
     StreamContext* TcpStrmContext{nullptr};
+
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+    void
+    OnTcpConnectionComplete(
+        _In_ TcpConnection* Connection
+        );
 
     _IRQL_requires_max_(DISPATCH_LEVEL)
     _Function_class_(TcpConnectCallback)

--- a/src/perf/lib/quicmain.cpp
+++ b/src/perf/lib/quicmain.cpp
@@ -32,6 +32,7 @@ CXPLAT_DATAPATH_UNREACHABLE_CALLBACK DatapathUnreachable;
 CXPLAT_DATAPATH* Datapath;
 CXPLAT_SOCKET* Binding;
 bool ServerMode = false;
+uint32_t MaxRuntime = 0;
 
 static
 void
@@ -71,6 +72,7 @@ QuicMainStart(
     }
 
     ServerMode = TestName == nullptr;
+    TryGetValue(argc, argv, "maxruntime", &MaxRuntime);
 
     QUIC_STATUS Status;
 
@@ -152,14 +154,8 @@ QuicMainStart(
 
 QUIC_STATUS
 QuicMainStop(
-    _In_ int Timeout
     ) {
-    if (TestToRun == nullptr) {
-        return QUIC_STATUS_SUCCESS;
-    }
-
-    QUIC_STATUS Status = TestToRun->Wait(Timeout);
-    return Status;
+    return TestToRun ? TestToRun->Wait((int)MaxRuntime) : QUIC_STATUS_SUCCESS;
 }
 
 void


### PR DESCRIPTION
It seems sometime TCP was getting hung during periodic perf test run. This makes sure to exit each test case after a maximum amount of time (duration + 5 second).