### PR TITLE
Deferred Certificate Validation Support

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2553,6 +2553,27 @@ Error:
     QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicConnDeferredCertValidation(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint32_t ErrorFlags,
+    _In_ QUIC_STATUS Status
+    )
+{
+    QUIC_CONNECTION_EVENT Event;
+    Event.Type = QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION;
+    Event.PEER_CERTIFICATE_VALIDATION.ErrorFlags = ErrorFlags;
+    Event.PEER_CERTIFICATE_VALIDATION.Status = Status;
+    QuicTraceLogConnVerbose(
+        IndicatePeerCertificateValidation,
+        Connection,
+        "Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION (0x%x, 0x%x)",
+        ErrorFlags,
+        Status);
+    return QUIC_SUCCEEDED(QuicConnIndicateEvent(Connection, &Event));
+}
+
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicConnQueueRecvDatagrams(

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -26,11 +26,13 @@ Abstract:
 CXPLAT_TLS_PROCESS_COMPLETE_CALLBACK QuicTlsProcessDataCompleteCallback;
 CXPLAT_TLS_RECEIVE_TP_CALLBACK QuicConnReceiveTP;
 CXPLAT_TLS_RECEIVE_TICKET_CALLBACK QuicConnRecvResumptionTicket;
+CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK QuicConnDeferredCertValidation;
 
 CXPLAT_TLS_CALLBACKS QuicTlsCallbacks = {
     QuicTlsProcessDataCompleteCallback,
     QuicConnReceiveTP,
-    QuicConnRecvResumptionTicket
+    QuicConnRecvResumptionTicket,
+    QuicConnDeferredCertValidation
 };
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -74,12 +74,12 @@ typedef enum QUIC_EXECUTION_PROFILE {
     QUIC_EXECUTION_PROFILE_LOW_LATENCY,         // Default
     QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT,
     QUIC_EXECUTION_PROFILE_TYPE_SCAVENGER,
-    QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME
+    QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME,
 } QUIC_EXECUTION_PROFILE;
 
 typedef enum QUIC_LOAD_BALANCING_MODE {
     QUIC_LOAD_BALANCING_DISABLED,               // Default
-    QUIC_LOAD_BALANCING_SERVER_ID_IP            // Encodes IP address in Server ID
+    QUIC_LOAD_BALANCING_SERVER_ID_IP,           // Encodes IP address in Server ID
 } QUIC_LOAD_BALANCING_MODE;
 
 typedef enum QUIC_CREDENTIAL_TYPE {
@@ -87,7 +87,7 @@ typedef enum QUIC_CREDENTIAL_TYPE {
     QUIC_CREDENTIAL_TYPE_CERTIFICATE_HASH,
     QUIC_CREDENTIAL_TYPE_CERTIFICATE_HASH_STORE,
     QUIC_CREDENTIAL_TYPE_CERTIFICATE_CONTEXT,
-    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE
+    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE,
 } QUIC_CREDENTIAL_TYPE;
 
 typedef enum QUIC_CREDENTIAL_FLAGS {
@@ -103,14 +103,14 @@ DEFINE_ENUM_FLAG_OPERATORS(QUIC_CREDENTIAL_FLAGS);
 
 typedef enum QUIC_CERTIFICATE_HASH_STORE_FLAGS {
     QUIC_CERTIFICATE_HASH_STORE_FLAG_NONE           = 0x0000,
-    QUIC_CERTIFICATE_HASH_STORE_FLAG_MACHINE_STORE  = 0x0001
+    QUIC_CERTIFICATE_HASH_STORE_FLAG_MACHINE_STORE  = 0x0001,
 } QUIC_CERTIFICATE_HASH_STORE_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_CERTIFICATE_HASH_STORE_FLAGS);
 
 typedef enum QUIC_CONNECTION_SHUTDOWN_FLAGS {
     QUIC_CONNECTION_SHUTDOWN_FLAG_NONE      = 0x0000,
-    QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT    = 0x0001    // Don't send the close frame over the network.
+    QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT    = 0x0001,   // Don't send the close frame over the network.
 } QUIC_CONNECTION_SHUTDOWN_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_CONNECTION_SHUTDOWN_FLAGS);
@@ -118,12 +118,12 @@ DEFINE_ENUM_FLAG_OPERATORS(QUIC_CONNECTION_SHUTDOWN_FLAGS);
 typedef enum QUIC_SERVER_RESUMPTION_LEVEL {
     QUIC_SERVER_NO_RESUME,
     QUIC_SERVER_RESUME_ONLY,
-    QUIC_SERVER_RESUME_AND_ZERORTT
+    QUIC_SERVER_RESUME_AND_ZERORTT,
 } QUIC_SERVER_RESUMPTION_LEVEL;
 
 typedef enum QUIC_SEND_RESUMPTION_FLAGS {
     QUIC_SEND_RESUMPTION_FLAG_NONE          = 0x0000,
-    QUIC_SEND_RESUMPTION_FLAG_FINAL         = 0x0001    // Free TLS state after sending this ticket.
+    QUIC_SEND_RESUMPTION_FLAG_FINAL         = 0x0001,   // Free TLS state after sending this ticket.
 } QUIC_SEND_RESUMPTION_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_SEND_RESUMPTION_FLAGS);
@@ -131,13 +131,13 @@ DEFINE_ENUM_FLAG_OPERATORS(QUIC_SEND_RESUMPTION_FLAGS);
 typedef enum QUIC_STREAM_SCHEDULING_SCHEME {
     QUIC_STREAM_SCHEDULING_SCHEME_FIFO          = 0x0000,   // Sends stream data first come, first served. (Default)
     QUIC_STREAM_SCHEDULING_SCHEME_ROUND_ROBIN   = 0x0001,   // Sends stream data evenly multiplexed.
-    QUIC_STREAM_SCHEDULING_SCHEME_COUNT                     // The number of stream scheduling schemes.
+    QUIC_STREAM_SCHEDULING_SCHEME_COUNT,                    // The number of stream scheduling schemes.
 } QUIC_STREAM_SCHEDULING_SCHEME;
 
 typedef enum QUIC_STREAM_OPEN_FLAGS {
     QUIC_STREAM_OPEN_FLAG_NONE              = 0x0000,
     QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL    = 0x0001,   // Indicates the stream is unidirectional.
-    QUIC_STREAM_OPEN_FLAG_0_RTT             = 0x0002    // The stream was opened via a 0-RTT packet.
+    QUIC_STREAM_OPEN_FLAG_0_RTT             = 0x0002,   // The stream was opened via a 0-RTT packet.
 } QUIC_STREAM_OPEN_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_OPEN_FLAGS);
@@ -146,7 +146,7 @@ typedef enum QUIC_STREAM_START_FLAGS {
     QUIC_STREAM_START_FLAG_NONE             = 0x0000,
     QUIC_STREAM_START_FLAG_FAIL_BLOCKED     = 0x0001,   // Only opens the stream if flow control allows.
     QUIC_STREAM_START_FLAG_IMMEDIATE        = 0x0002,   // Immediately informs peer that stream is open.
-    QUIC_STREAM_START_FLAG_ASYNC            = 0x0004    // Don't block the API call to wait for completion.
+    QUIC_STREAM_START_FLAG_ASYNC            = 0x0004,   // Don't block the API call to wait for completion.
 } QUIC_STREAM_START_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_START_FLAGS);
@@ -157,7 +157,7 @@ typedef enum QUIC_STREAM_SHUTDOWN_FLAGS {
     QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND    = 0x0002,   // Abruptly closes the send path.
     QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE = 0x0004,   // Abruptly closes the receive path.
     QUIC_STREAM_SHUTDOWN_FLAG_ABORT         = 0x0006,   // Abruptly closes both send and receive paths.
-    QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE     = 0x0008    // Immediately sends completion events to app.
+    QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE     = 0x0008,   // Immediately sends completion events to app.
 } QUIC_STREAM_SHUTDOWN_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_SHUTDOWN_FLAGS);
@@ -165,7 +165,7 @@ DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_SHUTDOWN_FLAGS);
 typedef enum QUIC_RECEIVE_FLAGS {
     QUIC_RECEIVE_FLAG_NONE                  = 0x0000,
     QUIC_RECEIVE_FLAG_0_RTT                 = 0x0001,   // Data was encrypted with 0-RTT key.
-    QUIC_RECEIVE_FLAG_FIN                   = 0x0002    // FIN was included with this data.
+    QUIC_RECEIVE_FLAG_FIN                   = 0x0002,   // FIN was included with this data.
 } QUIC_RECEIVE_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_RECEIVE_FLAGS);
@@ -175,7 +175,7 @@ typedef enum QUIC_SEND_FLAGS {
     QUIC_SEND_FLAG_ALLOW_0_RTT              = 0x0001,   // Allows the use of encrypting with 0-RTT key.
     QUIC_SEND_FLAG_START                    = 0x0002,   // Asynchronously starts the stream with the sent data.
     QUIC_SEND_FLAG_FIN                      = 0x0004,   // Indicates the request is the one last sent on the stream.
-    QUIC_SEND_FLAG_DGRAM_PRIORITY           = 0x0008    // Indicates the datagram is higher priority than others.
+    QUIC_SEND_FLAG_DGRAM_PRIORITY           = 0x0008,   // Indicates the datagram is higher priority than others.
 } QUIC_SEND_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_SEND_FLAGS);
@@ -186,7 +186,7 @@ typedef enum QUIC_DATAGRAM_SEND_STATE {
     QUIC_DATAGRAM_SEND_LOST_DISCARDED,                  // Lost and not longer being tracked
     QUIC_DATAGRAM_SEND_ACKNOWLEDGED,                    // Acknowledged
     QUIC_DATAGRAM_SEND_ACKNOWLEDGED_SPURIOUS,           // Acknowledged after being suspected lost
-    QUIC_DATAGRAM_SEND_CANCELED                         // Canceled before send
+    QUIC_DATAGRAM_SEND_CANCELED,                        // Canceled before send
 } QUIC_DATAGRAM_SEND_STATE;
 
 //
@@ -363,7 +363,7 @@ typedef enum QUIC_PERFORMANCE_COUNTERS {
     QUIC_PERF_COUNTER_WORK_OPER_QUEUE_DEPTH,// Current worker operations queued.
     QUIC_PERF_COUNTER_WORK_OPER_QUEUED,     // Total worker operations queued ever.
     QUIC_PERF_COUNTER_WORK_OPER_COMPLETED,  // Total worker operations processed ever.
-    QUIC_PERF_COUNTER_MAX
+    QUIC_PERF_COUNTER_MAX,
 } QUIC_PERFORMANCE_COUNTERS;
 
 typedef struct QUIC_SETTINGS {
@@ -474,7 +474,7 @@ typedef enum QUIC_PARAM_LEVEL {
     QUIC_PARAM_LEVEL_LISTENER,
     QUIC_PARAM_LEVEL_CONNECTION,
     QUIC_PARAM_LEVEL_TLS,
-    QUIC_PARAM_LEVEL_STREAM
+    QUIC_PARAM_LEVEL_STREAM,
 } QUIC_PARAM_LEVEL;
 
 //
@@ -664,7 +664,7 @@ QUIC_STATUS
 //
 
 typedef enum QUIC_LISTENER_EVENT_TYPE {
-    QUIC_LISTENER_EVENT_NEW_CONNECTION      = 0
+    QUIC_LISTENER_EVENT_NEW_CONNECTION      = 0,
 } QUIC_LISTENER_EVENT_TYPE;
 
 typedef struct QUIC_LISTENER_EVENT {
@@ -934,7 +934,7 @@ typedef enum QUIC_STREAM_EVENT_TYPE {
     QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED      = 5,
     QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE    = 6,
     QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE         = 7,
-    QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE    = 8
+    QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE    = 8,
 } QUIC_STREAM_EVENT_TYPE;
 
 typedef struct QUIC_STREAM_EVENT {

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -91,11 +91,12 @@ typedef enum QUIC_CREDENTIAL_TYPE {
 } QUIC_CREDENTIAL_TYPE;
 
 typedef enum QUIC_CREDENTIAL_FLAGS {
-    QUIC_CREDENTIAL_FLAG_NONE                       = 0x00000000,
-    QUIC_CREDENTIAL_FLAG_CLIENT                     = 0x00000001, // Lack of client flag indicates server.
-    QUIC_CREDENTIAL_FLAG_LOAD_ASYNCHRONOUS          = 0x00000002,
-    QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION  = 0x00000004,
-    QUIC_CREDENTIAL_FLAG_ENABLE_OCSP                = 0x00000008
+    QUIC_CREDENTIAL_FLAG_NONE                           = 0x00000000,
+    QUIC_CREDENTIAL_FLAG_CLIENT                         = 0x00000001, // Lack of client flag indicates server.
+    QUIC_CREDENTIAL_FLAG_LOAD_ASYNCHRONOUS              = 0x00000002,
+    QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION      = 0x00000004,
+    QUIC_CREDENTIAL_FLAG_ENABLE_OCSP                    = 0x00000008, // Schannel only currently
+    QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION   = 0x00000010, // Schannel only currently
 } QUIC_CREDENTIAL_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_CREDENTIAL_FLAGS);
@@ -757,7 +758,8 @@ typedef enum QUIC_CONNECTION_EVENT_TYPE {
     QUIC_CONNECTION_EVENT_DATAGRAM_RECEIVED                 = 11,
     QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED       = 12,
     QUIC_CONNECTION_EVENT_RESUMED                           = 13,   // Server-only; provides resumption data, if any.
-    QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED        = 14    // Client-only; provides ticket to persist, if any.
+    QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED        = 14,   // Client-only; provides ticket to persist, if any.
+    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION       = 15,   // Only with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION set
 } QUIC_CONNECTION_EVENT_TYPE;
 
 typedef struct QUIC_CONNECTION_EVENT {
@@ -817,6 +819,10 @@ typedef struct QUIC_CONNECTION_EVENT {
             uint32_t ResumptionTicketLength;
             const uint8_t* ResumptionTicket;
         } RESUMPTION_TICKET_RECEIVED;
+        struct {
+            uint32_t ErrorFlags;                // Bit flag of errors
+            QUIC_STATUS Status;                 // Most severe error status
+        } PEER_CERTIFICATE_VALIDATION;
     };
 } QUIC_CONNECTION_EVENT;
 

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -77,6 +77,19 @@ BOOLEAN
 
 typedef CXPLAT_TLS_RECEIVE_TICKET_CALLBACK *CXPLAT_TLS_RECEIVE_TICKET_CALLBACK_HANDLER;
 
+//
+// Callback for indicating the result of deferred certificate validation.
+typedef
+_IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+(CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK)(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint32_t ErrorFlags,
+    _In_ QUIC_STATUS Status
+    );
+
+typedef CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK *CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK_HANDLER;
+
 typedef struct CXPLAT_TLS_CALLBACKS {
 
     //
@@ -93,6 +106,12 @@ typedef struct CXPLAT_TLS_CALLBACKS {
     // Invoked when a resumption ticket is received.
     //
     CXPLAT_TLS_RECEIVE_TICKET_CALLBACK_HANDLER ReceiveTicket;
+
+    //
+    // Invoked only in the deferred certificate validation scenario, with the
+    // results.
+    //
+    CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK_HANDLER DeferredCertValidation;
 
 } CXPLAT_TLS_CALLBACKS;
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1006,6 +1006,26 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
+    "IndicatePeerCertificateValidation": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION (0x%x, 0x%x)",
+      "UniqueId": "IndicatePeerCertificateValidation",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
     "QueueDatagrams": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Queuing %u UDP datagrams",
@@ -10214,6 +10234,10 @@
       {
         "UniquenessHash": "920800a1-3a54-af40-19d9-fdfaf274a6d4",
         "TraceID": "IndicateResumptionTicketReceived"
+      },
+      {
+        "UniquenessHash": "8105e9a0-04b4-e941-7052-170d8a7ec108",
+        "TraceID": "IndicatePeerCertificateValidation"
       },
       {
         "UniquenessHash": "18ef147d-5376-d7f2-f624-3b27af96dd05",

--- a/src/platform/tls_mitls.c
+++ b/src/platform/tls_mitls.c
@@ -400,7 +400,8 @@ CxPlatTlsSecConfigCreate(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP) {
+    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP ||
+        CredConfig->Flags & QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION) {
         return QUIC_STATUS_NOT_SUPPORTED; // Not supported by this TLS implementation
     }
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -521,7 +521,8 @@ CxPlatTlsSecConfigCreate(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP) {
+    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP ||
+        CredConfig->Flags & QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION) {
         return QUIC_STATUS_NOT_SUPPORTED; // Not supported by this TLS implementation
     }
 

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -290,7 +290,8 @@ CxPlatTlsSecConfigCreate(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP) {
+    if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_ENABLE_OCSP ||
+        CredConfig->Flags & QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION) {
         return QUIC_STATUS_NOT_SUPPORTED; // Not supported by this TLS implementation
     }
 

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -15,7 +15,9 @@
 #include "TlsTest.cpp.clog.h"
 #endif
 
+#ifdef _WIN32
 const uint16_t BadCertError = 42;
+#endif
 const uint16_t UnknownCaError = 48;
 
 const uint32_t DefaultFragmentSize = 1200;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -872,8 +872,12 @@ TEST_F(TlsTest, DeferredCertificateValidationAllow)
     TlsContext ServerContext, ClientContext;
     ServerContext.InitializeServer(ServerSecConfig);
     ClientContext.InitializeClient(ClientSecConfigDeferredCertValidation);
+#ifdef _WIN32
     ClientContext.ExpectedErrorFlags = CERT_TRUST_IS_UNTRUSTED_ROOT;
     ClientContext.ExpectedValidationStatus = CERT_E_UNTRUSTEDROOT;
+#else
+    // TODO - Add platform specific values if support is added.
+#endif
     {
         auto Result = ClientContext.ProcessData(nullptr);
         ASSERT_TRUE(Result & CXPLAT_TLS_RESULT_DATA);


### PR DESCRIPTION
Exposes the Schannel TLS feature to do "deferred certificate validation" and exposes those results to the app.