### PR TITLE
Remove use of POOL_FLAG_UNINITIALIZED from non lookaside list allocations

### DIFF
--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -264,8 +264,8 @@ CxPlatLogAssert(
 
 extern uint64_t CxPlatTotalMemory;
 
-#define CXPLAT_ALLOC_PAGED(Size, Tag) ExAllocatePool2(POOL_FLAG_PAGED | POOL_FLAG_UNINITIALIZED, Size, Tag)
-#define CXPLAT_ALLOC_NONPAGED(Size, Tag) ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, Size, Tag)
+#define CXPLAT_ALLOC_PAGED(Size, Tag) ExAllocatePool2(POOL_FLAG_PAGED, Size, Tag)
+#define CXPLAT_ALLOC_NONPAGED(Size, Tag) ExAllocatePool2(POOL_FLAG_NON_PAGED, Size, Tag)
 #define CXPLAT_FREE(Mem, Tag) ExFreePoolWithTag((void*)Mem, Tag)
 
 typedef LOOKASIDE_LIST_EX CXPLAT_POOL;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2532,7 +2532,7 @@ CxPlatSendBufferPoolAlloc(
     //
     // ExAllocatePool2 requires a different set of flags, so the assert above must keep the pool sane.
     //
-    SendBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, NumberOfBytes, Tag);
+    SendBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, NumberOfBytes, Tag);
     if (SendBuffer == NULL) {
         return NULL;
     }

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2532,7 +2532,7 @@ CxPlatSendBufferPoolAlloc(
     //
     // ExAllocatePool2 requires a different set of flags, so the assert above must keep the pool sane.
     //
-    SendBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, NumberOfBytes, Tag);
+    SendBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, NumberOfBytes, Tag);
     if (SendBuffer == NULL) {
         return NULL;
     }


### PR DESCRIPTION
This parameter has a high bar to allow being used, and the recommendation is to not use it. In the lookaside list function, it's ok since those are reused anyway, but for generic allocations keep everything the way it is.

For now, this will keep any explicit zeroing as well. This doesn't seem to result in any performance regressions, but is something we can look at.

Closes #1194 