### PR TITLE
Remove unused submodules from kernel build

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -85,6 +85,11 @@ if ($InitSubmodules) {
         git submodule update
     }
 
+    if ($Kernel) {
+        git submodule init submodules/openssl
+        git submodule init submodules/everest
+    }
+
     if (!$Extra.Contains("-DisableTest")) {
         Write-Host "Initializing googletest submodule"
         git submodule init submodules/googletest

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -86,8 +86,8 @@ if ($InitSubmodules) {
     }
 
     if ($Kernel) {
-        git submodule init submodules/openssl
-        git submodule init submodules/everest
+        git init submodules/openssl
+        git init submodules/everest
     }
 
     if (!$Extra.Contains("-DisableTest")) {

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -86,8 +86,9 @@ if ($InitSubmodules) {
     }
 
     if ($Kernel) {
-        git init submodules/openssl
-        git init submodules/everest
+        # Remove OpenSSL and Everest
+        git rm submodules/everest
+        git rm submodules/openssl
     }
 
     if (!$Extra.Contains("-DisableTest")) {


### PR DESCRIPTION
MSBuild spits out a bunch of warnings when submodules are missing. By removing submodules, this issue is avoided.