### PR TITLE
Fix missing field initializer in TlsTest

### DIFF
--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -95,6 +95,7 @@ protected:
             QUIC_CREDENTIAL_TYPE_NONE,
             QUIC_CREDENTIAL_FLAG_CLIENT,
             NULL,
+            NULL,
             NULL
         };
         VERIFY_QUIC_SUCCESS(

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -96,6 +96,7 @@ protected:
             QUIC_CREDENTIAL_FLAG_CLIENT,
             NULL,
             NULL,
+            NULL,
             NULL
         };
         VERIFY_QUIC_SUCCESS(


### PR DESCRIPTION
There are 6 fields, but only 4 initializers, which means TicketKey and AsyncHandler were never initialized.