### PR TITLE
Refactor Certificate Received Code Paths

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -412,7 +412,7 @@ stages:
       image: ubuntu-latest
       platform: linux
       tls: stub
-      extraArgs: -Filter -*TlsTest.CertificateError:*.Tcp*
+      extraArgs: -Filter -*TlsTest.CertificateError:TlsTest.ExtraCertificateValidation:*.Tcp*
 
 #
 # SpinQuic Tests

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2555,37 +2555,24 @@ Error:
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
-QuicConnDeferredCertValidation(
-    _In_ QUIC_CONNECTION* Connection,
-    _In_ uint32_t ErrorFlags,
-    _In_ QUIC_STATUS Status
-    )
-{
-    QUIC_CONNECTION_EVENT Event;
-    Event.Type = QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION;
-    Event.PEER_CERTIFICATE_VALIDATION.ErrorFlags = ErrorFlags;
-    Event.PEER_CERTIFICATE_VALIDATION.Status = Status;
-    QuicTraceLogConnVerbose(
-        IndicatePeerCertificateValidation,
-        Connection,
-        "Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION (0x%x, 0x%x)",
-        ErrorFlags,
-        Status);
-    return QUIC_SUCCEEDED(QuicConnIndicateEvent(Connection, &Event));
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
 QuicConnPeerCertReceived(
-    _In_ QUIC_CONNECTION* Connection
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ void* Certificate,
+    _In_ uint32_t DeferredErrorFlags,
+    _In_ QUIC_STATUS DeferredStatus
     )
 {
     QUIC_CONNECTION_EVENT Event;
     Event.Type = QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED;
+    Event.PEER_CERTIFICATE_RECEIVED.Certificate = Certificate;
+    Event.PEER_CERTIFICATE_RECEIVED.DeferredErrorFlags = DeferredErrorFlags;
+    Event.PEER_CERTIFICATE_RECEIVED.DeferredStatus = DeferredStatus;
     QuicTraceLogConnVerbose(
         IndicatePeerCertificateReceived,
         Connection,
-        "Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED");
+        "Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED (0x%x, 0x%x)",
+        DeferredErrorFlags,
+        DeferredStatus);
     QUIC_STATUS Status = QuicConnIndicateEvent(Connection, &Event);
     if (QUIC_FAILED(Status)) {
         QuicTraceEvent(

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -26,14 +26,12 @@ Abstract:
 CXPLAT_TLS_PROCESS_COMPLETE_CALLBACK QuicTlsProcessDataCompleteCallback;
 CXPLAT_TLS_RECEIVE_TP_CALLBACK QuicConnReceiveTP;
 CXPLAT_TLS_RECEIVE_TICKET_CALLBACK QuicConnRecvResumptionTicket;
-CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK QuicConnDeferredCertValidation;
 CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK QuicConnPeerCertReceived;
 
 CXPLAT_TLS_CALLBACKS QuicTlsCallbacks = {
     QuicTlsProcessDataCompleteCallback,
     QuicConnReceiveTP,
     QuicConnRecvResumptionTicket,
-    QuicConnDeferredCertValidation,
     QuicConnPeerCertReceived
 };
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -96,8 +96,8 @@ typedef enum QUIC_CREDENTIAL_FLAGS {
     QUIC_CREDENTIAL_FLAG_LOAD_ASYNCHRONOUS              = 0x00000002,
     QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION      = 0x00000004,
     QUIC_CREDENTIAL_FLAG_ENABLE_OCSP                    = 0x00000008, // Schannel only currently
-    QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION   = 0x00000010, // Schannel only currently
-    QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION  = 0x00000020,
+    QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED  = 0x00000010,
+    QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION   = 0x00000020, // Schannel only currently
 } QUIC_CREDENTIAL_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_CREDENTIAL_FLAGS);
@@ -761,8 +761,7 @@ typedef enum QUIC_CONNECTION_EVENT_TYPE {
     QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED       = 12,
     QUIC_CONNECTION_EVENT_RESUMED                           = 13,   // Server-only; provides resumption data, if any.
     QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED        = 14,   // Client-only; provides ticket to persist, if any.
-    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION       = 15,   // Only with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION set
-    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 16,   // Only with QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION set
+    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 15,   // Only with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION|QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION set
 } QUIC_CONNECTION_EVENT_TYPE;
 
 typedef struct QUIC_CONNECTION_EVENT {
@@ -823,11 +822,9 @@ typedef struct QUIC_CONNECTION_EVENT {
             const uint8_t* ResumptionTicket;
         } RESUMPTION_TICKET_RECEIVED;
         struct {
-            uint32_t ErrorFlags;                // Bit flag of errors
-            QUIC_STATUS Status;                 // Most severe error status
-        } PEER_CERTIFICATE_VALIDATION;
-        struct {
-            void* Reserved;                     // TODO - Expose certificate
+            void* Certificate;                  // Peer certificate (only valid with QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION)
+            uint32_t DeferredErrorFlags;        // Bit flag of errors (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)
+            QUIC_STATUS DeferredStatus;         // Most severe error status (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)
         } PEER_CERTIFICATE_RECEIVED;
     };
 } QUIC_CONNECTION_EVENT;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -761,7 +761,7 @@ typedef enum QUIC_CONNECTION_EVENT_TYPE {
     QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED       = 12,
     QUIC_CONNECTION_EVENT_RESUMED                           = 13,   // Server-only; provides resumption data, if any.
     QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED        = 14,   // Client-only; provides ticket to persist, if any.
-    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 15,   // Only with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION|QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION set
+    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 15,   // Only with QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED set
 } QUIC_CONNECTION_EVENT_TYPE;
 
 typedef struct QUIC_CONNECTION_EVENT {
@@ -822,7 +822,7 @@ typedef struct QUIC_CONNECTION_EVENT {
             const uint8_t* ResumptionTicket;
         } RESUMPTION_TICKET_RECEIVED;
         struct {
-            void* Certificate;                  // Peer certificate (only valid with QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION)
+            void* Certificate;                  // Peer certificate (platform specific)
             uint32_t DeferredErrorFlags;        // Bit flag of errors (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)
             QUIC_STATUS DeferredStatus;         // Most severe error status (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)
         } PEER_CERTIFICATE_RECEIVED;

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -89,28 +89,16 @@ BOOLEAN
 typedef CXPLAT_TLS_RECEIVE_TICKET_CALLBACK *CXPLAT_TLS_RECEIVE_TICKET_CALLBACK_HANDLER;
 
 //
-// Callback for indicating the result of deferred certificate validation.
-//
-typedef
-_IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
-(CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK)(
-    _In_ QUIC_CONNECTION* Connection,
-    _In_ uint32_t ErrorFlags,
-    _In_ QUIC_STATUS Status
-    );
-
-typedef CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK *CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK_HANDLER;
-
-//
 // Callback for indicating the peer certificate is ready for custom validation.
 //
 typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 (CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK)(
-    _In_ QUIC_CONNECTION* Connection
-    // TODO - Expose certificate details as well
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ void* Certificate,
+    _In_ uint32_t DeferredErrorFlags,
+    _In_ QUIC_STATUS DeferredStatus
     );
 
 typedef CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK *CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK_HANDLER;
@@ -131,12 +119,6 @@ typedef struct CXPLAT_TLS_CALLBACKS {
     // Invoked when a resumption ticket is received.
     //
     CXPLAT_TLS_RECEIVE_TICKET_CALLBACK_HANDLER ReceiveTicket;
-
-    //
-    // Invoked only in the deferred certificate validation scenario, with the
-    // results.
-    //
-    CXPLAT_TLS_DEFERRED_CERTIFICATE_VALIDATION_CALLBACK_HANDLER DeferredCertValidation;
 
     //
     // Invokved only in the custom certificate validation scenario, when the

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1018,10 +1018,10 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
-    "IndicatePeerCertificateValidation": {
+    "IndicatePeerCertificateReceived": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_VALIDATION (0x%x, 0x%x)",
-      "UniqueId": "IndicatePeerCertificateValidation",
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED (0x%x, 0x%x)",
+      "UniqueId": "IndicatePeerCertificateReceived",
       "splitArgs": [
         {
           "DefinationEncoding": "p",
@@ -1034,18 +1034,6 @@
         {
           "DefinationEncoding": "x",
           "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
-    "IndicatePeerCertificateReceived": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED",
-      "UniqueId": "IndicatePeerCertificateReceived",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
@@ -10276,11 +10264,7 @@
         "TraceID": "IndicateResumptionTicketReceived"
       },
       {
-        "UniquenessHash": "8105e9a0-04b4-e941-7052-170d8a7ec108",
-        "TraceID": "IndicatePeerCertificateValidation"
-      },
-      {
-        "UniquenessHash": "cb2eb64a-f957-6a29-5b6e-35ec67c01884",
+        "UniquenessHash": "506a0bfb-88c2-6ef1-149b-8c6e2d9dd836",
         "TraceID": "IndicatePeerCertificateReceived"
       },
       {

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -51,6 +51,11 @@ typedef struct CXPLAT_SEC_CONFIG {
     //
     CXPLAT_TLS_CALLBACKS Callbacks;
 
+    //
+    // The application supplied credential flags.
+    //
+    QUIC_CREDENTIAL_FLAGS Flags;
+
 } CXPLAT_SEC_CONFIG;
 
 //
@@ -200,21 +205,34 @@ CxPlatTlsAlpnSelectCallback(
 static
 int
 CxPlatTlsCertificateVerifyCallback(
-    X509_STORE_CTX* x509_ctx,
-    void* app_ctx
+    int preverify_ok,
+    X509_STORE_CTX *x509_ctx
     )
 {
     SSL *Ssl = X509_STORE_CTX_get_ex_data(x509_ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
     CXPLAT_TLS* TlsContext = SSL_get_app_data(Ssl);
-    UNREFERENCED_PARAMETER(app_ctx);
 
-    if (!TlsContext->SecConfig->Callbacks.CertificateReceived(
-            TlsContext->Connection)) {
+    if (!(TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION) &&
+        !preverify_ok) {
         QuicTraceEvent(
             TlsError,
             "[ tls][%p] ERROR, %s.",
             TlsContext->Connection,
-            "Custom certificate validation failed");
+            "Internal certificate validation failed");
+        return FALSE;
+    }
+
+    if ((TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) &&
+        !TlsContext->SecConfig->Callbacks.CertificateReceived(
+            TlsContext->Connection,
+            NULL,
+            0,
+            0)) {
+        QuicTraceEvent(
+            TlsError,
+            "[ tls][%p] ERROR, %s.",
+            TlsContext->Connection,
+            "Indicate certificate received failed");
         X509_STORE_CTX_set_error(x509_ctx, X509_V_ERR_CERT_REJECTED);
         return FALSE;
     }
@@ -601,6 +619,7 @@ CxPlatTlsSecConfigCreate(
     }
 
     SecurityConfig->Callbacks = *TlsCallbacks;
+    SecurityConfig->Flags = CredConfig->Flags;
 
     //
     // Create the a SSL context for the security config.
@@ -694,22 +713,14 @@ CxPlatTlsSecConfigCreate(
     }
 
     if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_CLIENT) {
-        if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION) {
-            SSL_CTX_set_verify(SecurityConfig->SSLCtx, SSL_VERIFY_NONE, NULL);
+        SSL_CTX_set_verify(SecurityConfig->SSLCtx, SSL_VERIFY_PEER, CxPlatTlsCertificateVerifyCallback);
+        SSL_CTX_set_verify_depth(SecurityConfig->SSLCtx, CXPLAT_TLS_DEFAULT_VERIFY_DEPTH);
 
-        } else if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION) {
-            SSL_CTX_set_verify(SecurityConfig->SSLCtx, SSL_VERIFY_PEER, NULL);
-            SSL_CTX_set_cert_verify_callback(SecurityConfig->SSLCtx, CxPlatTlsCertificateVerifyCallback, NULL);
+        //
+        // TODO - Support additional certificate validation parameters, such as
+        // the location of the trusted root CAs (SSL_CTX_load_verify_locations)?
+        //
 
-        } else {
-            SSL_CTX_set_verify(SecurityConfig->SSLCtx, SSL_VERIFY_PEER, NULL);
-            SSL_CTX_set_verify_depth(SecurityConfig->SSLCtx, CXPLAT_TLS_DEFAULT_VERIFY_DEPTH);
-
-            //
-            // TODO - Support additional certificate validation parameters, such as
-            // the location of the trusted root CAs (SSL_CTX_load_verify_locations)?
-            //
-        }
     } else {
         SSL_CTX_set_options(
             SecurityConfig->SSLCtx,

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -225,7 +225,7 @@ CxPlatTlsCertificateVerifyCallback(
     if ((TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) &&
         !TlsContext->SecConfig->Callbacks.CertificateReceived(
             TlsContext->Connection,
-            NULL,
+            x509_ctx,
             0,
             0)) {
         QuicTraceEvent(

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -926,33 +926,34 @@ CxPlatTlsClientProcess(
                     break;
                 }
 
-                if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION) {
-                    if (!TlsContext->SecConfig->Callbacks.CertificateReceived(
-                            TlsContext->Connection)) {
-                        QuicTraceEvent(
-                            TlsError,
-                            "[ tls][%p] ERROR, %s.",
-                            TlsContext->Connection,
-                            "Custom certificate validation failed");
-                        *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
-                        State->AlertCode = 42; // bad_certificate
-                        break;
-                    }
+                if (!CxPlatCertValidateChain(
+                        ServerCert,
+                        TlsContext->SNI,
+                        0)) {
+                    QuicTraceEvent(
+                        TlsError,
+                        "[ tls][%p] ERROR, %s.",
+                        TlsContext->Connection,
+                        "CxPlatCertValidateChain Mismatch");
+                    *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
+                    break;
+                }
+            }
 
-                } else {
-
-                    if (!CxPlatCertValidateChain(
-                            ServerCert,
-                            TlsContext->SNI,
-                            TlsContext->SecConfig->Flags)) {
-                        QuicTraceEvent(
-                            TlsError,
-                            "[ tls][%p] ERROR, %s.",
-                            TlsContext->Connection,
-                            "CxPlatCertValidateChain Mismatch");
-                        *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
-                        break;
-                    }
+            if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) {
+                if (!TlsContext->SecConfig->Callbacks.CertificateReceived(
+                        TlsContext->Connection,
+                        NULL,
+                        0,
+                        0)) {
+                    QuicTraceEvent(
+                        TlsError,
+                        "[ tls][%p] ERROR, %s.",
+                        TlsContext->Connection,
+                        "Indicate certificate received failed");
+                    *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
+                    State->AlertCode = CXPLAT_TLS_ALERT_CODE_BAD_CERTIFICATE;
+                    break;
                 }
             }
 

--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -940,21 +940,20 @@ CxPlatTlsClientProcess(
                 }
             }
 
-            if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) {
-                if (!TlsContext->SecConfig->Callbacks.CertificateReceived(
-                        TlsContext->Connection,
-                        NULL,
-                        0,
-                        0)) {
-                    QuicTraceEvent(
-                        TlsError,
-                        "[ tls][%p] ERROR, %s.",
-                        TlsContext->Connection,
-                        "Indicate certificate received failed");
-                    *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
-                    State->AlertCode = CXPLAT_TLS_ALERT_CODE_BAD_CERTIFICATE;
-                    break;
-                }
+            if ((TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) &&
+                !TlsContext->SecConfig->Callbacks.CertificateReceived(
+                    TlsContext->Connection,
+                    NULL,
+                    0,
+                    0)) {
+                QuicTraceEvent(
+                    TlsError,
+                    "[ tls][%p] ERROR, %s.",
+                    TlsContext->Connection,
+                    "Indicate certificate received failed");
+                *ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
+                State->AlertCode = CXPLAT_TLS_ALERT_CODE_BAD_CERTIFICATE;
+                break;
             }
 
             State->HandshakeComplete = TRUE;

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -744,7 +744,7 @@ QuicTestCustomCertificateValidation(
     MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, SelfSignedCredConfig);
     TEST_TRUE(ServerConfiguration.IsValid());
 
-    MsQuicCredentialConfig ClientCredConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_CUSTOM_CERTIFICATE_VALIDATION);
+    MsQuicCredentialConfig ClientCredConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION | QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED);
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 


### PR DESCRIPTION
Now MsQuic only has one event that can be used by the app for multiple purposes. The new flags were slightly refactored as well.

Fixes #1063.