### PR TITLE
RPS Latency Test Case

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -46,7 +46,6 @@ parameters:
   - ThroughputUp
   - ThroughputDown
   - RPS
-  - RPSLatency
   - HPS
 - name: testTypes
   type: string

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -46,6 +46,7 @@ parameters:
   - ThroughputUp
   - ThroughputDown
   - RPS
+  - RPSLatency
   - HPS
 - name: testTypes
   type: string

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -138,6 +138,7 @@
                 {
                     "Name": "ConnectionCount",
                     "Local": {
+                        "40": "-conns:40 -requests:20",
                         "250": "-conns:250 -requests:7500"
                     },
                     "Default": "250"
@@ -156,45 +157,6 @@
                         "512": "-response:512",
                         "4096": "-response:4096",
                         "16384": "-response:16384"
-                    },
-                    "Default": "4096"
-                }
-            ],
-            "AllowLoopback": false,
-            "Iterations": 5,
-            "RemoteReadyMatcher": "Started!",
-            "ResultsMatcher": "Result: (.*) RPS, Min: (.*), Max: (.*), 50th: (.*), 90th: (.*), 99th: (.*), 99.9th: (.*), 99.99th: (.*), 99.999th: (.*), 99.9999th: (.*), StdErr: (.*)",
-            "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"],
-            "RegressionThreshold": "-50.0"
-        },
-        {
-            "TestName": "RPSLatency",
-            "Local": {
-                "Platform": "Windows",
-                "Tls": ["stub", "schannel", "openssl", "mitls"],
-                "Arch": ["x64", "x86", "arm", "arm64"],
-                "Exe": "quicperf",
-                "Arguments": "-test:RPS -target:$RemoteAddress"
-            },
-            "Variables": [
-                {
-                    "Name": "ConnectionCount",
-                    "Local": {
-                        "40": "-conns:40 -requests:20"
-                    },
-                    "Default": "40"
-                },
-                {
-                    "Name": "RequestSize",
-                    "Local": {
-                        "0": "-request:0"
-                    },
-                    "Default": "0"
-                },
-                {
-                    "Name": "ResponseSize",
-                    "Local": {
-                        "4096": "-response:4096"
                     },
                     "Default": "4096"
                 }

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -168,6 +168,45 @@
             "RegressionThreshold": "-50.0"
         },
         {
+            "TestName": "RPSLatency",
+            "Local": {
+                "Platform": "Windows",
+                "Tls": ["stub", "schannel", "openssl", "mitls"],
+                "Arch": ["x64", "x86", "arm", "arm64"],
+                "Exe": "quicperf",
+                "Arguments": "-test:RPS -target:$RemoteAddress"
+            },
+            "Variables": [
+                {
+                    "Name": "ConnectionCount",
+                    "Local": {
+                        "40": "-conns:40 -requests:20"
+                    },
+                    "Default": "40"
+                },
+                {
+                    "Name": "RequestSize",
+                    "Local": {
+                        "0": "-request:0"
+                    },
+                    "Default": "0"
+                },
+                {
+                    "Name": "ResponseSize",
+                    "Local": {
+                        "4096": "-response:4096"
+                    },
+                    "Default": "4096"
+                }
+            ],
+            "AllowLoopback": false,
+            "Iterations": 5,
+            "RemoteReadyMatcher": "Started!",
+            "ResultsMatcher": "Result: (.*) RPS, Min: (.*), Max: (.*), 50th: (.*), 90th: (.*), 99th: (.*), 99.9th: (.*), 99.99th: (.*), 99.999th: (.*), 99.9999th: (.*), StdErr: (.*)",
+            "Formats": ["{0} RPS", "Minimum: {0}", "Maximum: {0}", "Percentiles: 50th: {0}", "90th: {0}", "99th: {0}", "99.9th: {0}", "99.99th: {0}", "99.999th: {0}", "99.9999th: {0}", "Standard Error: {0}"],
+            "RegressionThreshold": "-50.0"
+        },
+        {
             "TestName": "HPS",
             "Local": {
                 "Platform": "Windows",


### PR DESCRIPTION
Adds a new perf test that uses few connections and parallel requests (that should not max out CPU) in an attempt to calculate reasonable latency numbers.