### PR TITLE
Periodically Snap-shot Performance Counters

### DIFF
--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -175,6 +175,12 @@ QuicPerfCounterAdd(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
+QuicPerfCounterTrySnapShot(
+    void
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
 QuicStreamAddRef(
     _In_ QUIC_STREAM* Stream,
     _In_ QUIC_STREAM_REF Ref

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -176,7 +176,7 @@ QuicPerfCounterAdd(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPerfCounterTrySnapShot(
-    void
+    _In_ uint64_t TimeNow
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -134,6 +134,8 @@ QuicPerfCounterSnapShot(
     _In_ uint64_t TimeDiffUs
     )
 {
+    UNREFERENCED_PARAMETER(TimeDiffUs); // Only used in asserts below.
+
     int64_t PerfCounterSamples[QUIC_PERF_COUNTER_MAX];
     QuicLibrarySumPerfCounters(
         (uint8_t*)PerfCounterSamples,

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -239,6 +239,7 @@ MsQuicLibraryInitialize(
 
     CXPLAT_DBG_ASSERT(US_TO_MS(CxPlatGetTimerResolution()) + 1 <= UINT8_MAX);
     MsQuicLib.TimerResolutionMs = (uint8_t)US_TO_MS(CxPlatGetTimerResolution()) + 1;
+    MsQuicLib.PerfCounterSamplesTime = CxPlatTimeUs64();
 
     CxPlatRandom(sizeof(MsQuicLib.ToeplitzHash.HashKey), MsQuicLib.ToeplitzHash.HashKey);
     CxPlatToeplitzHashInitialize(&MsQuicLib.ToeplitzHash);

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -155,7 +155,7 @@ QuicPerfCounterSnapShot(
     // values should be configurable dynamically, somehow.
     //
     QUIC_COUNTER_LIMIT_HZ(QUIC_PERF_COUNTER_CONN_HANDSHAKE_FAIL, 1000000); // Don't have 1 million failed handshakes per second
-    QUIC_COUNTER_CAP(QUIC_PERF_COUNTER_WORK_OPER_QUEUE_DEPTH, 1000); // Don't maintain huge queue depths
+    QUIC_COUNTER_CAP(QUIC_PERF_COUNTER_CONN_QUEUE_DEPTH, 100000); // Don't maintain huge queue depths
 
     CxPlatCopyMemory(
         MsQuicLib.PerfCounterSamples,

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -131,7 +131,7 @@ QuicLibrarySumPerfCountersExternal(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPerfCounterSnapShot(
-    void
+    _In_ uint64_t TimeDiffUs
     )
 {
     int64_t PerfCounterSamples[QUIC_PERF_COUNTER_MAX];
@@ -142,7 +142,7 @@ QuicPerfCounterSnapShot(
 // Ensure a perf counter stays below a given max Hz/frequency.
 #define QUIC_COUNTER_LIMIT_HZ(TYPE, LIMIT_PER_SECOND) \
     CXPLAT_TEL_ASSERT( \
-        ((PerfCounterSamples[TYPE] - MsQuicLib.PerfCounterSamples[TYPE]) / QUIC_PERF_SAMPLE_INTERVAL_S) < LIMIT_PER_SECOND)
+        ((1000 * 1000 * (PerfCounterSamples[TYPE] - MsQuicLib.PerfCounterSamples[TYPE])) / TimeDiffUs) < LIMIT_PER_SECOND)
 
 // Ensures a perf counter doesn't consistently (both samples) go above a give max value.
 #define QUIC_COUNTER_CAP(TYPE, MAX_LIMIT) \

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -241,7 +241,9 @@ MsQuicLibraryInitialize(
 
     CXPLAT_DBG_ASSERT(US_TO_MS(CxPlatGetTimerResolution()) + 1 <= UINT8_MAX);
     MsQuicLib.TimerResolutionMs = (uint8_t)US_TO_MS(CxPlatGetTimerResolution()) + 1;
+
     MsQuicLib.PerfCounterSamplesTime = CxPlatTimeUs64();
+    CxPlatZeroMemory(MsQuicLib.PerfCounterSamples, sizeof(MsQuicLib.PerfCounterSamples));
 
     CxPlatRandom(sizeof(MsQuicLib.ToeplitzHash.HashKey), MsQuicLib.ToeplitzHash.HashKey);
     CxPlatToeplitzHashInitialize(&MsQuicLib.ToeplitzHash);

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -361,7 +361,7 @@ QuicPerfCounterTrySnapShot(
         return; // Not time to resample yet.
     }
 
-    if (TimeLast !=
+    if ((int64_t)TimeLast !=
         InterlockedCompareExchange64(
             (int64_t*)&MsQuicLib.PerfCounterSamplesTime,
             (int64_t)TimeNow,

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -345,19 +345,19 @@ QuicPerfCounterAdd(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPerfCounterSnapShot(
-    void
+    _In_ uint64_t TimeDiffUs
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 inline
 void
 QuicPerfCounterTrySnapShot(
-    void
+    _In_ uint64_t TimeNow
     )
 {
-    uint64_t TimeNow = CxPlatTimeUs64();
     uint64_t TimeLast = MsQuicLib.PerfCounterSamplesTime;
-    if (CxPlatTimeDiff64(TimeLast, TimeNow) < S_TO_US(QUIC_PERF_SAMPLE_INTERVAL_S)) {
+    uint64_t TimeDiff = CxPlatTimeDiff64(TimeLast, TimeNow);
+    if (TimeDiff < S_TO_US(QUIC_PERF_SAMPLE_INTERVAL_S)) {
         return; // Not time to resample yet.
     }
 
@@ -369,7 +369,7 @@ QuicPerfCounterTrySnapShot(
         return; // Someone else already is updating.
     }
 
-    QuicPerfCounterSnapShot();
+    QuicPerfCounterSnapShot(TimeDiff);
 }
 
 //

--- a/src/core/timer_wheel.c
+++ b/src/core/timer_wheel.c
@@ -391,12 +391,12 @@ QuicTimerWheelUpdateConnection(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 uint64_t
 QuicTimerWheelGetWaitTime(
-    _In_ QUIC_TIMER_WHEEL* TimerWheel
+    _In_ QUIC_TIMER_WHEEL* TimerWheel,
+    _In_ uint64_t TimeNow
     )
 {
     uint64_t Delay;
     if (TimerWheel->NextExpirationTime != UINT64_MAX) {
-        uint64_t TimeNow = CxPlatTimeUs64();
         if (TimerWheel->NextExpirationTime <= TimeNow) {
             //
             // The next timer is already in the past. It needs to be processed

--- a/src/core/timer_wheel.h
+++ b/src/core/timer_wheel.h
@@ -81,7 +81,8 @@ QuicTimerWheelUpdateConnection(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 uint64_t
 QuicTimerWheelGetWaitTime(
-    _In_ QUIC_TIMER_WHEEL* TimerWheel
+    _In_ QUIC_TIMER_WHEEL* TimerWheel,
+    _In_ uint64_t TimeNow
     );
 
 //

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -585,13 +585,13 @@ CXPLAT_THREAD_CALLBACK(QuicWorkerThread, Context)
             QuicPerfCounterIncrement(QUIC_PERF_COUNTER_WORK_OPER_COMPLETED);
         }
 
-        if (Worker->IdealProcessor == 0) {
-            //
-            // Core zero will opportunistically try to snap-shot performance
-            // counters and do some validation.
-            //
-            QuicPerfCounterTrySnapShot();
-        }
+        uint64_t TimeNow = CxPlatTimeUs64();
+
+        //
+        // Opportunistically try to snap-shot performance counters and do
+        // some validation.
+        //
+        QuicPerfCounterTrySnapShot(TimeNow);
 
         //
         // Get the delay until the next timer expires. Check to see if any
@@ -599,7 +599,7 @@ CXPLAT_THREAD_CALLBACK(QuicWorkerThread, Context)
         // next timer if we have run out of connections and stateless operations
         // to process.
         //
-        uint64_t Delay = QuicTimerWheelGetWaitTime(&Worker->TimerWheel);
+        uint64_t Delay = QuicTimerWheelGetWaitTime(&Worker->TimerWheel, TimeNow);
 
         if (Delay == 0) {
             //

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -585,6 +585,14 @@ CXPLAT_THREAD_CALLBACK(QuicWorkerThread, Context)
             QuicPerfCounterIncrement(QUIC_PERF_COUNTER_WORK_OPER_COMPLETED);
         }
 
+        if (Worker->IdealProcessor == 0) {
+            //
+            // Core zero will opportunistically try to snap-shot performance
+            // counters and do some validation.
+            //
+            QuicPerfCounterTrySnapShot();
+        }
+
         //
         // Get the delay until the next timer expires. Check to see if any
         // timers have expired; if so, process them. If not, only wait for the

--- a/src/inc/quic_platform_linux.h
+++ b/src/inc/quic_platform_linux.h
@@ -150,6 +150,17 @@ InterlockedCompareExchange16(
 
 inline
 short
+InterlockedCompareExchange64(
+    _Inout_ _Interlocked_operand_ int64_t volatile *Destination,
+    _In_ int64_t ExChange,
+    _In_ int64_t Comperand
+    )
+{
+    return __sync_val_compare_and_swap(Destination, Comperand, ExChange);
+}
+
+inline
+short
 InterlockedIncrement16(
     _Inout_ _Interlocked_operand_ short volatile *Addend
     )

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -129,6 +129,13 @@ InterlockedCompareExchange16(
     );
 
 short
+InterlockedCompareExchange64(
+    _Inout_ _Interlocked_operand_ int64_t volatile *Destination,
+    _In_ int64_t ExChange,
+    _In_ int64_t Comperand
+    );
+
+short
 InterlockedIncrement16(
     _Inout_ _Interlocked_operand_ short volatile *Addend
     );


### PR DESCRIPTION
Periodically (currently hard coded to once ever 30 seconds) the library will snap shot the performance counters. Then it can compare the new snap shot to the previous values and have some heuristics to alert the system that something bad might be happening.