### PR TITLE
Fix Test Code Leak on Failure

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -198,11 +198,14 @@ PingConnectionShutdown(
     )
 {
     auto ConnState = (PingConnState*)Connection->Context;
-    if (ConnState->GetPingStats()->ExpectedCloseStatus == QUIC_STATUS_SUCCESS) {
+    auto ExpectedSuccess =
+        ConnState->GetPingStats()->ExpectedCloseStatus == QUIC_STATUS_SUCCESS;
+    delete ConnState;
+
+    if (ExpectedSuccess) {
         TEST_FALSE(Connection->GetTransportClosed());
         TEST_FALSE(Connection->GetPeerClosed());
     }
-    delete ConnState;
 }
 
 _Function_class_(NEW_STREAM_CALLBACK)


### PR DESCRIPTION
ConnState wasn't getting deleted on failure of the TEST_FALSE because they returned prematurely.