### PR TITLE
Fix lookup debug helpers to use correct variables

### DIFF
--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -429,7 +429,7 @@ QuicLookupFindConnectionByRemoteHashInternal(
                 "[look][%p] Lookup RemoteHash=%u found %p",
                 Lookup,
                 Hash,
-                Connection);
+                Entry->Connection);
 #endif
             return Entry->Connection;
         }
@@ -505,7 +505,7 @@ QuicLookupInsertLocalCid(
         LookupCidInsert,
         "[look][%p] Insert Conn=%p Hash=%u",
         Lookup,
-        Connection,
+        SourceCid->Connection,
         Hash);
 #endif
 


### PR DESCRIPTION
They are normally disabled, and they were using the wrong variables, which makes it harder to enable when needed for debugging