### PR TITLE
Fix stub tls stateless key generation

### DIFF
--- a/src/platform/tls_stub.c
+++ b/src/platform/tls_stub.c
@@ -1468,8 +1468,7 @@ CxPlatHashCompute(
     )
 {
     UNREFERENCED_PARAMETER(Hash);
-    UNREFERENCED_PARAMETER(Input);
-    UNREFERENCED_PARAMETER(InputLength);
     CxPlatZeroMemory(Output, OutputLength);
+    CxPlatCopyMemory(Output, Input, min(OutputLength, InputLength));
     return QUIC_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Since for now, they cid's are always less then the stateless key size, juse use the cid as the stateless key. Not secure at all, but will make stub not fail tests anymore.