### PR TITLE
CXPLAT_TEL_ASSERT Log Only

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -538,7 +538,7 @@ QuicConnRegister(
     Connection->Registration = Registration;
     BOOLEAN Success = CxPlatRundownAcquire(&Registration->Rundown);
     CXPLAT_DBG_ASSERT(Success); UNREFERENCED_PARAMETER(Success);
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
     Connection->State.IsVerifying = Registration->IsVerifying;
 #endif
 

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -153,7 +153,7 @@ typedef union QUIC_CONNECTION_STATE {
         //
         BOOLEAN AppCloseInProgress: 1;
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
         //
         // The calling app is being verified (app or driver verifier).
         //
@@ -573,10 +573,10 @@ typedef struct QUIC_SERIALIZED_RESUMPTION_STATE {
     1024 /* Extra QUIC stuff */ \
 )
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
 #define QUIC_CONN_VERIFY(Connection, Expr) \
     if (Connection->State.IsVerifying) { CXPLAT_FRE_ASSERT(Expr); }
-#elif defined(QuicVerifierEnabled)
+#elif defined(CxPlatVerifierEnabled)
 #define QUIC_CONN_VERIFY(Connection, Expr) \
     if (MsQuicLib.IsVerifying) { CXPLAT_FRE_ASSERT(Expr); }
 #else

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -333,11 +333,11 @@ MsQuicLibraryInitialize(
         MsQuicLib.PartitionCount,
         CxPlatDataPathGetSupportedFeatures(MsQuicLib.Datapath));
 
-#ifdef QuicVerifierEnabled
+#ifdef CxPlatVerifierEnabled
     uint32_t Flags;
-    MsQuicLib.IsVerifying = QuicVerifierEnabled(Flags);
+    MsQuicLib.IsVerifying = CxPlatVerifierEnabled(Flags);
     if (MsQuicLib.IsVerifying) {
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
         QuicTraceLogInfo(
             LibraryVerifierEnabledPerRegistration,
             "[ lib] Verifing enabled, per-registration!");

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -73,7 +73,7 @@ typedef struct QUIC_LIBRARY {
     //
     BOOLEAN Loaded : 1;
 
-#ifdef QuicVerifierEnabled
+#ifdef CxPlatVerifierEnabled
     //
     // The app or driver verifier is globally enabled.
     //
@@ -240,7 +240,7 @@ typedef struct QUIC_LIBRARY {
 
 extern QUIC_LIBRARY MsQuicLib;
 
-#ifdef QuicVerifierEnabled
+#ifdef CxPlatVerifierEnabled
 #define QUIC_LIB_VERIFY(Expr) \
     if (MsQuicLib.IsVerifying) { CXPLAT_FRE_ASSERT(Expr); }
 #else

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -133,10 +133,10 @@ MsQuicRegistrationOpen(
         Registration,
         Registration->AppName);
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
 #pragma prefast(suppress:6001, "SAL doesn't understand checking whether memory is tracked by Verifier.")
     if (MsQuicLib.IsVerifying &&
-        QuicVerifierEnabledByAddr(NewRegistration)) {
+        CxPlatVerifierEnabledByAddr(NewRegistration)) {
         Registration->IsVerifying = TRUE;
         QuicTraceLogInfo(
             RegistrationVerifierEnabled,

--- a/src/core/registration.h
+++ b/src/core/registration.h
@@ -28,7 +28,7 @@ typedef struct QUIC_REGISTRATION {
 
     struct QUIC_HANDLE;
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
     //
     // The calling app is being verified (app or driver verifier).
     //
@@ -101,10 +101,10 @@ typedef struct QUIC_REGISTRATION {
 
 } QUIC_REGISTRATION;
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
 #define QUIC_REG_VERIFY(Registration, Expr) \
     if (Registration->IsVerifying) { CXPLAT_FRE_ASSERT(Expr); }
-#elif defined(QuicVerifierEnabled)
+#elif defined(CxPlatVerifierEnabled)
 #define QUIC_REG_VERIFY(Registration, Expr) \
     if (MsQuicLib.IsVerifying) { CXPLAT_FRE_ASSERT(Expr); }
 #else

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -183,7 +183,7 @@ CxPlatLogAssert(
 #define CXPLAT_WIDE_STRING(_str) L##_str
 
 #define CXPLAT_ASSERT_NOOP(_exp, _msg) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), ((!(_exp)) ? FALSE : TRUE))
+    (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
 
 #define CXPLAT_ASSERT_LOG(_exp, _msg) \
     (CXPLAT_ANALYSIS_ASSUME(_exp), \

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -183,12 +183,7 @@ CxPlatLogAssert(
 #define CXPLAT_WIDE_STRING(_str) L##_str
 
 #define CXPLAT_ASSERT_NOOP(_exp, _msg) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", _msg), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE))
+    (CXPLAT_ANALYSIS_ASSUME(_exp), ((!(_exp)) ? FALSE : TRUE))
 
 #define CXPLAT_ASSERT_LOG(_exp, _msg) \
     (CXPLAT_ANALYSIS_ASSUME(_exp), \

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -213,31 +213,31 @@ CxPlatLogAssert(
 
 #if DEBUG
 #define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 #else
 #define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, _msg)
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #endif
 
 #if DEBUG
 #define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-                                         CXPLAT_ASSERT_CRASH(_exp, _msg)
+                                         CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 #elif QUIC_TELEMETRY_ASSERTS
 #define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_LOG(_exp, _msg)
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(_msg))
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-                                         CXPLAT_ASSERT_LOG(_exp, _msg)
+                                         CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(_msg))
 #else
 #define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, _msg)
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-                                         CXPLAT_ASSERT_NOOP(_exp, _msg)
+                                         CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #endif
 
 #define CXPLAT_FRE_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
-#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
+#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 
 //
 // Verifier is enabled.

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -144,42 +144,10 @@ CxPlatUninitialize(
     );
 
 //
-// Assertion Interfaces
+// Static Analysis Interfaces
 //
-
-#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X,Y)
-
-#define CXPLAT_ANALYSIS_ASSERT(X) __analysis_assert(X)
-
-//
-// Logs the assertion failure to ETW.
-//
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-CxPlatLogAssert(
-    _In_z_ const char* File,
-    _In_ int Line,
-    _In_z_ const char* Expr
-    );
-
-#define QUIC_WIDE_STRING(_str) L##_str
-
-#define QUIC_ASSERT_ACTION(_exp) \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", QUIC_WIDE_STRING(#_exp)), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE)
-
-#define QUIC_ASSERTMSG_ACTION(_msg, _exp) \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", L##_msg), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE)
 
 #define QUIC_NO_SANITIZE(X)
-
 
 #if defined(_PREFAST_)
 // _Analysis_assume_ will never result in any code generation for _exp,
@@ -197,43 +165,85 @@ CxPlatLogAssert(
 #endif // DEBUG
 #endif // _PREFAST_
 
+#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X,Y)
+
+#define CXPLAT_ANALYSIS_ASSERT(X) __analysis_assert(X)
+
+//
+// Assertion Interfaces
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+CxPlatLogAssert(
+    _In_z_ const char* File,
+    _In_ int Line,
+    _In_z_ const char* Expr
+    );
+
+#define CXPLAT_WIDE_STRING(_str) L##_str
+
+#define CXPLAT_ASSERT_NOOP(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? \
+        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
+         __annotation(L"Debug", L"AssertFail", _msg), \
+         DbgRaiseAssertionFailure(), FALSE) : \
+        TRUE))
+
+#define CXPLAT_ASSERT_LOG(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? (CxPlatLogAssert(__FILE__, __LINE__, #_exp), FALSE) : TRUE))
+
+#define CXPLAT_ASSERT_CRASH(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? \
+        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
+         __annotation(L"Debug", L"AssertFail", _msg), \
+         DbgRaiseAssertionFailure(), FALSE) : \
+        TRUE))
+
 //
 // MsQuic uses three types of asserts:
 //
 //  CXPLAT_DBG_ASSERT - Asserts that are too expensive to evaluate all the time.
 //  CXPLAT_TEL_ASSERT - Asserts that are acceptable to always evaluate, but not
-//                    always crash the system.
+//                      always crash the system.
 //  CXPLAT_FRE_ASSERT - Asserts that must always crash the system.
 //
 
 #if DEBUG
-#define CXPLAT_DBG_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
 #else
-#define CXPLAT_DBG_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+#define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, _msg)
 #endif
 
-#if DEBUG || QUIC_TELEMETRY_ASSERTS
-#define CXPLAT_TEL_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#if DEBUG
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-     (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+                                         CXPLAT_ASSERT_CRASH(_exp, _msg)
+#elif QUIC_TELEMETRY_ASSERTS
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_LOG(_exp, _msg)
+#define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
+                                         CXPLAT_ASSERT_LOG(_exp, _msg)
 #else
-#define CXPLAT_TEL_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, _msg)
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+                                         CXPLAT_ASSERT_NOOP(_exp, _msg)
 #endif
 
-#define CXPLAT_FRE_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#define CXPLAT_FRE_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, _msg)
 
 //
 // Verifier is enabled.
 //
-#define QuicVerifierEnabled(Flags) NT_SUCCESS(MmIsVerifierEnabled((PULONG)&Flags))
-#define QuicVerifierEnabledByAddr(Address) MmIsDriverVerifyingByAddress(Address)
+#define CxPlatVerifierEnabled(Flags) NT_SUCCESS(MmIsVerifierEnabled((PULONG)&Flags))
+#define CxPlatVerifierEnabledByAddr(Address) MmIsDriverVerifyingByAddress(Address)
 
 //
 // Debugger check.

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -161,12 +161,7 @@ CxPlatLogAssert(
 #define CXPLAT_WIDE_STRING(_str) L##_str
 
 #define CXPLAT_ASSERT_NOOP(_exp, _msg) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", _msg), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE))
+    (CXPLAT_ANALYSIS_ASSUME(_exp), ((!(_exp)) ? FALSE : TRUE))
 
 #define CXPLAT_ASSERT_LOG(_exp, _msg) \
     (CXPLAT_ANALYSIS_ASSUME(_exp), \

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -161,7 +161,7 @@ CxPlatLogAssert(
 #define CXPLAT_WIDE_STRING(_str) L##_str
 
 #define CXPLAT_ASSERT_NOOP(_exp, _msg) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), ((!(_exp)) ? FALSE : TRUE))
+    (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
 
 #define CXPLAT_ASSERT_LOG(_exp, _msg) \
     (CXPLAT_ANALYSIS_ASSUME(_exp), \

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -122,39 +122,10 @@ CxPlatUninitialize(
     );
 
 //
-// Assertion Interfaces
+// Static Analysis Interfaces
 //
 
-#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X,Y)
-
-#define CXPLAT_ANALYSIS_ASSERT(X) __analysis_assert(X)
-
-//
-// Logs the assertion failure to ETW.
-//
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-CxPlatLogAssert(
-    _In_z_ const char* File,
-    _In_ int Line,
-    _In_z_ const char* Expr
-    );
-
-#define QUIC_WIDE_STRING(_str) L##_str
-
-#define QUIC_ASSERT_ACTION(_exp) \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", QUIC_WIDE_STRING(#_exp)), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE)
-
-#define QUIC_ASSERTMSG_ACTION(_msg, _exp) \
-    ((!(_exp)) ? \
-        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
-         __annotation(L"Debug", L"AssertFail", L##_msg), \
-         DbgRaiseAssertionFailure(), FALSE) : \
-        TRUE)
+#define QUIC_NO_SANITIZE(X)
 
 #if defined(_PREFAST_)
 // _Analysis_assume_ will never result in any code generation for _exp,
@@ -172,45 +143,84 @@ CxPlatLogAssert(
 #endif // DEBUG
 #endif // _PREFAST_
 
-#define QUIC_NO_SANITIZE(X)
+#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X,Y)
 
+#define CXPLAT_ANALYSIS_ASSERT(X) __analysis_assert(X)
+
+//
+// Assertion Interfaces
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+CxPlatLogAssert(
+    _In_z_ const char* File,
+    _In_ int Line,
+    _In_z_ const char* Expr
+    );
+
+#define CXPLAT_WIDE_STRING(_str) L##_str
+
+#define CXPLAT_ASSERT_NOOP(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? \
+        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
+         __annotation(L"Debug", L"AssertFail", _msg), \
+         DbgRaiseAssertionFailure(), FALSE) : \
+        TRUE))
+
+#define CXPLAT_ASSERT_LOG(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? (CxPlatLogAssert(__FILE__, __LINE__, #_exp), FALSE) : TRUE))
+
+#define CXPLAT_ASSERT_CRASH(_exp, _msg) \
+    (CXPLAT_ANALYSIS_ASSUME(_exp), \
+    ((!(_exp)) ? \
+        (CxPlatLogAssert(__FILE__, __LINE__, #_exp), \
+         __annotation(L"Debug", L"AssertFail", _msg), \
+         DbgRaiseAssertionFailure(), FALSE) : \
+        TRUE))
 
 //
 // MsQuic uses three types of asserts:
 //
 //  CXPLAT_DBG_ASSERT - Asserts that are too expensive to evaluate all the time.
 //  CXPLAT_TEL_ASSERT - Asserts that are acceptable to always evaluate, but not
-//                    always crash the process.
-//  CXPLAT_FRE_ASSERT - Asserts that must always crash the process.
+//                      always crash the system.
+//  CXPLAT_FRE_ASSERT - Asserts that must always crash the system.
 //
 
 #if DEBUG
-#define CXPLAT_DBG_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 #else
-#define CXPLAT_DBG_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
-#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+#define CXPLAT_DBG_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_DBG_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #endif
 
-#if DEBUG || QUIC_TELEMETRY_ASSERTS
-#define CXPLAT_TEL_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#if DEBUG
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-     (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+                                         CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
+#elif QUIC_TELEMETRY_ASSERTS
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(_msg))
+#define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
+                                         CXPLAT_ASSERT_LOG(_exp, CXPLAT_WIDE_STRING(_msg))
 #else
-#define CXPLAT_TEL_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
-#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+#define CXPLAT_TEL_ASSERT(_exp)          CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_TEL_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #define CXPLAT_TEL_ASSERTMSG_ARGS(_exp, _msg, _origin, _bucketArg1, _bucketArg2) \
-    (CXPLAT_ANALYSIS_ASSUME(_exp), 0)
+                                         CXPLAT_ASSERT_NOOP(_exp, CXPLAT_WIDE_STRING(_msg))
 #endif
 
-#define CXPLAT_FRE_ASSERT(_exp)          (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERT_ACTION(_exp))
-#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) (CXPLAT_ANALYSIS_ASSUME(_exp), QUIC_ASSERTMSG_ACTION(_msg, _exp))
+#define CXPLAT_FRE_ASSERT(_exp)          CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(#_exp))
+#define CXPLAT_FRE_ASSERTMSG(_exp, _msg) CXPLAT_ASSERT_CRASH(_exp, CXPLAT_WIDE_STRING(_msg))
 
 //
 // Verifier is enabled.
 //
-#define QuicVerifierEnabled(Flags) \
+#define CxPlatVerifierEnabled(Flags) \
     (GetModuleHandleW(L"verifier.dll") != NULL && \
      GetModuleHandleW(L"vrfcore.dll") != NULL), \
     Flags = 0

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -196,7 +196,7 @@ typedef union QUIC_CONNECTION_STATE {
         //
         BOOLEAN AppCloseInProgress: 1;
 
-#ifdef QuicVerifierEnabledByAddr
+#ifdef CxPlatVerifierEnabledByAddr
         //
         // The calling app is being verified (app or driver verifier).
         //


### PR DESCRIPTION
Updates the recently refactored CXPLAT_TEL_ASSERT to make sure it doesn't crash in release mode, just log.