### PR TITLE
Add more bad-case testing of Resumption Tickets

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -2139,7 +2139,7 @@ QuicCryptoDecodeServerTicket(
         goto Error;
     }
 
-    if (TicketLength - Offset < sizeof(uint32_t)) {
+    if (TicketLength < Offset + sizeof(uint32_t)) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
@@ -2187,7 +2187,7 @@ QuicCryptoDecodeServerTicket(
         goto Error;
     }
 
-    if (TicketLength - Offset < AlpnLength) {
+    if (TicketLength < Offset + AlpnLength) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
@@ -2206,7 +2206,7 @@ QuicCryptoDecodeServerTicket(
     }
     Offset += (uint16_t)AlpnLength;
 
-    if (TicketLength - Offset < TPLength) {
+    if (TicketLength < Offset + TPLength) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -2393,7 +2393,7 @@ QuicCryptoDecodeClientTicket(
             "Client Ticket version unsupported");
         goto Error;
     }
-    if (ClientTicketLength - Offset < sizeof(uint32_t)) {
+    if (ClientTicketLength < Offset + sizeof(uint32_t)) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
@@ -2427,7 +2427,7 @@ QuicCryptoDecodeClientTicket(
             "Resumption Ticket data length failed to decode");
         goto Error;
     }
-    if (ClientTicketLength - Offset < TPLength) {
+    if (ClientTicketLength < Offset + TPLength) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -2139,6 +2139,15 @@ QuicCryptoDecodeServerTicket(
         goto Error;
     }
 
+    if (TicketLength - Offset < sizeof(uint32_t)) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Resumption Ticket too short to hold QUIC version");
+        goto Error;
+    }
+
     uint32_t QuicVersion;
     memcpy(&QuicVersion, Ticket + Offset, sizeof(QuicVersion));
     if (!QuicIsVersionSupported(QuicVersion)) {
@@ -2178,6 +2187,15 @@ QuicCryptoDecodeServerTicket(
         goto Error;
     }
 
+    if (TicketLength - Offset < AlpnLength) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Resumption Ticket too small for ALPN");
+        goto Error;
+    }
+
     if (CxPlatTlsAlpnFindInList(AlpnListLength, AlpnList, (uint8_t)AlpnLength, Ticket + Offset) == NULL) {
         QuicTraceEvent(
             ConnError,
@@ -2187,6 +2205,15 @@ QuicCryptoDecodeServerTicket(
         goto Error;
     }
     Offset += (uint16_t)AlpnLength;
+
+    if (TicketLength - Offset < TPLength) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Resumption Ticket too small for Transport Parameters");
+        goto Error;
+    }
 
     if (!QuicCryptoTlsDecodeTransportParameters(
             Connection,
@@ -2342,7 +2369,7 @@ QuicCryptoDecodeClientTicket(
     _Out_ uint32_t* QuicVersion
     )
 {
-    QUIC_STATUS Status;
+    QUIC_STATUS Status = QUIC_STATUS_INVALID_PARAMETER;
     uint16_t Offset = 0;
     QUIC_VAR_INT TicketVersion = 0, TPLength = 0, TicketLength = 0;
 
@@ -2356,7 +2383,6 @@ QuicCryptoDecodeClientTicket(
             "[conn][%p] ERROR, %s.",
             Connection,
             "Client Ticket version failed to decode");
-        Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }
     if (TicketVersion != CXPLAT_TLS_RESUMPTION_CLIENT_TICKET_VERSION) {
@@ -2365,10 +2391,25 @@ QuicCryptoDecodeClientTicket(
             "[conn][%p] ERROR, %s.",
             Connection,
             "Client Ticket version unsupported");
-        Status = QUIC_STATUS_INVALID_PARAMETER;
+        goto Error;
+    }
+    if (ClientTicketLength - Offset < sizeof(uint32_t)) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Client Ticket not long enough for QUIC version");
         goto Error;
     }
     CxPlatCopyMemory(QuicVersion, ClientTicket + Offset, sizeof(*QuicVersion));
+    if (!QuicIsVersionSupported(*QuicVersion)) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Resumption Ticket for unsupported QUIC version");
+        goto Error;
+    }
     Offset += sizeof(*QuicVersion);
     if (!QuicVarIntDecode(ClientTicketLength, ClientTicket, &Offset, &TPLength)) {
         QuicTraceEvent(
@@ -2376,7 +2417,6 @@ QuicCryptoDecodeClientTicket(
             "[conn][%p] ERROR, %s.",
             Connection,
             "Client Ticket TP length failed to decode");
-        Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }
     if (!QuicVarIntDecode(ClientTicketLength, ClientTicket, &Offset, &TicketLength)) {
@@ -2385,7 +2425,14 @@ QuicCryptoDecodeClientTicket(
             "[conn][%p] ERROR, %s.",
             Connection,
             "Resumption Ticket data length failed to decode");
-        Status = QUIC_STATUS_INVALID_PARAMETER;
+        goto Error;
+    }
+    if (ClientTicketLength - Offset < TPLength) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Client Ticket not long enough for Client Transport Parameters");
         goto Error;
     }
     if (!QuicCryptoTlsDecodeTransportParameters(
@@ -2399,12 +2446,10 @@ QuicCryptoDecodeClientTicket(
             "[conn][%p] ERROR, %s.",
             Connection,
             "Resumption Ticket TParams failed to decode");
-        Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }
     Offset += (uint16_t)TPLength;
     if (Offset + TicketLength != ClientTicketLength) {
-        Status = QUIC_STATUS_INVALID_PARAMETER;
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",

--- a/src/core/unittest/TicketTest.cpp
+++ b/src/core/unittest/TicketTest.cpp
@@ -332,7 +332,7 @@ TEST(ResumptionTicketTest, ClientDecFail)
     }
 
     // Client TP length longer than actual
-     InputTicketBuffer[5] = (uint8_t)(TransportParametersLength - (uint8_t)CxPlatTlsTPHeaderSize) + 1;
+    InputTicketBuffer[5] = (uint8_t)(TransportParametersLength - (uint8_t)CxPlatTlsTPHeaderSize) + 1;
     ASSERT_EQ(
         QUIC_STATUS_INVALID_PARAMETER,
         QuicCryptoDecodeClientTicket(

--- a/src/core/unittest/TicketTest.cpp
+++ b/src/core/unittest/TicketTest.cpp
@@ -93,6 +93,16 @@ TEST(ResumptionTicketTest, ClientEncDec)
     CXPLAT_FREE(DecodedServerTicket, QUIC_POOL_CRYPTO_RESUMPTION_TICKET);
 }
 
+struct TransportParamsScope {
+    const uint8_t* const TP;
+    TransportParamsScope(const uint8_t* newTP) : TP(newTP) {}
+    ~TransportParamsScope() {
+        if (TP != nullptr) {
+            CXPLAT_FREE(TP, QUIC_POOL_TLS_TRANSPARAMS);
+        }
+    }
+};
+
 TEST(ResumptionTicketTest, ClientDecFail)
 {
     const uint8_t TransportParametersLength = 21; // Update if TP size changes
@@ -131,6 +141,7 @@ TEST(ResumptionTicketTest, ClientDecFail)
             &ServerTP,
             nullptr,
             &EncodedTPLength);
+    TransportParamsScope TPScope(EncodedServerTP);
     ASSERT_NE(EncodedServerTP, nullptr);
     ASSERT_LE(EncodedTPLength - CxPlatTlsTPHeaderSize, TransportParametersLength);
     ASSERT_GT(sizeof(InputTicketBuffer), EncodedTPLength);
@@ -580,6 +591,7 @@ TEST(ResumptionTicketTest, ServerDecFail)
             &HandshakeTP,
             nullptr,
             &EncodedTPLength);
+    TransportParamsScope TPScope(EncodedHandshakeTP);
     ASSERT_NE(EncodedHandshakeTP, nullptr);
     ASSERT_LE(EncodedTPLength - CxPlatTlsTPHeaderSize, TransportParametersLength);
     ASSERT_GT(sizeof(InputTicketBuffer), EncodedTPLength);

--- a/src/core/unittest/TicketTest.cpp
+++ b/src/core/unittest/TicketTest.cpp
@@ -313,7 +313,7 @@ TEST(ResumptionTicketTest, ClientDecFail)
     InputTicketBuffer[4] = 1;
 
     // Client TP length shorter than actual
-    for (uint8_t s = 0; s < (uint8_t)EncodedTPLength - (uint8_t)CxPlatTlsTPHeaderSize; ++s) {
+    for (uint8_t s = 0; s < (uint8_t)(EncodedTPLength - CxPlatTlsTPHeaderSize); ++s) {
         QuicTraceLogInfo(
             ClientResumptionTicketDecodeFailTpLengthShort,
             "[test] Attempting to decode Server TP with length %u (Actual: %u)",
@@ -874,7 +874,7 @@ TEST(ResumptionTicketTest, ServerDecFail)
     InputTicketBuffer[5] = (uint8_t)sizeof(Alpn);
 
     // Handshake TP length shorter than actual
-    for (uint8_t s = 0; s < EncodedTPLength - CxPlatTlsTPHeaderSize; ++s) {
+    for (uint8_t s = 0; s < (uint8_t)(EncodedTPLength - CxPlatTlsTPHeaderSize); ++s) {
         QuicTraceLogInfo(
             ServerResumptionTicketDecodeFailTpLengthShort,
             "[test] Attempting to decode Handshake TP with length %u (Actual: %u)",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -7192,6 +7192,166 @@
       ],
       "macroName": "QuicTraceLogConnWarning"
     },
+    "ClientResumptionTicketDecodeFailTpLengthShort": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Server TP with length %u (Actual: %u)",
+      "UniqueId": "ClientResumptionTicketDecodeFailTpLengthShort",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ClientResumptionTicketDecodeFailTpLengthEncodedWrong": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Server TP length (improperly encoded) %x (Actual: %u)",
+      "UniqueId": "ClientResumptionTicketDecodeFailTpLengthEncodedWrong",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ClientResumptionTicketDecodeFailTicketLengthShort": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Server Ticket with length %u (Actual: %u)",
+      "UniqueId": "ClientResumptionTicketDecodeFailTicketLengthShort",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ClientResumptionTicketDecodeFailTicketLengthEncodedWrong": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Server Ticket length (improperly encoded) %x (Actual: %u)",
+      "UniqueId": "ClientResumptionTicketDecodeFailTicketLengthEncodedWrong",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailAlpnLengthShort": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Negotiated ALPN with length %u (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailAlpnLengthShort",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailAlpnLengthEncodedWrong": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Negotiated ALPN length (improperly encoded) %x (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailAlpnLengthEncodedWrong",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailTpLengthShort": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Handshake TP with length %u (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailTpLengthShort",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailTpLengthEncodedWrong": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode Handshake TP length (improperly encoded) %x (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailTpLengthEncodedWrong",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailAppDataLengthShort": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode App Data with length %u (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailAppDataLengthShort",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "ServerResumptionTicketDecodeFailAppDataLengthEncodedWrong": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Attempting to decode App Data length (improperly encoded) %x (Actual: %u)",
+      "UniqueId": "ServerResumptionTicketDecodeFailAppDataLengthEncodedWrong",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
     "ClientVersionNegotiationInfoDecodeFailed1": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Client version negotiation info too short to contain Current Version (%hu bytes)",
@@ -12509,6 +12669,46 @@
       {
         "UniquenessHash": "badaa7e5-aa9e-7979-b334-154a884827b6",
         "TraceID": "StillInTimerWheel"
+      },
+      {
+        "UniquenessHash": "4af1859d-901e-496c-6684-5e90fd1ed197",
+        "TraceID": "ClientResumptionTicketDecodeFailTpLengthShort"
+      },
+      {
+        "UniquenessHash": "05e7754f-0f5d-dbb8-f6f2-9bd78260dd9a",
+        "TraceID": "ClientResumptionTicketDecodeFailTpLengthEncodedWrong"
+      },
+      {
+        "UniquenessHash": "42e92d4d-1384-a1c1-4414-39cb9de5f346",
+        "TraceID": "ClientResumptionTicketDecodeFailTicketLengthShort"
+      },
+      {
+        "UniquenessHash": "e095ab6a-5a7c-2fdc-91e7-70711b273610",
+        "TraceID": "ClientResumptionTicketDecodeFailTicketLengthEncodedWrong"
+      },
+      {
+        "UniquenessHash": "9140659a-eab1-dd55-73fd-e065acfab968",
+        "TraceID": "ServerResumptionTicketDecodeFailAlpnLengthShort"
+      },
+      {
+        "UniquenessHash": "10a2af3e-b6e9-d046-42b5-49a1f96ef4f2",
+        "TraceID": "ServerResumptionTicketDecodeFailAlpnLengthEncodedWrong"
+      },
+      {
+        "UniquenessHash": "2626d036-0f88-3cee-bb11-acbe28b5b31a",
+        "TraceID": "ServerResumptionTicketDecodeFailTpLengthShort"
+      },
+      {
+        "UniquenessHash": "cacc6514-e0b1-37a7-c68f-82e9273ecdea",
+        "TraceID": "ServerResumptionTicketDecodeFailTpLengthEncodedWrong"
+      },
+      {
+        "UniquenessHash": "6761da36-f0a0-a9dc-43ab-76c5dc83e833",
+        "TraceID": "ServerResumptionTicketDecodeFailAppDataLengthShort"
+      },
+      {
+        "UniquenessHash": "ad1f93df-84e1-c836-2743-2d3b5324a0b4",
+        "TraceID": "ServerResumptionTicketDecodeFailAppDataLengthEncodedWrong"
       },
       {
         "UniquenessHash": "4dcd57d1-2fc6-a95d-73fd-b4f658f3a886",


### PR DESCRIPTION
Adds test cases which stress bounds-checking on resumption ticket parsing.
This PR largely addresses #1219 