### PR TITLE
Prevent Re-entrant Events on Shutdown Complete

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -970,7 +970,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicConnIndicateEvent(
     _In_ QUIC_CONNECTION* Connection,
-    _Inout_ QUIC_CONNECTION_EVENT* Event
+    _Inout_ QUIC_CONNECTION_EVENT* Event,
+    _In_ BOOLEAN IsLastEvent
     );
 
 //

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1545,7 +1545,7 @@ QuicCryptoProcessTlsCompletion(
             Connection,
             "Indicating QUIC_CONNECTION_EVENT_CONNECTED (Resume=%hhu)",
             Event.CONNECTED.SessionResumed);
-        (void)QuicConnIndicateEvent(Connection, &Event);
+        (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
         if (Crypto->TlsState.SessionResumed) {
             QuicPerfCounterIncrement(QUIC_PERF_COUNTER_CONN_RESUMED);
         }

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -103,7 +103,7 @@ QuicDatagramIndicateSendStateChange(
         Connection,
         "Indicating DATAGRAM_SEND_STATE_CHANGED to %u",
         State);
-    (void)QuicConnIndicateEvent(Connection, &Event);
+    (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
 
     *ClientContext = Event.DATAGRAM_SEND_STATE_CHANGED.ClientContext;
 }
@@ -304,7 +304,7 @@ QuicDatagramOnSendStateChanged(
             "Indicating QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED [SendEnabled=%hhu] [MaxSendLength=%hu]",
             Event.DATAGRAM_STATE_CHANGED.SendEnabled,
             Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
-        (void)QuicConnIndicateEvent(Connection, &Event);
+        (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
     }
 
     if (!SendEnabled) {
@@ -572,7 +572,7 @@ QuicDatagramProcessFrame(
         Connection,
         "Indicating DATAGRAM_RECEIVED [len=%hu]",
         (uint16_t)Frame.Length);
-    (void)QuicConnIndicateEvent(Connection, &Event);
+    (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
 
     QuicPerfCounterAdd(QUIC_PERF_COUNTER_APP_RECV_BYTES, QuicBuffer.Length);
 

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -242,7 +242,7 @@ QuicSendBufferStreamAdjust(
             Stream,
             "Indicating QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE = %llu",
             Event.IDEAL_SEND_BUFFER_SIZE.ByteCount);
-        (void)QuicStreamIndicateEvent(Stream, &Event);
+        (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
     }
 }
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -380,13 +380,18 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicStreamIndicateEvent(
     _In_ QUIC_STREAM* Stream,
-    _Inout_ QUIC_STREAM_EVENT* Event
+    _Inout_ QUIC_STREAM_EVENT* Event,
+    _In_ BOOLEAN IsLastEvent
     )
 {
     QUIC_STATUS Status;
     if (Stream->ClientCallbackHandler != NULL) {
+        QUIC_STREAM_CALLBACK_HANDLER ClientCallbackHandler = Stream->ClientCallbackHandler;
+        if (IsLastEvent) {
+            Stream->ClientCallbackHandler = NULL;
+        }
         Status =
-            Stream->ClientCallbackHandler(
+            ClientCallbackHandler(
                 (HQUIC)Stream,
                 Stream->ClientContext,
                 Event);
@@ -416,7 +421,7 @@ QuicStreamIndicateStartComplete(
         Stream,
         "Indicating QUIC_STREAM_EVENT_START_COMPLETE (0x%x)",
         Status);
-    (void)QuicStreamIndicateEvent(Stream, &Event);
+    (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -434,9 +439,7 @@ QuicStreamIndicateShutdownComplete(
             IndicateStreamShutdownComplete,
             Stream,
             "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE");
-        (void)QuicStreamIndicateEvent(Stream, &Event);
-
-        Stream->ClientCallbackHandler = NULL;
+        (void)QuicStreamIndicateEvent(Stream, &Event, TRUE);
     }
 }
 

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -520,7 +520,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicStreamIndicateEvent(
     _In_ QUIC_STREAM* Stream,
-    _Inout_ QUIC_STREAM_EVENT* Event
+    _Inout_ QUIC_STREAM_EVENT* Event,
+    _In_ BOOLEAN IsLastEvent
     );
 
 //

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -206,7 +206,7 @@ QuicStreamProcessResetFrame(
                 Stream,
                 "Indicating QUIC_STREAM_EVENT_PEER_SEND_ABORTED (0x%llX)",
                 ErrorCode);
-            (void)QuicStreamIndicateEvent(Stream, &Event);
+            (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
         }
 
         //
@@ -250,7 +250,7 @@ QuicStreamProcessStopSendingFrame(
             Stream,
             "Indicating QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED (0x%llX)",
             ErrorCode);
-        (void)QuicStreamIndicateEvent(Stream, &Event);
+        (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
 
         //
         // The peer has requested that we stop sending. Close abortively.
@@ -745,7 +745,7 @@ QuicStreamRecvFlush(
             Event.RECEIVE.BufferCount,
             Event.RECEIVE.Flags);
 
-        QUIC_STATUS Status = QuicStreamIndicateEvent(Stream, &Event);
+        QUIC_STATUS Status = QuicStreamIndicateEvent(Stream, &Event, FALSE);
         if (Status == QUIC_STATUS_PENDING) {
             if (Stream->Flags.ReceiveCallPending) {
                 //
@@ -892,7 +892,7 @@ QuicStreamReceiveComplete(
             IndicatePeerSendShutdown,
             Stream,
             "Indicating QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN");
-        (void)QuicStreamIndicateEvent(Stream, &Event);
+        (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
 
         //
         // Now that the close event has been delivered to the app, we can shut

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -95,7 +95,7 @@ QuicStreamIndicateSendShutdownComplete(
             IndicateSendShutdownComplete,
             Stream,
             "Indicating QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE");
-        (void)QuicStreamIndicateEvent(Stream, &Event);
+        (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
     }
 }
 
@@ -395,7 +395,7 @@ QuicStreamCompleteSendRequest(
                 SendRequest);
         }
 
-        (void)QuicStreamIndicateEvent(Stream, &Event);
+        (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
     } else if (SendRequest->InternalBuffer.Length != 0) {
         QuicSendBufferFree(
             &Connection->SendBuffer,
@@ -469,7 +469,7 @@ QuicStreamSendBufferRequest(
         Stream,
         "Indicating QUIC_STREAM_EVENT_SEND_COMPLETE [%p]",
         Req);
-    (void)QuicStreamIndicateEvent(Stream, &Event);
+    (void)QuicStreamIndicateEvent(Stream, &Event, FALSE);
 
     Req->ClientContext = NULL;
 

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -251,7 +251,7 @@ QuicStreamSetIndicateStreamsAvailable(
         "Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [%hu] [%hu]",
         Event.STREAMS_AVAILABLE.BidirectionalCount,
         Event.STREAMS_AVAILABLE.UnidirectionalCount);
-    (void)QuicConnIndicateEvent(Connection, &Event);
+    (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -655,7 +655,7 @@ QuicStreamSetGetStreamForPeer(
                 "Indicating QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED [%p, 0x%x]",
                 Event.PEER_STREAM_STARTED.Stream,
                 Event.PEER_STREAM_STARTED.Flags);
-            Status = QuicConnIndicateEvent(Connection, &Event);
+            Status = QuicConnIndicateEvent(Connection, &Event, FALSE);
 
             if (QUIC_FAILED(Status)) {
                 QuicTraceLogStreamWarning(

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -478,7 +478,7 @@ QuicWorkerProcessConnection(
             IndicateIdealProcChanged,
             Connection,
             "Indicating QUIC_CONNECTION_EVENT_IDEAL_PROCESSOR_CHANGED");
-        (void)QuicConnIndicateEvent(Connection, &Event);
+        (void)QuicConnIndicateEvent(Connection, &Event, FALSE);
     }
 
     //


### PR DESCRIPTION
Ensure that further events aren't delivered to the app after (inline) the shutdown complete event is delivered. (I'm still unsure if this is needed)