### PR TITLE
Add unreachable support to datapath_kqueue, add synchronous case to datapath_epoll

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2218,6 +2218,19 @@ CxPlatSocketSendInternal(
                 SocketContext->Binding,
                 Status,
                 "sendmsg failed");
+
+            //
+            // Unreachable events can sometimes come synchronously.
+            // Send unreachable notification to MsQuic if any related
+            // errors were received.
+            //
+            if (Status == ECONNREFUSED ||
+                Status == EHOSTUNREACH ||
+                Status == ENETUNREACH) {
+                SocketContext->Binding->Datapath->UdpHandlers.Unreachable(
+                    SocketContext->Binding,
+                    SocketContext->Binding->ClientContext,
+                    &SocketContext->Binding->RemoteAddress);
             goto Exit;
         }
     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2231,6 +2231,7 @@ CxPlatSocketSendInternal(
                     SocketContext->Binding,
                     SocketContext->Binding->ClientContext,
                     &SocketContext->Binding->RemoteAddress);
+            }
             goto Exit;
         }
     }

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1393,7 +1393,7 @@ CxPlatSocketContextProcessEvents(
                             SocketContext->Binding,
                             SocketContext->Binding->ClientContext,
                             &SocketContext->Binding->RemoteAddress);
-            }
+                    }
                 }
                 break;
             }
@@ -1971,6 +1971,7 @@ CxPlatSocketSendInternal(
                     SocketContext->Binding,
                     SocketContext->Binding->ClientContext,
                     &SocketContext->Binding->RemoteAddress);
+            }
             goto Exit;
         }
     }


### PR DESCRIPTION
The synchronous cases can sometimes occur, theyre likely rare but still probably good to handle.

kqueue doesn't give a special event type for socket error, but does give a recvmsg with an error in that case.

I want to do some double checking that this works, but initial testing looks like it does.