### PR TITLE
fix compilation on macOS with XCode 11.5

### DIFF
--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1843,7 +1843,8 @@ CxPlatSocketSendInternal(
     BOOLEAN SendPending = FALSE;
     uint32_t ProcNumber;
 
-    static_assert(CMSG_SPACE(sizeof(struct in6_pktinfo)) >= CMSG_SPACE(sizeof(struct in_pktinfo)), "sizeof(struct in6_pktinfo) >= sizeof(struct in_pktinfo) failed");
+    static_assert(sizeof(struct in6_pktinfo) >= sizeof(struct in_pktinfo), "sizeof(struct in6_pktinfo) >= sizeof(struct in_pktinfo) failed");
+
     char ControlBuffer[CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(int))] = {0};
 
     CXPLAT_DBG_ASSERT(Socket != NULL && RemoteAddress != NULL && SendData != NULL);


### PR DESCRIPTION
I'm getting following error when trying to build squick on 10.15.
```
[ 31%] Building C object src/platform/CMakeFiles/platform.dir/datapath_kqueue.c.o
cd /Users/furt/github/wfurt-msquic/build/macos/x64_openssl/src/platform && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DCX_PLATFORM_DARWIN -DQUIC_DISABLE_0RTT_TESTS -DQUIC_DISABLE_CLIENT_CERT_TESTS -DQUIC_DISABLE_RESUMPTION -DQUIC_EVENTS_STUB -DQUIC_LOGS_STUB -DVER_BUILD_ID=0 -DVER_SUFFIX=-private -D_GNU_SOURCE -I/Users/furt/github/wfurt-msquic/src/inc -isystem /Users/furt/github/wfurt-msquic/build/macos/x64_openssl/openssl/include  -Og -ggdb3 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk   -fms-extensions -fPIC -Wno-microsoft-anon-tag -Wno-tautological-constant-out-of-range-compare -Wmissing-field-initializers -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-multichar -Wno-missing-field-initializers -Wno-missing-braces -o CMakeFiles/platform.dir/datapath_kqueue.c.o   -c /Users/furt/github/wfurt-msquic/src/platform/datapath_kqueue.c
/Users/furt/github/wfurt-msquic/src/platform/datapath_kqueue.c:1846:19: error: static_assert expression is not an integral constant expression
    static_assert(CMSG_SPACE(sizeof(struct in6_pktinfo)) >= CMSG_SPACE(sizeof(struct in_pktinfo)), "sizeof(struct in6_pktinfo) >= sizeof(struct in_pktinfo) failed");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/socket.h:652:33: note: expanded from macro 'CMSG_SPACE'
#define CMSG_SPACE(l)           (__DARWIN_ALIGN32(sizeof(struct cmsghdr)) + __DARWIN_ALIGN32(l))
                                ^
/Users/furt/github/wfurt-msquic/src/platform/datapath_kqueue.c:1846:19: note: cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/socket.h:652:34: note: expanded from macro 'CMSG_SPACE'
#define CMSG_SPACE(l)           (__DARWIN_ALIGN32(sizeof(struct cmsghdr)) + __DARWIN_ALIGN32(l))
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/i386/_param.h:43:42: note: expanded from macro '__DARWIN_ALIGN32'
#define       __DARWIN_ALIGN32(p)       ((__darwin_size_t)((char *)(__darwin_size_t)(p) + __DARWIN_ALIGNBYTES32) &~ __DARWIN_ALIGNBYTES32)
                                         ^
1 error generated.
make[2]: *** [src/platform/CMakeFiles/platform.dir/datapath_kqueue.c.o] Error 1
```

we could turn this into plain `assert()`  but if struct size is smaller or equal than aligned CMSG_SPACE() should be as well. 