### PR TITLE
fix posix QuicAddrToString

### DIFF
--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -434,11 +434,11 @@ QuicAddr6FromString(
         }
 
         char TmpAddrStr[64];
-        size_t AddrLength = BracketEnd - AddrStr;
+        size_t AddrLength = BracketEnd - AddrStr - 1;
         if (AddrLength >= sizeof(TmpAddrStr)) {
             return FALSE;
         }
-        memcpy(TmpAddrStr, AddrStr, AddrLength);
+        memcpy(TmpAddrStr, AddrStr + 1, AddrLength);
         TmpAddrStr[AddrLength] = '\0';
 
         if (inet_pton(AF_INET6, TmpAddrStr, &Addr->Ipv6.sin6_addr) != 1) {
@@ -488,8 +488,8 @@ QuicAddrToString(
         Address++;
     }
     if (inet_ntop(
-            Addr->Ip.sa_family,
-            &Addr->Ipv4.sin_addr,
+            Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET ? AF_INET : AF_INET6,
+            Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET ? (void*)&Addr->Ipv4.sin_addr : (void*)&Addr->Ipv6.sin6_addr,
             Address,
             sizeof(QUIC_ADDR_STR)) == NULL) {
         return FALSE;

--- a/src/platform/unittest/CMakeLists.txt
+++ b/src/platform/unittest/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     main.cpp
     CryptTest.cpp
     DataPathTest.cpp
+    Platform.cpp
     # StorageTest.cpp
     TlsTest.cpp
 )

--- a/src/platform/unittest/CMakeLists.txt
+++ b/src/platform/unittest/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES
     main.cpp
     CryptTest.cpp
     DataPathTest.cpp
-    Platform.cpp
+    PlatformTest.cpp
     # StorageTest.cpp
     TlsTest.cpp
 )

--- a/src/platform/unittest/Platform.cpp
+++ b/src/platform/unittest/Platform.cpp
@@ -1,0 +1,58 @@
+/*++
+
+    Copyright (c) Microsoft Corporation.
+    Licensed under the MIT License.
+
+Abstract:
+
+    QUIC Platform Unit test
+
+--*/
+
+#include "main.h"
+
+#include "msquic.h"
+#ifdef QUIC_CLOG
+#include "Platform.cpp.clog.h"
+#endif
+
+struct PlatformTest : public ::testing::TestWithParam<int32_t>
+{
+};
+
+TEST(PlatformTest, QuicAddrParsing)
+{
+    struct TestEntry {
+        const char* Input;
+        int Family;
+        int Port;
+    };
+
+    TestEntry TestData[] = {
+        { "::", QUIC_ADDRESS_FAMILY_INET6, 0 },
+        { "fe80::9c3a:b64d:6249:1de8", QUIC_ADDRESS_FAMILY_INET6, 0 },
+        { "[::1]:80", QUIC_ADDRESS_FAMILY_INET6, 80 },
+        { "127.0.0.1", QUIC_ADDRESS_FAMILY_INET, 0 },
+        { "127.0.0.1:90", QUIC_ADDRESS_FAMILY_INET, 90 }
+    };
+
+    QUIC_ADDR Addr;
+    QUIC_ADDR_STR AddrStr;
+
+    for (int i = 0; i < (int)(sizeof(TestData) / sizeof(struct TestEntry)); i++) {
+        CxPlatZeroMemory(&Addr, sizeof(QUIC_ADDR));
+        TestEntry* entry = &TestData[i];
+
+        if (entry->Family == QUIC_ADDRESS_FAMILY_INET)
+        {
+            ASSERT_TRUE(QuicAddr4FromString(entry->Input, &Addr));
+        } else {
+            ASSERT_TRUE(QuicAddr6FromString(entry->Input, &Addr));
+        }
+        ASSERT_EQ(entry->Family, Addr.Ip.sa_family);
+        ASSERT_EQ(entry->Port, ntohs(Addr.Ipv4.sin_port));
+        ASSERT_TRUE(QuicAddrToString(&Addr, &AddrStr));
+        ASSERT_EQ(0, strcmp(entry->Input, AddrStr.Address));
+    }
+}
+

--- a/src/platform/unittest/PlatformTest.cpp
+++ b/src/platform/unittest/PlatformTest.cpp
@@ -13,7 +13,7 @@ Abstract:
 
 #include "msquic.h"
 #ifdef QUIC_CLOG
-#include "Platform.cpp.clog.h"
+#include "PlatformTest.cpp.clog.h"
 #endif
 
 struct PlatformTest : public ::testing::TestWithParam<int32_t>

--- a/src/platform/unittest/PlatformTest.cpp
+++ b/src/platform/unittest/PlatformTest.cpp
@@ -44,13 +44,8 @@ TEST(PlatformTest, QuicAddrParsing)
         TestEntry* entry = &TestData[i];
 
         ASSERT_TRUE(QuicAddrFromString(entry->Input, entry->Port, &Addr));
-        if (entry->Family == QUIC_ADDRESS_FAMILY_INET) {
-            ASSERT_EQ(entry->Family, Addr.Ipv4.sin_family);
-            ASSERT_EQ(entry->Port, ntohs(Addr.Ipv4.sin_port));
-        } else {
-            ASSERT_EQ(entry->Family, Addr.Ipv6.sin6_family);
-            ASSERT_EQ(entry->Port, ntohs(Addr.Ipv6.sin6_port));
-        }
+        ASSERT_EQ(entry->Port, QuicAddrGetPort(&Addr));
+        ASSERT_EQ(entry->Family, QuicAddrGetFamily(&Addr));
         ASSERT_TRUE(QuicAddrToString(&Addr, &AddrStr));
         ASSERT_EQ(0, strcmp(entry->Input, AddrStr.Address));
     }


### PR DESCRIPTION
QuicAddrToString has two issues:

1. Addr->Ip.sa_family is either QUIC_ADDRESS_FAMILY_INET or QUIC_ADDRESS_FAMILY_INET6. Passing it directly to `inet_ntop()` does not work on platforms where QUIC_ADDRESS_FAMILY_INET6 differs from AF_INET6.
2. The underlying socket structures are:
```c
 struct sockaddr_in {
               sa_family_t    sin_family; /* address family: AF_INET */
               in_port_t      sin_port;   /* port in network byte order */
               struct in_addr sin_addr;   /* internet address */
 };
 struct sockaddr_in6 {
               sa_family_t     sin6_family;   /* AF_INET6 */
               in_port_t       sin6_port;     /* port number */
               uint32_t        sin6_flowinfo; /* IPv6 flow information */
               struct in6_addr sin6_addr;     /* IPv6 address */
               uint32_t        sin6_scope_id; /* Scope ID (new in 2.4) */
 };
```

since the v6 has flowinfo, passing `&Addr->Ipv4.sin_addr` gives wrong pointer for IPv6. 

In process of writing test, I discover that `QuicAddr6FromString` did not work properly either for IPv6 case with port. Existing code would leave leading '[' in TmpAddrStr and  `inet_pton` would fail. 


I added basic test for the functions. Since it did not seem to fit anywhere else, I added new test class for helper functions. 