### PR TITLE
prepare-machine: Detect default PS and warn dev to install the latest

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -64,6 +64,13 @@ $ClogDownloadUrl = "https://github.com/microsoft/CLOG/releases/download/v$ClogVe
 
 $MessagesAtEnd = New-Object Collections.Generic.List[string]
 
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+
+    Write-Error ("`nPowerShell v7.x is needed for this script to work. " +
+                 "Please visit https://github.com/microsoft/msquic/blob/main/docs/BUILD.md#powershell-usage")
+    exit
+}
+
 if ($InitSubmodules) {
 
     # Default TLS based on current platform.

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -68,7 +68,6 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 
     Write-Error ("`nPowerShell v7.x is needed for this script to work. " +
                  "Please visit https://github.com/microsoft/msquic/blob/main/docs/BUILD.md#powershell-usage")
-    exit
 }
 
 if ($InitSubmodules) {


### PR DESCRIPTION
`IsWindows` is not defined within the default PS. 