### PR TITLE
Build requires cmake 3.19

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Building MsQuic
 
-The full MsQuic build system relies on [CMake](https://cmake.org/) (3.16 or better), [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) (Core 3.1 or 5.0 SDK) and [Powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (7.0 or better) on all platforms.
+The full MsQuic build system relies on [CMake](https://cmake.org/) (3.19 or better), [.NET Core](https://dotnet.microsoft.com/download/dotnet-core) (Core 3.1 or 5.0 SDK) and [Powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (7.0 or better) on all platforms.
 
 > **Note** - clone the repo recursively or run `git submodule update --init --recursive`
 to get all the submodules.


### PR DESCRIPTION
On Windows (although the issue is not platform specific), when the `openssl` Tls option is chosen. CMakeLists takes the path that one of the `PROPERTY FOLDER` lines are touched. CMAKE versions under 3.19 doesn't allow FOLDER property to be used.

Repro Steps : Try `scripts/build.ps1 -Tls openssl` with cmake 3.18.xx