### PR TITLE
Switch assert for validation pending in validation complete to a TEL assert

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1631,7 +1631,7 @@ QuicCryptoCustomCertValidationComplete(
     _In_ BOOLEAN Result
     )
 {
-    CXPLAT_DBG_ASSERT(Crypto->CertValidationPending);
+    CXPLAT_TEL_ASSERT(Crypto->CertValidationPending);
     if (!Crypto->CertValidationPending) {
         return;
     }


### PR DESCRIPTION
Its possible a bad app will send the parameter when a connection either hasn't been started, or hasn't received anything back from the server. Instead of using a DBG assert, use a TEL assert so this will get entered into the logs