### PR TITLE
Signal condition variable in CxPlatEventSet while holding lock

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -398,14 +398,16 @@ CxPlatEventSet(
 
     EventObj->Signaled = true;
 
-    Result = pthread_mutex_unlock(&EventObj->Mutex);
-    CXPLAT_FRE_ASSERT(Result == 0);
-
     //
-    // Signal the condition.
+    // Signal the condition while holding the lock for predictable scheduling,
+    // better performance and removing possibility of use after free for the
+    // condition.
     //
 
     Result = pthread_cond_broadcast(&EventObj->Cond);
+    CXPLAT_FRE_ASSERT(Result == 0);
+
+    Result = pthread_mutex_unlock(&EventObj->Mutex);
     CXPLAT_FRE_ASSERT(Result == 0);
 }
 


### PR DESCRIPTION
When you call pthread_cond_wait, the mutex and condition variable become linked together. This means that signaling the condition while holding the variable results in increased performance.

In addition, the scheduler can be smarter, as it knows that signaling the variable can never wake up a waiting thread, only the unlock can.

Finally, if a thread were to get preempted between the unlock and the signal, and a spurious wakeup were to occur, this could result in the condition variable being freed before the signal can be fired.

By firing the condition while holding the lock, all of these issues can be avoided.