### PR TITLE
Loss Detection Immediately

### DIFF
--- a/src/core/loss_detection.h
+++ b/src/core/loss_detection.h
@@ -100,7 +100,8 @@ QuicLossDetectionOnZeroRttRejected(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicLossDetectionUpdateTimer(
-    _In_ QUIC_LOSS_DETECTION* LossDetection
+    _In_ QUIC_LOSS_DETECTION* LossDetection,
+    _In_ BOOLEAN ExecuteImmediatelyIfNecessary
     );
 
 //

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -96,7 +96,7 @@ QuicPacketBuilderCleanup(
     CXPLAT_DBG_ASSERT(Builder->SendContext == NULL);
 
     if (Builder->PacketBatchSent && Builder->PacketBatchRetransmittable) {
-        QuicLossDetectionUpdateTimer(&Builder->Connection->LossDetection);
+        QuicLossDetectionUpdateTimer(&Builder->Connection->LossDetection, FALSE);
     }
 
     QuicSentPacketMetadataReleaseFrames(Builder->Metadata);

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -80,6 +80,7 @@ QuicPathSetAllowance(
         if (WasBlocked) {
             QuicConnRemoveOutFlowBlockedReason(
                 Connection, QUIC_FLOW_BLOCKED_AMPLIFICATION_PROT);
+
             if (Connection->Send.SendFlags != 0) {
                 //
                 // We were blocked by amplification protection (no allowance
@@ -87,13 +88,15 @@ QuicPathSetAllowance(
                 //
                 QuicSendQueueFlush(&Connection->Send, REASON_AMP_PROTECTION);
             }
+
             //
             // Now that we are no longer blocked by amplification protection
             // we need to re-enable the loss detection timers. This call may
-            // even cause the loss timer to fire (be queued) immediately
-            // because packets were already lost, but we didn't know it.
+            // even cause the loss timer to fire immediately because packets
+            // were already lost, but we didn't know it.
             //
-            QuicLossDetectionUpdateTimer(&Connection->LossDetection);
+            QuicLossDetectionUpdateTimer(&Connection->LossDetection, TRUE);
+
         } else {
             QuicConnAddOutFlowBlockedReason(
                 Connection, QUIC_FLOW_BLOCKED_AMPLIFICATION_PROT);


### PR DESCRIPTION
See https://github.com/quicwg/base-drafts/issues/4830 for more details about the issue. This ensures that if we get unblocked from amplification protection logic, we trigger loss detection immediately (if necessary) instead of queuing it up, so that we can send lost packets first (and not application payload).