### PR TITLE
Don't affinitize datapath threads on macOS

### DIFF
--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -380,7 +380,7 @@ CxPlatProcessorContextInitialize(
     //
 
     CXPLAT_THREAD_CONFIG ThreadConfig = {
-        CXPLAT_THREAD_FLAG_SET_AFFINITIZE,
+        0,
         (uint16_t)Index,
         NULL,
         CxPlatDataPathWorkerThread,


### PR DESCRIPTION
As macOS doesn't support sockets spread across multiple threads, we shouldn't hard affinitize the datapath thread, and instead let the scheduler handle this correctly.