### PR TITLE
Use no wait flag when cancelling lttng

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -141,7 +141,7 @@ function Log-Cancel {
         if (!(Test-Path $TempDir)) {
             Write-Debug "LTTng session ($InstanceName) not currently running"
         } else {
-            Invoke-Expression "lttng destroy $InstanceName" | Write-Debug
+            Invoke-Expression "lttng destroy -n $InstanceName" | Write-Debug
             Remove-Item -Path $TempDir -Recurse -Force | Out-Null
             Write-Debug "Destroyed LTTng session ($InstanceName) and deleted $TempDir"
         }


### PR DESCRIPTION
By default, destroy will ensure all trace data has been finalized before returning. When cancelling, we don't need this behavior, so pass the no wait flag, which massively reduces the amount of time needed for logging.

Closes #679 