### PR TITLE
Remove OpenSSL interface folder in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,7 +492,6 @@ if(QUIC_TLS STREQUAL "openssl")
 
             add_library(OpenSSL_Build_Tgt INTERFACE)
             add_dependencies(OpenSSL_Build_Tgt OpenSSL_Build)
-            set_property(TARGET OpenSSL_Build_Tgt PROPERTY FOLDER "helpers")
 
             target_link_libraries(OpenSSL INTERFACE OpenSSL_Build_Tgt)
         endif()


### PR DESCRIPTION
Older versions of CMake don't allow setting folders on interface targets. They don't show up in VS anyway, so theyre not necessary.

Replaces #1264 