### PR TITLE
Reduce Max Pacing Window

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -191,8 +191,8 @@ QuicCongestionControlGetSendAllowance(
         if (SendAllowance > (Cc->CongestionWindow - Cc->BytesInFlight)) {
             SendAllowance = Cc->CongestionWindow - Cc->BytesInFlight;
         }
-        if (SendAllowance > (Cc->CongestionWindow >> 4)) {
-            SendAllowance = Cc->CongestionWindow >> 4; // Don't send more than an eigth of the current window.
+        if (SendAllowance > (Cc->CongestionWindow >> 2)) {
+            SendAllowance = Cc->CongestionWindow >> 2; // Don't send more than a quarter of the current window.
         }
     }
     return SendAllowance;

--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -191,8 +191,8 @@ QuicCongestionControlGetSendAllowance(
         if (SendAllowance > (Cc->CongestionWindow - Cc->BytesInFlight)) {
             SendAllowance = Cc->CongestionWindow - Cc->BytesInFlight;
         }
-        if (SendAllowance > (Cc->CongestionWindow >> 1)) {
-            SendAllowance = Cc->CongestionWindow >> 1; // Don't send more than half the current window.
+        if (SendAllowance > (Cc->CongestionWindow >> 4)) {
+            SendAllowance = Cc->CongestionWindow >> 4; // Don't send more than an eigth of the current window.
         }
     }
     return SendAllowance;


### PR DESCRIPTION
Reduces the max pacing burst size to 1/4 CWND, instead of 1/2. Initial testing seems to indicate this helps the small bottleneck buffer WAN perf tests.