### PR TITLE
Initial ACK Frequency Support

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -118,6 +118,7 @@ QuicConnAlloc(
     Connection->Stats.Timing.Start = CxPlatTimeUs64();
     Connection->SourceCidLimit = QUIC_ACTIVE_CONNECTION_ID_LIMIT;
     Connection->AckDelayExponent = QUIC_ACK_DELAY_EXPONENT;
+    Connection->PacketTolerance = QUIC_MIN_ACK_SEND_NUMBER;
     Connection->PeerTransportParams.AckDelayExponent = QUIC_TP_ACK_DELAY_EXPONENT_DEFAULT;
     Connection->ReceiveQueueTail = &Connection->ReceiveQueue;
     Connection->Settings = MsQuicLib.Settings;
@@ -2183,6 +2184,7 @@ QuicConnGenerateLocalTransportParameters(
                 Connection->Paths[0].Binding->Socket));
     LocalTP->MaxAckDelay =
         Connection->Settings.MaxAckDelayMs + MsQuicLib.TimerResolutionMs;
+    LocalTP->MinAckDelay = MsQuicLib.TimerResolutionMs;
     LocalTP->ActiveConnectionIdLimit = QUIC_ACTIVE_CONNECTION_ID_LIMIT;
     LocalTP->Flags =
         QUIC_TP_FLAG_INITIAL_MAX_DATA |
@@ -2191,6 +2193,7 @@ QuicConnGenerateLocalTransportParameters(
         QUIC_TP_FLAG_INITIAL_MAX_STRM_DATA_UNI |
         QUIC_TP_FLAG_MAX_UDP_PAYLOAD_SIZE |
         QUIC_TP_FLAG_MAX_ACK_DELAY |
+        QUIC_TP_FLAG_MIN_ACK_DELAY |
         QUIC_TP_FLAG_ACTIVE_CONNECTION_ID_LIMIT;
 
     if (Connection->Settings.IdleTimeoutMs != 0) {
@@ -4692,6 +4695,53 @@ QuicConnRecvFrames(
                 return FALSE;
             }
             AckPacketImmediately = TRUE;
+            break;
+        }
+
+        case QUIC_FRAME_ACK_FREQUENCY: {
+            if (!(Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_MIN_ACK_DELAY)) {
+                QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Received ACK frequency frame when not negotiated");
+                QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+                return FALSE;
+            }
+
+            QUIC_ACK_FREQUENCY_EX Frame;
+            if (!QuicAckFrequencyFrameDecode(PayloadLength, Payload, &Offset, &Frame)) {
+                QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Decoding ACK_FREQUENCY frame");
+                QuicConnTransportError(Connection, QUIC_ERROR_FRAME_ENCODING_ERROR);
+                return FALSE;
+            }
+
+            AckPacketImmediately = TRUE;
+            if (Frame.SequenceNumber < Connection->NextAckFrequencySequenceNumber) {
+                //
+                // This sequence number (or a higher one) has already been
+                // received. Ignore this one.
+                //
+                break;
+            }
+
+            Connection->NextAckFrequencySequenceNumber = Frame.SequenceNumber + 1;
+            Connection->State.IgnoreReordering = Frame.IgnoreOrder;
+            if (Frame.UpdateMaxAckDelay < 1000) {
+                Connection->Settings.MaxAckDelayMs = 1;
+            } else {
+                CXPLAT_DBG_ASSERT(US_TO_MS(Frame.UpdateMaxAckDelay) <= UINT32_MAX);
+                Connection->Settings.MaxAckDelayMs = (uint32_t)US_TO_MS(Frame.UpdateMaxAckDelay);
+            }
+            if (Frame.PacketTolerance < UINT8_MAX) {
+                Connection->PacketTolerance = (uint8_t)Frame.PacketTolerance;
+            } else {
+                Connection->PacketTolerance = UINT8_MAX; // Cap to 0xFF for space savings.
+            }
             break;
         }
 

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -153,6 +153,12 @@ typedef union QUIC_CONNECTION_STATE {
         //
         BOOLEAN AppCloseInProgress: 1;
 
+        //
+        // When true, this indicates that reordering shouldn't elict an
+        // immediate acknowledgement.
+        //
+        BOOLEAN IgnoreReordering : 1;
+
 #ifdef CxPlatVerifierEnabledByAddr
         //
         // The calling app is being verified (app or driver verifier).
@@ -380,6 +386,17 @@ typedef struct QUIC_CONNECTION {
     // 2 ^ ack_delay_exponent.
     //
     uint8_t AckDelayExponent;
+
+    //
+    // The number of packets that must be received before eliciting an immediate
+    // acknowledgement.
+    //
+    uint8_t PacketTolerance;
+
+    //
+    // The next ACK frequency frame we expect to receive.
+    //
+    uint64_t NextAckFrequencySequenceNumber;
 
     //
     // The sequence number to use for the next source CID.

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -62,8 +62,8 @@ typedef enum eSniNameType {
 //
 #define QUIC_TP_ID_MAX_DATAGRAM_FRAME_SIZE                  32  // varint
 #define QUIC_TP_ID_DISABLE_1RTT_ENCRYPTION                  0xBAAD  // N/A
-#define QUIC_TP_ID_MIN_ACK_DELAY                            0xFF02DE1A  // varint
 #define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0x73DB  // Blob
+#define QUIC_TP_ID_MIN_ACK_DELAY                            0xFF02DE1Aull  // varint
 
 BOOLEAN
 QuicTpIdIsReserved(
@@ -113,7 +113,7 @@ TlsReadUint24(
 static
 uint8_t*
 TlsWriteTransportParam(
-    _In_ uint16_t Id,
+    _In_ QUIC_VAR_INT Id,
     _In_ uint16_t Length,
     _In_reads_bytes_opt_(Length) const uint8_t* Param,
     _Out_writes_bytes_(_Inexpressible_("Too Dynamic"))
@@ -133,7 +133,7 @@ TlsWriteTransportParam(
 static
 uint8_t*
 TlsWriteTransportParamVarInt(
-    _In_ uint16_t Id,
+    _In_ QUIC_VAR_INT Id,
     _In_ QUIC_VAR_INT Value,
     _Out_writes_bytes_(_Inexpressible_("Too Dynamic"))
         uint8_t* Buffer

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -62,7 +62,7 @@ typedef enum eSniNameType {
 //
 #define QUIC_TP_ID_MAX_DATAGRAM_FRAME_SIZE                  32  // varint
 #define QUIC_TP_ID_DISABLE_1RTT_ENCRYPTION                  0xBAAD  // N/A
-#define QUIC_TP_ID_MIN_ACK_DELAY                            0xDE1A  // varint
+#define QUIC_TP_ID_MIN_ACK_DELAY                            0xFF02DE1A  // varint
 #define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0x73DB  // Blob
 
 BOOLEAN

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -63,7 +63,7 @@ typedef enum eSniNameType {
 #define QUIC_TP_ID_MAX_DATAGRAM_FRAME_SIZE                  32  // varint
 #define QUIC_TP_ID_DISABLE_1RTT_ENCRYPTION                  0xBAAD  // N/A
 #define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0x73DB  // Blob
-#define QUIC_TP_ID_MIN_ACK_DELAY                            0xFF02DE1Aull  // varint
+#define QUIC_TP_ID_MIN_ACK_DELAY                            0xFF02DE1AULL  // varint
 
 BOOLEAN
 QuicTpIdIsReserved(

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -822,9 +822,9 @@ QuicCryptoTlsEncodeTransportParameters(
     if (TransportParams->Flags & QUIC_TP_FLAG_MIN_ACK_DELAY) {
         CXPLAT_DBG_ASSERT(
             (TransportParams->Flags & QUIC_TP_FLAG_MIN_ACK_DELAY &&
-             TransportParams->MinAckDelay <= TransportParams->MaxAckDelay) ||
+             US_TO_MS(TransportParams->MinAckDelay) <= TransportParams->MaxAckDelay) ||
             (!(TransportParams->Flags & QUIC_TP_FLAG_MIN_ACK_DELAY) &&
-             TransportParams->MinAckDelay <= QUIC_TP_MAX_ACK_DELAY_DEFAULT));
+             US_TO_MS(TransportParams->MinAckDelay) <= QUIC_TP_MAX_ACK_DELAY_DEFAULT));
         RequiredTPLen +=
             TlsTransportParamLength(
                 QUIC_TP_ID_MIN_ACK_DELAY,
@@ -1114,7 +1114,7 @@ QuicCryptoTlsEncodeTransportParameters(
         QuicTraceLogConnVerbose(
             EncodeTPMinAckDelay,
             Connection,
-            "TP: Min ACK Delay (%llu ms)",
+            "TP: Min ACK Delay (%llu us)",
             TransportParams->MinAckDelay);
     }
     if (TestParam != NULL) {
@@ -1737,7 +1737,7 @@ QuicCryptoTlsDecodeTransportParameters(
             QuicTraceLogConnVerbose(
                 DecodeTPMinAckDelay,
                 Connection,
-                "TP: Min ACK Delay (%llu ms)",
+                "TP: Min ACK Delay (%llu us)",
                 TransportParams->MinAckDelay);
             break;
 
@@ -1764,7 +1764,7 @@ QuicCryptoTlsDecodeTransportParameters(
     }
 
     if (TransportParams->Flags & QUIC_TP_FLAG_MIN_ACK_DELAY &&
-        TransportParams->MinAckDelay > TransportParams->MaxAckDelay) {
+        TransportParams->MinAckDelay > MS_TO_US(TransportParams->MaxAckDelay)) {
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1209,7 +1209,7 @@ QuicCryptoTlsDecodeTransportParameters(
             ParamsPresent |= (1ULL << Id);
         }
 
-        QUIC_VAR_INT ParamLength;
+        QUIC_VAR_INT ParamLength INIT_NO_SAL(0);
         if (!QuicVarIntDecode(TPLen, TPBuf, &Offset, &ParamLength)) {
             QuicTraceEvent(
                 ConnError,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -27,6 +27,27 @@ QuicUint8Encode(
 
 _Success_(return != FALSE)
 BOOLEAN
+QuicUint8tDecode(
+    _In_ uint16_t BufferLength,
+    _In_reads_bytes_(BufferLength)
+        const uint8_t * const Buffer,
+    _Inout_
+    _Deref_in_range_(0, BufferLength)
+    _Deref_out_range_(0, BufferLength)
+        uint16_t* Offset,
+    _Out_ uint8_t* Value
+    )
+{
+    if (BufferLength < sizeof(uint8_t) + *Offset) {
+        return FALSE;
+    }
+    *Value = Buffer[*Offset];
+    *Offset += sizeof(uint8_t);
+    return TRUE;
+}
+
+_Success_(return != FALSE)
+BOOLEAN
 QuicAckHeaderEncode(
     _In_ const QUIC_ACK_EX * const Frame,
     _In_opt_ QUIC_ACK_ECN_EX* Ecn,
@@ -1160,6 +1181,59 @@ QuicDatagramFrameDecode(
     }
     Frame->Data = Buffer + *Offset;
     *Offset += (uint16_t)Frame->Length;
+    return TRUE;
+}
+
+_Success_(return != FALSE)
+BOOLEAN
+QuicAckFrequencyFrameEncode(
+    _In_ const QUIC_ACK_FREQUENCY_EX * const Frame,
+    _Inout_ uint16_t* Offset,
+    _In_ uint16_t BufferLength,
+    _Out_writes_to_(BufferLength, *Offset) uint8_t* Buffer
+    )
+{
+    uint16_t RequiredLength =
+        sizeof(uint8_t) +   // Type
+        QuicVarIntSize(Frame->SequenceNumber) +
+        QuicVarIntSize(Frame->PacketTolerance) +
+        QuicVarIntSize(Frame->UpdateMaxAckDelay) +
+        sizeof(uint8_t);    // IgnoreOrder
+
+    if (BufferLength < *Offset + RequiredLength) {
+        return FALSE;
+    }
+
+    CXPLAT_DBG_ASSERT(Frame->IgnoreOrder <= 1); // IgnoreOrder should only be 0 or 1.
+
+    Buffer = Buffer + *Offset;
+    Buffer = QuicUint8Encode(QUIC_FRAME_ACK_FREQUENCY, Buffer);
+    Buffer = QuicVarIntEncode(Frame->SequenceNumber, Buffer);
+    Buffer = QuicVarIntEncode(Frame->PacketTolerance, Buffer);
+    Buffer = QuicVarIntEncode(Frame->UpdateMaxAckDelay, Buffer);
+    QuicUint8Encode(Frame->IgnoreOrder, Buffer);
+    *Offset += RequiredLength;
+
+    return TRUE;
+}
+
+_Success_(return != FALSE)
+BOOLEAN
+QuicAckFrequencyFrameDecode(
+    _In_ uint16_t BufferLength,
+    _In_reads_bytes_(BufferLength)
+        const uint8_t * const Buffer,
+    _Inout_ uint16_t* Offset,
+    _Out_ QUIC_ACK_FREQUENCY_EX* Frame
+    )
+{
+    if (!QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->SequenceNumber) ||
+        !QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->PacketTolerance) ||
+        !QuicVarIntDecode(BufferLength, Buffer, Offset, &Frame->UpdateMaxAckDelay) ||
+        !QuicUint8tDecode(BufferLength, Buffer, Offset, &Frame->IgnoreOrder) ||
+        Frame->IgnoreOrder > 1) { // IgnoreOrder should only be 0 or 1.
+        return FALSE;
+    }
     return TRUE;
 }
 

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1829,6 +1829,31 @@ QuicFrameLog(
         break;
     }
 
+    case QUIC_FRAME_ACK_FREQUENCY: {
+        QUIC_ACK_FREQUENCY_EX Frame;
+        if (!QuicAckFrequencyFrameDecode(PacketLength, Packet, Offset, &Frame)) {
+            QuicTraceLogVerbose(
+                FrameLogAckFrequencyInvalid,
+                "[%c][%cX][%llu]   ACK_FREQUENCY [Invalid]",
+                PtkConnPre(Connection),
+                PktRxPre(Rx),
+                PacketNumber);
+            return FALSE;
+        }
+
+        QuicTraceLogVerbose(
+            FrameLogAckFrequency,
+            "[%c][%cX][%llu]   ACK_FREQUENCY SeqNum:%llu PktTolerance:%llu MaxAckDelay:%llu IgnoreOrder:%hhu",
+            PtkConnPre(Connection),
+            PktRxPre(Rx),
+            PacketNumber,
+            Frame.SequenceNumber,
+            Frame.PacketTolerance,
+            Frame.UpdateMaxAckDelay,
+            Frame.IgnoreOrder);
+        break;
+    }
+
     default:
         CXPLAT_FRE_ASSERT(FALSE);
         break;

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -143,12 +143,16 @@ typedef enum QUIC_FRAME_TYPE {
     /* 0x1f to 0x2f are unused currently */
     QUIC_FRAME_DATAGRAM             = 0x30, // to 0x31
     QUIC_FRAME_DATAGRAM_1           = 0x31,
+    /* 0x32 to 0xad are unused currently */
+    QUIC_FRAME_ACK_FREQUENCY        = 0xaf,
 
 } QUIC_FRAME_TYPE;
 
 #define QUIC_FRAME_IS_KNOWN(X) \
     (X <= QUIC_FRAME_HANDSHAKE_DONE || \
-    (X >= QUIC_FRAME_DATAGRAM && X <= QUIC_FRAME_DATAGRAM_1))
+     (X >= QUIC_FRAME_DATAGRAM && X <= QUIC_FRAME_DATAGRAM_1) || \
+     X == QUIC_FRAME_ACK_FREQUENCY \
+    )
 
 //
 // QUIC_FRAME_ACK Encoding/Decoding
@@ -777,6 +781,39 @@ QuicDatagramFrameDecode(
     _Deref_in_range_(0, BufferLength)
     _Inout_ uint16_t* Offset,
     _Out_ QUIC_DATAGRAM_EX* Frame
+    );
+
+//
+// QUIC_ACK_FREQUENCY Encoding/Decoding
+//
+
+typedef struct QUIC_ACK_FREQUENCY_EX {
+
+    QUIC_VAR_INT SequenceNumber;
+    QUIC_VAR_INT PacketTolerance;
+    QUIC_VAR_INT UpdateMaxAckDelay; // In microseconds (us)
+    uint8_t IgnoreOrder;
+
+} QUIC_ACK_FREQUENCY_EX;
+
+_Success_(return != FALSE)
+BOOLEAN
+QuicAckFrequencyFrameEncode(
+    _In_ const QUIC_ACK_FREQUENCY_EX * const Frame,
+    _Inout_ uint16_t* Offset,
+    _In_ uint16_t BufferLength,
+    _Out_writes_to_(BufferLength, *Offset)
+        uint8_t* Buffer
+    );
+
+_Success_(return != FALSE)
+BOOLEAN
+QuicAckFrequencyFrameDecode(
+    _In_ uint16_t BufferLength,
+    _In_reads_bytes_(BufferLength)
+        const uint8_t * const Buffer,
+    _Inout_ uint16_t* Offset,
+    _Out_ QUIC_ACK_FREQUENCY_EX* Frame
     );
 
 //

--- a/src/core/transport_params.h
+++ b/src/core/transport_params.h
@@ -29,6 +29,7 @@ Abstract:
 #define QUIC_TP_FLAG_RETRY_SOURCE_CONNECTION_ID             0x00020000
 #define QUIC_TP_FLAG_DISABLE_1RTT_ENCRYPTION                0x00040000
 #define QUIC_TP_FLAG_VERSION_NEGOTIATION                    0x00080000
+#define QUIC_TP_FLAG_MIN_ACK_DELAY                          0x00100000
 
 #define QUIC_TP_MAX_PACKET_SIZE_DEFAULT                     65527
 #define QUIC_TP_MAX_UDP_PAYLOAD_SIZE_MIN                    1200
@@ -39,6 +40,7 @@ Abstract:
 
 #define QUIC_TP_MAX_ACK_DELAY_DEFAULT                       25 // ms
 #define QUIC_TP_MAX_ACK_DELAY_MAX                           ((1 << 14) - 1)
+#define QUIC_TP_MIN_ACK_DELAY_MAX                           ((1 << 24) - 1)
 
 #define QUIC_TP_ACTIVE_CONNECTION_ID_LIMIT_DEFAULT          2
 #define QUIC_TP_ACTIVE_CONNECTION_ID_LIMIT_MIN              2
@@ -111,6 +113,17 @@ typedef struct QUIC_TRANSPORT_PARAMETERS {
     //
     _Field_range_(0, QUIC_TP_MAX_ACK_DELAY_MAX)
     QUIC_VAR_INT MaxAckDelay;
+
+    //
+    // A variable-length integer representing the minimum amount of time in
+    // microseconds by which the endpoint can delay an acknowledgement. Values
+    // of 2^24 or greater are invalid.
+    //
+    // The presence of the parameter also advertises support of the ACK
+    // Frequency extension.
+    //
+    _Field_range_(0, QUIC_TP_MIN_ACK_DELAY_MAX)
+    QUIC_VAR_INT MinAckDelay;
 
     //
     // The maximum number connection IDs from the peer that an endpoint is

--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -32,6 +32,7 @@ union QuicV1Frames {
     QUIC_PATH_CHALLENGE_EX PathChallengeFrame;
     QUIC_CONNECTION_CLOSE_EX ConnectionCloseFrame;
     QUIC_DATAGRAM_EX DatagramFrame;
+    QUIC_ACK_FREQUENCY_EX AckFrequencyFrame;
 };
 
 TEST(SpinFrame, SpinFrame1000000)
@@ -207,6 +208,13 @@ TEST(SpinFrame, SpinFrame1000000)
             case QUIC_FRAME_DATAGRAM:
             case QUIC_FRAME_DATAGRAM_1:
                 if (QuicDatagramFrameDecode((QUIC_FRAME_TYPE) FrameType, BufferLength, Buffer, &Offset, &DecodedFrame.DatagramFrame)) {
+                    SuccessfulDecodes++;
+                } else {
+                    FailedDecodes++;
+                }
+                break;
+            case QUIC_FRAME_ACK_FREQUENCY:
+                if (QuicAckFrequencyFrameDecode(BufferLength, Buffer, &Offset, &DecodedFrame.AckFrequencyFrame)) {
                     SuccessfulDecodes++;
                 } else {
                     FailedDecodes++;

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -96,6 +96,8 @@ ZwQueryInformationThread (
 
 #define QUIC_CACHEALIGN DECLSPEC_CACHEALIGN
 
+#define INIT_NO_SAL(X) // No-op since Windows supports SAL
+
 //
 // Library Initialization
 //

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -79,6 +79,8 @@ extern "C" {
 #define ALIGN_UP(length, type) \
     (ALIGN_DOWN(((ULONG)(length) + sizeof(type) - 1), type))
 
+#define INIT_NO_SAL(X) // No-op since Windows supports SAL
+
 //
 // Library Initialization
 //

--- a/src/inc/quic_sal_stub.h
+++ b/src/inc/quic_sal_stub.h
@@ -10,6 +10,11 @@
 
 #pragma once
 
+//
+// Necessary when SAL isn't supported to tell compiler it's not necessary.
+//
+#define INIT_NO_SAL(X) = x
+
 #ifndef _Must_inspect_result_
 #define _Must_inspect_result_
 #endif

--- a/src/inc/quic_sal_stub.h
+++ b/src/inc/quic_sal_stub.h
@@ -13,7 +13,7 @@
 //
 // Necessary when SAL isn't supported to tell compiler it's not necessary.
 //
-#define INIT_NO_SAL(X) = x
+#define INIT_NO_SAL(X) = X
 
 #ifndef _Must_inspect_result_
 #define _Must_inspect_result_

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -4390,6 +4390,62 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
+    "FrameLogAckFrequencyInvalid": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu]   ACK_FREQUENCY [Invalid]",
+      "UniqueId": "FrameLogAckFrequencyInvalid",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "FrameLogAckFrequency": {
+      "ModuleProperites": {},
+      "TraceString": "[%c][%cX][%llu]   ACK_FREQUENCY SeqNum:%llu PktTolerance:%llu MaxAckDelay:%llu IgnoreOrder:%hhu",
+      "UniqueId": "FrameLogAckFrequency",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "c",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg8"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
     "LibraryStorageOpenFailed": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Failed to open global settings, 0x%x",
@@ -12057,6 +12113,14 @@
       {
         "UniquenessHash": "a23b67c8-c2da-dfbe-2c86-728785bcdfb3",
         "TraceID": "FrameLogDatagram"
+      },
+      {
+        "UniquenessHash": "262b3f95-1062-851d-c2d8-c46867da793b",
+        "TraceID": "FrameLogAckFrequencyInvalid"
+      },
+      {
+        "UniquenessHash": "851bd2b1-e157-5cea-5989-07884c45d69e",
+        "TraceID": "FrameLogAckFrequency"
       },
       {
         "UniquenessHash": "5d4bb0a9-d10e-7ac9-a46a-dcfc5f7bf831",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2786,6 +2786,22 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
+    "EncodeTPMinAckDelay": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu ms)",
+      "UniqueId": "EncodeTPMinAckDelay",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
     "EncodeTPTest": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] TP: TEST TP (Type %hu, Length %hu)",
@@ -3145,6 +3161,22 @@
         },
         {
           "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "DecodeTPMinAckDelay": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu ms)",
+      "UniqueId": "DecodeTPMinAckDelay",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg3"
         }
       ],
@@ -8257,6 +8289,18 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
+    "DatapathRecvEmpty": {
+      "ModuleProperites": {},
+      "TraceString": "[data][%p] Dropping datagram with empty payload.",
+      "UniqueId": "DatapathRecvEmpty",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogWarning"
+    },
     "DatapathWorkerThreadStart": {
       "ModuleProperites": {},
       "TraceString": "[data][%p] Worker start",
@@ -8661,18 +8705,6 @@
       "ModuleProperites": {},
       "TraceString": "[data][%p] WSARecvMsg completion is missing IP_PKTINFO",
       "UniqueId": "DatapathMissingInfo",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogWarning"
-    },
-    "DatapathRecvEmpty": {
-      "ModuleProperites": {},
-      "TraceString": "[data][%p] Dropping datagram with empty payload.",
-      "UniqueId": "DatapathRecvEmpty",
       "splitArgs": [
         {
           "DefinationEncoding": "p",
@@ -11719,6 +11751,10 @@
         "TraceID": "EncodeTPVersionNegotiationExt"
       },
       {
+        "UniquenessHash": "5c58faeb-81c8-5127-d65d-50d8f92b7f71",
+        "TraceID": "EncodeTPMinAckDelay"
+      },
+      {
         "UniquenessHash": "4650353e-149e-c99a-1ab8-9b7e6a1e698e",
         "TraceID": "EncodeTPTest"
       },
@@ -11809,6 +11845,10 @@
       {
         "UniquenessHash": "0cffe1cb-49d2-ac2b-79ff-a691bdd7d53b",
         "TraceID": "DecodeTPVersionNegotiationInfo"
+      },
+      {
+        "UniquenessHash": "c43a7c7a-b5f7-dcb6-6a35-c1695c5a8999",
+        "TraceID": "DecodeTPMinAckDelay"
       },
       {
         "UniquenessHash": "152723b4-2b46-a936-ffaf-9cc429e8e66f",
@@ -13007,6 +13047,10 @@
         "TraceID": "CertOpenSslGetProcessAddressFailure"
       },
       {
+        "UniquenessHash": "e5973396-4dc6-d94f-5d67-921952ed35a5",
+        "TraceID": "DatapathRecvEmpty"
+      },
+      {
         "UniquenessHash": "f2af462d-2374-ab88-bb90-5b540254387e",
         "TraceID": "DatapathWorkerThreadStart"
       },
@@ -13121,10 +13165,6 @@
       {
         "UniquenessHash": "379a72cf-af97-5535-180f-f644b7513c0c",
         "TraceID": "DatapathMissingInfo"
-      },
-      {
-        "UniquenessHash": "e5973396-4dc6-d94f-5d67-921952ed35a5",
-        "TraceID": "DatapathRecvEmpty"
       },
       {
         "UniquenessHash": "fc873bff-2380-b7f7-a8be-4ff93b6d72d7",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2788,7 +2788,7 @@
     },
     "EncodeTPMinAckDelay": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu ms)",
+      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu us)",
       "UniqueId": "EncodeTPMinAckDelay",
       "splitArgs": [
         {
@@ -3168,7 +3168,7 @@
     },
     "DecodeTPMinAckDelay": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu ms)",
+      "TraceString": "[conn][%p] TP: Min ACK Delay (%llu us)",
       "UniqueId": "DecodeTPMinAckDelay",
       "splitArgs": [
         {
@@ -11807,7 +11807,7 @@
         "TraceID": "EncodeTPVersionNegotiationExt"
       },
       {
-        "UniquenessHash": "5c58faeb-81c8-5127-d65d-50d8f92b7f71",
+        "UniquenessHash": "2bcc548f-81c8-bf14-8378-f2c540783112",
         "TraceID": "EncodeTPMinAckDelay"
       },
       {
@@ -11903,7 +11903,7 @@
         "TraceID": "DecodeTPVersionNegotiationInfo"
       },
       {
-        "UniquenessHash": "c43a7c7a-b5f7-dcb6-6a35-c1695c5a8999",
+        "UniquenessHash": "94dce213-922c-7a7e-d752-7af836a806ab",
         "TraceID": "DecodeTPMinAckDelay"
       },
       {


### PR DESCRIPTION
First part of #929. Implements https://tools.ietf.org/html/draft-iyengar-quic-delayed-ack. Supports receiving the new ACK_FREQUENCY frame but never sends it currently.