### PR TITLE
Enable macOS SpinQuic

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -481,6 +481,7 @@ stages:
   dependsOn:
   - build_windows_debug
   - build_linux_debug
+  - build_macos_debug
   jobs:
   - template: ./templates/run-spinquic.yml
     parameters:
@@ -506,6 +507,11 @@ stages:
     parameters:
       image: ubuntu-latest
       platform: linux
+      tls: openssl
+  - template: ./templates/run-spinquic.yml
+    parameters:
+      image: macOS-10.15
+      platform: macos
       tls: openssl
 
 #


### PR DESCRIPTION
Because of updates to the datapath, spinquic should now be stable on macos.

Closes #1284 