### PR TITLE
Fix Frame Type Encoding Issues

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3963,7 +3963,7 @@ QuicConnRecvFrames(
         //
         // Read the frame type.
         //
-        QUIC_VAR_INT FrameType;
+        QUIC_VAR_INT FrameType INIT_NO_SAL(0);
         if (!QuicVarIntDecode(PayloadLength, Payload, &Offset, &FrameType)) {
             QuicTraceEvent(
                 ConnError,
@@ -4708,17 +4708,7 @@ QuicConnRecvFrames(
             break;
         }
 
-        case QUIC_FRAME_ACK_FREQUENCY: {
-            if (!(Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_MIN_ACK_DELAY)) {
-                QuicTraceEvent(
-                    ConnError,
-                    "[conn][%p] ERROR, %s.",
-                    Connection,
-                    "Received ACK frequency frame when not negotiated");
-                QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
-                return FALSE;
-            }
-
+        case QUIC_FRAME_ACK_FREQUENCY: { // Always accept the frame, because we always enable support.
             QUIC_ACK_FREQUENCY_EX Frame;
             if (!QuicAckFrequencyFrameDecode(PayloadLength, Payload, &Offset, &Frame)) {
                 QuicTraceEvent(

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1249,7 +1249,7 @@ QuicFrameLog(
     _Inout_ uint16_t* Offset
     )
 {
-    QUIC_VAR_INT FrameType;
+    QUIC_VAR_INT FrameType INIT_NO_SAL(0);
     if (!QuicVarIntDecode(PacketLength, Packet, Offset, &FrameType)) {
         QuicTraceEvent(
             ConnError,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1194,7 +1194,7 @@ QuicAckFrequencyFrameEncode(
     )
 {
     uint16_t RequiredLength =
-        sizeof(uint8_t) +   // Type
+        QuicVarIntSize(QUIC_FRAME_ACK_FREQUENCY) +
         QuicVarIntSize(Frame->SequenceNumber) +
         QuicVarIntSize(Frame->PacketTolerance) +
         QuicVarIntSize(Frame->UpdateMaxAckDelay) +
@@ -1207,7 +1207,7 @@ QuicAckFrequencyFrameEncode(
     CXPLAT_DBG_ASSERT(Frame->IgnoreOrder <= 1); // IgnoreOrder should only be 0 or 1.
 
     Buffer = Buffer + *Offset;
-    Buffer = QuicUint8Encode(QUIC_FRAME_ACK_FREQUENCY, Buffer);
+    Buffer = QuicVarIntEncode(QUIC_FRAME_ACK_FREQUENCY, Buffer);
     Buffer = QuicVarIntEncode(Frame->SequenceNumber, Buffer);
     Buffer = QuicVarIntEncode(Frame->PacketTolerance, Buffer);
     Buffer = QuicVarIntEncode(Frame->UpdateMaxAckDelay, Buffer);
@@ -1249,19 +1249,27 @@ QuicFrameLog(
     _Inout_ uint16_t* Offset
     )
 {
-    QUIC_FRAME_TYPE FrameType = Packet[*Offset];
+    QUIC_VAR_INT FrameType;
+    if (!QuicVarIntDecode(PacketLength, Packet, Offset, &FrameType)) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "Frame type decode failure");
+        QuicConnTransportError(Connection, QUIC_ERROR_FRAME_ENCODING_ERROR);
+        return FALSE;
+    }
+
     if (!QUIC_FRAME_IS_KNOWN(FrameType)) {
         QuicTraceLogVerbose(
             FrameLogUnknownType,
-            "[%c][%cX][%llu]   unknown frame (%hu)",
+            "[%c][%cX][%llu]   unknown frame (%llu)",
             PtkConnPre(Connection),
             PktRxPre(Rx),
             PacketNumber,
             FrameType);
         return FALSE;
     }
-
-    *Offset += 1;
 
     switch (FrameType) {
 

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -109,44 +109,50 @@ QuicErrorIsProtocolError(
 // Different types of QUIC frames
 //
 typedef enum QUIC_FRAME_TYPE {
-    QUIC_FRAME_PADDING              = 0x0,
-    QUIC_FRAME_PING                 = 0x1,
-    QUIC_FRAME_ACK                  = 0x2, // to 0x3
-    QUIC_FRAME_ACK_1                = 0x3,
-    QUIC_FRAME_RESET_STREAM         = 0x4,
-    QUIC_FRAME_STOP_SENDING         = 0x5,
-    QUIC_FRAME_CRYPTO               = 0x6,
-    QUIC_FRAME_NEW_TOKEN            = 0x7,
-    QUIC_FRAME_STREAM               = 0x8, // to 0xf
-    QUIC_FRAME_STREAM_1             = 0x9,
-    QUIC_FRAME_STREAM_2             = 0xa,
-    QUIC_FRAME_STREAM_3             = 0xb,
-    QUIC_FRAME_STREAM_4             = 0xc,
-    QUIC_FRAME_STREAM_5             = 0xd,
-    QUIC_FRAME_STREAM_6             = 0xe,
-    QUIC_FRAME_STREAM_7             = 0xf,
-    QUIC_FRAME_MAX_DATA             = 0x10,
-    QUIC_FRAME_MAX_STREAM_DATA      = 0x11,
-    QUIC_FRAME_MAX_STREAMS          = 0x12, // to 0x13
-    QUIC_FRAME_MAX_STREAMS_1        = 0x13,
-    QUIC_FRAME_DATA_BLOCKED         = 0x14,
-    QUIC_FRAME_STREAM_DATA_BLOCKED  = 0x15,
-    QUIC_FRAME_STREAMS_BLOCKED      = 0x16, // to 0x17
-    QUIC_FRAME_STREAMS_BLOCKED_1    = 0x17,
-    QUIC_FRAME_NEW_CONNECTION_ID    = 0x18,
-    QUIC_FRAME_RETIRE_CONNECTION_ID = 0x19,
-    QUIC_FRAME_PATH_CHALLENGE       = 0x1a,
-    QUIC_FRAME_PATH_RESPONSE        = 0x1b,
-    QUIC_FRAME_CONNECTION_CLOSE     = 0x1c, // to 0x1d
-    QUIC_FRAME_CONNECTION_CLOSE_1   = 0x1d,
-    QUIC_FRAME_HANDSHAKE_DONE       = 0x1e,
+    QUIC_FRAME_PADDING              = 0x0ULL,
+    QUIC_FRAME_PING                 = 0x1ULL,
+    QUIC_FRAME_ACK                  = 0x2ULL, // to 0x3
+    QUIC_FRAME_ACK_1                = 0x3ULL,
+    QUIC_FRAME_RESET_STREAM         = 0x4ULL,
+    QUIC_FRAME_STOP_SENDING         = 0x5ULL,
+    QUIC_FRAME_CRYPTO               = 0x6ULL,
+    QUIC_FRAME_NEW_TOKEN            = 0x7ULL,
+    QUIC_FRAME_STREAM               = 0x8ULL, // to 0xf
+    QUIC_FRAME_STREAM_1             = 0x9ULL,
+    QUIC_FRAME_STREAM_2             = 0xaULL,
+    QUIC_FRAME_STREAM_3             = 0xbULL,
+    QUIC_FRAME_STREAM_4             = 0xcULL,
+    QUIC_FRAME_STREAM_5             = 0xdULL,
+    QUIC_FRAME_STREAM_6             = 0xeULL,
+    QUIC_FRAME_STREAM_7             = 0xfULL,
+    QUIC_FRAME_MAX_DATA             = 0x10ULL,
+    QUIC_FRAME_MAX_STREAM_DATA      = 0x11ULL,
+    QUIC_FRAME_MAX_STREAMS          = 0x12ULL, // to 0x13
+    QUIC_FRAME_MAX_STREAMS_1        = 0x13ULL,
+    QUIC_FRAME_DATA_BLOCKED         = 0x14ULL,
+    QUIC_FRAME_STREAM_DATA_BLOCKED  = 0x15ULL,
+    QUIC_FRAME_STREAMS_BLOCKED      = 0x16ULL, // to 0x17
+    QUIC_FRAME_STREAMS_BLOCKED_1    = 0x17ULL,
+    QUIC_FRAME_NEW_CONNECTION_ID    = 0x18ULL,
+    QUIC_FRAME_RETIRE_CONNECTION_ID = 0x19ULL,
+    QUIC_FRAME_PATH_CHALLENGE       = 0x1aULL,
+    QUIC_FRAME_PATH_RESPONSE        = 0x1bULL,
+    QUIC_FRAME_CONNECTION_CLOSE     = 0x1cULL, // to 0x1d
+    QUIC_FRAME_CONNECTION_CLOSE_1   = 0x1dULL,
+    QUIC_FRAME_HANDSHAKE_DONE       = 0x1eULL,
     /* 0x1f to 0x2f are unused currently */
-    QUIC_FRAME_DATAGRAM             = 0x30, // to 0x31
-    QUIC_FRAME_DATAGRAM_1           = 0x31,
+    QUIC_FRAME_DATAGRAM             = 0x30ULL, // to 0x31
+    QUIC_FRAME_DATAGRAM_1           = 0x31ULL,
     /* 0x32 to 0xad are unused currently */
-    QUIC_FRAME_ACK_FREQUENCY        = 0xaf,
+    QUIC_FRAME_ACK_FREQUENCY        = 0xafULL,
+
+    QUIC_FRAME_MAX_SUPPORTED
 
 } QUIC_FRAME_TYPE;
+
+CXPLAT_STATIC_ASSERT(
+    QUIC_FRAME_MAX_SUPPORTED <= (uint64_t)UINT32_MAX,
+    "Logging assumes frames types fit in 32-bits");
 
 #define QUIC_FRAME_IS_KNOWN(X) \
     (X <= QUIC_FRAME_HANDSHAKE_DONE || \

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -74,6 +74,10 @@ typedef struct QUIC_SENT_FRAME_METADATA {
 
 } QUIC_SENT_FRAME_METADATA;
 
+CXPLAT_STATIC_ASSERT(
+    QUIC_FRAME_MAX_SUPPORTED <= (uint64_t)UINT8_MAX,
+    "Metadata 'Type' field above assumes frames types fit in 8-bits");
+
 typedef struct QUIC_SEND_PACKET_FLAGS {
 
     uint8_t KeyType                 : 2;

--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -47,7 +47,11 @@ TEST(SpinFrame, SpinFrame1000000)
     BOOLEAN InvalidFrame;
     uint8_t Buffer[255];
     uint8_t BufferLength = 0;
+
     uint8_t FrameType;
+    CXPLAT_STATIC_ASSERT(
+        QUIC_FRAME_MAX_SUPPORTED <= (uint64_t)UINT8_MAX,
+        "Tests below assumes frames fit in 8-bits");
 
     QuicRangeInitialize(QUIC_MAX_RANGE_DECODE_ACKS, &AckBlocks);
 

--- a/src/core/unittest/main.h
+++ b/src/core/unittest/main.h
@@ -79,6 +79,12 @@ std::ostream& operator << (std::ostream& o, const QUIC_FRAME_TYPE& type) {
             return o << "QUIC_FRAME_CONNECTION_CLOSE_1";
         case QUIC_FRAME_HANDSHAKE_DONE:
             return o << "QUIC_FRAME_HANDSHAKE_DONE";
+        case QUIC_FRAME_DATAGRAM:
+            return o << "QUIC_FRAME_DATAGRAM";
+        case QUIC_FRAME_DATAGRAM_1:
+            return o << "QUIC_FRAME_DATAGRAM_1";
+        case QUIC_FRAME_ACK_FREQUENCY:
+            return o << "QUIC_FRAME_ACK_FREQUENCY";
         default:
             return o << "UNRECOGNIZED_FRAME_TYPE(" << (uint32_t) type << ")";
     }

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -3272,7 +3272,7 @@
     },
     "FrameLogUnknownType": {
       "ModuleProperites": {},
-      "TraceString": "[%c][%cX][%llu]   unknown frame (%hu)",
+      "TraceString": "[%c][%cX][%llu]   unknown frame (%llu)",
       "UniqueId": "FrameLogUnknownType",
       "splitArgs": [
         {
@@ -3288,7 +3288,7 @@
           "MacroVariableName": "arg4"
         },
         {
-          "DefinationEncoding": "hu",
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         }
       ],
@@ -11927,7 +11927,7 @@
         "TraceID": "IndicateDatagramReceived"
       },
       {
-        "UniquenessHash": "9d92f733-cdde-7d96-f3b4-e4b129f86559",
+        "UniquenessHash": "0663ac49-e402-40ea-b23a-851ef032e5d5",
         "TraceID": "FrameLogUnknownType"
       },
       {

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -740,36 +740,44 @@ struct Send : Struct {
 };
 
 typedef enum QUIC_FRAME_TYPE {
-    QUIC_FRAME_PADDING              = 0x0,
-    QUIC_FRAME_PING                 = 0x1,
-    QUIC_FRAME_ACK                  = 0x2, // to 0x3
-    QUIC_FRAME_ACK_1                = 0x3,
-    QUIC_FRAME_RESET_STREAM         = 0x4,
-    QUIC_FRAME_STOP_SENDING         = 0x5,
-    QUIC_FRAME_CRYPTO               = 0x6,
-    QUIC_FRAME_NEW_TOKEN            = 0x7,
-    QUIC_FRAME_STREAM               = 0x8, // to 0xf
-    QUIC_FRAME_STREAM_1             = 0x9,
-    QUIC_FRAME_STREAM_2             = 0xa,
-    QUIC_FRAME_STREAM_3             = 0xb,
-    QUIC_FRAME_STREAM_4             = 0xc,
-    QUIC_FRAME_STREAM_5             = 0xd,
-    QUIC_FRAME_STREAM_6             = 0xe,
-    QUIC_FRAME_STREAM_7             = 0xf,
-    QUIC_FRAME_MAX_DATA             = 0x10,
-    QUIC_FRAME_MAX_STREAM_DATA      = 0x11,
-    QUIC_FRAME_MAX_STREAMS          = 0x12, // to 0x13
-    QUIC_FRAME_MAX_STREAMS_1        = 0x13,
-    QUIC_FRAME_DATA_BLOCKED         = 0x14,
-    QUIC_FRAME_STREAM_DATA_BLOCKED  = 0x15,
-    QUIC_FRAME_STREAMS_BLOCKED      = 0x16, // to 0x17
-    QUIC_FRAME_STREAMS_BLOCKED_1    = 0x17,
-    QUIC_FRAME_NEW_CONNECTION_ID    = 0x18,
-    QUIC_FRAME_RETIRE_CONNECTION_ID = 0x19,
-    QUIC_FRAME_PATH_CHALLENGE       = 0x1a,
-    QUIC_FRAME_PATH_RESPONSE        = 0x1b,
-    QUIC_FRAME_CONNECTION_CLOSE     = 0x1c, // to 0x1d
-    QUIC_FRAME_CONNECTION_CLOSE_1   = 0x1d
+    QUIC_FRAME_PADDING              = 0x0ULL,
+    QUIC_FRAME_PING                 = 0x1ULL,
+    QUIC_FRAME_ACK                  = 0x2ULL, // to 0x3
+    QUIC_FRAME_ACK_1                = 0x3ULL,
+    QUIC_FRAME_RESET_STREAM         = 0x4ULL,
+    QUIC_FRAME_STOP_SENDING         = 0x5ULL,
+    QUIC_FRAME_CRYPTO               = 0x6ULL,
+    QUIC_FRAME_NEW_TOKEN            = 0x7ULL,
+    QUIC_FRAME_STREAM               = 0x8ULL, // to 0xf
+    QUIC_FRAME_STREAM_1             = 0x9ULL,
+    QUIC_FRAME_STREAM_2             = 0xaULL,
+    QUIC_FRAME_STREAM_3             = 0xbULL,
+    QUIC_FRAME_STREAM_4             = 0xcULL,
+    QUIC_FRAME_STREAM_5             = 0xdULL,
+    QUIC_FRAME_STREAM_6             = 0xeULL,
+    QUIC_FRAME_STREAM_7             = 0xfULL,
+    QUIC_FRAME_MAX_DATA             = 0x10ULL,
+    QUIC_FRAME_MAX_STREAM_DATA      = 0x11ULL,
+    QUIC_FRAME_MAX_STREAMS          = 0x12ULL, // to 0x13
+    QUIC_FRAME_MAX_STREAMS_1        = 0x13ULL,
+    QUIC_FRAME_DATA_BLOCKED         = 0x14ULL,
+    QUIC_FRAME_STREAM_DATA_BLOCKED  = 0x15ULL,
+    QUIC_FRAME_STREAMS_BLOCKED      = 0x16ULL, // to 0x17
+    QUIC_FRAME_STREAMS_BLOCKED_1    = 0x17ULL,
+    QUIC_FRAME_NEW_CONNECTION_ID    = 0x18ULL,
+    QUIC_FRAME_RETIRE_CONNECTION_ID = 0x19ULL,
+    QUIC_FRAME_PATH_CHALLENGE       = 0x1aULL,
+    QUIC_FRAME_PATH_RESPONSE        = 0x1bULL,
+    QUIC_FRAME_CONNECTION_CLOSE     = 0x1cULL, // to 0x1d
+    QUIC_FRAME_CONNECTION_CLOSE_1   = 0x1dULL,
+    QUIC_FRAME_HANDSHAKE_DONE       = 0x1eULL,
+    /* 0x1f to 0x2f are unused currently */
+    QUIC_FRAME_DATAGRAM             = 0x30ULL, // to 0x31
+    QUIC_FRAME_DATAGRAM_1           = 0x31ULL,
+    /* 0x32 to 0xad are unused currently */
+    QUIC_FRAME_ACK_FREQUENCY        = 0xafULL,
+
+    QUIC_FRAME_MAX_SUPPORTED
 
 } QUIC_FRAME_TYPE;
 
@@ -836,6 +844,13 @@ struct SentFrameMetadata : Struct {
             return "CONNECTION_CLOSE";
         case QUIC_FRAME_CONNECTION_CLOSE_1:
             return "CONNECTION_CLOSE (APP)";
+        case QUIC_FRAME_HANDSHAKE_DONE:
+            return "HANDSHAKE_DONE";
+        case QUIC_FRAME_DATAGRAM:
+        case QUIC_FRAME_DATAGRAM_1:
+            return "DATAGRAM";
+        case QUIC_FRAME_ACK_FREQUENCY:
+            return "ACK_FREQUENCY";
         default:
             return "INVALID FRAME";
         }


### PR DESCRIPTION
Fixes #1313. The encoding is actually a variable length integer, not a simple byte. Up until the ACK_FREQUENCY frame, the assumption held, but now that we've added support for that, it no longer holds and breaks interop.