### PR TITLE
Switch to OpenSSL 1.1 quic branch

### DIFF
--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -48,7 +48,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_4" | .gitmodules'
+      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_5" | .gitmodules'
       path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
     displayName: Cache OpenSSL
     condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,11 +458,11 @@ if(QUIC_TLS STREQUAL "openssl")
 
             set(OPENSSL_CONFIG_FLAGS
                 enable-tls1_3 no-makedepend no-dgram no-ssl3 no-psk no-srp
-                no-zlib no-egd no-uplink no-idea no-rc5 no-rc4 no-afalgeng no-acvp_tests
-                no-comp no-cmp no-cms no-ct no-srp no-srtp no-ts no-fips no-gost no-padlockeng no-dso no-ec2m
+                no-zlib no-egd no-idea no-rc5 no-rc4 no-afalgeng
+                no-comp no-cms no-ct no-srp no-srtp no-ts no-gost no-dso no-ec2m
                 no-tls1 no-tls1_1 no-tls1_2 no-dtls no-dtls1 no-dtls1_2 no-ssl
                 no-ssl3-method no-tls1-method no-tls1_1-method no-tls1_2-method no-dtls1-method no-dtls1_2-method
-                no-siv no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
+                no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
                 no-weak-ssl-ciphers no-shared no-tests ${QUIC_OPENSSL_WIN_ARCH})
 
             add_custom_target(mkdir_openssl_build_debug
@@ -500,11 +500,11 @@ if(QUIC_TLS STREQUAL "openssl")
         set(OPENSSL_DIR ${QUIC_BUILD_DIR}/openssl)
         set(OPENSSL_CONFIG_FLAGS
             enable-tls1_3 no-makedepend no-dgram no-ssl3 no-psk no-srp
-            no-zlib no-egd no-uplink no-idea no-rc5 no-rc4 no-afalgeng no-acvp_tests
-            no-comp no-cmp no-cms no-ct no-srp no-srtp no-ts no-fips no-gost no-padlockeng no-dso no-ec2m
+            no-zlib no-egd no-idea no-rc5 no-rc4 no-afalgeng
+            no-comp no-cms no-ct no-srp no-srtp no-ts no-gost no-dso no-ec2m
             no-tls1 no-tls1_1 no-tls1_2 no-dtls no-dtls1 no-dtls1_2 no-ssl
             no-ssl3-method no-tls1-method no-tls1_1-method no-tls1_2-method no-dtls1-method no-dtls1_2-method
-            no-siv no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
+            no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
             no-weak-ssl-ciphers no-shared no-tests --prefix=${OPENSSL_DIR})
         if(CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
             set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/submodules/openssl/Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,9 +514,9 @@ if(QUIC_TLS STREQUAL "openssl")
         elseif(CX_PLATFORM STREQUAL "darwin")
             # need to build with Apple's compiler
             if (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
-                set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch arm64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-arm64)
+                set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch arm64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-arm64-cc)
             else()
-                set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch x86_64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-x86_64)
+                set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch x86_64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-x86_64-cc)
             endif()
         else()
             set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/submodules/openssl/config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,12 @@ if(QUIC_TLS STREQUAL "openssl")
 
             set(OPENSSL_CONFIG_FLAGS
                 enable-tls1_3 no-makedepend no-dgram no-ssl3 no-psk no-srp
+
+                #
+                # The following line is needed for the 3.0 branch.
+                #
+                # no-uplink no-cmp no-acvp_tests no-fips no-padlockeng no-siv
+
                 no-zlib no-egd no-idea no-rc5 no-rc4 no-afalgeng
                 no-comp no-cms no-ct no-srp no-srtp no-ts no-gost no-dso no-ec2m
                 no-tls1 no-tls1_1 no-tls1_2 no-dtls no-dtls1 no-dtls1_2 no-ssl
@@ -500,6 +506,12 @@ if(QUIC_TLS STREQUAL "openssl")
         set(OPENSSL_DIR ${QUIC_BUILD_DIR}/openssl)
         set(OPENSSL_CONFIG_FLAGS
             enable-tls1_3 no-makedepend no-dgram no-ssl3 no-psk no-srp
+
+            #
+            # The following line is needed for the 3.0 branch.
+            #
+            # no-uplink no-cmp no-acvp_tests no-fips no-padlockeng no-siv
+
             no-zlib no-egd no-idea no-rc5 no-rc4 no-afalgeng
             no-comp no-cms no-ct no-srp no-srtp no-ts no-gost no-dso no-ec2m
             no-tls1 no-tls1_1 no-tls1_2 no-dtls no-dtls1 no-dtls1_2 no-ssl

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -573,7 +573,7 @@ function Get-TestResultAtIndex($FullResults, $Index) {
 }
 
 function Get-MedianTestResults($FullResults) {
-    $sorted = $FullResults | Sort-Object
+    $sorted = $FullResults | Sort-Object {[int]$_}
     if ($sorted.Length -eq 1) {
         return $sorted[0]
     } else {


### PR DESCRIPTION
1.1 is going to be easier to get certification for.

There still needs to be work done on macos, because of M1 issues, I'll look into that.