### PR TITLE
Reduce batching counts for sends

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -161,7 +161,7 @@ typedef struct QUIC_PATH QUIC_PATH;
 // FLUSH_SEND operation. The actual number will generally exceed this value up
 // to the limit of the current USO buffer being filled.
 //
-#define QUIC_MAX_DATAGRAMS_PER_SEND             245
+#define QUIC_MAX_DATAGRAMS_PER_SEND             40
 
 //
 // The number of packets we write for a single stream before going to the next

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -120,7 +120,8 @@ private:
             .SetPeerBidiStreamCount(PERF_DEFAULT_STREAM_COUNT)
             .SetPeerUnidiStreamCount(PERF_DEFAULT_STREAM_COUNT)
             .SetDisconnectTimeoutMs(PERF_DEFAULT_DISCONNECT_TIMEOUT)
-            .SetIdleTimeoutMs(PERF_DEFAULT_IDLE_TIMEOUT)};
+            .SetIdleTimeoutMs(PERF_DEFAULT_IDLE_TIMEOUT)
+            .SetSendBufferingEnabled(false)};
     MsQuicListener Listener {Registration};
     uint16_t Port {PERF_DEFAULT_PORT};
     CXPLAT_EVENT* StopEvent {nullptr};

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -82,7 +82,7 @@ typedef enum {
 //
 // The maximum number of UDP datagrams that can be sent with one call.
 //
-#define CXPLAT_MAX_BATCH_SEND                 6
+#define CXPLAT_MAX_BATCH_SEND                 1
 
 //
 // The maximum number of UDP datagrams to preallocate for URO.

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -59,7 +59,7 @@ CxPlatFuzzerRecvMsg(
 //
 // The maximum number of UDP datagrams that can be sent with one call.
 //
-#define CXPLAT_MAX_BATCH_SEND                 7
+#define CXPLAT_MAX_BATCH_SEND                 1
 
 //
 // The maximum UDP receive coalescing payload.


### PR DESCRIPTION
Previously, we had our batch counts high. Reducing batching count caused a 200% increase in user mode Throughput download perf, and a 150% increase in kernel mode RPS pert. Both of those scenarios were lower then they should have been, and this change solves both of those issues.