### PR TITLE
Configure Schannel to Always Use Session Tickets for Resumption

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -418,7 +418,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Verbose
-      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:Alpn.ValidAlpnLengths:*ResumeRejection*
+      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:Alpn.ValidAlpnLengths
       kernel: true
 
 #
@@ -438,7 +438,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Verbose
-      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly:Alpn.ValidAlpnLengths:*ResumeRejection*
+      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly:Alpn.ValidAlpnLengths
   - template: ./templates/run-bvt.yml
     parameters:
       image: windows-latest

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1179,6 +1179,7 @@ CxPlatTlsSecConfigCreate(
         Credentials->pTlsParameters->grbitDisabledProtocols = (DWORD)~SP_PROT_TLS1_3_CLIENT;
     } else {
         Credentials->dwFlags |= SCH_CRED_NO_SYSTEM_MAPPER;
+        Credentials->dwFlags |= SCH_CRED_NO_SYSTEM_MAPPER;
         Credentials->pTlsParameters->grbitDisabledProtocols = (DWORD)~SP_PROT_TLS1_3_SERVER;
     }
     //
@@ -1879,9 +1880,11 @@ CxPlatTlsWriteDataToSchannel(
         ISC_REQ_CONFIDENTIALITY |
         ISC_RET_EXTENDED_ERROR |
         ISC_REQ_STREAM;
-    if (TlsContext->IsServer &&
-        TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_REQUIRE_CLIENT_AUTHENTICATION) {
-        ContextReq |= ASC_REQ_MUTUAL_AUTH;
+    if (TlsContext->IsServer) {
+        ContextReq |= ASC_REQ_SESSION_TICKET; // Always use session tickets for resumption
+        if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_REQUIRE_CLIENT_AUTHENTICATION) {
+            ContextReq |= ASC_REQ_MUTUAL_AUTH;
+        }
     }
     ULONG ContextAttr;
     SECURITY_STATUS SecStatus;

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1179,7 +1179,6 @@ CxPlatTlsSecConfigCreate(
         Credentials->pTlsParameters->grbitDisabledProtocols = (DWORD)~SP_PROT_TLS1_3_CLIENT;
     } else {
         Credentials->dwFlags |= SCH_CRED_NO_SYSTEM_MAPPER;
-        Credentials->dwFlags |= SCH_CRED_NO_SYSTEM_MAPPER;
         Credentials->pTlsParameters->grbitDisabledProtocols = (DWORD)~SP_PROT_TLS1_3_SERVER;
     }
     //


### PR DESCRIPTION
By default, Schannel wasn't actually using encrypted session tickets for resumption. That causes the session ticket key stuff not to work. This fixes that by configuring Schannel to always use them when doing resumption.