### PR TITLE
Fix interop reading out of range when running all tests (#1331)

### DIFF
--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -25,7 +25,6 @@ Abstract:
 
 const QUIC_API_TABLE* MsQuic;
 HQUIC Registration;
-int EndpointIndex = -1;
 uint32_t TestCases = QuicTestFeatureAll;
 uint32_t WaitTimeoutMs = 10000;
 uint32_t InitialVersion = 0;
@@ -939,7 +938,7 @@ QUIC_THREAD_CALLBACK(InteropTestCallback, Context)
     QuicTraceLogInfo(
         InteropTestStart,
         "[ntrp] Test Start, Server: %s, Port: %hu, Tests: 0x%x.",
-        PublicEndpoints[EndpointIndex].ServerName,
+        PublicEndpoints[TestContext->EndpointIndex].ServerName,
         TestContext->Port,
         (uint32_t)TestContext->Feature);
 
@@ -969,7 +968,7 @@ QUIC_THREAD_CALLBACK(InteropTestCallback, Context)
     QuicTraceLogInfo(
         InteropTestStop,
         "[ntrp] Test Stop, Server: %s, Port: %hu, Tests: 0x%x, Negotiated Alpn: %s, Passed: %s.",
-        PublicEndpoints[EndpointIndex].ServerName,
+        PublicEndpoints[TestContext->EndpointIndex].ServerName,
         TestContext->Port,
         (uint32_t)TestContext->Feature,
         Alpn,
@@ -1032,7 +1031,7 @@ PrintTestResults(
 }
 
 void
-RunInteropTests()
+RunInteropTests(int EndpointIndex)
 {
     const uint16_t* Ports = CustomPort == 0 ? PublicPorts : &CustomPort;
     const uint32_t PortsCount = CustomPort == 0 ? PublicPortsCount : 1;
@@ -1114,6 +1113,8 @@ main(
     _In_reads_(argc) _Null_terminated_ char* argv[]
     )
 {
+    int EndpointIndex = -1;
+
     if (GetValue(argc, argv, "help") ||
         GetValue(argc, argv, "?")) {
         PrintUsage();
@@ -1205,7 +1206,7 @@ main(
         EndpointIndex = (int)PublicEndpointsCount;
     }
 
-    RunInteropTests();
+    RunInteropTests(EndpointIndex);
 
     if (CustomUrlPath && TestFailed) {
         Status = QUIC_STATUS_ABORTED;


### PR DESCRIPTION
Cherry-Picked from main. Required due to an AZP update.