### PR TITLE
Fix issues with M1 mac build and running.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,8 +522,10 @@ if(QUIC_TLS STREQUAL "openssl")
             # need to build with Apple's compiler
             if (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
                 set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch arm64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-arm64-cc)
-            else()
+            elseif(CMAKE_OSX_ARCHITECTURES STREQUAL x86_64)
                 set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch x86_64" ${CMAKE_SOURCE_DIR}/submodules/openssl/Configure darwin64-x86_64-cc)
+            else()
+                set(OPENSSL_CONFIG_CMD ${CMAKE_SOURCE_DIR}/submodules/openssl/config)
             endif()
         else()
             set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/submodules/openssl/config

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -460,8 +460,13 @@ CxPlatProcCurrentNumber(
             "=c" (cpuinfo[2]),
             "=d" (cpuinfo[3])
             : "a"(1));
-    CXPLAT_FRE_ASSERT((cpuinfo[3] & (1 << 9)) != 0);
-    return (uint32_t)cpuinfo[1] >> 24;
+    //
+    // Cannot be an assert, as M1 running under Rosetta always has this flag 0.
+    //
+    if ((cpuinfo[3] & (1 << 9)) != 0) {
+        return (uint32_t)cpuinfo[1] >> 24;
+    }
+    return 0;
 #else
     //
     // arm64 macOS has no way to get the current proc, so just hardcode 0.

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -461,7 +461,9 @@ CxPlatProcCurrentNumber(
             "=d" (cpuinfo[3])
             : "a"(1));
     //
-    // Cannot be an assert, as M1 running under Rosetta always has this flag 0.
+    // Check flag to see if current core is part of cpuid. If not, assume
+    // core 0. Not all supported platforms (Specifically M1 under Rosetta)
+    // support this flag.
     //
     if ((cpuinfo[3] & (1 << 9)) != 0) {
         return (uint32_t)cpuinfo[1] >> 24;


### PR DESCRIPTION
Make the CMake build if no flags are set build for native platform. Doesn't currently affect pwsh builds.

Make rosetta builds not all throw a FRE assertion.

Closes #1338 mostly. Missing pwsh current system support, but that will need a lot more work.