### PR TITLE
essential fixes to build on Silicon Mac

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -688,7 +688,11 @@ CxPlatEventInitialize(
     _In_ BOOLEAN InitialState
     )
 {
+#if defined(CX_PLATFORM_DARWIN)
     pthread_condattr_t Attr = {0, 0};
+#else
+    pthread_condattr_t Attr = {{0, 0}};
+#endif
     int Result;
 
     Event->AutoReset = !ManualReset;

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -585,7 +585,8 @@ CxPlatTimeEpochMs64(
     void
     )
 {
-    struct timeval tv = { 0, 0 };
+    struct timeval tv;
+    CxPlatZeroMemory(&tv, sizeof(tv));
     gettimeofday(&tv, NULL);
     return S_TO_MS(tv.tv_sec) + US_TO_MS(tv.tv_usec);
 }
@@ -688,13 +689,10 @@ CxPlatEventInitialize(
     _In_ BOOLEAN InitialState
     )
 {
-#if defined(CX_PLATFORM_DARWIN)
-    pthread_condattr_t Attr = {0, 0};
-#else
-    pthread_condattr_t Attr = {{0, 0}};
-#endif
+    pthread_condattr_t Attr;
     int Result;
 
+    CxPlatZeroMemory(&Attr, sizeof(Attr));
     Event->AutoReset = !ManualReset;
     Event->Signaled = InitialState;
 

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -688,7 +688,7 @@ CxPlatEventInitialize(
     _In_ BOOLEAN InitialState
     )
 {
-    pthread_condattr_t Attr = {0};
+    pthread_condattr_t Attr = {0, 0};
     int Result;
 
     Event->AutoReset = !ManualReset;
@@ -800,7 +800,7 @@ CxPlatInternalEventWaitWithTimeout(
     )
 {
     BOOLEAN WaitSatisfied = FALSE;
-    struct timespec Ts = {0};
+    struct timespec Ts = {0, 0};
     int Result;
 
     //

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -49,7 +49,8 @@ public:
             printf("Initializing for Kernel Mode tests\n");
             const char* DriverName;
             const char* DependentDriverNames;
-            QUIC_RUN_CERTIFICATE_PARAMS CertParams = { { 0 } , { 0 } };
+            QUIC_RUN_CERTIFICATE_PARAMS CertParams;
+            CxPlatZeroMemory(&CertParams, sizeof(CertParams));
             CxPlatCopyMemory(
                 &CertParams.ServerCertHash.ShaHash,
                 (QUIC_CERTIFICATE_HASH*)(SelfSignedCertParams + 1),

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -49,7 +49,7 @@ public:
             printf("Initializing for Kernel Mode tests\n");
             const char* DriverName;
             const char* DependentDriverNames;
-            QUIC_RUN_CERTIFICATE_PARAMS CertParams = { 0 };
+            QUIC_RUN_CERTIFICATE_PARAMS CertParams = { { 0 } , { 0 } };
             CxPlatCopyMemory(
                 &CertParams.ServerCertHash.ShaHash,
                 (QUIC_CERTIFICATE_HASH*)(SelfSignedCertParams + 1),


### PR DESCRIPTION
most likely just compiler differences. 

note that build from`pwsh` creates x64 binaries
```
PS /Users/furt/github/wfurt-msquic> uname -a
Darwin Tomass-MacBook-Pro.local 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 x86_64
PS /Users/furt/github/wfurt-msquic> uname -m
x86_64
furt@Tomass-MacBook-Pro wfurt-msquic % file /Users/furt/github/wfurt-msquic/artifacts/bin/macos/x64_Debug_openssl/msquiccoretest
/Users/furt/github/wfurt-msquic/artifacts/bin/macos/x64_Debug_openssl/msquiccoretest: Mach-O 64-bit executable x86_64
```

this is described here: https://gitlab.kitware.com/cmake/cmake/-/issues/20989 

tests mostly pass
```
[----------] Global test environment tear-down
[==========] 1008 tests from 25 test suites ran. (206205 ms total)
[  PASSED  ] 1006 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] CredValidation.ConnectExpiredServerCertificate
[  FAILED  ] CredValidation.ConnectValidServerCertificate
```

running from shell:
```
furt@Tomass-MacBook-Pro wfurt-msquic % uname -m
arm64
```

I'll progress on native arm64 as time permits.