### PR TITLE
Rename SendContext and Datagram from datpath to SendData and Buffer

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -758,16 +758,16 @@ QuicBindingProcessStatelessOperation(
         Binding,
         OperationType);
 
-    CXPLAT_SEND_DATA* SendContext =
+    CXPLAT_SEND_DATA* SendData =
         CxPlatSendDataAlloc(
             Binding->Socket,
             CXPLAT_ECN_NON_ECT,
             0);
-    if (SendContext == NULL) {
+    if (SendData == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
-            "stateless send context",
+            "stateless send data",
             0);
         goto Exit;
     }
@@ -796,7 +796,7 @@ QuicBindingProcessStatelessOperation(
             (uint16_t)(SupportedVersionsLength * sizeof(uint32_t)); // Our actual supported versions
 
         SendDatagram =
-            CxPlatSendDataAllocBuffer(SendContext, PacketLength);
+            CxPlatSendDataAllocBuffer(SendData, PacketLength);
         if (SendDatagram == NULL) {
             QuicTraceEvent(
                 AllocFailure,
@@ -880,7 +880,7 @@ QuicBindingProcessStatelessOperation(
         CXPLAT_DBG_ASSERT(PacketLength >= QUIC_MIN_STATELESS_RESET_PACKET_LENGTH);
 
         SendDatagram =
-            CxPlatSendDataAllocBuffer(SendContext, PacketLength);
+            CxPlatSendDataAllocBuffer(SendData, PacketLength);
         if (SendDatagram == NULL) {
             QuicTraceEvent(
                 AllocFailure,
@@ -920,7 +920,7 @@ QuicBindingProcessStatelessOperation(
 
         uint16_t PacketLength = QuicPacketMaxBufferSizeForRetryV1();
         SendDatagram =
-            CxPlatSendDataAllocBuffer(SendContext, PacketLength);
+            CxPlatSendDataAllocBuffer(SendData, PacketLength);
         if (SendDatagram == NULL) {
             QuicTraceEvent(
                 AllocFailure,
@@ -1002,15 +1002,15 @@ QuicBindingProcessStatelessOperation(
         Binding,
         &RecvDatagram->Tuple->LocalAddress,
         &RecvDatagram->Tuple->RemoteAddress,
-        SendContext,
+        SendData,
         SendDatagram->Length,
         1);
-    SendContext = NULL;
+    SendData = NULL;
 
 Exit:
 
-    if (SendContext != NULL) {
-        CxPlatSendDataFree(SendContext);
+    if (SendData != NULL) {
+        CxPlatSendDataFree(SendData);
     }
 }
 
@@ -1687,7 +1687,7 @@ QuicBindingSend(
     _In_ QUIC_BINDING* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendContext,
+    _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend
     )
@@ -1704,14 +1704,14 @@ QuicBindingSend(
             Hooks->Send(
                 &RemoteAddressCopy,
                 &LocalAddressCopy,
-                SendContext);
+                SendData);
 
         if (Drop) {
             QuicTraceLogVerbose(
                 BindingSendTestDrop,
                 "[bind][%p] Test dropped packet",
                 Binding);
-            CxPlatSendDataFree(SendContext);
+            CxPlatSendDataFree(SendData);
             Status = QUIC_STATUS_SUCCESS;
         } else {
             Status =
@@ -1719,7 +1719,7 @@ QuicBindingSend(
                     Binding->Socket,
                     &LocalAddressCopy,
                     &RemoteAddressCopy,
-                    SendContext);
+                    SendData);
             if (QUIC_FAILED(Status)) {
                 QuicTraceLogWarning(
                     BindingSendFailed,
@@ -1735,7 +1735,7 @@ QuicBindingSend(
                 Binding->Socket,
                 LocalAddress,
                 RemoteAddress,
-                SendContext);
+                SendData);
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 BindingSendFailed,

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -428,7 +428,7 @@ QuicBindingSend(
     _In_ QUIC_BINDING* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendContext,
+    _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend
     );

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -93,7 +93,7 @@ QuicPacketBuilderCleanup(
     _Inout_ QUIC_PACKET_BUILDER* Builder
     )
 {
-    CXPLAT_DBG_ASSERT(Builder->SendContext == NULL);
+    CXPLAT_DBG_ASSERT(Builder->SendData == NULL);
 
     if (Builder->PacketBatchSent && Builder->PacketBatchRetransmittable) {
         QuicLossDetectionUpdateTimer(&Builder->Connection->LossDetection, FALSE);
@@ -159,10 +159,10 @@ QuicPacketBuilderPrepare(
         // The current data cannot go in the current QUIC packet. Finalize the
         // current QUIC packet up so we can create another.
         //
-        if (Builder->SendContext != NULL) {
+        if (Builder->SendData != NULL) {
             QuicPacketBuilderFinalize(Builder, IsPathMtuDiscovery);
         }
-        if (Builder->SendContext == NULL &&
+        if (Builder->SendData == NULL &&
             Builder->TotalCountDatagrams >= QUIC_MAX_DATAGRAMS_PER_SEND) {
             goto Error;
         }
@@ -181,8 +181,8 @@ QuicPacketBuilderPrepare(
         // Allocate and initialize a new send buffer (UDP packet/payload).
         //
 
-        if (Builder->SendContext == NULL) {
-            Builder->SendContext =
+        if (Builder->SendData == NULL) {
+            Builder->SendData =
                 CxPlatSendDataAlloc(
                     Builder->Path->Binding->Socket,
                     CXPLAT_ECN_NON_ECT,
@@ -191,7 +191,7 @@ QuicPacketBuilderPrepare(
                         MaxUdpPayloadSizeForFamily(
                             QuicAddrGetFamily(&Builder->Path->RemoteAddress),
                             DatagramSize));
-            if (Builder->SendContext == NULL) {
+            if (Builder->SendData == NULL) {
                 QuicTraceEvent(
                     AllocFailure,
                     "Allocation of '%s' failed. (%llu bytes)",
@@ -212,7 +212,7 @@ QuicPacketBuilderPrepare(
 
         Builder->Datagram =
             CxPlatSendDataAllocBuffer(
-                Builder->SendContext,
+                Builder->SendData,
                 NewDatagramLength);
         if (Builder->Datagram == NULL) {
             QuicTraceEvent(
@@ -585,7 +585,7 @@ QuicPacketBuilderFinalize(
             Builder->DatagramLength -= Builder->HeaderLength;
 
             if (Builder->DatagramLength == 0) {
-                CxPlatSendDataFreeBuffer(Builder->SendContext, Builder->Datagram);
+                CxPlatSendDataFreeBuffer(Builder->SendData, Builder->Datagram);
                 Builder->Datagram = NULL;
             }
         }
@@ -859,7 +859,7 @@ Exit:
             Builder->TotalDatagramsLength += Builder->DatagramLength;
         }
 
-        if (FlushBatchedDatagrams || CxPlatSendDataIsFull(Builder->SendContext)) {
+        if (FlushBatchedDatagrams || CxPlatSendDataIsFull(Builder->SendData)) {
             if (Builder->BatchCount != 0) {
                 QuicPacketBuilderFinalizeHeaderProtection(Builder);
             }
@@ -893,11 +893,11 @@ QuicPacketBuilderSendBatch(
         Builder->Path->Binding,
         &Builder->Path->LocalAddress,
         &Builder->Path->RemoteAddress,
-        Builder->SendContext,
+        Builder->SendData,
         Builder->TotalDatagramsLength,
         Builder->TotalCountDatagrams);
 
     Builder->PacketBatchSent = TRUE;
-    Builder->SendContext = NULL;
+    Builder->SendData = NULL;
     Builder->TotalDatagramsLength = 0;
 }

--- a/src/core/packet_builder.h
+++ b/src/core/packet_builder.h
@@ -28,7 +28,7 @@ typedef struct QUIC_PACKET_BUILDER {
     //
     // Represents a set of UDP datagrams.
     //
-    CXPLAT_SEND_DATA* SendContext;
+    CXPLAT_SEND_DATA* SendData;
 
     //
     // Represents a single UDP payload. Can contain multiple coalesced QUIC

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1188,10 +1188,10 @@ QuicSendFlush(
             QuicPacketBuilderFinalize(&Builder, FlushBatchedDatagrams);
         }
 
-    } while (Builder.SendContext != NULL ||
+    } while (Builder.SendData != NULL ||
         Builder.TotalCountDatagrams < QUIC_MAX_DATAGRAMS_PER_SEND);
 
-    if (Builder.SendContext != NULL) {
+    if (Builder.SendData != NULL) {
         //
         // Final send, if there is anything left over.
         //

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -42,7 +42,7 @@ BOOLEAN
 (QUIC_API * QUIC_TEST_DATAPATH_SEND_HOOK)(
     _Inout_ QUIC_ADDR* RemoteAddress,
     _Inout_opt_ QUIC_ADDR* LocalAddress,
-    _Inout_ CXPLAT_SEND_DATA* SendContext
+    _Inout_ CXPLAT_SEND_DATA* SendData
     );
 
 typedef struct QUIC_TEST_DATAPATH_HOOKS {

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2241,7 +2241,7 @@ CxPlatSendDataFinalizeSendBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendDataAllocBuffer(
+CxPlatSendDataAllocDataBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -2267,7 +2267,7 @@ CxPlatSendDataAllocPacketBuffer(
     )
 {
     QUIC_BUFFER* Buffer =
-        CxPlatSendDataAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
+        CxPlatSendDataAllocDataBuffer(SendData, &SendData->Owner->SendBufferPool);
     if (Buffer != NULL) {
         Buffer->Length = MaxBufferLength;
     }
@@ -2298,7 +2298,7 @@ CxPlatSendDataAllocSegmentBuffer(
         return &SendData->ClientBuffer;
     }
 
-    Buffer = CxPlatSendDataAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
+    Buffer = CxPlatSendDataAllocDataBuffer(SendData, &DatapathProc->LargeSendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -206,12 +206,12 @@ typedef struct CXPLAT_SOCKET_CONTEXT {
     //
     // The head of list containg all pending sends on this socket.
     //
-    CXPLAT_LIST_ENTRY PendingSendContextHead;
+    CXPLAT_LIST_ENTRY PendingSendDataHead;
 
     //
-    // Lock around the PendingSendContext list.
+    // Lock around the PendingSendData list.
     //
-    CXPLAT_LOCK PendingSendContextLock;
+    CXPLAT_LOCK PendingSendDataLock;
 
 } CXPLAT_SOCKET_CONTEXT;
 
@@ -326,9 +326,9 @@ typedef struct CXPLAT_DATAPATH_PROC_CONTEXT {
     CXPLAT_POOL LargeSendBufferPool;
 
     //
-    // Pool of send contexts to be shared by all sockets on this core.
+    // Pool of send data contexts to be shared by all sockets on this core.
     //
-    CXPLAT_POOL SendContextPool;
+    CXPLAT_POOL SendDataPool;
 
 } CXPLAT_DATAPATH_PROC_CONTEXT;
 
@@ -483,7 +483,7 @@ CxPlatProcessorContextInitialize(
         TRUE,
         sizeof(CXPLAT_SEND_DATA),
         QUIC_POOL_PLATFORM_SENDCTX,
-        &ProcContext->SendContextPool);
+        &ProcContext->SendDataPool);
 
     EpollFd = epoll_create1(EPOLL_CLOEXEC);
     if (EpollFd == INVALID_SOCKET) {
@@ -570,7 +570,7 @@ Exit:
         CxPlatPoolUninitialize(&ProcContext->RecvBlockPool);
         CxPlatPoolUninitialize(&ProcContext->LargeSendBufferPool);
         CxPlatPoolUninitialize(&ProcContext->SendBufferPool);
-        CxPlatPoolUninitialize(&ProcContext->SendContextPool);
+        CxPlatPoolUninitialize(&ProcContext->SendDataPool);
     }
 
     return Status;
@@ -593,7 +593,7 @@ CxPlatProcessorContextUninitialize(
     CxPlatPoolUninitialize(&ProcContext->RecvBlockPool);
     CxPlatPoolUninitialize(&ProcContext->LargeSendBufferPool);
     CxPlatPoolUninitialize(&ProcContext->SendBufferPool);
-    CxPlatPoolUninitialize(&ProcContext->SendContextPool);
+    CxPlatPoolUninitialize(&ProcContext->SendDataPool);
 }
 
 QUIC_STATUS
@@ -1312,10 +1312,10 @@ CxPlatSocketContextUninitializeComplete(
         }
     }
 
-    while (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+    while (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
         CxPlatSendDataFree(
             CXPLAT_CONTAINING_RECORD(
-                CxPlatListRemoveHead(&SocketContext->PendingSendContextHead),
+                CxPlatListRemoveHead(&SocketContext->PendingSendDataHead),
                 CXPLAT_SEND_DATA,
                 PendingSendLinkage));
     }
@@ -1539,7 +1539,7 @@ Drop:
 }
 
 //
-// N.B Requires SocketContext->PendingSendContextLock to be locked.
+// N.B Requires SocketContext->PendingSendDataLock to be locked.
 //
 void
 CxPlatSocketContextPendSend(
@@ -1567,7 +1567,7 @@ CxPlatSocketContextPendSend(
     // of the queue.
     //
     CxPlatListInsertTail(
-        &SocketContext->PendingSendContextHead,
+        &SocketContext->PendingSendDataHead,
         &SendData->PendingSendLinkage);
 }
 
@@ -1603,15 +1603,15 @@ CxPlatSocketContextSendComplete(
         return Status;
     }
 
-    CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
-    if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+    CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
+    if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
         SendData =
             CXPLAT_CONTAINING_RECORD(
-                SocketContext->PendingSendContextHead.Flink,
+                SocketContext->PendingSendDataHead.Flink,
                 CXPLAT_SEND_DATA,
                 PendingSendLinkage);
     }
-    CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+    CxPlatLockRelease(&SocketContext->PendingSendDataLock);
     if (SendData == NULL) {
         return Status;
     }
@@ -1624,21 +1624,21 @@ CxPlatSocketContextSendComplete(
                 &SendData->RemoteAddress,
                 SendData,
                 TRUE);
-        CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
+        CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
         if (Status != QUIC_STATUS_PENDING) {
-            CxPlatListRemoveHead(&SocketContext->PendingSendContextHead);
+            CxPlatListRemoveHead(&SocketContext->PendingSendDataHead);
             CxPlatSendDataFree(SendData);
-            if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+            if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
                 SendData =
                     CXPLAT_CONTAINING_RECORD(
-                        SocketContext->PendingSendContextHead.Flink,
+                        SocketContext->PendingSendDataHead.Flink,
                         CXPLAT_SEND_DATA,
                         PendingSendLinkage);
             } else {
                 SendData = NULL;
             }
         }
-        CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+        CxPlatLockRelease(&SocketContext->PendingSendDataLock);
     } while (Status == QUIC_STATUS_SUCCESS && SendData != NULL);
 
     return Status;
@@ -1814,8 +1814,8 @@ CxPlatSocketCreateUdp(
                 Binding->Mtu - CXPLAT_MIN_IPV4_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE;
         }
         Binding->SocketContexts[i].ProcContext = &Datapath->ProcContexts[IsServerSocket ? i : CurrentProc];
-        CxPlatListInitializeHead(&Binding->SocketContexts[i].PendingSendContextHead);
-        CxPlatLockInitialize(&Binding->SocketContexts[i].PendingSendContextLock);
+        CxPlatListInitializeHead(&Binding->SocketContexts[i].PendingSendDataHead);
+        CxPlatLockInitialize(&Binding->SocketContexts[i].PendingSendDataLock);
         CxPlatRundownAcquire(&Binding->Rundown);
     }
 
@@ -1883,7 +1883,7 @@ Exit:
             CxPlatRundownRelease(&Datapath->BindingsRundown);
             CxPlatRundownUninitialize(&Binding->Rundown);
             for (uint32_t i = 0; i < SocketCount; i++) {
-                CxPlatLockUninitialize(&Binding->SocketContexts[i].PendingSendContextLock);
+                CxPlatLockUninitialize(&Binding->SocketContexts[i].PendingSendDataLock);
             }
             CXPLAT_FREE(Binding, QUIC_POOL_SOCKET);
             Binding = NULL;
@@ -1961,7 +1961,7 @@ CxPlatSocketDelete(
 
     CxPlatRundownUninitialize(&Socket->Rundown);
     for (uint32_t i = 0; i < SocketCount; i++) {
-        CxPlatLockUninitialize(&Socket->SocketContexts[i].PendingSendContextLock);
+        CxPlatLockUninitialize(&Socket->SocketContexts[i].PendingSendDataLock);
     }
     CXPLAT_FREE(Socket, QUIC_POOL_SOCKET);
 #endif
@@ -2116,7 +2116,7 @@ CxPlatSendDataAlloc(
         &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatPoolAlloc(&DatapathProc->SendContextPool);
+        CxPlatPoolAlloc(&DatapathProc->SendDataPool);
 
     if (SendData == NULL) {
         QuicTraceEvent(
@@ -2158,20 +2158,20 @@ CxPlatSendDataFree(
         CxPlatPoolFree(BufferPool, SendData->Buffers[i].Buffer);
     }
 
-    CxPlatPoolFree(&DatapathProc->SendContextPool, SendData);
+    CxPlatPoolFree(&DatapathProc->SendDataPool, SendData);
 #endif
 }
 
 static
 BOOLEAN
-CxPlatSendContextCanAllocSendSegment(
+CxPlatSendDataCanAllocSendSegment(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
 {
     CXPLAT_DBG_ASSERT(SendData->SegmentSize > 0);
     CXPLAT_DBG_ASSERT(SendData->BufferCount > 0);
-    //CXPLAT_DBG_ASSERT(SendContext->BufferCount <= SendContext->Owner->Datapath->MaxSendBatchSize);
+    //CXPLAT_DBG_ASSERT(SendData->BufferCount <= SendData->Owner->Datapath->MaxSendBatchSize);
 
     uint64_t BytesAvailable =
         CXPLAT_LARGE_SEND_BUFFER_SIZE -
@@ -2183,7 +2183,7 @@ CxPlatSendContextCanAllocSendSegment(
 
 static
 BOOLEAN
-CxPlatSendContextCanAllocSend(
+CxPlatSendDataCanAllocSend(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
@@ -2191,12 +2191,12 @@ CxPlatSendContextCanAllocSend(
     return
         (SendData->BufferCount < SendData->Owner->Datapath->MaxSendBatchSize) ||
         ((SendData->SegmentSize > 0) &&
-            CxPlatSendContextCanAllocSendSegment(SendData, MaxBufferLength));
+            CxPlatSendDataCanAllocSendSegment(SendData, MaxBufferLength));
 }
 
 static
 void
-CxPlatSendContextFinalizeSendBuffer(
+CxPlatSendDataFinalizeSendBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ BOOLEAN IsSendingImmediately
     )
@@ -2215,7 +2215,7 @@ CxPlatSendContextFinalizeSendBuffer(
 
     CXPLAT_DBG_ASSERT(SendData->SegmentSize > 0 && SendData->BufferCount > 0);
     CXPLAT_DBG_ASSERT(SendData->ClientBuffer.Length > 0 && SendData->ClientBuffer.Length <= SendData->SegmentSize);
-    CXPLAT_DBG_ASSERT(CxPlatSendContextCanAllocSendSegment(SendData, 0));
+    CXPLAT_DBG_ASSERT(CxPlatSendDataCanAllocSendSegment(SendData, 0));
 
     //
     // Append the client's buffer segment to our internal send buffer.
@@ -2241,7 +2241,7 @@ CxPlatSendContextFinalizeSendBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocBuffer(
+CxPlatSendDataAllocBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -2261,13 +2261,13 @@ CxPlatSendContextAllocBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocPacketBuffer(
+CxPlatSendDataAllocPacketBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
 {
     QUIC_BUFFER* Buffer =
-        CxPlatSendContextAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
+        CxPlatSendDataAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
     if (Buffer != NULL) {
         Buffer->Length = MaxBufferLength;
     }
@@ -2277,7 +2277,7 @@ CxPlatSendContextAllocPacketBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocSegmentBuffer(
+CxPlatSendDataAllocSegmentBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
@@ -2289,7 +2289,7 @@ CxPlatSendContextAllocSegmentBuffer(
     QUIC_BUFFER* Buffer;
 
     if (SendData->ClientBuffer.Buffer != NULL &&
-        CxPlatSendContextCanAllocSendSegment(SendData, MaxBufferLength)) {
+        CxPlatSendDataCanAllocSendSegment(SendData, MaxBufferLength)) {
 
         //
         // All clear to return the next segment of our contiguous buffer.
@@ -2298,7 +2298,7 @@ CxPlatSendContextAllocSegmentBuffer(
         return &SendData->ClientBuffer;
     }
 
-    Buffer = CxPlatSendContextAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
+    Buffer = CxPlatSendDataAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }
@@ -2332,16 +2332,16 @@ CxPlatSendDataAllocBuffer(
     CXPLAT_DBG_ASSERT(MaxBufferLength > 0);
     //CXPLAT_DBG_ASSERT(MaxBufferLength <= CXPLAT_MAX_MTU - CXPLAT_MIN_IPV4_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE);
 
-    CxPlatSendContextFinalizeSendBuffer(SendData, FALSE);
+    CxPlatSendDataFinalizeSendBuffer(SendData, FALSE);
 
-    if (!CxPlatSendContextCanAllocSend(SendData, MaxBufferLength)) {
+    if (!CxPlatSendDataCanAllocSend(SendData, MaxBufferLength)) {
         return NULL;
     }
 
     if (SendData->SegmentSize == 0) {
-        return CxPlatSendContextAllocPacketBuffer(SendData, MaxBufferLength);
+        return CxPlatSendDataAllocPacketBuffer(SendData, MaxBufferLength);
     }
-    return CxPlatSendContextAllocSegmentBuffer(SendData, MaxBufferLength);
+    return CxPlatSendDataAllocSegmentBuffer(SendData, MaxBufferLength);
 #endif
 }
 
@@ -2390,12 +2390,12 @@ CxPlatSendDataIsFull(
 #ifdef CX_PLATFORM_DISPATCH_TABLE
     return PlatDispatch->SendDataIsFull(SendData);
 #else
-    return !CxPlatSendContextCanAllocSend(SendData, SendData->SegmentSize);
+    return !CxPlatSendDataCanAllocSend(SendData, SendData->SegmentSize);
 #endif
 }
 
 void
-CxPlatSendContextComplete(
+CxPlatSendDataComplete(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketProc,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint64_t IoResult
@@ -2416,7 +2416,7 @@ CxPlatSendContextComplete(
     //         SocketProc->Parent,
     //         SocketProc->Parent->ClientContext,
     //         IoResult,
-    //         SendContext->TotalSize);
+    //         SendData->TotalSize);
     // }
 
     CxPlatSendDataFree(SendData);
@@ -2463,7 +2463,7 @@ CxPlatSocketSendInternal(
     }
 
     if (!IsPendedSend) {
-        CxPlatSendContextFinalizeSendBuffer(SendData, TRUE);
+        CxPlatSendDataFinalizeSendBuffer(SendData, TRUE);
         for (size_t i = SendData->SentMessagesCount; i < SendData->BufferCount; ++i) {
             SendData->Iovs[i].iov_base = SendData->Buffers[i].Buffer;
             SendData->Iovs[i].iov_len = SendData->Buffers[i].Length;
@@ -2481,8 +2481,8 @@ CxPlatSocketSendInternal(
         //
         // Check to see if we need to pend.
         //
-        CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
-        if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+        CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
+        if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
             CxPlatSocketContextPendSend(
                 SocketContext,
                 SendData,
@@ -2490,7 +2490,7 @@ CxPlatSocketSendInternal(
                 RemoteAddress);
             SendPending = TRUE;
         }
-        CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+        CxPlatLockRelease(&SocketContext->PendingSendDataLock);
         if (SendPending) {
             Status = QUIC_STATUS_PENDING;
             goto Exit;
@@ -2579,13 +2579,13 @@ CxPlatSocketSendInternal(
         if (SuccessfullySentMessages < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 if (!IsPendedSend) {
-                    CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
+                    CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
                     CxPlatSocketContextPendSend(
                         SocketContext,
                         SendData,
                         LocalAddress,
                         RemoteAddress);
-                    CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+                    CxPlatLockRelease(&SocketContext->PendingSendDataLock);
                 }
                 SendPending = TRUE;
                 struct epoll_event SockFdEpEvt = {
@@ -2650,7 +2650,7 @@ Exit:
 
     if (!SendPending && !IsPendedSend) {
         // TODO Add TCP when necessary
-        CxPlatSendContextComplete(SocketContext, SendData, Status);
+        CxPlatSendDataComplete(SocketContext, SendData, Status);
     }
 
     return Status;

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -187,12 +187,12 @@ typedef struct CXPLAT_SOCKET_CONTEXT {
     //
     // The head of list containg all pending sends on this socket.
     //
-    CXPLAT_LIST_ENTRY PendingSendContextHead;
+    CXPLAT_LIST_ENTRY PendingSendDataHead;
 
     //
-    // Lock around the PendingSendContext list.
+    // Lock around the PendingSendData list.
     //
-    CXPLAT_LOCK PendingSendContextLock;
+    CXPLAT_LOCK PendingSendDataLock;
 
 } CXPLAT_SOCKET_CONTEXT;
 
@@ -304,7 +304,7 @@ typedef struct CXPLAT_DATAPATH_PROC_CONTEXT {
     //
     // Pool of send contexts to be shared by all sockets on this core.
     //
-    CXPLAT_POOL SendContextPool;
+    CXPLAT_POOL SendDataPool;
 
 } CXPLAT_DATAPATH_PROC_CONTEXT;
 
@@ -408,7 +408,7 @@ CxPlatProcessorContextInitialize(
         TRUE,
         sizeof(CXPLAT_SEND_DATA),
         QUIC_POOL_PLATFORM_SENDCTX,
-        &ProcContext->SendContextPool);
+        &ProcContext->SendDataPool);
 
     KqueueFd = kqueue();
     if (KqueueFd == INVALID_SOCKET) {
@@ -457,7 +457,7 @@ Exit:
         CxPlatPoolUninitialize(&ProcContext->RecvBlockPool);
         CxPlatPoolUninitialize(&ProcContext->LargeSendBufferPool);
         CxPlatPoolUninitialize(&ProcContext->SendBufferPool);
-        CxPlatPoolUninitialize(&ProcContext->SendContextPool);
+        CxPlatPoolUninitialize(&ProcContext->SendDataPool);
     }
 
     return Status;
@@ -479,7 +479,7 @@ CxPlatProcessorContextUninitialize(
     CxPlatPoolUninitialize(&ProcContext->RecvBlockPool);
     CxPlatPoolUninitialize(&ProcContext->LargeSendBufferPool);
     CxPlatPoolUninitialize(&ProcContext->SendBufferPool);
-    CxPlatPoolUninitialize(&ProcContext->SendContextPool);
+    CxPlatPoolUninitialize(&ProcContext->SendDataPool);
 }
 
 QUIC_STATUS
@@ -1057,10 +1057,10 @@ CxPlatSocketContextUninitializeComplete(
         CxPlatRecvDataReturn(&SocketContext->CurrentRecvBlock->RecvPacket);
     }
 
-    while (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+    while (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
         CxPlatSendDataFree(
             CXPLAT_CONTAINING_RECORD(
-                CxPlatListRemoveHead(&SocketContext->PendingSendContextHead),
+                CxPlatListRemoveHead(&SocketContext->PendingSendDataHead),
                 CXPLAT_SEND_DATA,
                 PendingSendLinkage));
     }
@@ -1252,7 +1252,7 @@ CxPlatSocketContextRecvComplete(
 }
 
 //
-// N.B Requires SocketContext->PendingSendContextLock to be locked.
+// N.B Requires SocketContext->PendingSendDataLock to be locked.
 //
 void
 CxPlatSocketContextPendSend(
@@ -1280,7 +1280,7 @@ CxPlatSocketContextPendSend(
     // of the queue.
     //
     CxPlatListInsertTail(
-        &SocketContext->PendingSendContextHead,
+        &SocketContext->PendingSendDataHead,
         &SendData->PendingSendLinkage);
 }
 
@@ -1294,15 +1294,15 @@ CxPlatSocketContextSendComplete(
 
     // Disable kqueue already disables events
 
-    CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
-    if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+    CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
+    if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
         SendData =
             CXPLAT_CONTAINING_RECORD(
-                SocketContext->PendingSendContextHead.Flink,
+                SocketContext->PendingSendDataHead.Flink,
                 CXPLAT_SEND_DATA,
                 PendingSendLinkage);
     }
-    CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+    CxPlatLockRelease(&SocketContext->PendingSendDataLock);
     if (SendData == NULL) {
         return Status;
     }
@@ -1315,21 +1315,21 @@ CxPlatSocketContextSendComplete(
                 &SendData->RemoteAddress,
                 SendData,
                 TRUE);
-        CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
+        CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
         if (Status != QUIC_STATUS_PENDING) {
-            CxPlatListRemoveHead(&SocketContext->PendingSendContextHead);
+            CxPlatListRemoveHead(&SocketContext->PendingSendDataHead);
             CxPlatSendDataFree(SendData);
-            if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+            if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
                 SendData =
                     CXPLAT_CONTAINING_RECORD(
-                        SocketContext->PendingSendContextHead.Flink,
+                        SocketContext->PendingSendDataHead.Flink,
                         CXPLAT_SEND_DATA,
                         PendingSendLinkage);
             } else {
                 SendData = NULL;
             }
         }
-        CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+        CxPlatLockRelease(&SocketContext->PendingSendDataLock);
     } while (Status == QUIC_STATUS_SUCCESS && SendData != NULL);
 
     return Status;
@@ -1457,8 +1457,8 @@ CxPlatSocketCreateUdp(
         Binding->SocketContexts[i].RecvIov.iov_len =
             Binding->Mtu - CXPLAT_MIN_IPV4_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE;
         Binding->SocketContexts[i].ProcContext = &Datapath->ProcContexts[IsServerSocket ? i : CurrentProc];
-        CxPlatListInitializeHead(&Binding->SocketContexts[i].PendingSendContextHead);
-        CxPlatLockInitialize(&Binding->SocketContexts[i].PendingSendContextLock);
+        CxPlatListInitializeHead(&Binding->SocketContexts[i].PendingSendDataHead);
+        CxPlatLockInitialize(&Binding->SocketContexts[i].PendingSendDataLock);
         CxPlatRundownAcquire(&Binding->Rundown);
     }
 
@@ -1516,7 +1516,7 @@ Exit:
             CxPlatRundownRelease(&Datapath->BindingsRundown);
             CxPlatRundownUninitialize(&Binding->Rundown);
             for (uint32_t i = 0; i < SocketCount; i++) {
-                CxPlatLockUninitialize(&Binding->SocketContexts[i].PendingSendContextLock);
+                CxPlatLockUninitialize(&Binding->SocketContexts[i].PendingSendDataLock);
             }
             CXPLAT_FREE(Binding, QUIC_POOL_SOCKET);
             Binding = NULL;
@@ -1590,7 +1590,7 @@ CxPlatSocketDelete(
 
     CxPlatRundownUninitialize(&Socket->Rundown);
     for (uint32_t i = 0; i < SocketCount; i++) {
-        CxPlatLockUninitialize(&Socket->SocketContexts[i].PendingSendContextLock);
+        CxPlatLockUninitialize(&Socket->SocketContexts[i].PendingSendDataLock);
     }
     CXPLAT_FREE(Socket, QUIC_POOL_SOCKET);
 }
@@ -1697,7 +1697,7 @@ CxPlatSendDataAlloc(
         &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatPoolAlloc(&DatapathProc->SendContextPool);
+        CxPlatPoolAlloc(&DatapathProc->SendDataPool);
 
     if (SendData == NULL) {
         QuicTraceEvent(
@@ -1735,19 +1735,19 @@ CxPlatSendDataFree(
         CxPlatPoolFree(BufferPool, SendData->Buffers[i].Buffer);
     }
 
-    CxPlatPoolFree(&DatapathProc->SendContextPool, SendData);
+    CxPlatPoolFree(&DatapathProc->SendDataPool, SendData);
 }
 
 static
 BOOLEAN
-CxPlatSendContextCanAllocSendSegment(
+CxPlatSendDataCanAllocSendSegment(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
 {
     CXPLAT_DBG_ASSERT(SendData->SegmentSize > 0);
     CXPLAT_DBG_ASSERT(SendData->BufferCount > 0);
-    //CXPLAT_DBG_ASSERT(SendContext->BufferCount <= SendContext->Owner->Datapath->MaxSendBatchSize);
+    //CXPLAT_DBG_ASSERT(SendData->BufferCount <= SendData->Owner->Datapath->MaxSendBatchSize);
 
     uint64_t BytesAvailable =
         CXPLAT_LARGE_SEND_BUFFER_SIZE -
@@ -1759,7 +1759,7 @@ CxPlatSendContextCanAllocSendSegment(
 
 static
 BOOLEAN
-CxPlatSendContextCanAllocSend(
+CxPlatSendDataCanAllocSend(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
@@ -1767,12 +1767,12 @@ CxPlatSendContextCanAllocSend(
     return
         (SendData->BufferCount < SendData->Owner->Datapath->MaxSendBatchSize) ||
         ((SendData->SegmentSize > 0) &&
-            CxPlatSendContextCanAllocSendSegment(SendData, MaxBufferLength));
+            CxPlatSendDataCanAllocSendSegment(SendData, MaxBufferLength));
 }
 
 static
 void
-CxPlatSendContextFinalizeSendBuffer(
+CxPlatSendDataFinalizeSendBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ BOOLEAN IsSendingImmediately
     )
@@ -1791,7 +1791,7 @@ CxPlatSendContextFinalizeSendBuffer(
 
     CXPLAT_DBG_ASSERT(SendData->SegmentSize > 0 && SendData->BufferCount > 0);
     CXPLAT_DBG_ASSERT(SendData->ClientBuffer.Length > 0 && SendData->ClientBuffer.Length <= SendData->SegmentSize);
-    CXPLAT_DBG_ASSERT(CxPlatSendContextCanAllocSendSegment(SendData, 0));
+    CXPLAT_DBG_ASSERT(CxPlatSendDataCanAllocSendSegment(SendData, 0));
 
     //
     // Append the client's buffer segment to our internal send buffer.
@@ -1817,7 +1817,7 @@ CxPlatSendContextFinalizeSendBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocBuffer(
+CxPlatSendDataAllocBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -1837,13 +1837,13 @@ CxPlatSendContextAllocBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocPacketBuffer(
+CxPlatSendDataAllocPacketBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
 {
     QUIC_BUFFER* Buffer =
-        CxPlatSendContextAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
+        CxPlatSendDataAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
     if (Buffer != NULL) {
         Buffer->Length = MaxBufferLength;
     }
@@ -1853,7 +1853,7 @@ CxPlatSendContextAllocPacketBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendContextAllocSegmentBuffer(
+CxPlatSendDataAllocSegmentBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t MaxBufferLength
     )
@@ -1865,7 +1865,7 @@ CxPlatSendContextAllocSegmentBuffer(
     QUIC_BUFFER* Buffer;
 
     if (SendData->ClientBuffer.Buffer != NULL &&
-        CxPlatSendContextCanAllocSendSegment(SendData, MaxBufferLength)) {
+        CxPlatSendDataCanAllocSendSegment(SendData, MaxBufferLength)) {
 
         //
         // All clear to return the next segment of our contiguous buffer.
@@ -1874,7 +1874,7 @@ CxPlatSendContextAllocSegmentBuffer(
         return &SendData->ClientBuffer;
     }
 
-    Buffer = CxPlatSendContextAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
+    Buffer = CxPlatSendDataAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }
@@ -1902,16 +1902,16 @@ CxPlatSendDataAllocBuffer(
     CXPLAT_DBG_ASSERT(MaxBufferLength > 0);
     //CXPLAT_DBG_ASSERT(MaxBufferLength <= CXPLAT_MAX_MTU - CXPLAT_MIN_IPV4_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE);
 
-    CxPlatSendContextFinalizeSendBuffer(SendData, FALSE);
+    CxPlatSendDataFinalizeSendBuffer(SendData, FALSE);
 
-    if (!CxPlatSendContextCanAllocSend(SendData, MaxBufferLength)) {
+    if (!CxPlatSendDataCanAllocSend(SendData, MaxBufferLength)) {
         return NULL;
     }
 
     if (SendData->SegmentSize == 0) {
-        return CxPlatSendContextAllocPacketBuffer(SendData, MaxBufferLength);
+        return CxPlatSendDataAllocPacketBuffer(SendData, MaxBufferLength);
     }
-    return CxPlatSendContextAllocSegmentBuffer(SendData, MaxBufferLength);
+    return CxPlatSendDataAllocSegmentBuffer(SendData, MaxBufferLength);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -1952,11 +1952,11 @@ CxPlatSendDataIsFull(
     _In_ CXPLAT_SEND_DATA* SendData
     )
 {
-    return !CxPlatSendContextCanAllocSend(SendData, SendData->SegmentSize);
+    return !CxPlatSendDataCanAllocSend(SendData, SendData->SegmentSize);
 }
 
 void
-CxPlatSendContextComplete(
+CxPlatSendDataComplete(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketProc,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint64_t IoResult
@@ -1977,7 +1977,7 @@ CxPlatSendContextComplete(
     //         SocketProc->Parent,
     //         SocketProc->Parent->ClientContext,
     //         IoResult,
-    //         SendContext->TotalSize);
+    //         SendData->TotalSize);
     // }
 
     CxPlatSendDataFree(SendData);
@@ -2017,7 +2017,7 @@ CxPlatSocketSendInternal(
     }
 
     if (!IsPendedSend) {
-        CxPlatSendContextFinalizeSendBuffer(SendData, TRUE);
+        CxPlatSendDataFinalizeSendBuffer(SendData, TRUE);
         for (size_t i = 0; i < SendData->BufferCount; ++i) {
             SendData->Iovs[i].iov_base = SendData->Buffers[i].Buffer;
             SendData->Iovs[i].iov_len = SendData->Buffers[i].Length;
@@ -2035,8 +2035,8 @@ CxPlatSocketSendInternal(
         //
         // Check to see if we need to pend.
         //
-        CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
-        if (!CxPlatListIsEmpty(&SocketContext->PendingSendContextHead)) {
+        CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
+        if (!CxPlatListIsEmpty(&SocketContext->PendingSendDataHead)) {
             CxPlatSocketContextPendSend(
                 SocketContext,
                 SendData,
@@ -2044,7 +2044,7 @@ CxPlatSocketSendInternal(
                 RemoteAddress);
             SendPending = TRUE;
         }
-        CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+        CxPlatLockRelease(&SocketContext->PendingSendDataLock);
         if (SendPending) {
             Status = QUIC_STATUS_PENDING;
             goto Exit;
@@ -2105,13 +2105,13 @@ CxPlatSocketSendInternal(
     if (SentByteCount < 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             if (!IsPendedSend) {
-                CxPlatLockAcquire(&SocketContext->PendingSendContextLock);
+                CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
                 CxPlatSocketContextPendSend(
                     SocketContext,
                     SendData,
                     LocalAddress,
                     RemoteAddress);
-                CxPlatLockRelease(&SocketContext->PendingSendContextLock);
+                CxPlatLockRelease(&SocketContext->PendingSendDataLock);
             }
             SendPending = TRUE;
             struct kevent Event = {0};
@@ -2170,7 +2170,7 @@ Exit:
 
     if (!SendPending && !IsPendedSend) {
         // TODO Add TCP when necessary
-        CxPlatSendContextComplete(SocketContext, SendData, Status);
+        CxPlatSendDataComplete(SocketContext, SendData, Status);
     }
 
     return Status;

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1817,7 +1817,7 @@ CxPlatSendDataFinalizeSendBuffer(
 _Success_(return != NULL)
 static
 QUIC_BUFFER*
-CxPlatSendDataAllocBuffer(
+CxPlatSendDataAllocDataBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -1843,7 +1843,7 @@ CxPlatSendDataAllocPacketBuffer(
     )
 {
     QUIC_BUFFER* Buffer =
-        CxPlatSendDataAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
+        CxPlatSendDataAllocDataBuffer(SendData, &SendData->Owner->SendBufferPool);
     if (Buffer != NULL) {
         Buffer->Length = MaxBufferLength;
     }
@@ -1874,7 +1874,7 @@ CxPlatSendDataAllocSegmentBuffer(
         return &SendData->ClientBuffer;
     }
 
-    Buffer = CxPlatSendDataAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
+    Buffer = CxPlatSendDataAllocDataBuffer(SendData, &DatapathProc->LargeSendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2584,7 +2584,7 @@ CxPlatSendBufferPoolAlloc(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 static
 UINT8*
-CxPlatSendDataAllocBuffer(
+CxPlatSendDataAllocDataBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -2619,7 +2619,7 @@ CxPlatSendDataAllocPacketBuffer(
     CXPLAT_DATAPATH_PROC_CONTEXT* ProcContext = SendData->Owner;
     UINT8* Buffer;
 
-    Buffer = CxPlatSendDataAllocBuffer(SendData, &ProcContext->SendBufferPool);
+    Buffer = CxPlatSendDataAllocDataBuffer(SendData, &ProcContext->SendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }
@@ -2655,7 +2655,7 @@ CxPlatSendDataAllocSegmentBuffer(
         return (QUIC_BUFFER*)&SendData->ClientBuffer;
     }
 
-    Buffer = CxPlatSendDataAllocBuffer(SendData, &ProcContext->LargeSendBufferPool);
+    Buffer = CxPlatSendDataAllocDataBuffer(SendData, &ProcContext->LargeSendBufferPool);
     if (Buffer == NULL) {
         return NULL;
     }

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3446,7 +3446,7 @@ CxPlatSendDataFinalizeSendBuffer(
 _Success_(return != NULL)
 static
 WSABUF*
-CxPlatSendDataAllocBuffer(
+CxPlatSendDataAllocDataBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ CXPLAT_POOL* BufferPool
     )
@@ -3472,7 +3472,7 @@ CxPlatSendDataAllocPacketBuffer(
     )
 {
     WSABUF* WsaBuffer =
-        CxPlatSendDataAllocBuffer(SendData, &SendData->Owner->SendBufferPool);
+        CxPlatSendDataAllocDataBuffer(SendData, &SendData->Owner->SendBufferPool);
     if (WsaBuffer != NULL) {
         WsaBuffer->len = MaxBufferLength;
     }
@@ -3503,7 +3503,7 @@ CxPlatSendDataAllocSegmentBuffer(
         return (QUIC_BUFFER*)&SendData->ClientBuffer;
     }
 
-    WsaBuffer = CxPlatSendDataAllocBuffer(SendData, &DatapathProc->LargeSendBufferPool);
+    WsaBuffer = CxPlatSendDataAllocDataBuffer(SendData, &DatapathProc->LargeSendBufferPool);
     if (WsaBuffer == NULL) {
         return NULL;
     }
@@ -3524,7 +3524,7 @@ _Success_(return != NULL)
 QUIC_BUFFER*
 CxPlatSendDataAllocBuffer(
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ UINT16 MaxBufferLength
+    _In_ uint16_t MaxBufferLength
     )
 {
     CXPLAT_DBG_ASSERT(SendData != NULL);

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -385,16 +385,16 @@ CxPlatPcpSendMapRequestInternal(
     QUIC_ADDR LocalMappedAddress;
     CxPlatConvertToMappedV6(&LocalAddress, &LocalMappedAddress);
 
-    CXPLAT_SEND_DATA* SendContext =
+    CXPLAT_SEND_DATA* SendData =
         CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE);
-    if (SendContext == NULL) {
+    if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
     QUIC_BUFFER* SendBuffer =
-        CxPlatSendDataAllocBuffer(SendContext, PCP_MAP_REQUEST_SIZE);
+        CxPlatSendDataAllocBuffer(SendData, PCP_MAP_REQUEST_SIZE);
     if (SendBuffer == NULL) {
-        CxPlatSendDataFree(SendContext);
+        CxPlatSendDataFree(SendData);
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
@@ -423,7 +423,7 @@ CxPlatPcpSendMapRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendContext);
+            SendData);
     if (QUIC_FAILED(Status)) {
         return Status;
     }
@@ -485,16 +485,16 @@ CxPlatPcpSendPeerRequestInternal(
     QUIC_ADDR RemotePeerMappedAddress;
     CxPlatConvertToMappedV6(RemotePeerAddress, &RemotePeerMappedAddress);
 
-    CXPLAT_SEND_DATA* SendContext =
+    CXPLAT_SEND_DATA* SendData =
         CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_PEER_REQUEST_SIZE);
-    if (SendContext == NULL) {
+    if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
     QUIC_BUFFER* SendBuffer =
-        CxPlatSendDataAllocBuffer(SendContext, PCP_PEER_REQUEST_SIZE);
+        CxPlatSendDataAllocBuffer(SendData, PCP_PEER_REQUEST_SIZE);
     if (SendBuffer == NULL) {
-        CxPlatSendDataFree(SendContext);
+        CxPlatSendDataFree(SendData);
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
@@ -528,7 +528,7 @@ CxPlatPcpSendPeerRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendContext);
+            SendData);
     if (QUIC_FAILED(Status)) {
         return Status;
     }

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -220,22 +220,22 @@ protected:
 
             if (RecvData->Tuple->LocalAddress.Ipv4.sin_port == RecvContext->ServerAddress.Ipv4.sin_port) {
 
-                auto ServerSendContext =
+                auto ServerSendData =
                     CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, 0);
-                ASSERT_NE(nullptr, ServerSendContext);
+                ASSERT_NE(nullptr, ServerSendData);
 
-                auto ServerDatagram =
-                    CxPlatSendDataAllocBuffer(ServerSendContext, ExpectedDataSize);
-                ASSERT_NE(nullptr, ServerDatagram);
+                auto ServerBuffer =
+                    CxPlatSendDataAllocBuffer(ServerSendData, ExpectedDataSize);
+                ASSERT_NE(nullptr, ServerBuffer);
 
-                memcpy(ServerDatagram->Buffer, RecvData->Buffer, RecvData->BufferLength);
+                memcpy(ServerBuffer->Buffer, RecvData->Buffer, RecvData->BufferLength);
 
                 VERIFY_QUIC_SUCCESS(
                     CxPlatSocketSend(
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendContext
+                        ServerSendData
                     ));
 
             } else {
@@ -268,23 +268,23 @@ protected:
 
                 CXPLAT_ECN_TYPE ecn = (CXPLAT_ECN_TYPE)RecvData->TypeOfService;
 
-                auto ServerSendContext =
+                auto ServerSendData =
                     CxPlatSendDataAlloc(Socket, CXPLAT_ECN_ECT_0, 0);
-                ASSERT_NE(nullptr, ServerSendContext);
+                ASSERT_NE(nullptr, ServerSendData);
 
-                auto ServerDatagram =
-                    CxPlatSendDataAllocBuffer(ServerSendContext, ExpectedDataSize);
-                ASSERT_NE(nullptr, ServerDatagram);
+                auto ServerBuffer =
+                    CxPlatSendDataAllocBuffer(ServerSendData, ExpectedDataSize);
+                ASSERT_NE(nullptr, ServerBuffer);
                 ASSERT_EQ(ecn, CXPLAT_ECN_ECT_0);
 
-                memcpy(ServerDatagram->Buffer, RecvData->Buffer, RecvData->BufferLength);
+                memcpy(ServerBuffer->Buffer, RecvData->Buffer, RecvData->BufferLength);
 
                 VERIFY_QUIC_SUCCESS(
                     CxPlatSocketSend(
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendContext
+                        ServerSendData
                     ));
 
             } else {
@@ -614,15 +614,15 @@ TEST_P(DataPathTest, UdpData)
             &client));
     ASSERT_NE(nullptr, client);
 
-    auto ClientSendContext =
+    auto ClientSendData =
         CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
-    ASSERT_NE(nullptr, ClientSendContext);
+    ASSERT_NE(nullptr, ClientSendData);
 
-    auto ClientDatagram =
-        CxPlatSendDataAllocBuffer(ClientSendContext, ExpectedDataSize);
-    ASSERT_NE(nullptr, ClientDatagram);
+    auto ClientBuffer =
+        CxPlatSendDataAllocBuffer(ClientSendData, ExpectedDataSize);
+    ASSERT_NE(nullptr, ClientBuffer);
 
-    memcpy(ClientDatagram->Buffer, ExpectedData, ExpectedDataSize);
+    memcpy(ClientBuffer->Buffer, ExpectedData, ExpectedDataSize);
 
     QUIC_ADDR ClientAddress;
     CxPlatSocketGetLocalAddress(client, &ClientAddress);
@@ -632,7 +632,7 @@ TEST_P(DataPathTest, UdpData)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendContext));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -699,15 +699,15 @@ TEST_P(DataPathTest, UdpDataRebind)
             &client));
     ASSERT_NE(nullptr, client);
 
-    auto ClientSendContext =
+    auto ClientSendData =
         CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
-    ASSERT_NE(nullptr, ClientSendContext);
+    ASSERT_NE(nullptr, ClientSendData);
 
-    auto ClientDatagram =
-        CxPlatSendDataAllocBuffer(ClientSendContext, ExpectedDataSize);
-    ASSERT_NE(nullptr, ClientDatagram);
+    auto ClientBuffer =
+        CxPlatSendDataAllocBuffer(ClientSendData, ExpectedDataSize);
+    ASSERT_NE(nullptr, ClientBuffer);
 
-    memcpy(ClientDatagram->Buffer, ExpectedData, ExpectedDataSize);
+    memcpy(ClientBuffer->Buffer, ExpectedData, ExpectedDataSize);
 
     QUIC_ADDR ClientAddress;
     CxPlatSocketGetLocalAddress(client, &ClientAddress);
@@ -717,7 +717,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendContext));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -735,15 +735,15 @@ TEST_P(DataPathTest, UdpDataRebind)
             &client));
     ASSERT_NE(nullptr, client);
 
-    ClientSendContext =
+    ClientSendData =
         CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
-    ASSERT_NE(nullptr, ClientSendContext);
+    ASSERT_NE(nullptr, ClientSendData);
 
-    ClientDatagram =
-        CxPlatSendDataAllocBuffer(ClientSendContext, ExpectedDataSize);
-    ASSERT_NE(nullptr, ClientDatagram);
+    ClientBuffer =
+        CxPlatSendDataAllocBuffer(ClientSendData, ExpectedDataSize);
+    ASSERT_NE(nullptr, ClientBuffer);
 
-    memcpy(ClientDatagram->Buffer, ExpectedData, ExpectedDataSize);
+    memcpy(ClientBuffer->Buffer, ExpectedData, ExpectedDataSize);
 
     CxPlatSocketGetLocalAddress(client, &ClientAddress);
 
@@ -752,7 +752,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendContext));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -819,15 +819,15 @@ TEST_P(DataPathTest, UdpDataECT0)
             &client));
     ASSERT_NE(nullptr, client);
 
-    auto ClientSendContext =
+    auto ClientSendData =
         CxPlatSendDataAlloc(client, CXPLAT_ECN_ECT_0, 0);
-    ASSERT_NE(nullptr, ClientSendContext);
+    ASSERT_NE(nullptr, ClientSendData);
 
-    auto ClientDatagram =
-        CxPlatSendDataAllocBuffer(ClientSendContext, ExpectedDataSize);
-    ASSERT_NE(nullptr, ClientDatagram);
+    auto ClientBuffer =
+        CxPlatSendDataAllocBuffer(ClientSendData, ExpectedDataSize);
+    ASSERT_NE(nullptr, ClientBuffer);
 
-    memcpy(ClientDatagram->Buffer, ExpectedData, ExpectedDataSize);
+    memcpy(ClientBuffer->Buffer, ExpectedData, ExpectedDataSize);
 
     QUIC_ADDR ClientAddress;
     CxPlatSocketGetLocalAddress(client, &ClientAddress);
@@ -837,7 +837,7 @@ TEST_P(DataPathTest, UdpDataECT0)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendContext));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -1077,12 +1077,12 @@ TEST_P(DataPathTest, TcpDataClient)
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.AcceptEvent, 100));
     ASSERT_NE(nullptr, ListenerContext.Server);
 
-    auto SendContext =
+    auto SendData =
         CxPlatSendDataAlloc(Client, CXPLAT_ECN_NON_ECT, 0);
-    ASSERT_NE(nullptr, SendContext);
+    ASSERT_NE(nullptr, SendData);
 
     auto SendBuffer =
-        CxPlatSendDataAllocBuffer(SendContext, ExpectedDataSize);
+        CxPlatSendDataAllocBuffer(SendData, ExpectedDataSize);
     ASSERT_NE(nullptr, SendBuffer);
 
     memcpy(SendBuffer->Buffer, ExpectedData, ExpectedDataSize);
@@ -1092,7 +1092,7 @@ TEST_P(DataPathTest, TcpDataClient)
             Client,
             &ServerAddress,
             &ClientAddress,
-            SendContext));
+            SendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.ServerContext.ReceiveEvent, 100));
 
@@ -1163,12 +1163,12 @@ TEST_P(DataPathTest, TcpDataServer)
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.AcceptEvent, 100));
     ASSERT_NE(nullptr, ListenerContext.Server);
 
-    auto SendContext =
+    auto SendData =
         CxPlatSendDataAlloc(ListenerContext.Server, CXPLAT_ECN_NON_ECT, 0);
-    ASSERT_NE(nullptr, SendContext);
+    ASSERT_NE(nullptr, SendData);
 
     auto SendBuffer =
-        CxPlatSendDataAllocBuffer(SendContext, ExpectedDataSize);
+        CxPlatSendDataAllocBuffer(SendData, ExpectedDataSize);
     ASSERT_NE(nullptr, SendBuffer);
 
     memcpy(SendBuffer->Buffer, ExpectedData, ExpectedDataSize);
@@ -1178,7 +1178,7 @@ TEST_P(DataPathTest, TcpDataServer)
             ListenerContext.Server,
             &ServerAddress,
             &ClientAddress,
-            SendContext));
+            SendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ClientContext.ReceiveEvent, 100));
 

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -190,12 +190,12 @@ struct DrillSender {
         QUIC_ADDR LocalAddress;
         CxPlatSocketGetLocalAddress(Binding, &LocalAddress);
 
-        CXPLAT_SEND_DATA* SendContext =
+        CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
                 Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
 
         QUIC_BUFFER* SendBuffer =
-            CxPlatSendDataAllocBuffer(SendContext, DatagramLength);
+            CxPlatSendDataAllocBuffer(SendData, DatagramLength);
 
         if (SendBuffer == nullptr) {
             TEST_FAILURE("Buffer null");
@@ -213,7 +213,7 @@ struct DrillSender {
                 Binding,
                 &LocalAddress,
                 &ServerAddress,
-                SendContext);
+                SendData);
 
         return Status;
     }

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -168,7 +168,7 @@ struct DatapathHook
     Send(
         _Inout_ QUIC_ADDR* /* RemoteAddress */,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct CXPLAT_SEND_DATA* /* SendContext */
+        _Inout_ struct CXPLAT_SEND_DATA* /* SendData */
         ) {
         return FALSE; // Don't drop by default
     }
@@ -198,9 +198,9 @@ class DatapathHooks
     SendCallback(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* LocalAddress,
-        _Inout_ struct CXPLAT_SEND_DATA* SendContext
+        _Inout_ struct CXPLAT_SEND_DATA* SendData
         ) {
-        return Instance->Send(RemoteAddress, LocalAddress, SendContext);
+        return Instance->Send(RemoteAddress, LocalAddress, SendData);
     }
 
     void Register() {
@@ -269,13 +269,13 @@ class DatapathHooks
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* LocalAddress,
-        _Inout_ struct CXPLAT_SEND_DATA* SendContext
+        _Inout_ struct CXPLAT_SEND_DATA* SendData
         ) {
         BOOLEAN Result = FALSE;
         CxPlatDispatchLockAcquire(&Lock);
         DatapathHook* Iter = Hooks;
         while (Iter) {
-            if (Iter->Send(RemoteAddress, LocalAddress, SendContext)) {
+            if (Iter->Send(RemoteAddress, LocalAddress, SendData)) {
                 Result = TRUE;
                 break;
             }
@@ -415,7 +415,7 @@ struct ReplaceAddressHelper : public DatapathHook
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct CXPLAT_SEND_DATA* /* SendContext */
+        _Inout_ struct CXPLAT_SEND_DATA* /* SendData */
         ) {
         if (QuicAddrCompare(RemoteAddress, &New)) {
             *RemoteAddress = Original;
@@ -475,7 +475,7 @@ struct ReplaceAddressThenDropHelper : public DatapathHook
     Send(
         _Inout_ QUIC_ADDR* RemoteAddress,
         _Inout_opt_ QUIC_ADDR* /* LocalAddress */,
-        _Inout_ struct CXPLAT_SEND_DATA* /* SendContext */
+        _Inout_ struct CXPLAT_SEND_DATA* /* SendData */
         ) {
         if (QuicAddrCompare(RemoteAddress, &New)) {
             if (AllowPacketCount == 0) {

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -114,20 +114,20 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 
     while (CxPlatTimeDiff64(TimeStart, CxPlatTimeMs64()) < TimeoutMs) {
 
-        CXPLAT_SEND_DATA* SendContext =
+        CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
                 Binding, CXPLAT_ECN_NON_ECT, Length);
-        if (SendContext == nullptr) {
+        if (SendData == nullptr) {
             printf("CxPlatSendDataAlloc failed\n");
             return;
         }
 
-        while (!CxPlatSendDataIsFull(SendContext)) {
+        while (!CxPlatSendDataIsFull(SendData)) {
             QUIC_BUFFER* SendBuffer =
-                CxPlatSendDataAllocBuffer(SendContext, Length);
+                CxPlatSendDataAllocBuffer(SendData, Length);
             if (SendBuffer == nullptr) {
                 printf("CxPlatSendDataAllocBuffer failed\n");
-                CxPlatSendDataFree(SendContext);
+                CxPlatSendDataFree(SendData);
                 return;
             }
 
@@ -161,7 +161,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendContext)));
+            SendData)));
     }
 }
 
@@ -217,15 +217,15 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
 
     while (CxPlatTimeDiff64(TimeStart, CxPlatTimeMs64()) < TimeoutMs) {
 
-        CXPLAT_SEND_DATA* SendContext =
+        CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
                 Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
-        VERIFY(SendContext);
+        VERIFY(SendData);
 
         while (CxPlatTimeDiff64(TimeStart, CxPlatTimeMs64()) < TimeoutMs &&
-            !CxPlatSendDataIsFull(SendContext)) {
+            !CxPlatSendDataIsFull(SendData)) {
             QUIC_BUFFER* SendBuffer =
-                CxPlatSendDataAllocBuffer(SendContext, DatagramLength);
+                CxPlatSendDataAllocBuffer(SendData, DatagramLength);
             VERIFY(SendBuffer);
 
             (*DestCid)++; (*SrcCid)++;
@@ -291,7 +291,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendContext)));
+            SendData)));
     }
 }
 

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -709,7 +709,7 @@ BOOLEAN QUIC_API DatapathHookReceiveCallback(struct CXPLAT_RECV_DATA* /* Datagra
     return (RandomValue % 100) < Settings.LossPercent;
 }
 
-BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct CXPLAT_SEND_DATA* /* SendContext */)
+BOOLEAN QUIC_API DatapathHookSendCallback(QUIC_ADDR* /* RemoteAddress */, QUIC_ADDR* /* LocalAddress */, struct CXPLAT_SEND_DATA* /* SendData */)
 {
     return FALSE; // Don't drop
 }


### PR DESCRIPTION
The objects were renamed a while ago, but not the variables.