### PR TITLE
Switch to 43 packet receive batch size

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -30,7 +30,7 @@ CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Length) <= sizeof(size_t
 CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Buffer) == sizeof(void*)), "(sizeof(QUIC_BUFFER.Buffer) == sizeof(void*) must be TRUE.");
 
 #define CXPLAT_MAX_BATCH_SEND 1
-#define CXPLAT_MAX_BATCH_RECEIVE 40
+#define CXPLAT_MAX_BATCH_RECEIVE 43
 
 //
 // The maximum single buffer size for sending coalesced payloads.


### PR DESCRIPTION
For throughput tests, 43 is a magic number. Its 64,500 bytes, which is the largest UDP datagram able to be sent with a 1500 MTU. With a smaller batch size, we're not going to receive a full server send in 1 go, causing us to get behind. With a larger batch size, we can potentially grab a packet out of the next datagram send, causing send and receives to get out of sync with datagram boundaries. At 43, we pretty much run in lockstep, which results in the best performance

RPS should not be affected, we're not increasing the value enough to cause over allocations. Also, each packet is its own allocation, so underused packets are just used again without freeing and reallocating