### PR TITLE
quicipserver now prints out usage information when supplied with incorrect args.

### DIFF
--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -222,7 +222,7 @@ main(
         goto Error;
     }
 
-        if (argc < 2) {
+    if (argc < 2) {
         PrintUsage();
         goto Error;
     }

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -222,6 +222,12 @@ main(
         goto Error;
     }
 
+        if (argc < 2) {
+        PrintUsage();
+        goto Error;
+    }
+
+
     RunServer(argc, argv);
 
 Error:

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -227,7 +227,6 @@ main(
         goto Error;
     }
 
-
     RunServer(argc, argv);
 
 Error:


### PR DESCRIPTION
The quicipserver tool now prints out the usage arguments when supplied with no args.

Previously the ``PrintUsage()`` function was unused.

### old output
```bash
$ ./quicipserver 
Failed to load configuration from args!
```

### new output
```
$ ./quicipserver 

quicip runs a public IP lookup server.

Usage:
  quicipserver.exe -selfsign or -cert_hash:<...> [and -cert_store:<...> | -machine] or (-cert_file:<...> and -key_file:<...>)

```
