### PR TITLE
Delay Stream SHUTDOWN_COMPLETE Event While Data Pending

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -502,6 +502,7 @@ QuicStreamTryCompleteShutdown(
     )
 {
     if (!Stream->Flags.ShutdownComplete &&
+        !Stream->Flags.ReceiveDataPending &&
         Stream->Flags.LocalCloseAcked &&
         Stream->Flags.RemoteCloseAcked) {
 


### PR DESCRIPTION
Fixes an issue where the stream SHUTDOWN_COMPLETE event is incorrectly delivered while the app is still draining received data (in the graceful shutdown scenario).

Fixes #1384.

Opened #1383 to track improving the test coverage in this area.