### PR TITLE
Properly detect arm current platform for macos pwsh builds

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -186,8 +186,23 @@ Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
 if ("" -eq $Arch) {
-    # TODO Actually detect current platform
-    $Arch = "x64"
+    if ($IsMacOS) {
+        $RunningArch = uname -m
+        if ("x86_64" -eq $RunningArch) {
+            $IsTranslated = sysctl -in sysctl.proc_translated
+            if ($IsTranslated) {
+                $Arch = "arm64"
+            } else {
+                $Arch = "x64"
+            }
+        } elseif ("arm64" -eq $RunningArch) {
+            $Arch = "arm64"
+        } else {
+            Write-Error "Unknown architecture"
+        }
+    } else {
+        $Arch = "x64"
+    }
 }
 
 if ($Generator -eq "") {


### PR DESCRIPTION
Theres no direct flag in powershell to detect which architecture is being used. Use uname to get the processor, and if it shows up as x86_64 check to see if we're running in translated mode.

Works on an M1 mac. CI as that is running native on Intel, that will test the native intel case. Native arm powershell does not exist yet, but when it does that case is handled as well.

This also let me test the merge script. It worked, successfully merged all binaries, which ran tests on both platforms. Afterwards, I copies just the shared object file into the individual platform folders, and ran those tests as well, which succeeded. So an x86 only app can access the x86 portion of a universal msquic library binary, and same with arm.