### PR TITLE
Only set SO_REUSEPORT on server sockets

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1278,6 +1278,12 @@ CxPlatSocketContextInitialize(
 
     if (LocalAddress && LocalAddress->Ipv4.sin_port != 0) {
         CXPLAT_DBG_ASSERT(LocalAddress->Ipv4.sin_port == Binding->LocalAddress.Ipv4.sin_port);
+    } else if (RemoteAddress && LocalAddress && LocalAddress->Ipv4.sin_port == 0) {
+        //
+        // A client socket being assigned the same port as a remote socket causes issues later
+        // in the datapath and binding paths. Check to make sure this case was not given to us.
+        //
+        CXPLAT_DBG_ASSERT(Binding->LocalAddress.Ipv4.sin_port != RemoteAddress->Ipv4.sin_port);
     }
 
     if (Binding->LocalAddress.Ipv6.sin6_family == AF_INET6) {

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1276,6 +1276,7 @@ CxPlatSocketContextInitialize(
         goto Exit;
     }
 
+#if DEBUG
     if (LocalAddress && LocalAddress->Ipv4.sin_port != 0) {
         CXPLAT_DBG_ASSERT(LocalAddress->Ipv4.sin_port == Binding->LocalAddress.Ipv4.sin_port);
     } else if (RemoteAddress && LocalAddress && LocalAddress->Ipv4.sin_port == 0) {
@@ -1285,6 +1286,7 @@ CxPlatSocketContextInitialize(
         //
         CXPLAT_DBG_ASSERT(Binding->LocalAddress.Ipv4.sin_port != RemoteAddress->Ipv4.sin_port);
     }
+#endif
 
     if (Binding->LocalAddress.Ipv6.sin6_family == AF_INET6) {
         Binding->LocalAddress.Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1290,8 +1290,6 @@ CxPlatSocketContextInitialize(
     UNREFERENCED_PARAMETER(LocalAddress);
 #endif
 
-    CXPLAT_DBG_ASSERT()
-
     if (Binding->LocalAddress.Ipv6.sin6_family == AF_INET6) {
         Binding->LocalAddress.Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1179,25 +1179,31 @@ CxPlatSocketContextInitialize(
     }
 
     //
-    // The port is shared across processors.
+    // Only set SO_REUSEPORT on a server socket, otherwise the client could be
+    // assigned a server port.
     //
-    Option = TRUE;
-    Result =
-        setsockopt(
-            SocketContext->SocketFd,
-            SOL_SOCKET,
-            SO_REUSEPORT,
-            (const void*)&Option,
-            sizeof(Option));
-    if (Result == SOCKET_ERROR) {
-        Status = errno;
-        QuicTraceEvent(
-            DatapathErrorStatus,
-            "[data][%p] ERROR, %u, %s.",
-            Binding,
-            Status,
-            "setsockopt(SO_REUSEPORT) failed");
-        goto Exit;
+    if (RemoteAddress == NULL) {
+        //
+        // The port is shared across processors.
+        //
+        Option = TRUE;
+        Result =
+            setsockopt(
+                SocketContext->SocketFd,
+                SOL_SOCKET,
+                SO_REUSEPORT,
+                (const void*)&Option,
+                sizeof(Option));
+        if (Result == SOCKET_ERROR) {
+            Status = errno;
+            QuicTraceEvent(
+                DatapathErrorStatus,
+                "[data][%p] ERROR, %u, %s.",
+                Binding,
+                Status,
+                "setsockopt(SO_REUSEPORT) failed");
+            goto Exit;
+        }
     }
 
     CxPlatCopyMemory(&MappedAddress, &Binding->LocalAddress, sizeof(MappedAddress));

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1286,7 +1286,11 @@ CxPlatSocketContextInitialize(
         //
         CXPLAT_DBG_ASSERT(Binding->LocalAddress.Ipv4.sin_port != RemoteAddress->Ipv4.sin_port);
     }
+#else
+    UNREFERENCED_PARAMETER(LocalAddress);
 #endif
+
+    CXPLAT_DBG_ASSERT()
 
     if (Binding->LocalAddress.Ipv6.sin6_family == AF_INET6) {
         Binding->LocalAddress.Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;


### PR DESCRIPTION
Seeing an issue where sometimes the client receives the servers port, which causes issues in the unit test. Not setting SO_REUSEPORT for client side might avoid this issue. Right now we don't have a great way to guarantee this, but it might help.

Might fix #1389 