### PR TITLE
Add build flag to disable GSO on posix for interop runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ option(QUIC_RANDOM_ALLOC_FAIL "Randomly fails allocation calls" OFF)
 option(QUIC_TLS_SECRETS_SUPPORT "Enable export of TLS secrets" OFF)
 option(QUIC_TELEMETRY_ASSERTS "Enable telemetry asserts in release builds" OFF)
 option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
+option(QUIC_DISABLE_POSIX_GSO "Disable GSO for systems that say they support it but don't" OFF)
 
 # FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
 if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
@@ -340,6 +341,10 @@ else()
         list(APPEND QUIC_COMMON_FLAGS -Wno-microsoft-anon-tag -Wno-tautological-constant-out-of-range-compare -Wmissing-field-initializers)
     else()
         list(APPEND QUIC_COMMON_DEFINES CX_PLATFORM_LINUX)
+    endif()
+
+    if (QUIC_DISABLE_POSIX_GSO)
+        list(APPEND QUIC_COMMON_DEFINES DISABLE_POSIX_GSO)
     endif()
 
     if (QUIC_ENABLE_SANITIZERS)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN     chmod +x /src/scripts/install-powershell-docker.sh
 RUN     /src/scripts/install-powershell-docker.sh
 ENV     PATH="/root/.dotnet/tools:${PATH}"
 RUN     cmake -DQUIC_BUILD_TEST=OFF -DQUIC_BUILD_PERF=OFF \
-            -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS_SECRETS_SUPPORT=on ..
+            -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS_SECRETS_SUPPORT=on \
+            -DQUIC_DISABLE_POSIX_GSO=on ..
 RUN     cmake --build .
 
 FROM    martenseemann/quic-network-simulator-endpoint

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -37,6 +37,12 @@ CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Buffer) == sizeof(void*)
 //
 #define CXPLAT_LARGE_SEND_BUFFER_SIZE         0xFFFF
 
+#ifdef DISABLE_POSIX_GSO
+#ifdef UDP_SEGMENT
+#undef UDP_SEGMENT
+#endif
+#endif
+
 //
 // A receive block to receive a UDP packet over the sockets.
 //


### PR DESCRIPTION
The interop runner has issues with GSO, where it says its supported but it is not. Add a flag to completely disable GSO on the interop runner