### PR TITLE
Fix Cmake generator arguments (1.0) (#1405)

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -201,7 +201,7 @@ stages:
       arch: arm
       tls: openssl
       ubuntuVersion: 18.04
-      extraBuildArgs: -DisableLogs -Generator Ninja -ToolchainFile cmake/toolchains/arm-pi-gnueabihf.toolchain.cmake
+      extraBuildArgs: -DisableLogs -ToolchainFile cmake/toolchains/arm-pi-gnueabihf.toolchain.cmake
 
 #
 # Performance Tests

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -158,8 +158,6 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 if ($Generator -eq "") {
     if ($IsWindows) {
         $Generator = "Visual Studio 16 2019"
-    } elseif ($IsLinux) {
-        $Generator = "Ninja"
     } else {
         $Generator = "Unix Makefiles"
     }
@@ -238,9 +236,14 @@ function CMake-Execute([String]$Arguments) {
 
 # Uses cmake to generate the build configuration files.
 function CMake-Generate {
-    $Arguments = "-g"
+    $Arguments = "-G"
+
+    if ($Generator.Contains(" ")) {
+        $Generator = """$Generator"""
+    }
+
     if ($IsWindows) {
-        $Arguments += " '$Generator' -A "
+        $Arguments += " $Generator -A "
         switch ($Arch) {
             "x86"   { $Arguments += "Win32" }
             "x64"   { $Arguments += "x64" }
@@ -248,7 +251,7 @@ function CMake-Generate {
             "arm64" { $Arguments += "arm64" }
         }
     } else {
-        $Arguments += " '$Generator'"
+        $Arguments += " $Generator"
     }
     $Arguments += " -DQUIC_TLS=" + $Tls
     $Arguments += " -DQUIC_OUTPUT_DIR=" + $ArtifactsDir


### PR DESCRIPTION
* Fix Cmake generator arguments

CMake 3.20 seems to have gotten a lot more strict on the generator arguments. Properly use quotes, and also use -G not -g for generator

Cherry Picked from https://github.com/microsoft/msquic/pull/1405