### PR TITLE
Fix not matching ETW trace string in quic driver helpers.

### DIFF
--- a/src/inc/quic_driver_helpers.h
+++ b/src/inc/quic_driver_helpers.h
@@ -160,7 +160,7 @@ public:
         if (PathResult < 0 || PathResult >= sizeof(IoctlPath)) {
             QuicTraceEvent(
                 LibraryError,
-                "[ lib] ERRROR, %s",
+                "[ lib] ERROR, %s",
                 "Creating Driver File Path failed");
             return false;
         }


### PR DESCRIPTION
We'd never noticed this in the past, but I noticed while running the clog regenerate script it was spitting out this error. It wasn't breaking builds, but still worth fixing