### PR TITLE
Reduce the size of the receive packet queue

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -183,7 +183,14 @@ typedef struct QUIC_PATH QUIC_PATH;
 // The maximum number of received packets that may be queued on a single
 // connection. When this limit is reached, any additional packets are dropped.
 //
+#ifdef _KERNEL_MODE
+//
+// Kernel modes receive path is slightly different, so allow larger queue sizes.
+//
+#define QUIC_MAX_RECEIVE_QUEUE_COUNT            260
+#else
 #define QUIC_MAX_RECEIVE_QUEUE_COUNT            180
+#endif
 
 //
 // The maximum number of pending datagrams we will hold on to, per connection,

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -183,7 +183,7 @@ typedef struct QUIC_PATH QUIC_PATH;
 // The maximum number of received packets that may be queued on a single
 // connection. When this limit is reached, any additional packets are dropped.
 //
-#define QUIC_MAX_RECEIVE_QUEUE_COUNT            0x1000      // 4096
+#define QUIC_MAX_RECEIVE_QUEUE_COUNT            180
 
 //
 // The maximum number of pending datagrams we will hold on to, per connection,

--- a/src/plugins/wpa/Properties/launchSettings.json
+++ b/src/plugins/wpa/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "WPA": {
       "commandName": "Executable",
-      "executablePath": "f:\\xperf\\wpa.exe",
+        "executablePath": "E:\\xperf\\wpa.exe",
       "commandLineArgs": "-addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\wpa\\$(Configuration)",
       "nativeDebugging": false
     }

--- a/src/plugins/wpa/Properties/launchSettings.json
+++ b/src/plugins/wpa/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "WPA": {
       "commandName": "Executable",
-        "executablePath": "E:\\xperf\\wpa.exe",
+      "executablePath": "f:\\xperf\\wpa.exe",
       "commandLineArgs": "-addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\wpa\\$(Configuration)",
       "nativeDebugging": false
     }


### PR DESCRIPTION
We had a maximum of 4k packets queued on a connection before the receive side would drop. In larger CPU limited tests, a buffer this big could actually be hit, resulting in dropped packets, and because the buffer was so big, we'd hit the max buffer size pretty consistently. By decreasing the max queue to ~4 full segments (180), we both reduce the amount of time we spend decrypting, which means if the buffer is hit, its less likely to bloat out of control.