### PR TITLE
Always treat macOS as a single core platform

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -420,13 +420,14 @@ CxPlatProcMaxCount(
     void
     )
 {
-#if defined(CX_PLATFORM_DARWIN) && defined(__arm64__)
+#if defined(CX_PLATFORM_DARWIN)
     //
-    // arm64 macOS has no way to get the current proc, so act like a single core.
+    // arm64 macOS has no way to get the current proc, so treat as single core.
+    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
     //
     return 1;
 #else
-    return (uint32_t)sysconf(_SC_NPROCESSORS_CONF);
+    return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 }
 
@@ -435,13 +436,14 @@ CxPlatProcActiveCount(
     void
     )
 {
-#if defined(CX_PLATFORM_DARWIN) && defined(__arm64__)
+#if defined(CX_PLATFORM_DARWIN)
     //
-    // arm64 macOS has no way to get the current proc, so act like a single core.
+    // arm64 macOS has no way to get the current proc, so treat as single core.
+    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
     //
     return 1;
 #else
-    return (uint32_t)sysconf(_SC_NPROCESSORS_CONF);
+    return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 }
 
@@ -452,26 +454,10 @@ CxPlatProcCurrentNumber(
 {
 #if defined(CX_PLATFORM_LINUX)
     return (uint32_t)sched_getcpu();
-#elif defined(CX_PLATFORM_DARWIN) && !defined(__arm64__)
-    int cpuinfo[4];
-    asm("cpuid"
-            : "=a" (cpuinfo[0]),
-            "=b" (cpuinfo[1]),
-            "=c" (cpuinfo[2]),
-            "=d" (cpuinfo[3])
-            : "a"(1));
+#elif defined(CX_PLATFORM_DARWIN)
     //
-    // Check flag to see if current core is part of cpuid. If not, assume
-    // core 0. Not all supported platforms (Specifically M1 under Rosetta)
-    // support this flag.
-    //
-    if ((cpuinfo[3] & (1 << 9)) != 0) {
-        return (uint32_t)cpuinfo[1] >> 24;
-    }
-    return 0;
-#else
-    //
-    // arm64 macOS has no way to get the current proc, so just hardcode 0.
+    // arm64 macOS has no way to get the current proc, so treat as single core.
+    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
     //
     return 0;
 #endif // CX_PLATFORM_DARWIN

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -426,7 +426,7 @@ CxPlatProcMaxCount(
     //
     return 1;
 #else
-    return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+    return (uint32_t)sysconf(_SC_NPROCESSORS_CONF);
 #endif
 }
 
@@ -441,7 +441,7 @@ CxPlatProcActiveCount(
     //
     return 1;
 #else
-    return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+    return (uint32_t)sysconf(_SC_NPROCESSORS_CONF);
 #endif
 }
 


### PR DESCRIPTION
On M1 macs, there is no way to get the current CPU. So our only option is to treat the system as a single core.
On Intel macs, with certain configurations CPUID can return processor numbers that are greater then the number the syscall tells us. This results in assertions, or out of range calls in release mode. We don't currently have a workaround, so treat Intel macOS as a single core.

Since both platforms have current core issues, TL;DR just always treat macOS as a single core platform.