### PR TITLE
Remove Async TLS Support

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6690,10 +6690,6 @@ QuicConnDrainOperations(
             }
             break;
 
-        case QUIC_OPER_TYPE_TLS_COMPLETE:
-            QuicCryptoProcessCompleteOperation(&Connection->Crypto);
-            break;
-
         case QUIC_OPER_TYPE_TIMER_EXPIRED:
             QuicConnProcessExpiredTimer(Connection, Oper->TIMER_EXPIRED.Type);
             break;

--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -31,16 +31,6 @@ typedef struct QUIC_CRYPTO {
     BOOLEAN InRecovery : 1;
 
     //
-    // Indicates there is data ready to be passed to TLS.
-    //
-    BOOLEAN TlsDataPending : 1;
-
-    //
-    // Indicates a TLS call is outstanding.
-    //
-    BOOLEAN TlsCallPending : 1;
-
-    //
     // Indicates custom cert validation (by the app) is outstanding.
     //
     BOOLEAN CertValidationPending : 1;
@@ -249,15 +239,6 @@ QUIC_STATUS
 QuicCryptoProcessData(
     _In_ QUIC_CRYPTO* Crypto,
     _In_ BOOLEAN IsClientInitial
-    );
-
-//
-// Handles the completion operation for the TLS complete operation.
-//
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicCryptoProcessCompleteOperation(
-    _In_ QUIC_CRYPTO* Crypto
     );
 
 //

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -27,7 +27,7 @@ typedef enum QUIC_OPERATION_TYPE {
     QUIC_OPER_TYPE_UNREACHABLE,         // Process UDP unreachable event.
     QUIC_OPER_TYPE_FLUSH_STREAM_RECV,   // Indicate a stream data to the app.
     QUIC_OPER_TYPE_FLUSH_SEND,          // Frame packets and send them.
-    QUIC_OPER_TYPE_TLS_COMPLETE,        // A TLS process call completed.
+    QUIC_OPER_TYPE_DEPRECATED,          // No longer used.
     QUIC_OPER_TYPE_TIMER_EXPIRED,       // A timer expired.
     QUIC_OPER_TYPE_TRACE_RUNDOWN,       // A trace rundown was triggered.
 

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -119,17 +119,12 @@ typedef CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK *CXPLAT_TLS_PEER_CERTIFICA
 typedef struct CXPLAT_TLS_CALLBACKS {
 
     //
-    // Invoked for the completion of process calls that were pending.
-    //
-    CXPLAT_TLS_PROCESS_COMPLETE_CALLBACK_HANDLER ProcessComplete;
-
-    //
     // Invoked when QUIC transport parameters are received.
     //
     CXPLAT_TLS_RECEIVE_TP_CALLBACK_HANDLER ReceiveTP;
 
     //
-    // Invoked when a resumption ticket is received.
+    // Invoked when a session ticket is received.
     //
     CXPLAT_TLS_RECEIVE_TICKET_CALLBACK_HANDLER ReceiveTicket;
 
@@ -206,13 +201,12 @@ typedef struct CXPLAT_TLS_CONFIG {
 typedef enum CXPLAT_TLS_RESULT_FLAGS {
 
     CXPLAT_TLS_RESULT_CONTINUE            = 0x0001, // Needs immediate call again. (Used internally to schannel)
-    CXPLAT_TLS_RESULT_PENDING             = 0x0002, // The call is pending.
-    CXPLAT_TLS_RESULT_DATA                = 0x0004, // Data ready to be sent.
-    CXPLAT_TLS_RESULT_READ_KEY_UPDATED    = 0x0008, // ReadKey variable has been updated.
-    CXPLAT_TLS_RESULT_WRITE_KEY_UPDATED   = 0x0010, // WriteKey variable has been updated.
-    CXPLAT_TLS_RESULT_EARLY_DATA_ACCEPT   = 0x0020, // The server accepted the early (0-RTT) data.
-    CXPLAT_TLS_RESULT_EARLY_DATA_REJECT   = 0x0040, // The server rejected the early (0-RTT) data.
-    CXPLAT_TLS_RESULT_COMPLETE            = 0x0080, // Handshake complete.
+    CXPLAT_TLS_RESULT_DATA                = 0x0001, // Data ready to be sent.
+    CXPLAT_TLS_RESULT_READ_KEY_UPDATED    = 0x0004, // ReadKey variable has been updated.
+    CXPLAT_TLS_RESULT_WRITE_KEY_UPDATED   = 0x0008, // WriteKey variable has been updated.
+    CXPLAT_TLS_RESULT_EARLY_DATA_ACCEPT   = 0x0010, // The server accepted the early (0-RTT) data.
+    CXPLAT_TLS_RESULT_EARLY_DATA_REJECT   = 0x0020, // The server rejected the early (0-RTT) data.
+    CXPLAT_TLS_RESULT_HANDSHAKE_COMPLETE  = 0x0040, // Handshake complete.
     CXPLAT_TLS_RESULT_ERROR               = 0x8000  // An error occured.
 
 } CXPLAT_TLS_RESULT_FLAGS;
@@ -400,11 +394,7 @@ CxPlatTlsUninitialize(
 // Called to process any data received from the peer. In the case of the client,
 // the initial call is made with no input buffer to generate the initial output.
 // The returned CXPLAT_TLS_RESULT_FLAGS and CXPLAT_TLS_PROCESS_STATE are update with
-// any state changes as a result of the call. If the call returns
-// CXPLAT_TLS_RESULT_PENDING, then the registered CXPLAT_TLS_PROCESS_COMPLETE_CALLBACK_HANDLER
-// will be triggered at a later date; at which the QUIC code must then call
-// QuicTlsProcessDataComplete to complete the operation and get the resulting
-// flags.
+// any state changes as a result of the call.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 CXPLAT_TLS_RESULT_FLAGS
@@ -415,16 +405,6 @@ CxPlatTlsProcessData(
         const uint8_t * Buffer,
     _Inout_ uint32_t * BufferLength,
     _Inout_ CXPLAT_TLS_PROCESS_STATE* State
-    );
-
-//
-// Called when in response to receiving a process completed callback.
-//
-_IRQL_requires_max_(PASSIVE_LEVEL)
-CXPLAT_TLS_RESULT_FLAGS
-CxPlatTlsProcessDataComplete(
-    _In_ CXPLAT_TLS* TlsContext,
-    _Out_ uint32_t * ConsumedBuffer
     );
 
 //

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -201,7 +201,7 @@ typedef struct CXPLAT_TLS_CONFIG {
 typedef enum CXPLAT_TLS_RESULT_FLAGS {
 
     CXPLAT_TLS_RESULT_CONTINUE            = 0x0001, // Needs immediate call again. (Used internally to schannel)
-    CXPLAT_TLS_RESULT_DATA                = 0x0001, // Data ready to be sent.
+    CXPLAT_TLS_RESULT_DATA                = 0x0002, // Data ready to be sent.
     CXPLAT_TLS_RESULT_READ_KEY_UPDATED    = 0x0004, // ReadKey variable has been updated.
     CXPLAT_TLS_RESULT_WRITE_KEY_UPDATED   = 0x0008, // WriteKey variable has been updated.
     CXPLAT_TLS_RESULT_EARLY_DATA_ACCEPT   = 0x0010, // The server accepted the early (0-RTT) data.

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -93,7 +93,6 @@ const CXPLAT_TCP_DATAPATH_CALLBACKS TcpEngine::TcpCallbacks = {
 };
 
 const CXPLAT_TLS_CALLBACKS TcpEngine::TlsCallbacks = {
-    TcpConnection::TlsProcessCompleteCallback,
     TcpConnection::TlsReceiveTpCallback,
     TcpConnection::TlsReceiveTicketCallback
 };
@@ -455,15 +454,6 @@ TcpConnection::SendCompleteCallback(
     This->Queue();
 }
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-TcpConnection::TlsProcessCompleteCallback(
-    _In_ QUIC_CONNECTION* /* Context */
-    )
-{
-    // Unsupported
-}
-
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 TcpConnection::TlsReceiveTpCallback(
@@ -597,11 +587,6 @@ bool TcpConnection::ProcessTls(const uint8_t* Buffer, uint32_t BufferLength)
             Buffer,
             &BufferLength,
             &TlsState);
-    if (Results & CXPLAT_TLS_RESULT_PENDING) {
-        // TODO - Not supported yet
-        WriteOutput("CxPlatTlsProcessData PENDING (not supported)\n");
-        return false;
-    }
     if (Results & CXPLAT_TLS_RESULT_ERROR) {
         WriteOutput("CxPlatTlsProcessData FAILED\n");
         return false;

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -220,12 +220,6 @@ class TcpConnection {
         _In_ uint32_t ByteCount
         );
     static
-    _IRQL_requires_max_(DISPATCH_LEVEL)
-    void
-    TlsProcessCompleteCallback(
-        _In_ QUIC_CONNECTION* Connection
-        );
-    static
     _IRQL_requires_max_(PASSIVE_LEVEL)
     BOOLEAN
     TlsReceiveTpCallback(

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1700,7 +1700,7 @@ CxPlatTlsProcessData(
                 TlsContext->ResultFlags |= CXPLAT_TLS_RESULT_EARLY_DATA_REJECT;
             }
         }
-        TlsContext->ResultFlags |= CXPLAT_TLS_RESULT_COMPLETE;
+        TlsContext->ResultFlags |= CXPLAT_TLS_RESULT_HANDSHAKE_COMPLETE;
 
         if (TlsContext->IsServer) {
             TlsContext->State->ReadKey = QUIC_PACKET_KEY_1_RTT;
@@ -1764,18 +1764,6 @@ Exit:
     }
 
     return TlsContext->ResultFlags;
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-CXPLAT_TLS_RESULT_FLAGS
-CxPlatTlsProcessDataComplete(
-    _In_ CXPLAT_TLS* TlsContext,
-    _Out_ uint32_t * ConsumedBuffer
-    )
-{
-    UNREFERENCED_PARAMETER(TlsContext);
-    *ConsumedBuffer = 0;
-    return CXPLAT_TLS_RESULT_ERROR;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -369,7 +369,7 @@ const WORD TlsHandshake_ClientHello = 0x01;
 const WORD TlsHandshake_EncryptedExtensions = 0x08;
 
 // {791A59D6-34C8-4ADE-9B53-D13EEA4E9F0B}
-static const GUID CxPlatTlsClientCertPolicyGuid = 
+static const GUID CxPlatTlsClientCertPolicyGuid =
 {
     0x791a59d6,
     0x34c8,
@@ -2347,7 +2347,7 @@ CxPlatTlsWriteDataToSchannel(
                 "Handshake complete (resume=%hu)",
                 State->SessionResumed);
             State->HandshakeComplete = TRUE;
-            Result |= CXPLAT_TLS_RESULT_COMPLETE;
+            Result |= CXPLAT_TLS_RESULT_HANDSHAKE_COMPLETE;
         }
 
         __fallthrough;
@@ -2828,18 +2828,6 @@ CxPlatTlsProcessData(
 Error:
 
     return Result;
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-CXPLAT_TLS_RESULT_FLAGS
-CxPlatTlsProcessDataComplete(
-    _In_ CXPLAT_TLS* TlsContext,
-    _Out_ uint32_t * BufferConsumed
-    )
-{
-    UNREFERENCED_PARAMETER(TlsContext);
-    *BufferConsumed = 0;
-    return CXPLAT_TLS_RESULT_ERROR;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/tools/attack/packet_writer.cpp
+++ b/src/tools/attack/packet_writer.cpp
@@ -24,7 +24,6 @@ struct TlsContext
     CXPLAT_TLS* Ptr;
     CXPLAT_SEC_CONFIG* SecConfig;
     CXPLAT_TLS_PROCESS_STATE State;
-    CXPLAT_EVENT ProcessCompleteEvent;
     uint8_t AlpnListBuffer[256];
 
     TlsContext(_In_z_ const char* Alpn, _In_z_ const char* Sni) :
@@ -32,7 +31,6 @@ struct TlsContext
 
         AlpnListBuffer[0] = (uint8_t)strlen(Alpn);
         memcpy(&AlpnListBuffer[1], Alpn, AlpnListBuffer[0]);
-        CxPlatEventInitialize(&ProcessCompleteEvent, FALSE, FALSE);
 
         CxPlatZeroMemory(&State, sizeof(State));
         State.Buffer = (uint8_t*)CXPLAT_ALLOC_NONPAGED(8000, QUIC_POOL_TOOL);
@@ -44,7 +42,6 @@ struct TlsContext
             NULL, NULL, NULL, NULL
         };
         CXPLAT_TLS_CALLBACKS TlsCallbacks = {
-            OnProcessComplete,
             OnRecvQuicTP,
             NULL
         };
@@ -98,7 +95,6 @@ struct TlsContext
         if (SecConfig) {
             CxPlatTlsSecConfigDelete(SecConfig);
         }
-        CxPlatEventUninitialize(ProcessCompleteEvent);
         CXPLAT_FREE(State.Buffer, QUIC_POOL_TOOL);
         for (uint8_t i = 0; i < QUIC_PACKET_KEY_COUNT; ++i) {
             QuicPacketKeyFree(State.ReadKeys[i]);
@@ -128,8 +124,6 @@ private:
         _In_ uint32_t * BufferLength
         )
     {
-        CxPlatEventReset(ProcessCompleteEvent);
-
         auto Result =
             CxPlatTlsProcessData(
                 Ptr,
@@ -137,10 +131,6 @@ private:
                 Buffer,
                 BufferLength,
                 &State);
-        if (Result & CXPLAT_TLS_RESULT_PENDING) {
-            CxPlatEventWaitForever(ProcessCompleteEvent);
-            Result = CxPlatTlsProcessDataComplete(Ptr, BufferLength);
-        }
 
         if (Result & CXPLAT_TLS_RESULT_ERROR) {
             printf("Failed to process data!\n");
@@ -204,14 +194,6 @@ public:
     }
 
 private:
-
-    static void
-    OnProcessComplete(
-        _In_ QUIC_CONNECTION* Connection
-        )
-    {
-        CxPlatEventSet(((TlsContext*)Connection)->ProcessCompleteEvent);
-    }
 
     static BOOLEAN
     OnRecvQuicTP(


### PR DESCRIPTION
At one point in time we considered supporting the async version of the Schannel/SSPI API, so our TLS abstraction layer was built to support it. For various reasons, we've decided not to go down that path. So this PR removes support for it.