### PR TITLE
Disable async fiber support for openssl UWP

### DIFF
--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -49,7 +49,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_11" | .gitmodules'
+      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_12" | .gitmodules'
       path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
     displayName: Cache OpenSSL
     condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'), not(${{ parameters.skipOpenSSLCache }}))

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -65,6 +65,10 @@ set(OPENSSL_CONFIG_FLAGS
     no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
     no-weak-ssl-ciphers no-shared no-tests ${QUIC_OPENSSL_WIN_ARCH})
 
+if (QUIC_UWP_BUILD)
+    list(APPEND OPENSSL_CONFIG_FLAGS no-async)
+endif()
+
 # Create working and output directories as needed
 file(MAKE_DIRECTORY ${OPENSSL_DIR}/debug/include)
 file(MAKE_DIRECTORY ${OPENSSL_DIR}/release/include)


### PR DESCRIPTION
The 2 fiber APIs used by openssl when this mode is enabled are blocked in UWP mode. Disable async fiber mode for UWP builds