### PR TITLE
pass CA certificates to SSLCtx when provided by pkcs12

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1159,8 +1159,7 @@ CxPlatTlsSecConfigCreate(
                 PKCS12_parse(Pkcs12, CredConfig->CertificatePkcs12->PrivateKeyPassword, &PrivateKey, &X509Cert, &CaCertificates);
             if (CaCertificates) {
                 X509* CaCert;
-                while ((CaCert = sk_X509_pop(CaCertificates)) != NULL)
-                {
+                while ((CaCert = sk_X509_pop(CaCertificates)) != NULL) {
                     //
                     // This transfers ownership to SSLCtx and CaCert does not need to be freed.
                     //

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1159,9 +1159,11 @@ CxPlatTlsSecConfigCreate(
                 PKCS12_parse(Pkcs12, CredConfig->CertificatePkcs12->PrivateKeyPassword, &PrivateKey, &X509Cert, &CaCertificates);
             if (CaCertificates) {
                 X509* CaCert;
-                while ((CaCert = sk_X509_pop(CaCertificates)))
+                while ((CaCert = sk_X509_pop(CaCertificates)) != NULL)
                 {
+                    //
                     // This transfers ownership to SSLCtx and CaCert does not need to be freed.
+                    //
                     SSL_CTX_add_extra_chain_cert(SecurityConfig->SSLCtx, CaCert);
                 }
             }


### PR DESCRIPTION
More work may need to be done if the CAs would come wrong order of have unrelated entries. TLS should send the chain without root CA. 

TLS 1.3 seems more liberal about ordering: https://tools.ietf.org/html/rfc8446#section-4.4.2
```
   Note: Prior to TLS 1.3, "certificate_list" ordering required each
   certificate to certify the one immediately preceding it; however,
   some implementations allowed some flexibility.  Servers sometimes
   send both a current and deprecated intermediate for transitional
   purposes, and others are simply configured incorrectly, but these
   cases can nonetheless be validated properly.  For maximum
   compatibility, all implementations SHOULD be prepared to handle
   potentially extraneous certificates and arbitrary orderings from any
   TLS version, with the exception of the end-entity certificate which
   MUST be first.
```

seems to work OK incases I tested (e.g. valid ordered list) by watching certificate stack on receiver side.
contributes to https://github.com/dotnet/runtime/issues/49574

cc: @manickaP 
