### PR TITLE
Always send data through the datapath thread

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1004,7 +1004,8 @@ QuicBindingProcessStatelessOperation(
         &RecvDatagram->Tuple->RemoteAddress,
         SendData,
         SendDatagram->Length,
-        1);
+        1,
+        RecvDatagram->PartitionIndex % MsQuicLib.PartitionCount);
     SendData = NULL;
 
 Exit:
@@ -1689,7 +1690,8 @@ QuicBindingSend(
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
-    _In_ uint32_t DatagramsToSend
+    _In_ uint32_t DatagramsToSend,
+    _In_ uint16_t PartitionIndex
     )
 {
     QUIC_STATUS Status;
@@ -1719,7 +1721,8 @@ QuicBindingSend(
                     Binding->Socket,
                     &LocalAddressCopy,
                     &RemoteAddressCopy,
-                    SendData);
+                    SendData,
+                    PartitionIndex);
             if (QUIC_FAILED(Status)) {
                 QuicTraceLogWarning(
                     BindingSendFailed,
@@ -1735,7 +1738,8 @@ QuicBindingSend(
                 Binding->Socket,
                 LocalAddress,
                 RemoteAddress,
-                SendData);
+                SendData,
+                PartitionIndex);
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 BindingSendFailed,

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -430,7 +430,8 @@ QuicBindingSend(
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
-    _In_ uint32_t DatagramsToSend
+    _In_ uint32_t DatagramsToSend,
+    _In_ uint16_t PartitionIndex
     );
 
 //

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -30,7 +30,8 @@ QuicFuzzInjectHook(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPacketBuilderSendBatch(
-    _Inout_ QUIC_PACKET_BUILDER* Builder
+    _Inout_ QUIC_PACKET_BUILDER* Builder,
+    _In_ uint16_t PartitionIndex
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -863,7 +864,7 @@ Exit:
             if (Builder->BatchCount != 0) {
                 QuicPacketBuilderFinalizeHeaderProtection(Builder);
             }
-            QuicPacketBuilderSendBatch(Builder);
+            QuicPacketBuilderSendBatch(Builder, QuicPartitionIdGetIndex(Connection->PartitionID));
         }
 
         if (Builder->PacketType == QUIC_RETRY) {
@@ -880,7 +881,8 @@ Exit:
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPacketBuilderSendBatch(
-    _Inout_ QUIC_PACKET_BUILDER* Builder
+    _Inout_ QUIC_PACKET_BUILDER* Builder,
+    _In_ uint16_t PartitionIndex
     )
 {
     QuicTraceLogConnVerbose(
@@ -895,7 +897,8 @@ QuicPacketBuilderSendBatch(
         &Builder->Path->RemoteAddress,
         Builder->SendData,
         Builder->TotalDatagramsLength,
-        Builder->TotalCountDatagrams);
+        Builder->TotalCountDatagrams,
+        PartitionIndex);
 
     Builder->PacketBatchSent = TRUE;
     Builder->SendData = NULL;

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -537,7 +537,8 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData
+    _In_ CXPLAT_SEND_DATA* SendData,
+    _In_ uint16_t PartitionId
     );
 
 //

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -522,7 +522,7 @@ void TcpConnection::Process()
     }
     if (BatchedSendData) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, 0))) {
             IndicateDisconnect = true;
         }
         BatchedSendData = nullptr;
@@ -905,7 +905,7 @@ bool TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
     if (SendBuffer->Length != TLS_BLOCK_SIZE ||
         CxPlatSendDataIsFull(BatchedSendData)) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, 0))) {
             WriteOutput("CxPlatSocketSend FAILED\n");
             return false;
         }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -523,7 +523,7 @@ void TcpConnection::Process()
     }
     if (BatchedSendData) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, this->PartitionIndex))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
             IndicateDisconnect = true;
         }
         BatchedSendData = nullptr;
@@ -906,7 +906,7 @@ bool TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
     if (SendBuffer->Length != TLS_BLOCK_SIZE ||
         CxPlatSendDataIsFull(BatchedSendData)) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, this->PartitionIndex))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
             WriteOutput("CxPlatSocketSend FAILED\n");
             return false;
         }

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -173,6 +173,7 @@ class TcpConnection {
     TcpConnection* Next{nullptr};
     TcpEngine* Engine;
     TcpWorker* Worker{nullptr};
+    uint16_t PartitionIndex;
     CXPLAT_REF_COUNT Ref;
     CXPLAT_DISPATCH_LOCK Lock;
     QUIC_ADDR LocalAddress;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1649,8 +1649,7 @@ CxPlatSocketContextSendComplete(
                 SocketContext,
                 SendData->Bind ? &SendData->LocalAddress : NULL,
                 &SendData->RemoteAddress,
-                SendData,
-                TRUE);
+                SendData);
         CxPlatLockAcquire(&SocketContext->PendingSendDataLock);
         if (Status != QUIC_STATUS_PENDING) {
             CxPlatListRemoveHead(&SocketContext->PendingSendDataHead);
@@ -2510,7 +2509,7 @@ CxPlatSocketSendInternal(
         CMsg->cmsg_len = CMSG_LEN(sizeof(int));
         *(int *)CMSG_DATA(CMsg) = SendData->ECN;
 
-        if (!Socket->Connected) {
+        if (!SocketContext->Binding->Connected) {
             Mhdr->msg_controllen += CMSG_SPACE(sizeof(struct in6_pktinfo));
             CMsg = CMSG_NXTHDR(Mhdr, CMsg);
             CXPLAT_DBG_ASSERT(LocalAddress != NULL);

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -404,7 +404,7 @@ CxPlatSocketSendInternal(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t PartitionIndex,
     _In_ BOOLEAN IsPendedSend
     );
 

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -95,6 +95,9 @@ typedef struct CXPLAT_SEND_DATA {
     //
     QUIC_ADDR RemoteAddress;
 
+    //
+    // The Partition Index for this send.
+    //
     uint16_t PartitionIndex;
 
     //

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -404,6 +404,7 @@ CxPlatSocketSendInternal(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
+    _In_ uint16_t PartitionIndex
     _In_ BOOLEAN IsPendedSend
     );
 
@@ -2456,7 +2457,7 @@ CxPlatSocketSendInternal(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t PartitionIndex,
     _In_ BOOLEAN IsPendedSend
     )
 {
@@ -2708,7 +2709,7 @@ CxPlatSocketSend(
             LocalAddress,
             RemoteAddress,
             SendData,
-            PartitionIndex
+            PartitionIndex,
             FALSE);
     if (Status == QUIC_STATUS_PENDING) {
         Status = QUIC_STATUS_SUCCESS;

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2181,9 +2181,11 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData
+    _In_ CXPLAT_SEND_DATA* SendData,
+    _In_ uint16_t PartitionIndex
     )
 {
+    UNREFERENCED_PARAMETER(PartitionIndex);
     QUIC_STATUS Status =
         CxPlatSocketSendInternal(
             Socket,

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2825,12 +2825,14 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData
+    _In_ CXPLAT_SEND_DATA* SendData,
+    _In_ uint16_t PartitionIndex
     )
 {
     QUIC_STATUS Status;
     PDWORD SegmentSize;
 
+    UNREFERENCED_PARAMETER(PartitionIndex);
     CXPLAT_DBG_ASSERT(
         Binding != NULL && LocalAddress != NULL &&
         RemoteAddress != NULL && SendData != NULL);

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3621,7 +3621,8 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData
+    _In_ CXPLAT_SEND_DATA* SendData,
+    _In_ uint16_t PartitionIndex
     )
 {
     QUIC_STATUS Status;
@@ -3637,7 +3638,7 @@ CxPlatSocketSend(
         goto Exit;
     }
 
-    SocketProc = &Socket->Processors[Socket->HasFixedRemoteAddress ? 0 : GetCurrentProcessorNumber()];
+    SocketProc = &Socket->Processors[Socket->HasFixedRemoteAddress ? 0 : PartitionIndex];
 
     CxPlatSendDataFinalizeSendBuffer(SendData, TRUE);
 
@@ -3653,7 +3654,7 @@ CxPlatSocketSend(
 
     RtlZeroMemory(&SendData->Overlapped, sizeof(OVERLAPPED));
     Result = PostQueuedCompletionStatus(
-        Socket->Datapath->Processors[GetCurrentProcessorNumber()].IOCP,
+        Socket->Datapath->Processors[PartitionIndex].IOCP,
         UINT32_MAX,
         (ULONG_PTR)SocketProc,
         &SendData->Overlapped);

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -183,8 +183,15 @@ typedef struct CXPLAT_SEND_DATA {
     //
     WSABUF ClientBuffer;
 
-    QUIC_ADDR RemoteAddress;
+    //
+    // The local address to bind to.
+    //
     QUIC_ADDR LocalAddress;
+
+    //
+    // The remote address to send to.
+    //
+    QUIC_ADDR RemoteAddress;
 
 } CXPLAT_SEND_DATA;
 

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -423,7 +423,8 @@ CxPlatPcpSendMapRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData, 0);
+            SendData,
+            CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {
         return Status;
     }
@@ -528,7 +529,8 @@ CxPlatPcpSendPeerRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData, 0);
+            SendData,
+            CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {
         return Status;
     }

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -423,7 +423,7 @@ CxPlatPcpSendMapRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData);
+            SendData, 0);
     if (QUIC_FAILED(Status)) {
         return Status;
     }
@@ -528,7 +528,7 @@ CxPlatPcpSendPeerRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData);
+            SendData, 0);
     if (QUIC_FAILED(Status)) {
         return Status;
     }

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -424,7 +424,7 @@ CxPlatPcpSendMapRequestInternal(
             &LocalAddress,
             &RemoteAddress,
             SendData,
-            CxPlatProcCurrentNumber());
+            (uint16_t)CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {
         return Status;
     }
@@ -530,7 +530,7 @@ CxPlatPcpSendPeerRequestInternal(
             &LocalAddress,
             &RemoteAddress,
             SendData,
-            CxPlatProcCurrentNumber());
+            (uint16_t)CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {
         return Status;
     }

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -235,7 +235,7 @@ protected:
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendData
+                        ServerSendData, 0
                     ));
 
             } else {
@@ -284,7 +284,7 @@ protected:
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendData
+                        ServerSendData, 0
                     ));
 
             } else {
@@ -632,7 +632,7 @@ TEST_P(DataPathTest, UdpData)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData));
+            ClientSendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -717,7 +717,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData));
+            ClientSendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -752,7 +752,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData));
+            ClientSendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -837,7 +837,7 @@ TEST_P(DataPathTest, UdpDataECT0)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData));
+            ClientSendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -1092,7 +1092,7 @@ TEST_P(DataPathTest, TcpDataClient)
             Client,
             &ServerAddress,
             &ClientAddress,
-            SendData));
+            SendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.ServerContext.ReceiveEvent, 100));
 
@@ -1178,7 +1178,7 @@ TEST_P(DataPathTest, TcpDataServer)
             ListenerContext.Server,
             &ServerAddress,
             &ClientAddress,
-            SendData));
+            SendData, 0));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ClientContext.ReceiveEvent, 100));
 

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -213,7 +213,8 @@ struct DrillSender {
                 Binding,
                 &LocalAddress,
                 &ServerAddress,
-                SendData);
+                SendData,
+                0);
 
         return Status;
     }

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -162,7 +162,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             &LocalAddress,
             &ServerAddress,
             SendData,
-            CxPlatProcCurrentNumber())));
+            (uint16_6)CxPlatProcCurrentNumber())));
     }
 }
 
@@ -293,7 +293,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             &LocalAddress,
             &ServerAddress,
             SendData,
-            CxPlatProcCurrentNumber())));
+            (uint16_6)CxPlatProcCurrentNumber())));
     }
 }
 

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -162,7 +162,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             &LocalAddress,
             &ServerAddress,
             SendData,
-            (uint16_6)CxPlatProcCurrentNumber())));
+            (uint16_t)CxPlatProcCurrentNumber())));
     }
 }
 
@@ -293,7 +293,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             &LocalAddress,
             &ServerAddress,
             SendData,
-            (uint16_6)CxPlatProcCurrentNumber())));
+            (uint16_t)CxPlatProcCurrentNumber())));
     }
 }
 

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -161,7 +161,8 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendData)));
+            SendData,
+            CxPlatProcCurrentNumber())));
     }
 }
 
@@ -291,7 +292,8 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendData)));
+            SendData,
+            CxPlatProcCurrentNumber())));
     }
 }
 


### PR DESCRIPTION
By doing this, the worker thread will get more time to handle encryption and decryption, as the datapath thread will handle the send. This slooks to be about 8-10% throughput improvement with no regressions elsewhere.

Closes https://github.com/microsoft/msquic/issues/1223