### PR TITLE
Default to send buffering off in secnetpert

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -56,7 +56,7 @@
             "RemoteReadyMatcher": "Started!",
             "ResultsMatcher": ".*@ (.*) kbps.*",
             "Formats": ["{0} kbps"],
-            "RegressionThreshold": "-8.0"
+            "RegressionThreshold": "-50.0"
         },
         {
             "TestName": "ThroughputUp",
@@ -135,7 +135,7 @@
             "RemoteReadyMatcher": "Started!",
             "ResultsMatcher": ".*@ (.*) kbps.*",
             "Formats": ["{0} kbps"],
-            "RegressionThreshold": "-8.0"
+            "RegressionThreshold": "-50.0"
         },
         {
             "TestName": "ThroughputDown",

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -26,8 +26,8 @@
                 {
                     "Name": "SendBuffering",
                     "Local": {
-                        "On": "",
-                        "Off": "-sendbuf:0"
+                        "On": "-sendbuf:1",
+                        "Off": ""
                     },
                     "Default": "Off"
                 }
@@ -79,8 +79,8 @@
                 {
                     "Name": "SendBuffering",
                     "Local": {
-                        "On": "",
-                        "Off": "-sendbuf:0"
+                        "On": "-sendbuf:1",
+                        "Off": ""
                     },
                     "Default": "Off"
                 }

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -32,7 +32,7 @@ PrintHelp(
         "  -port:<####>                The UDP port of the server. (def:%u)\n"
         "  -ip:<0/4/6>                 A hint for the resolving the hostname to an IP address. (def:0)\n"
         "  -encrypt:<0/1>              Enables/disables encryption. (def:1)\n"
-        "  -sendbuf:<0/1>              Whether to use send buffering. (def:1)\n"
+        "  -sendbuf:<0/1>              Whether to use send buffering. (def:0)\n"
         "  -pacing:<0/1>               Whether to use pacing. (def:1)\n"
         "  -timed:<0/1>                Indicates the upload/download arg time (ms). (def:0)\n"
         "  -upload:<####>              The length of data (or time with -timed:1 arg) to send. (def:0)\n"

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -120,7 +120,7 @@ private:
     CXPLAT_EVENT* StopEvent {nullptr};
     QUIC_BUFFER* DataBuffer {nullptr};
     uint8_t UseTcp {FALSE};
-    uint8_t UseSendBuffer {TRUE};
+    uint8_t UseSendBuffer {FALSE};
     uint8_t UsePacing {TRUE};
     uint8_t UseEncryption {TRUE};
     uint8_t TimedTransfer {FALSE};


### PR DESCRIPTION
We usually want to be testing with no send buffering, however thats not the default. That makes manual testing more difficult, as thats something we have to explicitly set. Make the default no send buffering, and require it to be enabled explcitly