### PR TITLE
Use worker ideal processor rather then connection partition ID for send.

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1691,7 +1691,7 @@ QuicBindingSend(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     )
 {
     QUIC_STATUS Status;
@@ -1722,7 +1722,7 @@ QuicBindingSend(
                     &LocalAddressCopy,
                     &RemoteAddressCopy,
                     SendData,
-                    PartitionIndex);
+                    IdealProcessor);
             if (QUIC_FAILED(Status)) {
                 QuicTraceLogWarning(
                     BindingSendFailed,
@@ -1739,7 +1739,7 @@ QuicBindingSend(
                 LocalAddress,
                 RemoteAddress,
                 SendData,
-                PartitionIndex);
+                IdealProcessor);
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 BindingSendFailed,

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -431,7 +431,7 @@ QuicBindingSend(
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     );
 
 //

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -30,8 +30,7 @@ QuicFuzzInjectHook(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPacketBuilderSendBatch(
-    _Inout_ QUIC_PACKET_BUILDER* Builder,
-    _In_ uint16_t PartitionIndex
+    _Inout_ QUIC_PACKET_BUILDER* Builder
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -864,7 +863,7 @@ Exit:
             if (Builder->BatchCount != 0) {
                 QuicPacketBuilderFinalizeHeaderProtection(Builder);
             }
-            QuicPacketBuilderSendBatch(Builder, QuicPartitionIdGetIndex(Connection->PartitionID));
+            QuicPacketBuilderSendBatch(Builder);
         }
 
         if (Builder->PacketType == QUIC_RETRY) {
@@ -881,8 +880,7 @@ Exit:
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPacketBuilderSendBatch(
-    _Inout_ QUIC_PACKET_BUILDER* Builder,
-    _In_ uint16_t PartitionIndex
+    _Inout_ QUIC_PACKET_BUILDER* Builder
     )
 {
     QuicTraceLogConnVerbose(
@@ -898,7 +896,7 @@ QuicPacketBuilderSendBatch(
         Builder->SendData,
         Builder->TotalDatagramsLength,
         Builder->TotalCountDatagrams,
-        PartitionIndex);
+        Builder->Connection->Worker->IdealProcessor);
 
     Builder->PacketBatchSent = TRUE;
     Builder->SendData = NULL;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2684,7 +2684,7 @@ CxPlatSocketSend(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     )
 {
     UNREFERENCED_PARAMETER(PartitionIndex);

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2687,7 +2687,7 @@ CxPlatSocketSend(
     _In_ uint16_t IdealProcessor
     )
 {
-    UNREFERENCED_PARAMETER(PartitionIndex);
+    UNREFERENCED_PARAMETER(IdealProcessor);
 #ifdef CX_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->SocketSend(

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2185,7 +2185,7 @@ CxPlatSocketSend(
     _In_ uint16_t IdealProcessor
     )
 {
-    UNREFERENCED_PARAMETER(PartitionIndex);
+    UNREFERENCED_PARAMETER(IdealProcessor);
     QUIC_STATUS Status =
         CxPlatSocketSendInternal(
             Socket,

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2182,7 +2182,7 @@ CxPlatSocketSend(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     )
 {
     UNREFERENCED_PARAMETER(PartitionIndex);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2826,7 +2826,7 @@ CxPlatSocketSend(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     )
 {
     QUIC_STATUS Status;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2832,7 +2832,7 @@ CxPlatSocketSend(
     QUIC_STATUS Status;
     PDWORD SegmentSize;
 
-    UNREFERENCED_PARAMETER(PartitionIndex);
+    UNREFERENCED_PARAMETER(IdealProcessor);
     CXPLAT_DBG_ASSERT(
         Binding != NULL && LocalAddress != NULL &&
         RemoteAddress != NULL && SendData != NULL);

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3629,7 +3629,7 @@ CxPlatSocketSend(
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionIndex
+    _In_ uint16_t IdealProcessor
     )
 {
     QUIC_STATUS Status;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3649,8 +3649,8 @@ CxPlatSocketSend(
     }
 
     Datapath = Socket->Datapath;
-    SocketProc = &Socket->Processors[Socket->HasFixedRemoteAddress ? 0 : PartitionIndex % Datapath->ProcCount];
-    Processor = Socket->HasFixedRemoteAddress ? Socket->ProcessorAffinity : PartitionIndex % Datapath->ProcCount;
+    SocketProc = &Socket->Processors[Socket->HasFixedRemoteAddress ? 0 : IdealProcessor % Datapath->ProcCount];
+    Processor = Socket->HasFixedRemoteAddress ? Socket->ProcessorAffinity : IdealProcessor % Datapath->ProcCount;
 
     CxPlatSendDataFinalizeSendBuffer(SendData, TRUE);
     RtlZeroMemory(&SendData->Overlapped, sizeof(OVERLAPPED));


### PR DESCRIPTION
In theory, these match, but computing the partition index from the connection is more expensive then the ideal processor of the worker thread. And ideally, we want the ideal processor of the worker thread anyway.

Attempt to see if we can gain some of the lost kernel performance back