### PR TITLE
Provide UWP implementations of GetProcessorCount functions

### DIFF
--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -735,8 +735,13 @@ extern CXPLAT_PROCESSOR_INFO* CxPlatProcessorInfo;
 extern uint64_t* CxPlatNumaMasks;
 extern uint32_t* CxPlatProcessorGroupOffsets;
 
+#ifdef QUIC_UWP_BUILD
+DWORD CxPlatProcMaxCount();
+DWORD CxPlatProcActiveCount();
+#else
 #define CxPlatProcMaxCount() GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)
 #define CxPlatProcActiveCount() GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)
+#endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 inline

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -58,9 +58,15 @@ CxPlatSystemUnload(
 #endif
 }
 
-BOOLEAN CxPlatProcessorGroupInfo(
+_IRQL_requires_max_(PASSIVE_LEVEL)
+__drv_allocatesMem(Mem)
+_Must_inspect_result_
+_Success_(return != FALSE)
+BOOLEAN
+CxPlatProcessorGroupInfo(
     _In_ LOGICAL_PROCESSOR_RELATIONSHIP Relationship,
-    _Out_ PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Buffer,
+    _Out_writes_bytes_to_opt_(*BufferLength,*BufferLength)
+        PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Buffer,
     _Out_ PDWORD BufferLength
     );
 
@@ -92,8 +98,7 @@ CxPlatProcessorInfoInit(
         goto Error;
     }
 
-    if (!
-        CxPlatProcessorGroupInfo(
+    if (!CxPlatProcessorGroupInfo(
             RelationAll,
             (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)&Buffer,
             &BufferLength)) {
@@ -527,6 +532,10 @@ Error:
     return HRESULT_FROM_WIN32(Error);
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+__drv_allocatesMem(Mem)
+_Must_inspect_result_
+_Success_(return != FALSE)
 BOOLEAN
 CxPlatProcessorGroupInfo(
     _In_ LOGICAL_PROCESSOR_RELATIONSHIP Relationship,
@@ -586,7 +595,7 @@ CxPlatProcActiveCount(
     DWORD ProcLength;
     DWORD Count;
 
-    if(!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
+    if (!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
         return 0;
     }
 
@@ -606,7 +615,7 @@ CxPlatProcMaxCount(
     DWORD ProcLength;
     DWORD Count;
 
-    if(!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
+    if (!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
         return 0;
     }
 

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -594,6 +594,7 @@ CxPlatProcActiveCount(
     DWORD Count;
 
     if (!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
+        CXPLAT_DBG_ASSERT(FALSE);
         return 0;
     }
 
@@ -602,6 +603,7 @@ CxPlatProcActiveCount(
         Count +=  ProcInfo->Group.GroupInfo[i].ActiveProcessorCount;
     }
     CXPLAT_FREE(ProcInfo, QUIC_POOL_PLATFORM_TMP_ALLOC);
+    CXPLAT_DBG_ASSERT(Count != 0);
     return Count;
 }
 
@@ -614,6 +616,7 @@ CxPlatProcMaxCount(
     DWORD Count;
 
     if (!CxPlatProcessorGroupInfo(RelationGroup, &ProcInfo, &ProcLength)) {
+        CXPLAT_DBG_ASSERT(FALSE);
         return 0;
     }
 
@@ -622,6 +625,7 @@ CxPlatProcMaxCount(
         Count +=  ProcInfo->Group.GroupInfo[i].MaximumProcessorCount;
     }
     CXPLAT_FREE(ProcInfo, QUIC_POOL_PLATFORM_TMP_ALLOC);
+    CXPLAT_DBG_ASSERT(Count != 0);
     return Count;
 }
 #endif

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -59,13 +59,12 @@ CxPlatSystemUnload(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-__drv_allocatesMem(Mem)
 _Must_inspect_result_
 _Success_(return != FALSE)
 BOOLEAN
 CxPlatProcessorGroupInfo(
     _In_ LOGICAL_PROCESSOR_RELATIONSHIP Relationship,
-    _Out_writes_bytes_to_opt_(*BufferLength,*BufferLength)
+    _Outptr_ _At_(*Buffer, __drv_allocatesMem(Mem)) _Pre_defensive_
         PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Buffer,
     _Out_ PDWORD BufferLength
     );
@@ -533,13 +532,12 @@ Error:
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-__drv_allocatesMem(Mem)
 _Must_inspect_result_
 _Success_(return != FALSE)
 BOOLEAN
 CxPlatProcessorGroupInfo(
     _In_ LOGICAL_PROCESSOR_RELATIONSHIP Relationship,
-    _Out_writes_bytes_to_opt_(*BufferLength,*BufferLength)
+    _Outptr_ _At_(*Buffer, __drv_allocatesMem(Mem)) _Pre_defensive_
         PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Buffer,
     _Out_ PDWORD BufferLength
     )


### PR DESCRIPTION
These are disallowed by WACK in UWP, however they are pretty easy to implement with simple functions we already were using. Provide custom impl's for UWP mode