### PR TITLE
Hardcode timer resolution call for UWP apps

### DIFF
--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -553,6 +553,14 @@ typedef HANDLE CXPLAT_EVENT;
 // Time Measurement Interfaces
 //
 
+#ifdef QUIC_UWP_BUILD
+inline
+uint64_t
+CxPlatGetTimerResolution()
+{
+    return 15625;
+}
+#else
 //
 // This is an undocumented API that is used to query the current timer
 // resolution.
@@ -578,6 +586,7 @@ CxPlatGetTimerResolution()
     NtQueryTimerResolution(&MaximumTime, &MinimumTime, &CurrentTime);
     return NS100_TO_US(MaximumTime);
 }
+#endif
 
 //
 // Performance counter frequency.


### PR DESCRIPTION
UWP apps have no WACK allowed API to grab that data. So just assume 15.625 ms, and use that.