### PR TITLE
Configure IdealProcessor as part of SendData

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -762,7 +762,8 @@ QuicBindingProcessStatelessOperation(
         CxPlatSendDataAlloc(
             Binding->Socket,
             CXPLAT_ECN_NON_ECT,
-            0);
+            0,
+            RecvDatagram->PartitionIndex);
     if (SendData == NULL) {
         QuicTraceEvent(
             AllocFailure,
@@ -1004,8 +1005,7 @@ QuicBindingProcessStatelessOperation(
         &RecvDatagram->Tuple->RemoteAddress,
         SendData,
         SendDatagram->Length,
-        1,
-        RecvDatagram->PartitionIndex % MsQuicLib.PartitionCount);
+        1);
     SendData = NULL;
 
 Exit:
@@ -1690,8 +1690,7 @@ QuicBindingSend(
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
-    _In_ uint32_t DatagramsToSend,
-    _In_ uint16_t IdealProcessor
+    _In_ uint32_t DatagramsToSend
     )
 {
     QUIC_STATUS Status;
@@ -1721,8 +1720,7 @@ QuicBindingSend(
                     Binding->Socket,
                     &LocalAddressCopy,
                     &RemoteAddressCopy,
-                    SendData,
-                    IdealProcessor);
+                    SendData);
             if (QUIC_FAILED(Status)) {
                 QuicTraceLogWarning(
                     BindingSendFailed,
@@ -1738,8 +1736,7 @@ QuicBindingSend(
                 Binding->Socket,
                 LocalAddress,
                 RemoteAddress,
-                SendData,
-                IdealProcessor);
+                SendData);
         if (QUIC_FAILED(Status)) {
             QuicTraceLogWarning(
                 BindingSendFailed,

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -430,8 +430,7 @@ QuicBindingSend(
     _In_ const QUIC_ADDR* RemoteAddress,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
-    _In_ uint32_t DatagramsToSend,
-    _In_ uint16_t IdealProcessor
+    _In_ uint32_t DatagramsToSend
     );
 
 //

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -190,7 +190,8 @@ QuicPacketBuilderPrepare(
                         0 :
                         MaxUdpPayloadSizeForFamily(
                             QuicAddrGetFamily(&Builder->Path->RemoteAddress),
-                            DatagramSize));
+                            DatagramSize),
+                    Builder->Connection->Worker->IdealProcessor);
             if (Builder->SendData == NULL) {
                 QuicTraceEvent(
                     AllocFailure,
@@ -895,8 +896,7 @@ QuicPacketBuilderSendBatch(
         &Builder->Path->RemoteAddress,
         Builder->SendData,
         Builder->TotalDatagramsLength,
-        Builder->TotalCountDatagrams,
-        Builder->Connection->Worker->IdealProcessor);
+        Builder->TotalCountDatagrams);
 
     Builder->PacketBatchSent = TRUE;
     Builder->SendData = NULL;

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -486,7 +486,8 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _In_ uint16_t IdealProcessor
     );
 
 //
@@ -537,8 +538,7 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t PartitionId
+    _In_ CXPLAT_SEND_DATA* SendData
     );
 
 //

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -523,7 +523,7 @@ void TcpConnection::Process()
     }
     if (BatchedSendData) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
             IndicateDisconnect = true;
         }
         BatchedSendData = nullptr;
@@ -889,7 +889,7 @@ bool TcpConnection::EncryptFrame(TcpFrame* Frame)
 QUIC_BUFFER* TcpConnection::NewSendBuffer()
 {
     if (!BatchedSendData) {
-        BatchedSendData = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, TLS_BLOCK_SIZE);
+        BatchedSendData = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, TLS_BLOCK_SIZE, PartitionIndex);
         if (!BatchedSendData) { return nullptr; }
     }
     return CxPlatSendDataAllocBuffer(BatchedSendData, TLS_BLOCK_SIZE);
@@ -906,7 +906,7 @@ bool TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
     if (SendBuffer->Length != TLS_BLOCK_SIZE ||
         CxPlatSendDataIsFull(BatchedSendData)) {
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
+            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData))) {
             WriteOutput("CxPlatSocketSend FAILED\n");
             return false;
         }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2126,6 +2126,7 @@ CxPlatSendDataAlloc(
     _In_ uint16_t IdealProcessor
     )
 {
+    UNREFERENCED_PARAMETER(IdealProcessor);
 #ifdef CX_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->SendDataAlloc(
@@ -2136,7 +2137,7 @@ CxPlatSendDataAlloc(
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =
-        &Socket->Datapath->ProcContexts[IdealProcessor % Socket->Datapath->ProcCount];
+        &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&DatapathProc->SendDataPool);

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2122,7 +2122,8 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _In_ uint16_t IdealProcessor
     )
 {
 #ifdef CX_PLATFORM_DISPATCH_TABLE
@@ -2135,7 +2136,7 @@ CxPlatSendDataAlloc(
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =
-        &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
+        &Socket->Datapath->ProcContexts[IdealProcessor % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&DatapathProc->SendDataPool);
@@ -2683,11 +2684,9 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t IdealProcessor
+    _In_ CXPLAT_SEND_DATA* SendData
     )
 {
-    UNREFERENCED_PARAMETER(IdealProcessor);
 #ifdef CX_PLATFORM_DISPATCH_TABLE
     return
         PlatDispatch->SocketSend(

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1688,13 +1688,14 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _In_ uint16_t IdealProcessor
     )
 {
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =
-        &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
+        &Socket->Datapath->ProcContexts[IdealProcessor % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&DatapathProc->SendDataPool);
@@ -2181,11 +2182,9 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t IdealProcessor
+    _In_ CXPLAT_SEND_DATA* SendData
     )
 {
-    UNREFERENCED_PARAMETER(IdealProcessor);
     QUIC_STATUS Status =
         CxPlatSocketSendInternal(
             Socket,

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1692,10 +1692,11 @@ CxPlatSendDataAlloc(
     _In_ uint16_t IdealProcessor
     )
 {
+    UNREFERENCED_PARAMETER(IdealProcessor);
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =
-        &Socket->Datapath->ProcContexts[IdealProcessor % Socket->Datapath->ProcCount];
+        &Socket->Datapath->ProcContexts[CxPlatProcCurrentNumber() % Socket->Datapath->ProcCount];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&DatapathProc->SendDataPool);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2412,10 +2412,11 @@ CxPlatSendDataAlloc(
     _In_ UINT16 IdealProcessor
     )
 {
+    UNREFERENCED_PARAMETER(IdealProcessor);
     CXPLAT_DBG_ASSERT(Binding != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* ProcContext =
-        &Binding->Datapath->ProcContexts[IdealProcessor];
+        &Binding->Datapath->ProcContexts[CxPlatProcCurrentNumber()];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&ProcContext->SendDataPool);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2408,13 +2408,14 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Binding,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ UINT16 MaxPacketSize
+    _In_ UINT16 MaxPacketSize,
+    _In_ UINT16 IdealProcessor
     )
 {
     CXPLAT_DBG_ASSERT(Binding != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* ProcContext =
-        &Binding->Datapath->ProcContexts[CxPlatProcCurrentNumber()];
+        &Binding->Datapath->ProcContexts[IdealProcessor];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&ProcContext->SendDataPool);
@@ -2825,14 +2826,12 @@ CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Binding,
     _In_ const QUIC_ADDR* LocalAddress,
     _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ CXPLAT_SEND_DATA* SendData,
-    _In_ uint16_t IdealProcessor
+    _In_ CXPLAT_SEND_DATA* SendData
     )
 {
     QUIC_STATUS Status;
     PDWORD SegmentSize;
 
-    UNREFERENCED_PARAMETER(IdealProcessor);
     CXPLAT_DBG_ASSERT(
         Binding != NULL && LocalAddress != NULL &&
         RemoteAddress != NULL && SendData != NULL);

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3344,7 +3344,7 @@ CxPlatSendDataAlloc(
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC* DatapathProc =
-        &Socket->Datapath->Processors[IdealProcessor];
+        &Socket->Datapath->Processors[GetCurrentProcessorNumber()];
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatPoolAlloc(&DatapathProc->SendDataPool);

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -386,7 +386,7 @@ CxPlatPcpSendMapRequestInternal(
     CxPlatConvertToMappedV6(&LocalAddress, &LocalMappedAddress);
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE);
+        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE, (uint16_t)CxPlatProcCurrentNumber());
     if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
@@ -423,8 +423,7 @@ CxPlatPcpSendMapRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData,
-            (uint16_t)CxPlatProcCurrentNumber());
+            SendData);
     if (QUIC_FAILED(Status)) {
         return Status;
     }
@@ -487,7 +486,7 @@ CxPlatPcpSendPeerRequestInternal(
     CxPlatConvertToMappedV6(RemotePeerAddress, &RemotePeerMappedAddress);
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_PEER_REQUEST_SIZE);
+        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_PEER_REQUEST_SIZE, (uint16_t)CxPlatProcCurrentNumber());
     if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
@@ -529,8 +528,7 @@ CxPlatPcpSendPeerRequestInternal(
             Socket,
             &LocalAddress,
             &RemoteAddress,
-            SendData,
-            (uint16_t)CxPlatProcCurrentNumber());
+            SendData);
     if (QUIC_FAILED(Status)) {
         return Status;
     }

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -221,7 +221,7 @@ protected:
             if (RecvData->Tuple->LocalAddress.Ipv4.sin_port == RecvContext->ServerAddress.Ipv4.sin_port) {
 
                 auto ServerSendData =
-                    CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, 0);
+                    CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
                 ASSERT_NE(nullptr, ServerSendData);
 
                 auto ServerBuffer =
@@ -235,8 +235,7 @@ protected:
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendData, 0
-                    ));
+                        ServerSendData));
 
             } else {
                 CxPlatEventSet(RecvContext->ClientCompletion);
@@ -269,7 +268,7 @@ protected:
                 CXPLAT_ECN_TYPE ecn = (CXPLAT_ECN_TYPE)RecvData->TypeOfService;
 
                 auto ServerSendData =
-                    CxPlatSendDataAlloc(Socket, CXPLAT_ECN_ECT_0, 0);
+                    CxPlatSendDataAlloc(Socket, CXPLAT_ECN_ECT_0, 0, (uint16_t)CxPlatProcCurrentNumber());
                 ASSERT_NE(nullptr, ServerSendData);
 
                 auto ServerBuffer =
@@ -284,8 +283,7 @@ protected:
                         Socket,
                         &RecvData->Tuple->LocalAddress,
                         &RecvData->Tuple->RemoteAddress,
-                        ServerSendData, 0
-                    ));
+                        ServerSendData));
 
             } else {
                 CxPlatEventSet(RecvContext->ClientCompletion);
@@ -615,7 +613,7 @@ TEST_P(DataPathTest, UdpData)
     ASSERT_NE(nullptr, client);
 
     auto ClientSendData =
-        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
+        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, ClientSendData);
 
     auto ClientBuffer =
@@ -632,7 +630,7 @@ TEST_P(DataPathTest, UdpData)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData, 0));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -700,7 +698,7 @@ TEST_P(DataPathTest, UdpDataRebind)
     ASSERT_NE(nullptr, client);
 
     auto ClientSendData =
-        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
+        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, ClientSendData);
 
     auto ClientBuffer =
@@ -717,7 +715,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData, 0));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -736,7 +734,7 @@ TEST_P(DataPathTest, UdpDataRebind)
     ASSERT_NE(nullptr, client);
 
     ClientSendData =
-        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0);
+        CxPlatSendDataAlloc(client, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, ClientSendData);
 
     ClientBuffer =
@@ -752,7 +750,7 @@ TEST_P(DataPathTest, UdpDataRebind)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData, 0));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -820,7 +818,7 @@ TEST_P(DataPathTest, UdpDataECT0)
     ASSERT_NE(nullptr, client);
 
     auto ClientSendData =
-        CxPlatSendDataAlloc(client, CXPLAT_ECN_ECT_0, 0);
+        CxPlatSendDataAlloc(client, CXPLAT_ECN_ECT_0, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, ClientSendData);
 
     auto ClientBuffer =
@@ -837,7 +835,7 @@ TEST_P(DataPathTest, UdpDataECT0)
             client,
             &ClientAddress,
             &serverAddress.SockAddr,
-            ClientSendData, 0));
+            ClientSendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(RecvContext.ClientCompletion, 2000));
 
@@ -1078,7 +1076,7 @@ TEST_P(DataPathTest, TcpDataClient)
     ASSERT_NE(nullptr, ListenerContext.Server);
 
     auto SendData =
-        CxPlatSendDataAlloc(Client, CXPLAT_ECN_NON_ECT, 0);
+        CxPlatSendDataAlloc(Client, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, SendData);
 
     auto SendBuffer =
@@ -1092,7 +1090,7 @@ TEST_P(DataPathTest, TcpDataClient)
             Client,
             &ServerAddress,
             &ClientAddress,
-            SendData, 0));
+            SendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.ServerContext.ReceiveEvent, 100));
 
@@ -1164,7 +1162,7 @@ TEST_P(DataPathTest, TcpDataServer)
     ASSERT_NE(nullptr, ListenerContext.Server);
 
     auto SendData =
-        CxPlatSendDataAlloc(ListenerContext.Server, CXPLAT_ECN_NON_ECT, 0);
+        CxPlatSendDataAlloc(ListenerContext.Server, CXPLAT_ECN_NON_ECT, 0, (uint16_t)CxPlatProcCurrentNumber());
     ASSERT_NE(nullptr, SendData);
 
     auto SendBuffer =
@@ -1178,7 +1176,7 @@ TEST_P(DataPathTest, TcpDataServer)
             ListenerContext.Server,
             &ServerAddress,
             &ClientAddress,
-            SendData, 0));
+            SendData));
 
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ClientContext.ReceiveEvent, 100));
 

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -192,7 +192,7 @@ struct DrillSender {
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
+                Binding, CXPLAT_ECN_NON_ECT, DatagramLength, (uint16_t)CxPlatProcCurrentNumber());
 
         QUIC_BUFFER* SendBuffer =
             CxPlatSendDataAllocBuffer(SendData, DatagramLength);
@@ -213,8 +213,7 @@ struct DrillSender {
                 Binding,
                 &LocalAddress,
                 &ServerAddress,
-                SendData,
-                0);
+                SendData);
 
         return Status;
     }

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -116,7 +116,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, Length);
+                Binding, CXPLAT_ECN_NON_ECT, Length, (uint16_t)CxPlatProcCurrentNumber());
         if (SendData == nullptr) {
             printf("CxPlatSendDataAlloc failed\n");
             return;
@@ -161,8 +161,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendData,
-            (uint16_t)CxPlatProcCurrentNumber())));
+            SendData)));
     }
 }
 
@@ -220,7 +219,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
+                Binding, CXPLAT_ECN_NON_ECT, DatagramLength, (uint16_t)CxPlatProcCurrentNumber());
         VERIFY(SendData);
 
         while (CxPlatTimeDiff64(TimeStart, CxPlatTimeMs64()) < TimeoutMs &&
@@ -292,8 +291,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             Binding,
             &LocalAddress,
             &ServerAddress,
-            SendData,
-            (uint16_t)CxPlatProcCurrentNumber())));
+            SendData)));
     }
 }
 


### PR DESCRIPTION
When passing IdealProcessor down to CxPlatSocketSend directly, we got some odd performance regressions on windows kernel. We might be spilling parameters onto the stack, so adjust to set the ideal processor on the send data.