### PR TITLE
Tune QUIC_MAX_RECEIVE_QUEUE_COUNT to be ideal for both kernel and user mode

### DIFF
--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -187,7 +187,7 @@ typedef struct QUIC_PATH QUIC_PATH;
 //
 // Kernel modes receive path is slightly different, so allow larger queue sizes.
 //
-#define QUIC_MAX_RECEIVE_QUEUE_COUNT            260
+#define QUIC_MAX_RECEIVE_QUEUE_COUNT            1024
 #else
 #define QUIC_MAX_RECEIVE_QUEUE_COUNT            180
 #endif


### PR DESCRIPTION
Kernel mode seems to need a higher queue length to get performance matches with user mode. Lower queue lengths result in a lot of dropped packets.