### PR TITLE
Add Name to SecNetPerf Registrations

### DIFF
--- a/src/perf/lib/HpsClient.h
+++ b/src/perf/lib/HpsClient.h
@@ -92,7 +92,10 @@ public:
     void StartConnection(HpsWorkerContext* Context);
 
     HpsWorkerContext Contexts[PERF_MAX_THREAD_COUNT];
-    MsQuicRegistration Registration;
+    MsQuicRegistration Registration {
+        "secnetperf-client-hps",
+        QUIC_EXECUTION_PROFILE_LOW_LATENCY,
+        false};
     MsQuicConfiguration Configuration {
         Registration,
         MsQuicAlpn(PERF_ALPN),

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -111,7 +111,10 @@ private:
         );
 
     QUIC_STATUS InitStatus;
-    MsQuicRegistration Registration {true};
+    MsQuicRegistration Registration {
+        "secnetperf-server",
+        QUIC_EXECUTION_PROFILE_LOW_LATENCY,
+        true};
     MsQuicAlpn Alpn {PERF_ALPN};
     MsQuicConfiguration Configuration {
         Registration,

--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -149,7 +149,10 @@ public:
         _Inout_ QUIC_CONNECTION_EVENT* Event
         );
 
-    MsQuicRegistration Registration {true};
+    MsQuicRegistration Registration {
+        "secnetperf-client-rps",
+        QUIC_EXECUTION_PROFILE_LOW_LATENCY,
+        true};
     MsQuicConfiguration Configuration {
         Registration,
         MsQuicAlpn(PERF_ALPN),

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -106,7 +106,10 @@ private:
 
     void OnStreamShutdownComplete(_In_ StreamContext* Context);
 
-    MsQuicRegistration Registration {true};
+    MsQuicRegistration Registration {
+        "secnetperf-client-tput",
+        QUIC_EXECUTION_PROFILE_LOW_LATENCY,
+        true};
     MsQuicConfiguration Configuration {
         Registration,
         MsQuicAlpn(PERF_ALPN),


### PR DESCRIPTION
Noticed we were missing the name when debugging some logs.