### PR TITLE
Disable UDP Send Queuing (Temporarily)

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3811,7 +3811,6 @@ CxPlatSocketSend(
     CXPLAT_SOCKET_PROC* SocketProc;
     CXPLAT_DATAPATH* Datapath;
     BOOL Result;
-    DWORD BytesSent;
     uint16_t Processor;
 
     CXPLAT_DBG_ASSERT(


### PR DESCRIPTION
Updates the UDP send logic to only queue to the worker thread if it's not actively doing something else. This is an attempt to stabilize perf. Note, it's possible this introduces reordering, which I have to think about.

UPDATE: Adds a build flag to control the UDP send queuing logic in general. Right now, disabling it because we have some other perf instability issues we need to debug before we can re-enable this.