### PR TITLE
Refactor Trace Rundown to Remove from Tools/Tests

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -16,11 +16,7 @@ Abstract:
 
 QUIC_LIBRARY MsQuicLib = { 0 };
 
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicTraceRundown(
-    void
-    );
+QUIC_TRACE_RUNDOWN_CALLBACK QuicTraceRundown;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
@@ -1587,6 +1583,7 @@ QuicLibraryGetWorker(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+_Function_class_(QUIC_TRACE_RUNDOWN_CALLBACK)
 void
 QuicTraceRundown(
     void

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -18,6 +18,12 @@ QUIC_LIBRARY MsQuicLib = { 0 };
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicTraceRundown(
+    void
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
 QuicLibApplyLoadBalancingSetting(
     void
     );
@@ -42,6 +48,7 @@ MsQuicLibraryLoad(
     CxPlatDispatchLockInitialize(&MsQuicLib.DatapathLock);
     CxPlatListInitializeHead(&MsQuicLib.Registrations);
     CxPlatListInitializeHead(&MsQuicLib.Bindings);
+    QuicTraceRundownCallback = QuicTraceRundown;
     MsQuicLib.Loaded = TRUE;
 }
 

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -104,11 +104,15 @@ typedef enum QUIC_TRACE_API_TYPE {
 #ifdef __cplusplus
 extern "C"
 #endif
+typedef
+_Function_class_(QUIC_TRACE_RUNDOWN_CALLBACK)
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicTraceRundown(
+(QUIC_TRACE_RUNDOWN_CALLBACK)(
     void
     );
+
+extern QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 #ifdef QUIC_CLOG
 

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -29,8 +29,6 @@ typedef struct {
 
 #endif
 
-extern "C" _IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 QUIC_STATUS
 QuicHandleRpsClient(
     _In_reads_(Length) uint8_t* ExtraData,

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -116,8 +116,6 @@ void __cdecl operator delete[] (_In_opt_ void* Mem, _In_opt_ size_t) {
     }
 }
 
-extern "C" _IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 extern "C"
 INITCODE
 _Function_class_(DRIVER_INITIALIZE)
@@ -280,7 +278,7 @@ SecNetPerfCtlInitialize(
         goto Error;
     }
 
-    Status = 
+    Status =
         SecNetPerfGetServiceName(
             BaseRegPath,
             &ServiceName);

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -36,6 +36,7 @@ CX_PLATFORM_DISPATCH* PlatDispatch = NULL;
 #else
 int RandomFd; // Used for reading random numbers.
 #endif
+QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 static const char TpLibName[] = "libmsquic.lttng.so";
 
@@ -423,7 +424,7 @@ CxPlatProcMaxCount(
 #if defined(CX_PLATFORM_DARWIN)
     //
     // arm64 macOS has no way to get the current proc, so treat as single core.
-    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
+    // Intel macOS can return incorrect values for CPUID, so treat as single core.
     //
     return 1;
 #else
@@ -439,7 +440,7 @@ CxPlatProcActiveCount(
 #if defined(CX_PLATFORM_DARWIN)
     //
     // arm64 macOS has no way to get the current proc, so treat as single core.
-    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
+    // Intel macOS can return incorrect values for CPUID, so treat as single core.
     //
     return 1;
 #else
@@ -457,7 +458,7 @@ CxPlatProcCurrentNumber(
 #elif defined(CX_PLATFORM_DARWIN)
     //
     // arm64 macOS has no way to get the current proc, so treat as single core.
-    // Intel macOS can return incorrect values for CPUID, so treat as single core. 
+    // Intel macOS can return incorrect values for CPUID, so treat as single core.
     //
     return 0;
 #endif // CX_PLATFORM_DARWIN

--- a/src/platform/platform_winkernel.c
+++ b/src/platform/platform_winkernel.c
@@ -59,6 +59,7 @@ typedef struct _SYSTEM_BASIC_INFORMATION {
 uint64_t CxPlatPerfFreq;
 uint64_t CxPlatTotalMemory;
 CX_PLATFORM CxPlatform = { NULL, NULL };
+QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 INITCODE
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -250,11 +251,15 @@ QuicEtwCallback(
     UNREFERENCED_PARAMETER(MatchAllKeyword);
     UNREFERENCED_PARAMETER(FilterData);
 
+    if (!QuicTraceRundownCallback) {
+        return;
+    }
+
     switch(ControlCode) {
     case EVENT_CONTROL_CODE_ENABLE_PROVIDER:
     case EVENT_CONTROL_CODE_CAPTURE_STATE:
         if (CallbackContext == &MICROSOFT_MSQUIC_PROVIDER_Context) {
-            QuicTraceRundown();
+            QuicTraceRundownCallback();
         }
         break;
     case EVENT_CONTROL_CODE_DISABLE_PROVIDER:

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -24,6 +24,7 @@ CX_PLATFORM CxPlatform = { NULL };
 CXPLAT_PROCESSOR_INFO* CxPlatProcessorInfo;
 uint64_t* CxPlatNumaMasks;
 uint32_t* CxPlatProcessorGroupOffsets;
+QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
@@ -651,11 +652,15 @@ QuicEtwCallback(
     UNREFERENCED_PARAMETER(MatchAllKeyword);
     UNREFERENCED_PARAMETER(FilterData);
 
+    if (!QuicTraceRundownCallback) {
+        return;
+    }
+
     switch(ControlCode) {
     case EVENT_CONTROL_CODE_ENABLE_PROVIDER:
     case EVENT_CONTROL_CODE_CAPTURE_STATE:
         if (CallbackContext == &MICROSOFT_MSQUIC_PROVIDER_Context) {
-            QuicTraceRundown();
+            QuicTraceRundownCallback();
         }
         break;
     case EVENT_CONTROL_CODE_DISABLE_PROVIDER:

--- a/src/platform/unittest/main.cpp
+++ b/src/platform/unittest/main.cpp
@@ -11,8 +11,6 @@
 #include "main.cpp.clog.h"
 #endif
 
-extern "C" _IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 const char* PfxPath = nullptr;
 
 class QuicCoreTestEnvironment : public ::testing::Environment {

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -18,8 +18,6 @@ QUIC_CREDENTIAL_CONFIG ServerSelfSignedCredConfigClientAuth;
 QUIC_CREDENTIAL_CONFIG ClientCertCredConfig;
 QuicDriverClient DriverClient;
 
-extern "C" _IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 class QuicTestEnvironment : public ::testing::Environment {
     QuicDriverService DriverService;
     const QUIC_CREDENTIAL_CONFIG* SelfSignedCertParams;

--- a/src/test/bin/winkernel/driver.cpp
+++ b/src/test/bin/winkernel/driver.cpp
@@ -68,8 +68,6 @@ void __cdecl operator delete[] (_In_opt_ void* Mem) {
     }
 }
 
-extern "C" _IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 extern "C"
 INITCODE
 _Function_class_(DRIVER_INITIALIZE)

--- a/src/tools/etw/main.c
+++ b/src/tools/etw/main.c
@@ -7,8 +7,6 @@
 
 #include "quicetw.h"
 
-_IRQL_requires_max_(PASSIVE_LEVEL) void QuicTraceRundown(void) { }
-
 #define USAGE \
 "QUIC Trace Analyzer\n" \
 "\n" \

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -121,8 +121,6 @@ std::vector<std::string> Urls;
 
 const char* SslKeyLogFileParam = nullptr;
 
-extern "C" void QuicTraceRundown(void) { }
-
 void
 PrintUsage()
 {

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -23,8 +23,6 @@ const QUIC_BUFFER SupportedALPNs[] = {
     { sizeof("siduck-00") - 1, (uint8_t*)"siduck-00" }
 };
 
-extern "C" void QuicTraceRundown(void) { }
-
 void
 PrintUsage()
 {

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -26,8 +26,6 @@ const QUIC_API_TABLE* MsQuic;
 HQUIC Registration;
 HQUIC Configuration;
 
-extern "C" void QuicTraceRundown(void) { }
-
 void
 PrintUsage()
 {

--- a/src/tools/ping/QuicPing.cpp
+++ b/src/tools/ping/QuicPing.cpp
@@ -16,8 +16,6 @@ HQUIC Registration;
 HQUIC Configuration;
 QUIC_PING_CONFIG PingConfig;
 
-extern "C" void QuicTraceRundown(void) { }
-
 void
 PrintUsage()
 {

--- a/src/tools/post/post.cpp
+++ b/src/tools/post/post.cpp
@@ -13,8 +13,6 @@ Abstract:
 
 #include <msquichelper.h>
 
-extern "C" void QuicTraceRundown(void) { }
-
 #define IO_SIZE (128 * 1024)
 
 #define POST_HEADER_FORMAT "POST %s\r\n"

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -26,8 +26,6 @@ const char* InputAlpn = nullptr;
 const QUIC_API_TABLE* MsQuic;
 HQUIC Registration;
 
-extern "C" void QuicTraceRundown(void) { }
-
 struct ConnectionContext {
     bool GotConnected;
     CXPLAT_EVENT Complete;

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -193,8 +193,6 @@ static struct {
     uint8_t LossPercent;
 } Settings;
 
-extern "C" void QuicTraceRundown(void) { }
-
 QUIC_STATUS QUIC_API SpinQuicHandleStreamEvent(HQUIC Stream, void * /* Context */, QUIC_STREAM_EVENT *Event)
 {
     switch (Event->Type) {


### PR DESCRIPTION
Refactors the trace rundown interface to remove the requirement for all cxplatform consumers, by making it a dynamic function pointer instead.