### PR TITLE
Skip publishing test results for codecoverage tasks

### DIFF
--- a/.azure/templates/upload-test-artifacts.yml
+++ b/.azure/templates/upload-test-artifacts.yml
@@ -37,7 +37,7 @@ steps:
         contents: '**/!(*-results.xml)'
         targetFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.tls }}
 
-  - ${{ if eq(parameters.publishTest, true) }}:
+  - ${{ if and(eq(parameters.publishTest, true), not(parameters.codeCoverage)) }}:
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       condition: succeededOrFailed()

--- a/.azure/templates/upload-test-artifacts.yml
+++ b/.azure/templates/upload-test-artifacts.yml
@@ -37,7 +37,7 @@ steps:
         contents: '**/!(*-results.xml)'
         targetFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.tls }}
 
-  - ${{ if and(eq(parameters.publishTest, true), not(parameters.codeCoverage)) }}:
+  - ${{ if and(eq(parameters.publishTest, true), eq(parameters.codeCoverage, false)) }}:
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       condition: succeededOrFailed()


### PR DESCRIPTION
We explicitly don't copy artifacts when codeCoverage is set, so the task always prints out a warning, which causes the build badge on the main page to show 1 test failed even though it didn't.