### PR TITLE
Enable valid alpn length tests on schannel

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -140,7 +140,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly:Alpn.ValidAlpnLengths
+      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly
       testCerts: true
 
 #
@@ -168,7 +168,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:Alpn.ValidAlpnLengths
+      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*
       kernel: true
       testCerts: true
 

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -407,7 +407,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Verbose
-      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:Alpn.ValidAlpnLengths
+      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*
       kernel: true
       testCerts: true
 
@@ -428,7 +428,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly:Alpn.ValidAlpnLengths
+      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly
       testCerts: true
   - template: ./templates/run-bvt.yml
     parameters:
@@ -512,7 +512,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly:Alpn.ValidAlpnLengths
+      extraArgs: -Filter -*CryptTest.HpMaskChaCha20:CryptTest.WellKnownChaChaPoly
       testCerts: true
       codeCoverage: true
   - template: ./templates/run-spinquic.yml


### PR DESCRIPTION
The bug has been fixed, and I think the builds on the test systems are new enough, so reenable the test.