### PR TITLE
Support running tests without administrator

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -120,6 +120,12 @@ param (
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
+function Test-Administrator
+{
+    $user = [Security.Principal.WindowsIdentity]::GetCurrent();
+    (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
 function Log($msg) {
     Write-Host "[$(Get-Date)] $msg"
 }
@@ -288,9 +294,11 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
         } else {
             $pinfo.FileName = $Path
             $pinfo.Arguments = $Arguments
-            # Enable WER dump collection.
-            New-ItemProperty -Path $WerDumpRegPath -Name DumpType -PropertyType DWord -Value 2 -Force | Out-Null
-            New-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -PropertyType ExpandString -Value $OutputDir -Force | Out-Null
+            if (Test-Administrator) {
+                # Enable WER dump collection.
+                New-ItemProperty -Path $WerDumpRegPath -Name DumpType -PropertyType DWord -Value 2 -Force | Out-Null
+                New-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -PropertyType ExpandString -Value $OutputDir -Force | Out-Null
+            }
         }
     } else {
         if ($Debugger) {
@@ -592,7 +600,7 @@ if ($ExecutionMode -eq "Parallel") {
 }
 
 # Initialize WER dump registry key if necessary.
-if ($IsWindows -and !(Test-Path $WerDumpRegPath)) {
+if ($IsWindows -and !(Test-Path $WerDumpRegPath) -and (Test-Administrator)) {
     New-Item -Path $WerDumpRegPath -Force | Out-Null
 }
 
@@ -685,7 +693,9 @@ try {
 
     if ($isWindows) {
         # Cleanup the WER registry.
-        Remove-Item -Path $WerDumpRegPath -Force | Out-Null
+        if (Test-Administrator) {
+            Remove-Item -Path $WerDumpRegPath -Force | Out-Null
+        }
         # Turn off App Verifier
         if ($EnableAppVerifier) {
             appverif.exe -disable * -for $Path

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -155,6 +155,16 @@ param (
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
+function Test-Administrator
+{
+    $user = [Security.Principal.WindowsIdentity]::GetCurrent();
+    (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
+if ($IsWindows -and !(Test-Administrator)) {
+    Write-Warning "We recommend running this test as administrator. Crash dumps will not work"
+}
+
 # Validate the the kernel switch.
 if ($Kernel -and !$IsWindows) {
     Write-Error "-Kernel switch only supported on Windows";


### PR DESCRIPTION
We shouldn't require administrator to run tests. A warning has been added that crash dumps will not be generated without administrator privileges.

Closes #1355