### PR TITLE
Reduce number of loops in RandomParitionId tests.

### DIFF
--- a/src/core/unittest/PartitionTest.cpp
+++ b/src/core/unittest/PartitionTest.cpp
@@ -70,7 +70,7 @@ TEST(PartitionTest, RandomPartitionId)
         for (uint32_t j = 0; j < i; ++j) {
             uint16_t PartitionIndex = (uint16_t)j;
 
-            for (uint32_t k = 0; k < 1000; ++k) {
+            for (uint32_t k = 0; k < 50; ++k) {
                 uint16_t PartitionId = QuicPartitionIdCreate(PartitionIndex);
                 ASSERT_EQ(PartitionIndex, QuicPartitionIdGetIndex(PartitionId));
             }


### PR DESCRIPTION
We run a LOT of test scenarios, and on unix platforms this test takes multiple minutes. On windows it takes > 10 seconds, which is still a bit crazy. This reduces the number of iterations. With how many times we run this test, the amount of randomness we are testing is still high.

Link to #1282 which was noticed by this test.