### PR TITLE
fix encoding collision issues

### DIFF
--- a/src/inc/quic_driver_helpers.h
+++ b/src/inc/quic_driver_helpers.h
@@ -160,7 +160,7 @@ public:
         if (PathResult < 0 || PathResult >= sizeof(IoctlPath)) {
             QuicTraceEvent(
                 LibraryError,
-                "[ lib] ERROR, %s",
+                "[ lib] ERROR, %s.",
                 "Creating Driver File Path failed");
             return false;
         }

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -947,7 +947,7 @@ SecNetPerfCtlEvtIoDeviceControl(
     if (!NT_SUCCESS(Status)) {
         QuicTraceEvent(
             LibraryErrorStatus,
-            "[ lib] Error, %u, %s.",
+            "[ lib] ERROR, %u, %s.",
             Status,
             "WfdRequestRetreiveInputBuffer failed");
     } else if (Params == nullptr) {


### PR DESCRIPTION
these are some minor errors in encoding that I caught in clog 0.3.0, hoping to get them accepted into quic to streamline my build processes