### PR TITLE
Add Unhealthy Worker Check to Report Command

### DIFF
--- a/src/plugins/trace/dll/DataModel/QuicEvents.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvents.cs
@@ -138,7 +138,8 @@ namespace QuicTrace.DataModel
     {
         Idle,
         Queued,
-        Processing
+        Processing,
+        Max
     }
 
     #region Global Events
@@ -480,8 +481,10 @@ namespace QuicTrace.DataModel
     {
         public uint State { get; }
 
+        public QuicScheduleState ScheduleState { get { return (QuicScheduleState)State; } }
+
         public override string PayloadString =>
-            string.Format("Scheduling: {0}", (QuicScheduleState)State);
+            string.Format("Scheduling: {0}", ScheduleState);
 
         internal QuicConnectionScheduleStateEvent(Timestamp timestamp, ushort processor, uint processId, uint threadId, int pointerSize, ulong objectPointer, uint state) :
             base(QuicEventId.ConnScheduleState, QuicObjectType.Connection, timestamp, processor, processId, threadId, pointerSize, objectPointer)

--- a/src/plugins/trace/dll/DataModel/QuicTimeStats.cs
+++ b/src/plugins/trace/dll/DataModel/QuicTimeStats.cs
@@ -1,0 +1,75 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+using Microsoft.Performance.SDK;
+
+namespace QuicTrace.DataModel
+{
+    public sealed class QuicTimeStats
+    {
+        public uint Count { get; private set; }
+
+        public uint MinCpuTimeUs { get; private set; }
+
+        public uint MaxCpuTimeUs { get; private set; }
+
+        public ulong TotalCpuTimeUs { get; private set; }
+
+        public uint AverageCpuTimeUs
+        {
+            get { return Count == 0 ? 0 : (uint)(TotalCpuTimeUs / Count); }
+        }
+
+        internal QuicTimeStats()
+        {
+            Count = 0;
+            MinCpuTimeUs = uint.MaxValue;
+            MaxCpuTimeUs = 0;
+            TotalCpuTimeUs = 0;
+        }
+
+        internal void AddCpuTime(uint cpuTimeUs)
+        {
+            Count++;
+            TotalCpuTimeUs += (ulong)cpuTimeUs;
+            if (cpuTimeUs < MinCpuTimeUs)
+            {
+                MinCpuTimeUs = cpuTimeUs;
+            }
+            if (cpuTimeUs > MaxCpuTimeUs)
+            {
+                MaxCpuTimeUs = cpuTimeUs;
+            }
+        }
+
+        internal void AddCpuTime(TimestampDelta delta)
+        {
+            AddCpuTime((uint)delta.ToMicroseconds);
+        }
+    }
+
+    public sealed class QuicSchedulingStats
+    {
+        readonly QuicTimeStats[] Stats = new QuicTimeStats[(int)QuicScheduleState.Max];
+
+        internal QuicSchedulingStats()
+        {
+            for (var i = 0; i < (int)QuicScheduleState.Max; ++i)
+            {
+                Stats[i] = new QuicTimeStats();
+            }
+        }
+
+        internal void AddCpuTime(QuicScheduleState state, TimestampDelta delta)
+        {
+            Stats[(int)state].AddCpuTime(delta);
+        }
+
+        public QuicTimeStats GetStats(QuicScheduleState state)
+        {
+            return Stats[(int)state];
+        }
+    }
+}

--- a/src/plugins/trace/exe/Program.cs
+++ b/src/plugins/trace/exe/Program.cs
@@ -65,15 +65,68 @@ namespace QuicTrace
 
         static void RunReport(QuicState quicState)
         {
+            //
+            // Worker info
+            //
+
             var workers = quicState.Workers;
-            Console.WriteLine("WORKERS ({0})\n", workers.Count);
+            Console.WriteLine("\nWORKERS ({0})\n", workers.Count);
+
+            uint unhealthyWorkers = 0;
+            uint mostlyIdleWorkers = 0;
+            uint reallyActiveWorkers = 0;
+
+            const uint UnhealthyQueueDelayUs = 25 * 1000; // More than 25 ms queue delay is "unhealthy"
+
+            foreach (var worker in workers)
+            {
+                if (worker.AverageQueueDelayUs >= UnhealthyQueueDelayUs)
+                {
+                    unhealthyWorkers++;
+                }
+
+                if (worker.ActivePercent <= 5)
+                {
+                    mostlyIdleWorkers++;
+                }
+                else if (worker.ActivePercent >= 80)
+                {
+                    reallyActiveWorkers++;
+                }
+            }
+
+            if (unhealthyWorkers == 0)
+            {
+                Console.WriteLine("  All workers healthy.");
+            }
+            else
+            {
+                Console.Write("  {0} workers unhealthy: [", unhealthyWorkers);
+                unhealthyWorkers = 0;
+                foreach (var worker in workers)
+                {
+                    if (worker.AverageQueueDelayUs >= UnhealthyQueueDelayUs)
+                    {
+                        if (unhealthyWorkers != 0)
+                        {
+                            Console.Write(", ");
+                        }
+                        Console.Write("#{0}", worker.Id);
+                        unhealthyWorkers++;
+                    }
+                }
+                Console.WriteLine("]");
+            }
+
+            Console.WriteLine("  {0} workers mostly idle.", mostlyIdleWorkers);
+            Console.WriteLine("  {0} workers really active.", reallyActiveWorkers);
 
             //
-            // TODO - Dump Worker info
+            // Connection info
             //
 
             var conns = quicState.Connections;
-            Console.WriteLine("CONNECTIONS ({0})\n", conns.Count);
+            Console.WriteLine("\nCONNECTIONS ({0})\n", conns.Count);
 
             //
             // TODO - Dump Connection info


### PR DESCRIPTION
Adds logic for reporting unhealthy, idle and active workers in the `--report` command for `quictrace`.