### PR TITLE
Upgrade QuicTrace to .NET 5

### DIFF
--- a/src/plugins/trace/exe/Program.cs
+++ b/src/plugins/trace/exe/Program.cs
@@ -234,7 +234,7 @@ namespace QuicTrace
                     Console.Write("quictrace> ");
 
                     var input = Console.ReadLine();
-                    if (input == "--exit" || input == "exit" || input == "-e")
+                    if (input == null || input == "--exit" || input == "exit" || input == "-e")
                     {
                         return;
                     }

--- a/src/plugins/trace/exe/QuicTrace.csproj
+++ b/src/plugins/trace/exe/QuicTrace.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
.NET 5 has been out for a while, and most tools should be updated. Also gives us some nice performance boosts.