### PR TITLE
Compare manually ran builds to main

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -341,7 +341,12 @@ if ([string]::IsNullOrWhiteSpace($PrBranchName)) {
         $BranchName = Get-CurrentBranch -RepoDir $RootDir
     } else {
         # Azure Build
-        $BranchName = $AzpBranchName.Substring(11);
+        $BuildReason = $env:BUILD_REASON
+        if ("Manual" -eq $BuildReason) {
+            $BranchName = "main"
+        } else {
+            $BranchName = $AzpBranchName.Substring(11);
+        }
     }
 } else {
     # PR Build


### PR DESCRIPTION
Before there would be no comparison, but often we want to compare to main.