### PR TITLE
Update GetValue function to check for full string, and validate length

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -347,7 +347,7 @@ function Start-TestCase([String]$Name) {
         $Arguments += " --kernelPriv"
     }
     if ($PfxPath -ne "") {
-        $Arguments += " -PfxPath $PfxPath"
+        $Arguments += " -PfxPath:$PfxPath"
     }
 
     # Start the test process and return some information about the test case.
@@ -384,7 +384,7 @@ function Start-AllTestCases {
         $Arguments += " --kernelPriv"
     }
     if ($PfxPath -ne "") {
-        $Arguments += " -PfxPath $PfxPath"
+        $Arguments += " -PfxPath:$PfxPath"
     }
     # Start the test process and return some information about the test case.
     [pscustomobject]@{

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -292,6 +292,24 @@ IsValue(
     return _strnicmp(name, toTestAgainst, min(strlen(name), strlen(toTestAgainst))) == 0;
 }
 
+inline
+bool
+GetFlag(
+    _In_ int argc,
+    _In_reads_(argc) _Null_terminated_ char* argv[],
+    _In_z_ const char* name
+    )
+{
+    const size_t nameLen = strlen(name);
+    for (int i = 0; i < argc; i++) {
+        if (_strnicmp(argv[i] + 1, name, nameLen) == 0
+            && strlen(argv[i]) == nameLen + 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
 //
 // Helper function that searches the list of args for a given
 // parameter name, insensitive to case.

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -306,7 +306,9 @@ GetValue(
 {
     const size_t nameLen = strlen(name);
     for (int i = 0; i < argc; i++) {
-        if (_strnicmp(argv[i] + 1, name, nameLen) == 0) {
+        if (_strnicmp(argv[i] + 1, name, nameLen) == 0
+            && strlen(argv[i]) > 1 + nameLen + 1
+            && *(argv[i] + 1 + nameLen) == ':') {
             return argv[i] + 1 + nameLen + 1;
         }
     }

--- a/src/platform/unittest/main.cpp
+++ b/src/platform/unittest/main.cpp
@@ -28,6 +28,6 @@ public:
 int main(int argc, char** argv) {
     ::testing::AddGlobalTestEnvironment(new QuicCoreTestEnvironment);
     ::testing::InitGoogleTest(&argc, argv);
-    PfxPath = GetFlag(argc, argv, "PfxPath");
+    PfxPath = GetValue(argc, argv, "PfxPath");
     return RUN_ALL_TESTS();
 }

--- a/src/platform/unittest/main.cpp
+++ b/src/platform/unittest/main.cpp
@@ -28,6 +28,6 @@ public:
 int main(int argc, char** argv) {
     ::testing::AddGlobalTestEnvironment(new QuicCoreTestEnvironment);
     ::testing::InitGoogleTest(&argc, argv);
-    PfxPath = GetValue(argc, argv, "PfxPath");
+    PfxPath = GetFlag(argc, argv, "PfxPath");
     return RUN_ALL_TESTS();
 }

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -1159,13 +1159,13 @@ main(
 {
     int EndpointIndex = -1;
 
-    if (GetValue(argc, argv, "help") ||
-        GetValue(argc, argv, "?")) {
+    if (GetFlag(argc, argv, "help") ||
+        GetFlag(argc, argv, "?")) {
         PrintUsage();
         return 0;
     }
 
-    if (GetValue(argc, argv, "list")) {
+    if (GetFlag(argc, argv, "list")) {
         printf("\nKnown implementations and servers:\n");
         for (uint32_t i = 0; i < PublicEndpointsCount; ++i) {
             printf("  %12s\t%s\n", PublicEndpoints[i].ImplementationName,
@@ -1194,7 +1194,7 @@ main(
         }
     }
 
-    RunSerially = GetValue(argc, argv, "serial") != nullptr;
+    RunSerially = GetFlag(argc, argv, "serial");
 
     CxPlatSystemLoad();
 

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -50,8 +50,8 @@ main(
     )
 {
     if (argc < 2 ||
-        GetValue(argc, argv, "help") ||
-        GetValue(argc, argv, "?")) {
+        GetFlag(argc, argv, "help") ||
+        GetFlag(argc, argv, "?")) {
         PrintUsage();
         return -1;
     }

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -125,7 +125,7 @@ main(
 
     {
         HttpServer Server(Registration, SupportedALPNs, ARRAYSIZE(SupportedALPNs), &ListenAddr, SslKeyLogFileParam);
-        if (!GetValue(argc, argv, "noexit")) {
+        if (!GetFlag(argc, argv, "noexit")) {
             printf("Press Enter to exit.\n\n");
             getchar();
         } else {

--- a/src/tools/ip/client/quicipclient.cpp
+++ b/src/tools/ip/client/quicipclient.cpp
@@ -20,7 +20,7 @@ main(
     _In_reads_(argc) _Null_terminated_ char* argv[]
     )
 {
-    if (GetValue(argc, argv, "?") || GetValue(argc, argv, "help")) {
+    if (GetFlag(argc, argv, "?") || GetFlag(argc, argv, "help")) {
         printf("Usage:\n");
         printf("  quicipclient.exe [-target:<...>] [-local:<...>] [-unsecure]\n");
         return 0;
@@ -34,7 +34,7 @@ main(
 
     TryGetValue(argc, argv, "target", &Target);
     TryGetValue(argc, argv, "local", &LocalAddressArg);
-    if (GetValue(argc, argv, "unsecure")) {
+    if (GetFlag(argc, argv, "unsecure")) {
         Unsecure = true;
     }
 

--- a/src/tools/sample/sample.cpp
+++ b/src/tools/sample/sample.cpp
@@ -101,8 +101,27 @@ void PrintUsage()
 }
 
 //
-// Helper function to look up a command line argument.
+// Helper functions to look up a command line arguments.
 //
+inline
+bool
+GetFlag(
+    _In_ int argc,
+    _In_reads_(argc) _Null_terminated_ char* argv[],
+    _In_z_ const char* name
+    )
+{
+    const size_t nameLen = strlen(name);
+    for (int i = 0; i < argc; i++) {
+        if (_strnicmp(argv[i] + 1, name, nameLen) == 0
+            && strlen(argv[i]) == nameLen + 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline
 _Ret_maybenull_ _Null_terminated_ const char*
 GetValue(
     _In_ int argc,
@@ -112,7 +131,9 @@ GetValue(
 {
     const size_t nameLen = strlen(name);
     for (int i = 0; i < argc; i++) {
-        if (_strnicmp(argv[i] + 1, name, nameLen) == 0) {
+        if (_strnicmp(argv[i] + 1, name, nameLen) == 0
+            && strlen(argv[i]) > 1 + nameLen + 1
+            && *(argv[i] + 1 + nameLen) == ':') {
             return argv[i] + 1 + nameLen + 1;
         }
     }
@@ -754,7 +775,7 @@ RunClient(
     //
     // Load the client configuration based on the "unsecure" command line option.
     //
-    if (!ClientLoadConfiguration(GetValue(argc, argv, "unsecure"))) {
+    if (!ClientLoadConfiguration(GetFlag(argc, argv, "unsecure"))) {
         return;
     }
 
@@ -835,11 +856,11 @@ main(
         goto Error;
     }
 
-    if (GetValue(argc, argv, "help") || GetValue(argc, argv, "?")) {
+    if (GetFlag(argc, argv, "help") || GetFlag(argc, argv, "?")) {
         PrintUsage();
-    } else if (GetValue(argc, argv, "client")) {
+    } else if (GetFlag(argc, argv, "client")) {
         RunClient(argc, argv);
-    } else if (GetValue(argc, argv, "server")) {
+    } else if (GetFlag(argc, argv, "server")) {
         RunServer(argc, argv);
     } else {
         PrintUsage();


### PR DESCRIPTION
Previously, -requests: would match a check for `request` as strnicmp just checks for length. This changes ensures that the character after the check is a :, and also that the string length for the argument is acceptable.