### PR TITLE
Update SAL annotation for ConnectionStart

### DIFF
--- a/docs/api/ConnectionStart.md
+++ b/docs/api/ConnectionStart.md
@@ -13,7 +13,7 @@ QUIC_STATUS
     _In_ _Pre_defensive_ HQUIC Connection,
     _In_ _Pre_defensive_ HQUIC Configuration,
     _In_ QUIC_ADDRESS_FAMILY Family,
-    _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+    _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
         const char* ServerName,
     _In_ uint16_t ServerPort // Host byte order
     );

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -240,7 +240,7 @@ MsQuicConnectionStart(
     _In_ _Pre_defensive_ HQUIC Handle,
     _In_ _Pre_defensive_ HQUIC ConfigHandle,
     _In_ QUIC_ADDRESS_FAMILY Family,
-    _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+    _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
         const char* ServerName,
     _In_ uint16_t ServerPort // Host byte order
     )

--- a/src/core/api.h
+++ b/src/core/api.h
@@ -135,7 +135,7 @@ MsQuicConnectionStart(
     _In_ _Pre_defensive_ HQUIC Handle,
     _In_ _Pre_defensive_ HQUIC ConfigHandle,
     _In_ QUIC_ADDRESS_FAMILY Family,
-    _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+    _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
         const char* ServerName,
     _In_ uint16_t ServerPort // Host byte order
     );

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -998,7 +998,7 @@ QUIC_STATUS
     _In_ _Pre_defensive_ HQUIC Connection,
     _In_ _Pre_defensive_ HQUIC Configuration,
     _In_ QUIC_ADDRESS_FAMILY Family,
-    _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+    _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
         const char* ServerName,
     _In_ uint16_t ServerPort // Host byte order
     );

--- a/src/inc/quic_sal_stub.h
+++ b/src/inc/quic_sal_stub.h
@@ -91,6 +91,10 @@
 #define _In_reads_opt_z_(...)
 #endif
 
+#ifndef _In_reads_or_z_opt_
+#define _In_reads_or_z_opt_(...)
+#endif
+
 #ifndef _Out_writes_bytes_opt_
 #define _Out_writes_bytes_opt_(...)
 #endif

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -294,7 +294,7 @@ TcpConnection::TcpConnection(
     TcpEngine* Engine,
     const QUIC_CREDENTIAL_CONFIG* CredConfig,
     _In_ QUIC_ADDRESS_FAMILY Family,
-    _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+    _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
         const char* ServerName,
     _In_ uint16_t ServerPort,
     const QUIC_ADDR* LocalAddress,

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -259,7 +259,7 @@ public:
         _In_ TcpEngine* Engine,
         _In_ const QUIC_CREDENTIAL_CONFIG* CredConfig,
         _In_ QUIC_ADDRESS_FAMILY Family,
-        _In_reads_opt_z_(QUIC_MAX_SNI_LENGTH)
+        _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
             const char* ServerName,
         _In_ uint16_t ServerPort,
         _In_ const QUIC_ADDR* LocalAddress = nullptr,


### PR DESCRIPTION
_In_reads_opt_z_(n) states either optional or reads n bytes. _In_reads_or_z_opt(n) states either optional, reads n, or reads to null terminator if less then n. This is the correct annotation for server name.