### PR TITLE
Ignore Zero-Length Receive Events in Tests

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -1056,7 +1056,9 @@ DummyStreamCallback(
     switch (Event->Type) {
 
     case QUIC_STREAM_EVENT_RECEIVE:
-        TEST_FAILURE("QUIC_STREAM_EVENT_RECEIVE should never be called!");
+        if (Event->RECEIVE.TotalBufferLength != 0) {
+            TEST_FAILURE("QUIC_STREAM_EVENT_RECEIVE with data should never be called!");
+        }
         break;
 
     case QUIC_STREAM_EVENT_SEND_COMPLETE:
@@ -1083,7 +1085,9 @@ ShutdownStreamCallback(
     switch (Event->Type) {
 
     case QUIC_STREAM_EVENT_RECEIVE:
-        TEST_FAILURE("QUIC_STREAM_EVENT_RECEIVE should never be called!");
+        if (Event->RECEIVE.TotalBufferLength != 0) {
+            TEST_FAILURE("QUIC_STREAM_EVENT_RECEIVE with data should never be called!");
+        }
         break;
 
     case QUIC_STREAM_EVENT_SEND_COMPLETE:


### PR DESCRIPTION
I was looking at a recent test failure on `main` and it was because the test didn't expect to receive a `QUIC_STREAM_EVENT_RECEIVE` event. Looking deeper, the event was delivered for a graceful shutdown of a FIN, which shows up as a zero length receive event:
```
[1]0004.69AC::2021/04/27-08:54:15.968742100 [Microsoft-Quic][strm][0xFFFFD4019ED43C80] Indicating QUIC_STREAM_EVENT_RECEIVE [0 bytes, 0 buffers, 0x2 flags]
[1]0004.69AC::2021/04/27-08:54:15.968745700 [Microsoft-Quic][test] File: D:\a\1\msquic\src\test\lib\ApiTest.cpp, Function: DummyStreamCallback, Line: 1059
```
This should be allowed by the tests. This PR makes the test code a bit smarter about this.
