### PR TITLE
Refactor Sent Packet Metadata Stream Ref Counting

### DIFF
--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -193,6 +193,18 @@ QuicStreamRelease(
     _In_ QUIC_STREAM_REF Ref
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicStreamSentMetadataDecrement(
+    _In_ QUIC_STREAM* Stream
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicStreamSentMetadataIncrement(
+    _In_ QUIC_STREAM* Stream
+    );
+
 QUIC_ENCRYPT_LEVEL
 QuicKeyTypeToEncryptLevel(
     QUIC_PACKET_KEY_TYPE KeyType

--- a/src/core/packet_builder.h
+++ b/src/core/packet_builder.h
@@ -258,6 +258,6 @@ QuicPacketBuilderAddStreamFrame(
     )
 {
     Builder->Metadata->Frames[Builder->Metadata->FrameCount].MAX_STREAM_DATA.Stream = Stream;
-    QuicStreamAddRef(Stream, QUIC_STREAM_REF_SEND_PACKET);
+    QuicStreamSentMetadataIncrement(Stream);
     return QuicPacketBuilderAddFrame(Builder, FrameType, TRUE);
 }

--- a/src/core/sent_packet_metadata.c
+++ b/src/core/sent_packet_metadata.c
@@ -32,19 +32,19 @@ QuicSentPacketMetadataReleaseFrames(
 #pragma warning(push)
 #pragma warning(disable:6001)
         case QUIC_FRAME_RESET_STREAM:
-            QuicStreamRelease(Metadata->Frames[i].RESET_STREAM.Stream, QUIC_STREAM_REF_SEND_PACKET);
+            QuicStreamSentMetadataDecrement(Metadata->Frames[i].RESET_STREAM.Stream);
             break;
         case QUIC_FRAME_MAX_STREAM_DATA:
-            QuicStreamRelease(Metadata->Frames[i].MAX_STREAM_DATA.Stream, QUIC_STREAM_REF_SEND_PACKET);
+            QuicStreamSentMetadataDecrement(Metadata->Frames[i].MAX_STREAM_DATA.Stream);
             break;
         case QUIC_FRAME_STREAM_DATA_BLOCKED:
-            QuicStreamRelease(Metadata->Frames[i].STREAM_DATA_BLOCKED.Stream, QUIC_STREAM_REF_SEND_PACKET);
+            QuicStreamSentMetadataDecrement(Metadata->Frames[i].STREAM_DATA_BLOCKED.Stream);
             break;
         case QUIC_FRAME_STOP_SENDING:
-            QuicStreamRelease(Metadata->Frames[i].STOP_SENDING.Stream, QUIC_STREAM_REF_SEND_PACKET);
+            QuicStreamSentMetadataDecrement(Metadata->Frames[i].STOP_SENDING.Stream);
             break;
         case QUIC_FRAME_STREAM:
-            QuicStreamRelease(Metadata->Frames[i].STREAM.Stream, QUIC_STREAM_REF_SEND_PACKET);
+            QuicStreamSentMetadataDecrement(Metadata->Frames[i].STREAM.Stream);
             break;
 #pragma warning(pop)
         default:

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -197,6 +197,12 @@ typedef struct QUIC_STREAM {
     short RefTypeCount[QUIC_STREAM_REF_COUNT];
 #endif
 
+    //
+    // Number of outstanding sent metadata items currently being tracked for
+    // this stream.
+    //
+    uint32_t OutstandingSentMetadata;
+
     union {
         //
         // The entry in the connection's hashtable of streams.
@@ -637,6 +643,40 @@ QuicStreamRelease(
     return FALSE;
 }
 #pragma warning(pop)
+
+//
+// Increments the sent metadata counter.
+// No synchronization necessary as it's always called on the worker thread.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+inline
+void
+QuicStreamSentMetadataIncrement(
+    _In_ QUIC_STREAM* Stream
+    )
+{
+    if (++Stream->OutstandingSentMetadata == 1) {
+        QuicStreamAddRef(Stream, QUIC_STREAM_REF_SEND_PACKET);
+    }
+    CXPLAT_DBG_ASSERT(Stream->OutstandingSentMetadata != 0);
+}
+
+//
+// Decrements the sent metadata counter.
+// No synchronization necessary as it's always called on the worker thread.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+inline
+void
+QuicStreamSentMetadataDecrement(
+    _In_ QUIC_STREAM* Stream
+    )
+{
+    CXPLAT_DBG_ASSERT(Stream->OutstandingSentMetadata != 0);
+    if (--Stream->OutstandingSentMetadata == 0) {
+        QuicStreamRelease(Stream, QUIC_STREAM_REF_SEND_PACKET);
+    }
+}
 
 //
 // Send Functions

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -799,7 +799,7 @@ QuicStreamWriteOneFrame(
         Stream->SendFlags &= ~QUIC_STREAM_SEND_FLAG_FIN;
         PacketMetadata->Frames[PacketMetadata->FrameCount].Flags |= QUIC_SENT_FRAME_FLAG_STREAM_FIN;
     }
-    QuicStreamAddRef(Stream, QUIC_STREAM_REF_SEND_PACKET);
+    QuicStreamSentMetadataIncrement(Stream);
     PacketMetadata->FrameCount++;
 }
 


### PR DESCRIPTION
We've seen from past performance measurements that sometimes the stream ref counting was a non-trivial CPU chunk when building/sending QUIC packets. This PR refactors the logic here to have a separate counter for metadata and only inc/dec stream ref count when that changes to/from zero.