### PR TITLE
Special case targets in HPS tests

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -256,7 +256,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:HPS -target:$RemoteAddress"
+                "Arguments": "-test:HPS -target:$RemoteAddress -incrementtarget:1"
             },
             "Variables": [],
             "AllowLoopback": false,

--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -9,9 +9,6 @@ Abstract:
 
 --*/
 
-#define _CRT_NONSTDC_NO_DEPRECATE 1 // Needed to work around itoa
-#define _CRT_SECURE_NO_WARNINGS
-
 #include "HpsClient.h"
 
 #ifdef QUIC_CLOG
@@ -97,6 +94,16 @@ HpsClient::Init(
     return QUIC_STATUS_SUCCESS;
 }
 
+
+
+static void AppendIntToString(char* String, uint8_t Value) {
+    const char* Hex = "0123456789ABCDEF";
+
+    String[0] = Hex[(Value >> 4) & 0xF];
+    String[1] = Hex[Value & 0xF];
+    String[2] = '\0';
+}
+
 CXPLAT_THREAD_CALLBACK(HpsWorkerThread, _Context)
 {
     auto Context = (HpsWorkerContext*)_Context;
@@ -109,7 +116,7 @@ CXPLAT_THREAD_CALLBACK(HpsWorkerThread, _Context)
     CxPlatCopyMemory(Context->Target.get(), Target, Len);
 
     if (Context->pThis->IncrementTarget) {
-        itoa(Context->Processor, Context->Target.get() + Len, 10);
+        AppendIntToString(Context->Target.get() + Len, (uint8_t)Context->Processor);
     } else {
         Context->Target.get()[Len] = '\0';
     }

--- a/src/perf/lib/HpsClient.h
+++ b/src/perf/lib/HpsClient.h
@@ -19,6 +19,7 @@ Abstract:
 
 struct HpsWorkerContext {
     class HpsClient* pThis {nullptr};
+    UniquePtr<char[]> Target;
     QUIC_ADDR RemoteAddr;
     QUIC_ADDR LocalAddrs[HPS_BINDINGS_PER_WORKER];
     uint16_t Processor {0};
@@ -110,6 +111,7 @@ public:
     UniquePtr<char[]> Target;
     uint32_t RunTime {HPS_DEFAULT_RUN_TIME};
     uint32_t Parallel {HPS_DEFAULT_PARALLEL_COUNT};
+    uint8_t IncrementTarget {FALSE};
     CXPLAT_EVENT* CompletionEvent {nullptr};
     uint64_t CreatedConnections {0};
     uint64_t StartedConnections {0};


### PR DESCRIPTION
Schannel has performance issues on the client side if connection the same client to the same server SNI multiple times. Work around that issue by having each core connect to a different address.