### PR TITLE
Increase BVT timeout

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -49,7 +49,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 40
+    timeoutInMinutes: 45
     ${{ if eq(parameters.codeCoverage, true) }}:
       continueOnError: true
     inputs:


### PR DESCRIPTION
The new tests put kernel mode right at the edge of passing. Increase the timeout so they don't fail