### PR TITLE
Log exception if a failure occurs in BVT run

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -686,6 +686,9 @@ try {
             }
         }
     }
+} catch {
+    Log "Exception Thrown"
+    Log $_
 } finally {
     if ($LogProfile -ne "None") {
         & $LogScript -Cancel | Out-Null


### PR DESCRIPTION
Previously, any exception would be suppressed by by the write-error if not every test passed. This will always print out the exception so we can figure out whats happening.