### PR TITLE
Fix Handshake Stall Bug

### DIFF
--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -637,10 +637,13 @@ QuicLossDetectionRetransmitFrames(
         switch (Packet->Frames[i].Type) {
         case QUIC_FRAME_PING:
             if (!Packet->Flags.IsPMTUD) {
-                NewDataQueued |=
-                    QuicSendSetSendFlag(
-                        &Connection->Send,
-                        QUIC_CONN_SEND_FLAG_PING);
+                //
+                // Don't consider PING "new data" so that we might still find
+                // "real" data later that should be sent instead.
+                //
+                QuicSendSetSendFlag(
+                    &Connection->Send,
+                    QUIC_CONN_SEND_FLAG_PING);
             }
             break;
 

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -227,7 +227,7 @@ QuicPacketBuilderPrepare(
         Builder->MinimumDatagramLength = 0;
 
         if (IsTailLossProbe && !QuicConnIsServer(Connection)) {
-            if (Connection->Crypto.TlsState.WriteKey == QUIC_PACKET_KEY_1_RTT) {
+            if (NewPacketType == SEND_PACKET_SHORT_HEADER_TYPE) {
                 //
                 // Short header (1-RTT) packets need to be padded enough to
                 // elicit stateless resets from the server.


### PR DESCRIPTION
Fixes #1546. Updates the probe retransmit code path to not consider older probe packets as part of the "new" data to resend. It will just continue until it finds 2 packets with real data to retransmit. Only if there aren't any will it eventually just send a new probe.

Also improves the logic that decides the minimum datagram length to decide based on the packet being built and not the keys available, as we might not be currently using the highest available key for "this" packet.