### PR TITLE
Properly update the start point of the current key phase to decide old or new encryption keys

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3631,7 +3631,7 @@ QuicConnRecvPrepareDecrypt(
         Packet->SH->KeyPhase != PacketSpace->CurrentKeyPhase) {
         if (Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
             if (Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL ||
-                Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] != NULL) {
+                Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL) {
                 //
                 // We don't have old keys to be able to decode this. Drop the packet.
                 //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3664,9 +3664,6 @@ QuicConnRecvPrepareDecrypt(
                 return FALSE;
             }
             Packet->KeyType = QUIC_PACKET_KEY_1_RTT_NEW;
-        } else {
-            QuicPacketLogDrop(Connection, Packet, "This packet can never be a legal packet");
-            return FALSE;
         }
     }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3665,7 +3665,6 @@ QuicConnRecvPrepareDecrypt(
             }
             Packet->KeyType = QUIC_PACKET_KEY_1_RTT_NEW;
         } else {
-            CXPLAT_TEL_ASSERTMSG(FALSE, "We should never receive an out of phase packet in a range we've already seen");
             QuicPacketLogDrop(Connection, Packet, "This packet can never be a legal packet");
             return FALSE;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3633,7 +3633,7 @@ QuicConnRecvPrepareDecrypt(
             //
             // The packet doesn't match our current key phase and the packet number
             // is less than the start of the current key phase, so this is likely
-            // using the old key phase.
+            // using the old keys.
             //
             QuicTraceLogConnVerbose(
                 DecryptOldKey,
@@ -3645,8 +3645,8 @@ QuicConnRecvPrepareDecrypt(
         } else {
             //
             // The packet doesn't match our key phase, and the packet number is higher
-            // than the end of the current key phase, so most likely using a new key phase.
-            // Update the keys and try it out.
+            // than the start of the current key phase, so most likely using a new key phase.
+            // Update the keys and try it out. If this fails, the packet was invalid anyway.
             //
             QuicTraceLogConnVerbose(
                 PossiblePeerKeyUpdate,
@@ -3914,8 +3914,8 @@ QuicConnRecvDecryptAndAuthenticate(
             Packet->SH->KeyPhase == PacketSpace->CurrentKeyPhase &&
             Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
             //
-            // This packet is in the current key phase, so update the packet space
-            // endpoints.
+            // This packet is in the current key phase and before the current phase
+            // start, so update the packet space start point.
             //
             PacketSpace->ReadKeyPhaseStartPacketNumber = Packet->PacketNumber;
             QuicTraceLogConnVerbose(

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3630,12 +3630,6 @@ QuicConnRecvPrepareDecrypt(
     if (Packet->IsShortHeader && EncryptLevel == QUIC_ENCRYPT_LEVEL_1_RTT &&
         Packet->SH->KeyPhase != PacketSpace->CurrentKeyPhase) {
         if (Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
-            if (Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL ||
-                Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL) {
-                    QuicPacketLogDrop(Connection, Packet, "Old packet without old keys");
-                    return FALSE;
-            }
-
             //
             // The packet doesn't match our current key phase and the packet number
             // is less than the start of the current key phase, so this is likely
@@ -3645,6 +3639,8 @@ QuicConnRecvPrepareDecrypt(
                 DecryptOldKey,
                 Connection,
                 "Using old key to decrypt");
+            CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] != NULL);
+            CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] != NULL);
             Packet->KeyType = QUIC_PACKET_KEY_1_RTT_OLD;
         } else if (Packet->PacketNumber > PacketSpace->ReadKeyPhaseEndPacketNumber) {
             //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3919,15 +3919,15 @@ QuicConnRecvDecryptAndAuthenticate(
             //
             if (Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
                 PacketSpace->ReadKeyPhaseStartPacketNumber = Packet->PacketNumber;
+                QuicTraceLogConnVerbose(
+                    UpdateReadKeyPhase,
+                    Connection,
+                    "Updating current read key phase and packet number[%llu]",
+                    Packet->PacketNumber);
             }
             if (Packet->PacketNumber > PacketSpace->ReadKeyPhaseEndPacketNumber) {
                 PacketSpace->ReadKeyPhaseEndPacketNumber = Packet->PacketNumber;
             }
-            QuicTraceLogConnVerbose(
-                UpdateReadKeyPhase,
-                Connection,
-                "Updating current read key phase and packet number[%llu]",
-                Packet->PacketNumber);
         }
     }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3630,16 +3630,6 @@ QuicConnRecvPrepareDecrypt(
     if (Packet->IsShortHeader && EncryptLevel == QUIC_ENCRYPT_LEVEL_1_RTT &&
         Packet->SH->KeyPhase != PacketSpace->CurrentKeyPhase) {
         if (Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
-            if (Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL ||
-                Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL) {
-                //
-                // We don't have old keys to be able to decode this. Drop the packet.
-                //
-                CXPLAT_TEL_ASSERTMSG(FALSE, "We are unable to decrypt an old packet without old keys");
-                QuicPacketLogDrop(Connection, Packet, "Old keys not available to decrypt packet");
-                return FALSE;
-            }
-
             //
             // The packet doesn't match our current key phase and the packet number
             // is less than the start of the current key phase, so this is likely
@@ -3658,7 +3648,6 @@ QuicConnRecvPrepareDecrypt(
             // than the end of the current key phase, so most likely using a new key phase.
             // Update the keys and try it out.
             //
-
             QuicTraceLogConnVerbose(
                 PossiblePeerKeyUpdate,
                 Connection,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3635,6 +3635,7 @@ QuicConnRecvPrepareDecrypt(
                 //
                 // We don't have old keys to be able to decode this. Drop the packet.
                 //
+                CXPLAT_TEL_ASSERTMSG(FALSE, "We are unable to decrypt an old packet without old keys");
                 QuicPacketLogDrop(Connection, Packet, "Old keys not available to decrypt packet");
                 return FALSE;
             }
@@ -3671,6 +3672,7 @@ QuicConnRecvPrepareDecrypt(
             }
             Packet->KeyType = QUIC_PACKET_KEY_1_RTT_NEW;
         } else {
+            CXPLAT_TEL_ASSERTMSG(FALSE, "We should never receive an out of phase packet in a range we've already seen");
             QuicPacketLogDrop(Connection, Packet, "This packet can never be a legal packet");
             return FALSE;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3630,6 +3630,12 @@ QuicConnRecvPrepareDecrypt(
     if (Packet->IsShortHeader && EncryptLevel == QUIC_ENCRYPT_LEVEL_1_RTT &&
         Packet->SH->KeyPhase != PacketSpace->CurrentKeyPhase) {
         if (Packet->PacketNumber < PacketSpace->ReadKeyPhaseStartPacketNumber) {
+            if (Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL ||
+                Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] == NULL) {
+                    QuicPacketLogDrop(Connection, Packet, "Old packet without old keys");
+                    return FALSE;
+            }
+
             //
             // The packet doesn't match our current key phase and the packet number
             // is less than the start of the current key phase, so this is likely
@@ -3639,8 +3645,6 @@ QuicConnRecvPrepareDecrypt(
                 DecryptOldKey,
                 Connection,
                 "Using old key to decrypt");
-            CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.ReadKeys[QUIC_PACKET_KEY_1_RTT_OLD] != NULL);
-            CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT_OLD] != NULL);
             Packet->KeyType = QUIC_PACKET_KEY_1_RTT_OLD;
         } else if (Packet->PacketNumber > PacketSpace->ReadKeyPhaseEndPacketNumber) {
             //

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1920,7 +1920,6 @@ QuicCryptoUpdateKeyPhase(
     // Reset the read packet space so any new packet will be properly detected.
     //
     PacketSpace->ReadKeyPhaseStartPacketNumber = UINT64_MAX;
-    PacketSpace->ReadKeyPhaseEndPacketNumber = 0;
 
     PacketSpace->AwaitingKeyPhaseConfirmation = TRUE;
 

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1916,6 +1916,12 @@ QuicCryptoUpdateKeyPhase(
     PacketSpace->WriteKeyPhaseStartPacketNumber = Connection->Send.NextPacketNumber;
     PacketSpace->CurrentKeyPhase = !PacketSpace->CurrentKeyPhase;
 
+    //
+    // Reset the read packet space so any new packet will be properly detected.
+    //
+    PacketSpace->ReadKeyPhaseStartPacketNumber = UINT64_MAX;
+    PacketSpace->ReadKeyPhaseEndPacketNumber = 0;
+
     PacketSpace->AwaitingKeyPhaseConfirmation = TRUE;
 
     PacketSpace->CurrentKeyPhaseBytesSent = 0;

--- a/src/core/packet_space.h
+++ b/src/core/packet_space.h
@@ -90,6 +90,11 @@ typedef struct QUIC_PACKET_SPACE {
     uint64_t ReadKeyPhaseStartPacketNumber;
 
     //
+    // Packet number of the latest received packet of the current key phase.
+    //
+    uint64_t ReadKeyPhaseEndPacketNumber;
+
+    //
     // Count of bytes sent at the current key phase.
     //
     uint64_t CurrentKeyPhaseBytesSent;

--- a/src/core/packet_space.h
+++ b/src/core/packet_space.h
@@ -90,11 +90,6 @@ typedef struct QUIC_PACKET_SPACE {
     uint64_t ReadKeyPhaseStartPacketNumber;
 
     //
-    // Packet number of the latest received packet of the current key phase.
-    //
-    uint64_t ReadKeyPhaseEndPacketNumber;
-
-    //
     // Count of bytes sent at the current key phase.
     //
     uint64_t CurrentKeyPhaseBytesSent;

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -268,6 +268,12 @@ QuicTestKeyUpdate(
     _In_ bool ServerKeyUpdate
     );
 
+void
+QuicTestKeyUpdateRandomLoss(
+    _In_ int Family,
+    _In_ uint8_t RandomLossPercentage
+    );
+
 typedef enum QUIC_ABORTIVE_TRANSFER_DIRECTION {
     ShutdownBoth,
     ShutdownSend,
@@ -786,4 +792,17 @@ typedef struct {
     QUIC_CTL_CODE(63, METHOD_BUFFERED, FILE_WRITE_DATA)
     // BOOLEAN
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 63
+#pragma pack(push)
+#pragma pack(1)
+
+typedef struct {
+    int Family;
+    uint8_t RandomLossPercentage;
+} QUIC_RUN_KEY_UPDATE_RANDOM_LOSS_PARAMS;
+
+#pragma pack(pop)
+
+#define IOCTL_QUIC_RUN_KEY_UPDATE_RANDOM_LOSS \
+    QUIC_CTL_CODE(64, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 64

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1196,6 +1196,23 @@ TEST_P(WithKeyUpdateArgs1, KeyUpdate) {
     }
 }
 
+#if QUIC_TEST_DATAPATH_HOOKS_ENABLED
+TEST_P(WithKeyUpdateArgs2, RandomLoss) {
+    TestLoggerT<ParamType> Logger("QuicTestKeyUpdateRandomLoss", GetParam());
+    if (TestingKernelMode) {
+        QUIC_RUN_KEY_UPDATE_PARAMS Params = {
+            GetParam().Family,
+            GetParam().RandomLossPercentage
+        };
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_KEY_UPDATE_RANDOM_LOSS, Params));
+    } else {
+        QuicTestKeyUpdateRandomLoss(
+            GetParam().Family,
+            GetParam().RandomLossPercentage);
+    }
+}
+#endif
+
 TEST_P(WithAbortiveArgs, AbortiveShutdown) {
     TestLoggerT<ParamType> Logger("QuicAbortiveTransfers", GetParam());
     if (TestingKernelMode) {
@@ -1444,6 +1461,11 @@ INSTANTIATE_TEST_SUITE_P(
     Misc,
     WithKeyUpdateArgs1,
     testing::ValuesIn(KeyUpdateArgs1::Generate()));
+
+INSTANTIATE_TEST_SUITE_P(
+    Misc,
+    WithKeyUpdateArgs2,
+    testing::ValuesIn(KeyUpdateArgs2::Generate()));
 
 INSTANTIATE_TEST_SUITE_P(
     Misc,

--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -390,6 +390,28 @@ class WithKeyUpdateArgs1 : public testing::Test,
     public testing::WithParamInterface<KeyUpdateArgs1> {
 };
 
+struct KeyUpdateArgs2 {
+    int Family;
+    uint8_t RandomLossPercentage;
+    static ::std::vector<KeyUpdateArgs2> Generate() {
+        ::std::vector<KeyUpdateArgs2> list;
+        for (int Family : { 4, 6 })
+        for (int RandomLossPercentage : { 1, 5, 10 })
+            list.push_back({ Family, (uint8_t)RandomLossPercentage });
+        return list;
+    }
+};
+
+std::ostream& operator << (std::ostream& o, const KeyUpdateArgs2& args) {
+    return o <<
+        (args.Family == 4 ? "v4" : "v6") << "/" <<
+        args.RandomLossPercentage;
+}
+
+class WithKeyUpdateArgs2 : public testing::Test,
+    public testing::WithParamInterface<KeyUpdateArgs2> {
+};
+
 struct AbortiveArgs {
     int Family;
     QUIC_ABORTIVE_TRANSFER_FLAGS Flags;

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -432,7 +432,8 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     sizeof(QUIC_RUN_CRED_VALIDATION),
     sizeof(QUIC_RUN_CRED_VALIDATION),
     sizeof(QUIC_RUN_CRED_VALIDATION),
-    sizeof(QUIC_ABORT_RECEIVE_TYPE)
+    sizeof(QUIC_ABORT_RECEIVE_TYPE),
+    sizeof(QUIC_RUN_KEY_UPDATE_RANDOM_LOSS_PARAMS)
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -459,6 +460,7 @@ typedef union {
     QUIC_RUN_CONNECT_CLIENT_CERT ConnectClientCertParams;
     QUIC_RUN_CRED_VALIDATION CredValidationParams;
     QUIC_ABORT_RECEIVE_TYPE AbortReceiveType;
+    QUIC_RUN_KEY_UPDATE_RANDOM_LOSS_PARAMS KeyUpdateRandomLossParams;
 
 } QUIC_IOCTL_PARAMS;
 
@@ -1019,6 +1021,13 @@ QuicTestCtlEvtIoDeviceControl(
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestAbortReceive(Params->AbortReceiveType));
         break;
+
+    case IOCTL_QUIC_RUN_KEY_UPDATE_RANDOM_LOSS:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(
+            QuicTestKeyUpdateRandomLoss(
+                Params->KeyUpdateRandomLossParams.Family,
+                Params->KeyUpdateRandomLossParams.RandomLossPercentage))
 
     default:
         Status = STATUS_NOT_IMPLEMENTED;

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -1028,7 +1028,7 @@ QuicTestCtlEvtIoDeviceControl(
             QuicTestKeyUpdateRandomLoss(
                 Params->KeyUpdateRandomLossParams.Family,
                 Params->KeyUpdateRandomLossParams.RandomLossPercentage))
-
+        break;
     default:
         Status = STATUS_NOT_IMPLEMENTED;
         break;

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1859,6 +1859,10 @@ QuicTestKeyUpdate(
                     CxPlatSleep(100);
                     TEST_EQUAL((uint16_t)(101+i), Server->GetLocalBidiStreamCount());
 
+                    if (ClientKeyUpdate) {
+                        TEST_QUIC_SUCCEEDED(Client.ForceKeyUpdate());
+                    }
+
                     TEST_QUIC_SUCCEEDED(Server->SetPeerBidiStreamCount((uint16_t)(100+i)));
                     TEST_EQUAL((uint16_t)(100+i), Server->GetPeerBidiStreamCount());
                     CxPlatSleep(100);

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1906,7 +1906,6 @@ QuicTestKeyUpdateRandomLoss(
     }
 }
 
-
 void
 QuicTestKeyUpdate(
     _In_ int Family,

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1859,6 +1859,10 @@ QuicTestKeyUpdate(
                     CxPlatSleep(100);
                     TEST_EQUAL((uint16_t)(101+i), Server->GetLocalBidiStreamCount());
 
+                    //
+                    // Force a client key update to occur again to check for double update
+                    // while server is still waiting for key response.
+                    //
                     if (ClientKeyUpdate) {
                         TEST_QUIC_SUCCEEDED(Client.ForceKeyUpdate());
                     }

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1794,7 +1794,6 @@ QuicTestKeyUpdateRandomLoss(
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
-
     const int Iterations = 10;
 
     {
@@ -1916,7 +1915,7 @@ QuicTestKeyUpdate(
     _In_ bool UseKeyUpdateBytes,
     _In_ bool ClientKeyUpdate,
     _In_ bool ServerKeyUpdate
-)
+    )
 {
     MsQuicRegistration Registration;
     TEST_TRUE(Registration.IsValid());


### PR DESCRIPTION
A bug was found while working on a separate PR that would cause the packets to be decoded incorrect upon key update. The root cause ended up being our method for choosing old or new keys when the opposite key phase was detected was incorrect. This PR updates the logic for selecting the keys to handle an updated key being used before the local side has confirmed its keys.

Closes #1552