### PR TITLE
Only compile in RSS support on linux if CBPF macro is found

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -863,7 +863,6 @@ Exit:
     return Status;
 }
 
-
 QUIC_STATUS
 CxPlatSocketConfigureRss(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketContext,

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -863,12 +863,14 @@ Exit:
     return Status;
 }
 
+
 QUIC_STATUS
 CxPlatSocketConfigureRss(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketContext,
     _In_ uint32_t SocketCount
     )
 {
+#ifdef SO_ATTACH_REUSEPORT_CBPF
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
 
@@ -901,6 +903,9 @@ CxPlatSocketConfigureRss(
     }
 
     return Status;
+#else
+    return QUIC_STATUS_NOT_SUPPORTED;
+#endif
 }
 
 //


### PR DESCRIPTION
Not defined on some distributions, so just skip it in those cases.

Closes #1549 