### PR TITLE
Add exit code debugging to kernel mode test runs

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -616,8 +616,17 @@ if ($Kernel -ne "") {
     Copy-Item (Join-Path $Kernel "msquictestpriv.sys") (Split-Path $Path -Parent)
     Copy-Item (Join-Path $Kernel "msquicpriv.sys") (Split-Path $Path -Parent)
     sc.exe create "msquicpriv" type= kernel binpath= (Join-Path (Split-Path $Path -Parent) "msquicpriv.sys") start= demand | Out-Null
+    if ($LastExitCode) {
+        Log ("sc.exe " + $LastExitCode)
+    }
     verifier.exe /volatile /adddriver afd.sys msquicpriv.sys msquictestpriv.sys netio.sys tcpip.sys /flags 0x9BB
+    if ($LastExitCode) {
+        Log ("verifier.exe " + $LastExitCode)
+    }
     net.exe start msquicpriv
+    if ($LastExitCode) {
+        Log ("net.exe " + $LastExitCode)
+    }
 }
 
 try {


### PR DESCRIPTION
We seem to have an issue that might be related to bad exit codes. So add some logging so we can figure out why.