### PR TITLE
Increase BVT Timeout to 60 Minutes

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -49,7 +49,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 45
+    timeoutInMinutes: 60
     ${{ if eq(parameters.codeCoverage, true) }}:
       continueOnError: true
     inputs:


### PR DESCRIPTION
We've been seeing some timeouts for kernel BVT recently. We want to invest some time to reduce those times, but for now I'd rather not keep failing the pipelines. Increase the timeout some in the interim.