### PR TITLE
Switch kernel mode BVT's back to Full.Light logging

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -406,7 +406,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      logProfile: Full.Verbose
+      logProfile: Full.Light
       extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*
       kernel: true
       testCerts: true


### PR DESCRIPTION
An earlier PR switched these to Full.Verbose. User mode was also switched, but reverted back in a later PR. This basically doubles the time for tests, and isn't usually necessary.