### PR TITLE
Add Peer Accept Stream Event

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -450,28 +450,28 @@ stages:
       image: ubuntu-latest
       platform: linux
       tls: openssl
-      extraArgs: -Filter -*.Tcp*:CredValidation*:*ValidateStream*:*ValidateConnection*
+      extraArgs: -Filter -*:CredValidation*:*ValidateStream*:*ValidateConnection*
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest
       platform: linux
       tls: openssl
       extraArtifactDir: '_Sanitize'
-      extraArgs: -Filter -*.Tcp*:CredValidation*:*ValidateStream*:*ValidateConnection* -ExtraArtifactDir Sanitize
+      extraArgs: -Filter -*:CredValidation*:*ValidateStream*:*ValidateConnection* -ExtraArtifactDir Sanitize
   - template: ./templates/run-bvt.yml
     parameters:
       image: macOS-10.15
       platform: macos
       tls: openssl
       logProfile: None
-      extraArgs: -Filter -*.Tcp*:CredValidation*:*ValidateStream*:*ValidateConnection*
+      extraArgs: -Filter -*:CredValidation*:*ValidateStream*:*ValidateConnection*
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest
       platform: linux
       tls: openssl
       extraArtifactDir: '_SystemCrypto'
-      extraArgs: -Filter -*.Tcp*:CredValidation*:*ValidateStream*:*ValidateConnection* -ExtraArtifactDir SystemCrypto
+      extraArgs: -Filter -*:CredValidation*:*ValidateStream*:*ValidateConnection* -ExtraArtifactDir SystemCrypto
 
 #
 # SpinQuic Tests

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -243,6 +243,7 @@ QuicStreamStart(
     }
 
     Stream->Flags.Started = TRUE;
+    Stream->Flags.IndicatePeerAccepted = !!(Flags & QUIC_STREAM_START_FLAG_INDICATE_PEER_ACCEPT);
 
     QuicTraceEvent(
         StreamCreated,
@@ -422,6 +423,8 @@ QuicStreamIndicateStartComplete(
     Event.Type = QUIC_STREAM_EVENT_START_COMPLETE;
     Event.START_COMPLETE.Status = Status;
     Event.START_COMPLETE.ID = Stream->ID;
+    Event.START_COMPLETE.PeerAccepted =
+        !!(Stream->OutFlowBlockedReasons & QUIC_FLOW_BLOCKED_STREAM_ID_FLOW_CONTROL);
     QuicTraceLogStreamVerbose(
         IndicateStartComplete,
         Stream,

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -111,6 +111,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Started                 : 1;    // The app has started the stream.
         BOOLEAN Unidirectional          : 1;    // Sends/receives in 1 direction only.
         BOOLEAN Opened0Rtt              : 1;    // A 0-RTT packet opened the stream.
+        BOOLEAN IndicatePeerAccepted    : 1;    // The app requested the PEER_ACCEPTED event.
 
         BOOLEAN SendOpen                : 1;    // Send a STREAM frame immediately on start.
         BOOLEAN SendOpenAcked           : 1;    // A STREAM frame has been acknowledged.

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -164,11 +164,12 @@ typedef enum QUIC_STREAM_OPEN_FLAGS {
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_OPEN_FLAGS)
 
 typedef enum QUIC_STREAM_START_FLAGS {
-    QUIC_STREAM_START_FLAG_NONE             = 0x0000,
-    QUIC_STREAM_START_FLAG_FAIL_BLOCKED     = 0x0001,   // Only opens the stream if flow control allows.
-    QUIC_STREAM_START_FLAG_IMMEDIATE        = 0x0002,   // Immediately informs peer that stream is open.
-    QUIC_STREAM_START_FLAG_ASYNC            = 0x0004,   // Don't block the API call to wait for completion.
-    QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL = 0x0008,   // Shutdown the stream immediately after start failure.
+    QUIC_STREAM_START_FLAG_NONE                 = 0x0000,
+    QUIC_STREAM_START_FLAG_FAIL_BLOCKED         = 0x0001,   // Only opens the stream if flow control allows.
+    QUIC_STREAM_START_FLAG_IMMEDIATE            = 0x0002,   // Immediately informs peer that stream is open.
+    QUIC_STREAM_START_FLAG_ASYNC                = 0x0004,   // Don't block the API call to wait for completion.
+    QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL     = 0x0008,   // Shutdown the stream immediately after start failure.
+    QUIC_STREAM_START_FLAG_INDICATE_PEER_ACCEPT = 0x0010,   // Indicate PEER_ACCEPTED event if not accepted at start.
 } QUIC_STREAM_START_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_START_FLAGS)
@@ -1044,6 +1045,7 @@ typedef enum QUIC_STREAM_EVENT_TYPE {
     QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE    = 6,
     QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE         = 7,
     QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE    = 8,
+    QUIC_STREAM_EVENT_PEER_ACCEPTED             = 9,
 } QUIC_STREAM_EVENT_TYPE;
 
 typedef struct QUIC_STREAM_EVENT {
@@ -1052,6 +1054,8 @@ typedef struct QUIC_STREAM_EVENT {
         struct {
             QUIC_STATUS Status;
             QUIC_UINT62 ID;
+            BOOLEAN PeerAccepted : 1;
+            BOOLEAN RESERVED : 7;
         } START_COMPLETE;
         struct {
             /* in */    uint64_t AbsoluteOffset;

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -7168,6 +7168,18 @@
       ],
       "macroName": "QuicTraceLogStreamWarning"
     },
+    "IndicatePeerAccepted": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_PEER_ACCEPTED",
+      "UniqueId": "IndicatePeerAccepted",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
     "MaxStreamCountUpdated": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] App configured max stream count of %hu (type=%hhu).",
@@ -12312,6 +12324,10 @@
       {
         "UniquenessHash": "48b0b691-89c1-4bb2-1ba4-5bc91586b2b3",
         "TraceID": "NotAccepted"
+      },
+      {
+        "UniquenessHash": "446a0073-26fb-eed7-4ed4-fa9838fbd654",
+        "TraceID": "IndicatePeerAccepted"
       },
       {
         "UniquenessHash": "418770bb-5594-978f-0b62-4bb47315bfa1",

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -850,6 +850,7 @@ TEST_P(DataPathTest, UdpDataECT0)
     CxPlatEventUninitialize(RecvContext.ClientCompletion);
 }
 
+#if WIN32
 TEST_F(DataPathTest, TcpListener)
 {
     CXPLAT_DATAPATH* Datapath = nullptr;
@@ -1189,5 +1190,6 @@ TEST_P(DataPathTest, TcpDataServer)
     CxPlatDataPathUninitialize(
         Datapath);
 }
+#endif // WIN32
 
 INSTANTIATE_TEST_SUITE_P(DataPathTest, DataPathTest, ::testing::Values(4, 6), testing::PrintToStringParamName());


### PR DESCRIPTION
Adds the ability for an app to request the peer accept event, which indicates when the peer has allowed the stream credit to be sent.

Also, cleaned up some test stuff on Linux so they all run by default (no extra filters necessary by default).

TODO - Add tests for new event