### PR TITLE
Add Stream Shutdown Complete Flag

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -431,7 +431,7 @@ QuicStreamIndicateStartComplete(
     QuicTraceLogStreamVerbose(
         IndicateStartComplete,
         Stream,
-        "Indicating QUIC_STREAM_EVENT_START_COMPLETE [status=0x%x id=%llu accepted=%hhu]",
+        "Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]",
         Status,
         Stream->ID,
         Event.START_COMPLETE.PeerAccepted);
@@ -449,10 +449,14 @@ QuicStreamIndicateShutdownComplete(
 
         QUIC_STREAM_EVENT Event;
         Event.Type = QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE;
+        Event.SHUTDOWN_COMPLETE.ConnectionShutdown =
+            Stream->Connection->State.ClosedLocally ||
+            Stream->Connection->State.ClosedRemotely;
         QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE");
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdown);
         (void)QuicStreamIndicateEvent(Stream, &Event);
 
         Stream->ClientCallbackHandler = NULL;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1081,6 +1081,9 @@ typedef struct QUIC_STREAM_EVENT {
             BOOLEAN Graceful;
         } SEND_SHUTDOWN_COMPLETE;
         struct {
+            BOOLEAN ConnectionShutdown;
+        } SHUTDOWN_COMPLETE;
+        struct {
             uint64_t ByteCount;
         } IDEAL_SEND_BUFFER_SIZE;
     };

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -6454,7 +6454,7 @@
     },
     "IndicateStartComplete": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [status=0x%x id=%llu accepted=%hhu]",
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]",
       "UniqueId": "IndicateStartComplete",
       "splitArgs": [
         {
@@ -6478,12 +6478,16 @@
     },
     "IndicateStreamShutdownComplete": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE",
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
       "UniqueId": "IndicateStreamShutdownComplete",
       "splitArgs": [
         {
           "DefinationEncoding": "p",
           "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceLogStreamVerbose"
@@ -12162,11 +12166,11 @@
         "TraceID": "EventSilentDiscard"
       },
       {
-        "UniquenessHash": "c6662310-649a-c716-2236-8eee77cd6db2",
+        "UniquenessHash": "66dd140b-9fd3-eddc-e34c-cb81639e1aca",
         "TraceID": "IndicateStartComplete"
       },
       {
-        "UniquenessHash": "0640b2d1-a929-3d01-b4c9-08733e3f0196",
+        "UniquenessHash": "8340b390-8b79-ab44-6593-7e449f0ec748",
         "TraceID": "IndicateStreamShutdownComplete"
       },
       {


### PR DESCRIPTION
Adds a new flag to the stream's shutdown complete event to indicate that this is because the connection is shutting down. Closes #1586.