### PR TITLE
Fail interop tests in CI if interop crashes

### DIFF
--- a/.azure/templates/run-quicinterop.yml
+++ b/.azure/templates/run-quicinterop.yml
@@ -42,7 +42,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/interop.ps1
-      arguments: -GenerateXmlResults -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
+      arguments: -AZP -GenerateXmlResults -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Tls ${{ parameters.tls }}
 
   - template: ./upload-test-artifacts.yml
     parameters:

--- a/scripts/interop.ps1
+++ b/scripts/interop.ps1
@@ -98,7 +98,10 @@ param (
     [switch]$Serial = $false,
 
     [Parameter(Mandatory = $false)]
-    [string]$UrlPath = ""
+    [string]$UrlPath = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AZP = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -152,6 +155,9 @@ if ($InitialBreak) {
 }
 if ("None" -ne $LogProfile) {
     $Arguments += " -LogProfile $($LogProfile)"
+}
+if ($AZP) {
+    $Arguments += " -AZP"
 }
 
 $ExtraArgs = ""


### PR DESCRIPTION
Previously a crash would still show as successful. We definitely do not want this.