### PR TITLE
Fix validation shutdown test to not deref null

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -564,8 +564,8 @@ QuicTestPathValidationTimeout(
                 Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, QUIC_TEST_NO_ERROR);
             }
 
-            if (!Server->WaitForShutdownComplete()) {
-                return;
+            if (Server) {
+                Server->WaitForShutdownComplete();
             }
         }
     }


### PR DESCRIPTION
If this test fails to connect, the test will currently segfault rather then print out the correct failures. Make this not occur