### PR TITLE
Run release mode tests in CI

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -172,6 +172,62 @@ stages:
       testCerts: true
 
 #
+# Windows Release BVTs
+#
+
+- stage: test_bvt_windows_release
+  displayName: BVT Windows Release
+  condition: |
+    and
+    (
+      or
+      (
+        startsWith(variables['Build.SourceBranch'], 'refs/pull'),
+        startsWith(variables['Build.SourceBranch'], 'refs/heads/integration/')
+      ),
+      succeeded()
+    )
+  dependsOn:
+  - build_windows
+  jobs:
+  - template: ./templates/run-bvt.yml
+    parameters:
+      pool: MsQuic-Win-Latest
+      platform: windows
+      tls: schannel
+      logProfile: Full.Light
+      config: Release
+      extraArgs: -SkipUnitTests
+
+#
+# Windows Release Kernel BVTs
+#
+
+- stage: test_bvt_windows_release
+  displayName: BVT Windows Kernel Release
+  condition: |
+    and
+    (
+      or
+      (
+        startsWith(variables['Build.SourceBranch'], 'refs/pull'),
+        startsWith(variables['Build.SourceBranch'], 'refs/heads/integration/')
+      ),
+      succeeded()
+    )
+  dependsOn:
+  - build_winkernel
+  jobs:
+  - template: ./templates/run-bvt.yml
+    parameters:
+      pool: MsQuic-Win-Latest
+      platform: windows
+      tls: schannel
+      logProfile: Full.Light
+      config: Release
+      kernel: true
+
+#
 # Package
 #
 

--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -140,6 +140,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
+      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
 
 #
@@ -168,7 +169,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*
+      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:*NthAllocFail*
       kernel: true
       testCerts: true
 

--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -203,7 +203,7 @@ stages:
 # Windows Release Kernel BVTs
 #
 
-- stage: test_bvt_windows_release
+- stage: test_bvt_winkernel_release
   displayName: BVT Windows Kernel Release
   condition: |
     and

--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -150,6 +150,7 @@ stages:
   displayName: BVT Kernel
   dependsOn:
   - build_winkernel
+  - build_windows
   condition: |
     and
     (
@@ -217,6 +218,7 @@ stages:
     )
   dependsOn:
   - build_winkernel
+  - build_windows
   jobs:
   - template: ./templates/run-bvt.yml
     parameters:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -401,6 +401,38 @@ stages:
     - template: ./templates/post-process-performance.yml
 
 #
+# Windows Release BVTs
+#
+
+- stage: test_bvt_windows_release
+  displayName: BVT Windows Release
+  dependsOn:
+  - build_windows_release
+  jobs:
+  - template: ./templates/run-bvt.yml
+    parameters:
+      pool: MsQuic-Win-Latest
+      platform: windows
+      tls: schannel
+      logProfile: Full.Light
+      config: Release
+      extraArgs: -SkipUnitTests
+
+- stage: test_bvt_windows_release
+  displayName: BVT Windows Kernel Release
+  dependsOn:
+  - build_winkernel_release
+  jobs:
+  - template: ./templates/run-bvt.yml
+    parameters:
+      pool: MsQuic-Win-Latest
+      platform: windows
+      tls: schannel
+      logProfile: Full.Light
+      config: Release
+      kernel: true
+
+#
 # Kernel Build Verification Tests
 #
 

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -449,7 +449,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*
+      extraArgs: -Kernel -Filter -*Handshake/WithHandshakeArgs6.ConnectClientCertificate/*:*NthAllocFail*
       kernel: true
       testCerts: true
 
@@ -470,6 +470,7 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
+      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
   - template: ./templates/run-bvt.yml
     parameters:
@@ -477,7 +478,7 @@ stages:
       platform: windows
       tls: openssl
       logProfile: Full.Light
-      extraArgs: -Filter -*Unreachable/0:CredValidation*
+      extraArgs: -Filter -*Unreachable/0:CredValidation*:*NthAllocFail*
   - template: ./templates/run-bvt.yml
     parameters:
       image: ubuntu-latest
@@ -521,7 +522,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      allocFail: 1000
+      # allocFail: 1000
       extraArtifactDir: '_Sanitize'
       extraArgs: -ExtraArtifactDir Sanitize
   - template: ./templates/run-spinquic.yml
@@ -556,6 +557,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
+      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
       codeCoverage: true
   - template: ./templates/run-spinquic.yml

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -422,6 +422,7 @@ stages:
   displayName: BVT Windows Kernel Release
   dependsOn:
   - build_winkernel_release
+  - build_windows_release
   jobs:
   - template: ./templates/run-bvt.yml
     parameters:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -418,7 +418,7 @@ stages:
       config: Release
       extraArgs: -SkipUnitTests
 
-- stage: test_bvt_windows_release
+- stage: test_bvt_winkernel_release
   displayName: BVT Windows Kernel Release
   dependsOn:
   - build_winkernel_release

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -142,7 +142,10 @@ param (
     [string]$ExtraArtifactDir = "",
 
     [Parameter(Mandatory = $false)]
-    [switch]$AZP = $false
+    [switch]$AZP = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipUnitTests = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -306,7 +309,7 @@ if ($AZP) {
 }
 
 # Run the script.
-if (!$Kernel) {
+if (!$Kernel -and !$SkipUnitTests) {
     Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
     Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
 }

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -56,6 +56,11 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 // testing helpers.
 //
 #define QUIC_TEST_DATAPATH_HOOKS_ENABLED 1
+
+//
+// Failing test certificates are only available for debug builds
+//
+#define QUIC_TEST_FAILING_TEST_CERTIFICATES 1
 #endif
 
 typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -61,6 +61,11 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 // Failing test certificates are only available for debug builds
 //
 #define QUIC_TEST_FAILING_TEST_CERTIFICATES 1
+
+//
+// Allocation failures are currently only enabled on debug builds.
+//
+#define QUIC_TEST_ALLOC_FAILURES_ENABLED 1
 #endif
 
 typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -625,6 +625,7 @@ TEST_P(WithHandshakeArgs6, ConnectClientCertificate) {
 }
 #endif
 
+#if QUIC_TEST_FAILING_TEST_CERTIFICATES
 TEST(CredValidation, ConnectExpiredServerCertificate) {
     QUIC_RUN_CRED_VALIDATION Params;
     for (auto CredType : { QUIC_CREDENTIAL_TYPE_CERTIFICATE_HASH, QUIC_CREDENTIAL_TYPE_CERTIFICATE_HASH_STORE }) {
@@ -787,6 +788,7 @@ TEST(CredValidation, ConnectValidClientCertificate) {
         CxPlatFreeTestCert((QUIC_CREDENTIAL_CONFIG*)&Params.CredConfig);
     }
 }
+#endif // QUIC_TEST_FAILING_TEST_CERTIFICATES
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
 TEST_P(WithHandshakeArgs4, RandomLoss) {
@@ -1427,10 +1429,12 @@ INSTANTIATE_TEST_SUITE_P(
     WithHandshakeArgs3,
     testing::ValuesIn(HandshakeArgs3::Generate()));
 
+#ifndef QUIC_DISABLE_RESUMPTION
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs4,
     testing::ValuesIn(HandshakeArgs4::Generate()));
+#endif
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1429,12 +1429,15 @@ INSTANTIATE_TEST_SUITE_P(
     WithHandshakeArgs3,
     testing::ValuesIn(HandshakeArgs3::Generate()));
 
-#ifndef QUIC_DISABLE_RESUMPTION
+#if !defined(QUIC_DISABLE_RESUMPTION) || defined(QUIC_TEST_DATAPATH_HOOKS_ENABLED)
+
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs4,
     testing::ValuesIn(HandshakeArgs4::Generate()));
+
 #endif
+
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
@@ -1484,10 +1487,14 @@ INSTANTIATE_TEST_SUITE_P(
     WithKeyUpdateArgs1,
     testing::ValuesIn(KeyUpdateArgs1::Generate()));
 
+#if QUIC_TEST_DATAPATH_HOOKS_ENABLED
+
 INSTANTIATE_TEST_SUITE_P(
     Misc,
     WithKeyUpdateArgs2,
     testing::ValuesIn(KeyUpdateArgs2::Generate()));
+
+#endif
 
 INSTANTIATE_TEST_SUITE_P(
     Misc,

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1429,7 +1429,7 @@ INSTANTIATE_TEST_SUITE_P(
     WithHandshakeArgs3,
     testing::ValuesIn(HandshakeArgs3::Generate()));
 
-#if !defined(QUIC_DISABLE_RESUMPTION) || defined(QUIC_TEST_DATAPATH_HOOKS_ENABLED)
+#ifdef QUIC_TEST_DATAPATH_HOOKS_ENABLED
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1329,6 +1329,8 @@ TEST(Misc, SlowReceive) {
     }
 }
 
+#ifdef QUIC_TEST_ALLOC_FAILURES_ENABLED
+
 TEST(Misc, NthAllocFail) {
     TestLogger Logger("NthAllocFail");
     if (TestingKernelMode) {
@@ -1337,6 +1339,8 @@ TEST(Misc, NthAllocFail) {
         QuicTestNthAllocFail();
     }
 }
+
+#endif
 
 TEST(Drill, VarIntEncoder) {
     TestLogger Logger("QuicDrillTestVarIntEncoder");

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1442,7 +1442,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 #endif
 
-
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs5,

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -245,7 +245,9 @@ QuicTestDatagramSend(
                     return;
                 }
 
+#if QUIC_TEST_DATAPATH_HOOKS_ENABLED
                 TEST_EQUAL(1, Client.GetDatagramsLost());
+#endif
 
                 TEST_FALSE(Client.GetPeerClosed());
                 TEST_FALSE(Client.GetTransportClosed());


### PR DESCRIPTION
The internal windows build uses release mode msquic and msquictest binaries, however this is not tested anywhere in CI. Its possible for tests to be added that break this, and this won't then be detectable until a windows build. Run a build in CI so this can be detected early.