### PR TITLE
Reenable Alloc Failures in CI

### DIFF
--- a/.azure/azure-pipelines-int.ci.yml
+++ b/.azure/azure-pipelines-int.ci.yml
@@ -140,7 +140,6 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
 
 #

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -522,7 +522,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      allocFail: 1000
+      allocFail: 100
       extraArtifactDir: '_Sanitize'
       extraArgs: -ExtraArtifactDir Sanitize
   - template: ./templates/run-spinquic.yml
@@ -564,7 +564,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      allocFail: 1000
+      allocFail: 100
       codeCoverage: true
   - template: ./templates/merge-publish-coverage.yml
     parameters:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -471,7 +471,6 @@ stages:
       platform: windows
       tls: schannel
       logProfile: Full.Light
-      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
   - template: ./templates/run-bvt.yml
     parameters:
@@ -523,7 +522,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      # allocFail: 1000
+      allocFail: 1000
       extraArtifactDir: '_Sanitize'
       extraArgs: -ExtraArtifactDir Sanitize
   - template: ./templates/run-spinquic.yml
@@ -558,7 +557,6 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
-      extraArgs: -Filter -*NthAllocFail*
       testCerts: true
       codeCoverage: true
   - template: ./templates/run-spinquic.yml
@@ -566,6 +564,7 @@ stages:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
+      allocFail: 1000
       codeCoverage: true
   - template: ./templates/merge-publish-coverage.yml
     parameters:

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -674,7 +674,8 @@ QuicPacketBuilderFinalize(
         Builder->DatagramLength + Builder->EncryptionOverhead;
 
     if (FlushBatchedDatagrams ||
-        Builder->PacketType == SEND_PACKET_SHORT_HEADER_TYPE) {
+        Builder->PacketType == SEND_PACKET_SHORT_HEADER_TYPE ||
+        (uint16_t)Builder->Datagram->Length - ExpectedFinalDatagramLength < QUIC_MIN_PACKET_SPARE_SPACE) {
 
         FinalQuicPacket = TRUE;
 

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -674,8 +674,7 @@ QuicPacketBuilderFinalize(
         Builder->DatagramLength + Builder->EncryptionOverhead;
 
     if (FlushBatchedDatagrams ||
-        Builder->PacketType == SEND_PACKET_SHORT_HEADER_TYPE ||
-        (uint16_t)Builder->Datagram->Length - ExpectedFinalDatagramLength < QUIC_MIN_PACKET_SPARE_SPACE) {
+        Builder->PacketType == SEND_PACKET_SHORT_HEADER_TYPE) {
 
         FinalQuicPacket = TRUE;
 

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1186,14 +1186,13 @@ QuicSendFlush(
 
         if (!WrotePacketFrames ||
             Builder.Metadata->FrameCount == QUIC_MAX_FRAMES_PER_PACKET ||
-            Builder.Datagram->Length - Builder.DatagramLength < QUIC_MIN_PACKET_SPARE_SPACE ||
-            FlushBatchedDatagrams) {
+            Builder.Datagram->Length - Builder.DatagramLength < QUIC_MIN_PACKET_SPARE_SPACE) {
 
             //
             // We now have enough data in the current packet that we should
             // finalize it.
             //
-            QuicPacketBuilderFinalize(&Builder, TRUE);
+            QuicPacketBuilderFinalize(&Builder, !WrotePacketFrames | FlushBatchedDatagrams);
         }
 
 #if DEBUG

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1186,13 +1186,14 @@ QuicSendFlush(
 
         if (!WrotePacketFrames ||
             Builder.Metadata->FrameCount == QUIC_MAX_FRAMES_PER_PACKET ||
-            Builder.Datagram->Length - Builder.DatagramLength < QUIC_MIN_PACKET_SPARE_SPACE) {
+            Builder.Datagram->Length - Builder.DatagramLength < QUIC_MIN_PACKET_SPARE_SPACE ||
+            FlushBatchedDatagrams) {
 
             //
             // We now have enough data in the current packet that we should
             // finalize it.
             //
-            QuicPacketBuilderFinalize(&Builder, FlushBatchedDatagrams);
+            QuicPacketBuilderFinalize(&Builder, TRUE);
         }
 
 #if DEBUG

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1192,7 +1192,7 @@ QuicSendFlush(
             // We now have enough data in the current packet that we should
             // finalize it.
             //
-            QuicPacketBuilderFinalize(&Builder, !WrotePacketFrames | FlushBatchedDatagrams);
+            QuicPacketBuilderFinalize(&Builder, !WrotePacketFrames || FlushBatchedDatagrams);
         }
 
 #if DEBUG

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1177,13 +1177,6 @@ QuicSendFlush(
 
         Send->TailLossProbeNeeded = FALSE;
 
-        //
-        // If the following assert is hit, then we just went through the
-        // framing logic and nothing was written to the packet. This is bad!
-        // It likely indicates an infinite loop will follow.
-        //
-        CXPLAT_DBG_ASSERT(Builder.Metadata->FrameCount != 0 || Builder.PacketStart != 0);
-
         if (!WrotePacketFrames ||
             Builder.Metadata->FrameCount == QUIC_MAX_FRAMES_PER_PACKET ||
             Builder.Datagram->Length - Builder.DatagramLength < QUIC_MIN_PACKET_SPARE_SPACE) {

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -593,97 +593,101 @@ void Spin(LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Listeners = nu
 CXPLAT_THREAD_CALLBACK(ServerSpin, Context)
 {
     UNREFERENCED_PARAMETER(Context);
-    LockableVector<HQUIC> Connections;
-    std::vector<HQUIC> Listeners;
+    bool InitializeSuccess = false;
+    do {
+        LockableVector<HQUIC> Connections;
+        std::vector<HQUIC> Listeners;
 
-    //
-    // Setup
-    //
+        //
+        // Setup
+        //
 
-    QUIC_SETTINGS QuicSettings{0};
-    QuicSettings.PeerBidiStreamCount = GetRandom((uint16_t)10);
-    QuicSettings.IsSet.PeerBidiStreamCount = TRUE;
-    QuicSettings.PeerUnidiStreamCount = GetRandom((uint16_t)10);
-    QuicSettings.IsSet.PeerUnidiStreamCount = TRUE;
-    // TODO - Randomize more of the settings.
+        QUIC_SETTINGS QuicSettings{0};
+        QuicSettings.PeerBidiStreamCount = GetRandom((uint16_t)10);
+        QuicSettings.IsSet.PeerBidiStreamCount = TRUE;
+        QuicSettings.PeerUnidiStreamCount = GetRandom((uint16_t)10);
+        QuicSettings.IsSet.PeerUnidiStreamCount = TRUE;
+        // TODO - Randomize more of the settings.
 
-    auto CredConfig = CxPlatGetSelfSignedCert(CXPLAT_SELF_SIGN_CERT_USER, FALSE);
-    if (!CredConfig) {
-        goto CredCreateFail;
-    }
-
-    if (!QUIC_SUCCEEDED(
-        MsQuic->ConfigurationOpen(
-            Registration,
-            Alpns,
-            AlpnCount,
-            &QuicSettings,
-            sizeof(QuicSettings),
-            nullptr,
-            &ServerConfiguration))) {
-        goto ConfigOpenFail;
-    }
-
-    ASSERT_ON_NOT(ServerConfiguration);
-
-    if (!QUIC_SUCCEEDED(
-        MsQuic->ConfigurationLoadCredential(
-            ServerConfiguration,
-            CredConfig))) {
-        goto CredLoadFail;
-    }
-
-    for (uint32_t i = 0; i < AlpnCount; ++i) {
-        for (auto &pt : Settings.Ports) {
-            HQUIC Listener;
-            if (!QUIC_SUCCEEDED(
-                (MsQuic->ListenerOpen(Registration, SpinQuicServerHandleListenerEvent, &Connections, &Listener)))) {
-                goto CleanupListeners;
-            }
-
-            QUIC_ADDR sockAddr = { 0 };
-            QuicAddrSetFamily(&sockAddr, GetRandom(2) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_UNSPEC);
-            QuicAddrSetPort(&sockAddr, pt);
-
-            if (!QUIC_SUCCEEDED(MsQuic->ListenerStart(Listener, &Alpns[i], 1, &sockAddr))) {
-                MsQuic->ListenerClose(Listener);
-                goto CleanupListeners;
-            }
-            Listeners.push_back(Listener);
+        auto CredConfig = CxPlatGetSelfSignedCert(CXPLAT_SELF_SIGN_CERT_USER, FALSE);
+        if (!CredConfig) {
+            goto CredCreateFail;
         }
-    }
 
-    //
-    // Run
-    //
+        if (!QUIC_SUCCEEDED(
+            MsQuic->ConfigurationOpen(
+                Registration,
+                Alpns,
+                AlpnCount,
+                &QuicSettings,
+                sizeof(QuicSettings),
+                nullptr,
+                &ServerConfiguration))) {
+            goto ConfigOpenFail;
+        }
 
-    Spin(Connections, &Listeners);
+        ASSERT_ON_NOT(ServerConfiguration);
 
-    //
-    // Clean up
-    //
+        if (!QUIC_SUCCEEDED(
+            MsQuic->ConfigurationLoadCredential(
+                ServerConfiguration,
+                CredConfig))) {
+            goto CredLoadFail;
+        }
+
+        for (uint32_t i = 0; i < AlpnCount; ++i) {
+            for (auto &pt : Settings.Ports) {
+                HQUIC Listener;
+                if (!QUIC_SUCCEEDED(
+                    (MsQuic->ListenerOpen(Registration, SpinQuicServerHandleListenerEvent, &Connections, &Listener)))) {
+                    goto CleanupListeners;
+                }
+
+                QUIC_ADDR sockAddr = { 0 };
+                QuicAddrSetFamily(&sockAddr, GetRandom(2) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_UNSPEC);
+                QuicAddrSetPort(&sockAddr, pt);
+
+                if (!QUIC_SUCCEEDED(MsQuic->ListenerStart(Listener, &Alpns[i], 1, &sockAddr))) {
+                    MsQuic->ListenerClose(Listener);
+                    goto CleanupListeners;
+                }
+                Listeners.push_back(Listener);
+            }
+        }
+
+        //
+        // Run
+        //
+
+        InitializeSuccess = true;
+        Spin(Connections, &Listeners);
+
+        //
+        // Clean up
+        //
 CleanupListeners:
-    while (Listeners.size() > 0) {
-        auto Listener = Listeners.back();
-        Listeners.pop_back();
-        MsQuic->ListenerClose(Listener);
-    }
+        while (Listeners.size() > 0) {
+            auto Listener = Listeners.back();
+            Listeners.pop_back();
+            MsQuic->ListenerClose(Listener);
+        }
 
-    for (auto &Connection : Connections) {
-        MsQuic->ConnectionShutdown(Connection, QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
-    }
+        for (auto &Connection : Connections) {
+            MsQuic->ConnectionShutdown(Connection, QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0);
+        }
 
-    while (Connections.size() > 0) {
-        auto Connection = Connections.back();
-        Connections.pop_back();
-        delete SpinQuicConnection::Get(Connection);
-    }
+        while (Connections.size() > 0) {
+            auto Connection = Connections.back();
+            Connections.pop_back();
+            delete SpinQuicConnection::Get(Connection);
+        }
 
 CredLoadFail:
-    MsQuic->ConfigurationClose(ServerConfiguration);
+        MsQuic->ConfigurationClose(ServerConfiguration);
 ConfigOpenFail:
-    CxPlatFreeSelfSignedCert(CredConfig);
+        CxPlatFreeSelfSignedCert(CredConfig);
 CredCreateFail:
+    } while (!InitializeSuccess);
 
     CXPLAT_THREAD_RETURN(0);
 }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -611,7 +611,7 @@ CXPLAT_THREAD_CALLBACK(ServerSpin, Context)
 
         auto CredConfig = CxPlatGetSelfSignedCert(CXPLAT_SELF_SIGN_CERT_USER, FALSE);
         if (!CredConfig) {
-            goto CredCreateFail;
+            continue;
         }
 
         if (!QUIC_SUCCEEDED(
@@ -686,7 +686,6 @@ CredLoadFail:
         MsQuic->ConfigurationClose(ServerConfiguration);
 ConfigOpenFail:
         CxPlatFreeSelfSignedCert(CredConfig);
-CredCreateFail:
     } while (!InitializeSuccess);
 
     CXPLAT_THREAD_RETURN(0);


### PR DESCRIPTION
Reenables all the allocation failure testing in BVT and SpinQuic (on Windows user mode).