### PR TITLE
Improve Handling of Ephemeral Port Reuse Scenario

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1464,7 +1464,7 @@ QuicLibraryGetBinding(
             // requested configuration.
             //
             QuicTraceEvent(
-                BindingErrorStatus,
+                BindingError,
                 "[bind][%p] ERROR, %s.",
                 Binding,
                 "Binding already in use");
@@ -1564,7 +1564,7 @@ NewBinding:
             // bail.
             //
             QuicTraceEvent(
-                BindingErrorStatus,
+                BindingError,
                 "[bind][%p] ERROR, %s.",
                 *NewBinding,
                 "Binding ephemeral port reuse encountered");
@@ -1574,7 +1574,7 @@ NewBinding:
 
         } else if (Binding->Exclusive) {
             QuicTraceEvent(
-                BindingErrorStatus,
+                BindingError,
                 "[bind][%p] ERROR, %s.",
                 Binding,
                 "Binding already in use");

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1560,7 +1560,7 @@ NewBinding:
             //
             // The datapath somehow returned us a "new" ephemeral socket that
             // already matched one of our existing ones. We've seen this on
-            // Linux occassionally. This shouldn't happen, but it does. Log and
+            // Linux occasionally. This shouldn't happen, but it does. Log and
             // bail.
             //
             QuicTraceEvent(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1438,9 +1438,10 @@ QuicLibraryGetBinding(
     // requested addresses.
     //
 
-    if (LocalAddress == NULL) {
+    if (LocalAddress == NULL || QuicAddrGetPort(LocalAddress) == 0) {
         //
-        // No specified local address, so we just always create a new binding.
+        // No specified local address or port, so we just always create a new
+        // binding.
         //
         goto NewBinding;
     }

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1568,6 +1568,8 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 *NewBinding,
                 "Binding ephemeral port reuse encountered");
+            QuicBindingUninitialize(*NewBinding);
+            *NewBinding = NULL;
             Status = QUIC_STATUS_INTERNAL_ERROR;
 
         } else if (Binding->Exclusive) {
@@ -1576,6 +1578,8 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 Binding,
                 "Binding already in use");
+            QuicBindingUninitialize(*NewBinding);
+            *NewBinding = NULL;
             Status = QUIC_STATUS_ADDRESS_IN_USE;
 
         } else {

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1432,16 +1432,17 @@ QuicLibraryGetBinding(
     QUIC_STATUS Status = QUIC_STATUS_NOT_FOUND;
     QUIC_BINDING* Binding;
     QUIC_ADDR NewLocalAddress;
+    BOOLEAN PortUnspecified = LocalAddress == NULL || QuicAddrGetPort(LocalAddress) == 0;
 
     //
     // First check to see if a binding already exists that matches the
     // requested addresses.
     //
-
-    if (LocalAddress == NULL || QuicAddrGetPort(LocalAddress) == 0) {
+    if (PortUnspecified) {
         //
-        // No specified local address or port, so we just always create a new
-        // binding.
+        // No specified local port, so we always create a new binding, and let
+        // the networking stack assign us a new ephemeral port. We can skip the
+        // lookup because the stack **should** always give us something new.
         //
         goto NewBinding;
     }
@@ -1462,7 +1463,12 @@ QuicLibraryGetBinding(
             // The binding does already exist, but cannot be shared with the
             // requested configuration.
             //
-            Status = QUIC_STATUS_INVALID_STATE;
+            QuicTraceEvent(
+                BindingErrorStatus,
+                "[bind][%p] ERROR, %s.",
+                Binding,
+                "Binding already in use");
+            Status = QUIC_STATUS_ADDRESS_IN_USE;
         } else {
             //
             // Match found and can be shared.
@@ -1526,9 +1532,10 @@ NewBinding:
             NULL);
 #endif
     if (Binding != NULL) {
-        if (!Binding->Exclusive) {
+        if (!PortUnspecified && !Binding->Exclusive) {
             //
-            // Another thread got the binding first, but it's not exclusive.
+            // Another thread got the binding first, but it's not exclusive,
+            // and it's not what should be a new ephemeral port.
             //
             CXPLAT_DBG_ASSERT(Binding->RefCount > 0);
             Binding->RefCount++;
@@ -1549,8 +1556,28 @@ NewBinding:
     CxPlatDispatchLockRelease(&MsQuicLib.DatapathLock);
 
     if (Binding != NULL) {
-        if (Binding->Exclusive) {
-            Status = QUIC_STATUS_INVALID_STATE;
+        if (PortUnspecified) {
+            //
+            // The datapath somehow returned us a "new" ephemeral socket that
+            // already matched one of our existing ones. We've seen this on
+            // Linux occassionally. This shouldn't happen, but it does. Log and
+            // bail.
+            //
+            QuicTraceEvent(
+                BindingErrorStatus,
+                "[bind][%p] ERROR, %s.",
+                *NewBinding,
+                "Binding ephemeral port reuse encountered");
+            Status = QUIC_STATUS_INTERNAL_ERROR;
+
+        } else if (Binding->Exclusive) {
+            QuicTraceEvent(
+                BindingErrorStatus,
+                "[bind][%p] ERROR, %s.",
+                Binding,
+                "Binding already in use");
+            Status = QUIC_STATUS_ADDRESS_IN_USE;
+
         } else {
             (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -4657,6 +4657,22 @@
       "splitArgs": [],
       "macroName": "QuicTraceEvent"
     },
+    "BindingError": {
+      "ModuleProperites": {},
+      "TraceString": "[bind][%p] ERROR, %s.",
+      "UniqueId": "BindingError",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "LibraryServerInit": {
       "ModuleProperites": {},
       "TraceString": "[ lib] Shared server state initializing",
@@ -11732,6 +11748,10 @@
       {
         "UniquenessHash": "0a866453-c89b-e8b7-d853-8f975458d9a9",
         "TraceID": "LibraryRelease"
+      },
+      {
+        "UniquenessHash": "36d08274-918b-3ecd-861c-ada8d4fda4d5",
+        "TraceID": "BindingError"
       },
       {
         "UniquenessHash": "58367e27-574f-14e0-4661-81f93cdb9e18",


### PR DESCRIPTION
While looking at the code, I noticed the `QuicLibraryGetBinding` function was unnecessarily doing a lookup for an existing binding if the local port was zero. This is unnecessary because we never actually have a binding with a zero port. This is generally used to indicate to the networking stack that we wish to have an ephemeral port assigned. So simply skip this step and go straight to creation.

Edit: Added additional logic to improve the handling of the scenario when Linux reuses the ephemeral port.