### PR TITLE
Add TAT Filter for API Failures

### DIFF
--- a/docs/TSG.md
+++ b/docs/TSG.md
@@ -111,6 +111,8 @@ MsQuic logs every API entry and exit. Depending on the platform and tool used to
 [cpu][process.thread][time][ api] Exit [optional status code]
 ```
 
+A [TextAnalysisTool](./Diagnostics.md#text-analysis-tool) filter (`api.tat`) is also included in [./docs/tat](./tat) to help quickly find all failed API calls.
+
 ### Example (ListenerStart failing with QUIC_STATUS_INVALID_STATE)
 
 In a recent example, we wanted to know why an app occasionally received `QUIC_STATUS_INVALID_STATE` when it called `ListenerStart`. We took the following steps to diagnose it.

--- a/docs/tat/api.tat
+++ b/docs/tat/api.tat
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<TextAnalysisTool.NET version="2015-05-18" showOnlyFilteredLines="True">
+  <filters>
+    <filter enabled="n" excluding="n" foreColor="006400" type="matches_text" case_sensitive="n" regex="n" text="[ api] Enter" />
+    <filter enabled="y" excluding="n" foreColor="ff0000" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit " />
+    <filter enabled="y" excluding="y" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit 0" />
+    <filter enabled="y" excluding="y" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit 459998" />
+    <filter enabled="y" excluding="y" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit 459749" />
+    <filter enabled="y" excluding="y" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit 4294967294" />
+    <filter enabled="y" excluding="y" type="matches_text" case_sensitive="n" regex="n" text="[ api] Exit 4294967295" />
+  </filters>
+</TextAnalysisTool.NET>


### PR DESCRIPTION
Adds a filter that helps show all the failed API results from a log file (Posix or Windows). cc @wfurt 