### PR TITLE
Fix Windows User Mode Build Breaks from VS v16.10 Update

### DIFF
--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -17,6 +17,8 @@ Supported Environments:
 
 #pragma once
 
+#include <stddef.h>
+
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
 
 //

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -30,6 +30,7 @@ Environment:
 #pragma warning(disable:26071)
 #pragma warning(disable:28118)
 #pragma warning(disable:28196)
+#pragma warning(disable:28251)
 #pragma warning(disable:28252)
 #pragma warning(disable:28253)
 #pragma warning(disable:28309)

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -35,6 +35,7 @@ Environment:
 
 #pragma warning(push) // Don't care about OACR warnings in publics
 #pragma warning(disable:26036)
+#pragma warning(disable:28251)
 #pragma warning(disable:28252)
 #pragma warning(disable:28253)
 #pragma warning(disable:5105) // The conformant preprocessor along with the newest SDK throws this warning for a macro.

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -12,9 +12,7 @@ Abstract:
 #include <quic_platform.h>
 #include <MsQuicTests.h>
 
-extern "C" {
 #include "quic_trace.h"
-}
 #ifdef QUIC_CLOG
 #include "control.cpp.clog.h"
 #endif
@@ -1094,7 +1092,7 @@ Return Value:
 
     va_list Args;
     va_start(Args, Format);
-    (void)_vsnprintf_s(Buffer, sizeof(Buffer), _TRUNCATE, Format, Args);
+    (void)_vsnprintf_s(Buffer, _TRUNCATE, Format, Args);
     va_end(Args);
 
     QuicTraceLogError(

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -1092,7 +1092,7 @@ Return Value:
 
     va_list Args;
     va_start(Args, Format);
-    (void)_vsnprintf_s(Buffer, _TRUNCATE, Format, Args);
+    (void)_vsnprintf_s(Buffer, sizeof(Buffer), _TRUNCATE, Format, Args);
     va_end(Args);
 
     QuicTraceLogError(

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -12,7 +12,9 @@ Abstract:
 #include <quic_platform.h>
 #include <MsQuicTests.h>
 
+extern "C" {
 #include "quic_trace.h"
+}
 #ifdef QUIC_CLOG
 #include "control.cpp.clog.h"
 #endif


### PR DESCRIPTION
AZP just started pushing an update that includes the VS 2019 v16.10 update, causing many of our builds to fail. This PR fixes most of those issues so at least Windows user mode builds pass. Kernel mode still has a link error that I can't quite figure out.