### PR TITLE
Ignore how the transports shutdown in key update random loss test

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1893,15 +1893,7 @@ QuicTestKeyUpdateRandomLoss(
                 if (!Client.WaitForShutdownComplete()) {
                     return;
                 }
-
-                TEST_FALSE(Client.GetPeerClosed());
-                TEST_FALSE(Client.GetTransportClosed());
             }
-
-#if !QUIC_SEND_FAKE_LOSS
-            TEST_TRUE(Server->GetPeerClosed());
-            TEST_EQUAL(Server->GetPeerCloseErrorCode(), QUIC_TEST_NO_ERROR);
-#endif
         }
     }
 }


### PR DESCRIPTION
We don't care how the transport shuts down or if it shuts down in this case. All we care is that no key update decryptions fail.

Helps #1596 