### PR TITLE
fix a few non-obvious mistakes in quic where the durable ID's conflic…

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -793,7 +793,7 @@ QuicConnUpdateRtt(
     if (RttUpdated) {
         CXPLAT_DBG_ASSERT(Path->SmoothedRtt != 0);
         QuicTraceLogConnVerbose(
-            RttUpdated,
+            RttUpdatedMsg,
             Connection,
             "Updated Rtt=%u.%03u ms, Var=%u.%03u",
             Path->SmoothedRtt / 1000, Path->SmoothedRtt % 1000,

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -278,7 +278,7 @@ QuicSendClearSendFlag(
 {
     if (Send->SendFlags & SendFlags) {
         QuicTraceLogConnVerbose(
-            RemoveSendFlags,
+            RemoveSendFlagsMsg,
             QuicSendGetConnection(Send),
             "Removing flags %x",
             (SendFlags & Send->SendFlags));

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -1304,7 +1304,7 @@ QuicStreamOnAck(
     CXPLAT_DBG_ASSERT(FollowingOffset <= Stream->QueuedSendOffset);
 
     QuicTraceLogStreamVerbose(
-        AckRange,
+        AckRangeMsg,
         Stream,
         "Received ack for %d bytes, offset=%llu, FF=0x%hx",
         (int32_t)Length,

--- a/src/inc/quic_driver_helpers.h
+++ b/src/inc/quic_driver_helpers.h
@@ -10,6 +10,10 @@ Abstract:
 
 #pragma once
 
+#ifdef QUIC_CLOG
+#include "quic_driver_helpers.h.clog.h"
+#endif
+
 #define QUIC_TEST_APIS 1
 #include "quic_platform.h"
 #include "quic_trace.h"

--- a/src/inc/quic_driver_helpers.h
+++ b/src/inc/quic_driver_helpers.h
@@ -10,10 +10,6 @@ Abstract:
 
 #pragma once
 
-#ifdef QUIC_CLOG
-#include "quic_driver_helpers.h.clog.h"
-#endif
-
 #define QUIC_TEST_APIS 1
 #include "quic_platform.h"
 #include "quic_trace.h"

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -10173,6 +10173,118 @@
         }
       ],
       "macroName": "QuicTraceLogInfo"
+    },
+    "RttUpdatedMsg": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Updated Rtt=%u.%03u ms, Var=%u.%03u",
+      "UniqueId": "RttUpdatedMsg",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "03u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "03u",
+          "MacroVariableName": "arg6"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "RemoveSendFlagsMsg": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Removing flags %x",
+      "UniqueId": "RemoveSendFlagsMsg",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnVerbose"
+    },
+    "AckRangeMsg": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Received ack for %d bytes, offset=%llu, FF=0x%hx",
+      "UniqueId": "AckRangeMsg",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hx",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
+    "TestSendIoctl": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Sending Write IOCTL %u with %u bytes.",
+      "UniqueId": "TestSendIoctl",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "TestReadIoctl": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Sending Read IOCTL %u.",
+      "UniqueId": "TestReadIoctl",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "DatapathUnreachableMsg": {
+      "ModuleProperites": {},
+      "TraceString": "[sock][%p] Unreachable error from %!ADDR!",
+      "UniqueId": "DatapathUnreachableMsg",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
     }
   },
   "Version": 1,
@@ -13194,6 +13306,18 @@
       {
         "UniquenessHash": "1f842f1b-027f-b5ec-e0ac-fc9491aeb629",
         "TraceID": "AckRangeMsg"
+      },
+      {
+        "UniquenessHash": "28f77853-916b-5ceb-e928-405aff056b0a",
+        "TraceID": "TestSendIoctl"
+      },
+      {
+        "UniquenessHash": "3c33979e-0db8-7562-7df1-41ef66cb75fa",
+        "TraceID": "TestReadIoctl"
+      },
+      {
+        "UniquenessHash": "29acd049-f710-a71e-1271-698510cfc519",
+        "TraceID": "DatapathUnreachableMsg"
       }
     ]
   }

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -13182,6 +13182,18 @@
       {
         "UniquenessHash": "7368812e-a46d-0924-7643-009511288886",
         "TraceID": "InteropTestStop"
+      },
+      {
+        "UniquenessHash": "dc25a415-b386-47ec-0128-415c6f31795b",
+        "TraceID": "RttUpdatedMsg"
+      },
+      {
+        "UniquenessHash": "b4aa5fad-d1de-466c-0214-1bbda4b9eb95",
+        "TraceID": "RemoveSendFlagsMsg"
+      },
+      {
+        "UniquenessHash": "1f842f1b-027f-b5ec-e0ac-fc9491aeb629",
+        "TraceID": "AckRangeMsg"
       }
     ]
   }

--- a/src/perf/bin/drvmain.cpp
+++ b/src/perf/bin/drvmain.cpp
@@ -14,7 +14,7 @@ Abstract:
 #include <new.h>
 
 #ifdef QUIC_CLOG
-#include "drivermain.cpp.clog.h"
+#include "drvmain.cpp.clog.h"
 #endif
 
 DECLARE_CONST_UNICODE_STRING(SecNetPerfCtlDeviceNameBase, L"\\Device\\");

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2090,7 +2090,7 @@ CxPlatDataPathSocketReceive(
         if (IsUnreachableError) {
 #if QUIC_CLOG
             QuicTraceLogVerbose(
-                DatapathUnreachable,
+                DatapathUnreachableMsg,
                 "[sock][%p] Unreachable error from %!ADDR!",
                 Binding,
                 CLOG_BYTEARRAY(sizeof(RemoteAddr), &RemoteAddr));


### PR DESCRIPTION
…t with macros defined elsewhere - these arent obvious because QUIC isnt using manifested ETW everywhere so it doesnt matter.  flipping event names to be clearer