### PR TITLE
Remove feature branches from automatically building in CI

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - main
     - release/*
-    - feature/*
   paths:
     exclude:
     - src/plugins/*
@@ -20,7 +19,6 @@ pr:
     include:
     - main
     - release/*
-    - feature/*
   paths:
     exclude:
     - src/plugins/*
@@ -610,7 +608,7 @@ stages:
 # Mirror
 #
 
-- ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(eq(variables['Build.Reason'], 'Schedule')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))) }}:
+- ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(eq(variables['Build.Reason'], 'Schedule'))) }}:
   - stage: mirror
     displayName: Mirror Branch
     dependsOn:
@@ -648,7 +646,7 @@ stages:
 # Distribution
 #
 
-- ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(eq(variables['Build.Reason'], 'Schedule')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))) }}:
+- ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(eq(variables['Build.Reason'], 'Schedule'))) }}:
   - stage: distribution
     displayName: Distribution
     dependsOn:

--- a/.azure/azure-pipelines.plugins.yml
+++ b/.azure/azure-pipelines.plugins.yml
@@ -7,7 +7,6 @@ trigger:
     include:
     - main
     - release/*
-    - feature/*
   paths:
     include:
     - .azure/*
@@ -17,7 +16,6 @@ pr:
     include:
     - main
     - release/*
-    - feature/*
   paths:
     include:
     - .azure/*

--- a/.azure/templates/post-process-performance.yml
+++ b/.azure/templates/post-process-performance.yml
@@ -36,7 +36,7 @@ jobs:
 
   - task: Powershell@2
     displayName: Merge coverage (Release)
-    condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
+    condition: and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     inputs:
       pwsh: true
       filePath: msquic/powershell/merge-performance.ps1
@@ -46,7 +46,7 @@ jobs:
 
   - task: Powershell@2
     displayName: Merge coverage (PR/Feature)
-    condition: not(and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))))
+    condition: not(and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')))
     inputs:
       pwsh: true
       filePath: msquic/powershell/merge-performance.ps1

--- a/.azure/templates/post-process-periodic-performance.yml
+++ b/.azure/templates/post-process-periodic-performance.yml
@@ -35,7 +35,6 @@ jobs:
 
   - task: Powershell@2
     displayName: Merge coverage (Release)
-    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))
     inputs:
       pwsh: true
       filePath: msquic/powershell/merge-periodic-performance.ps1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,13 +6,11 @@ on:
     branches:
       - main
       - release/*
-      - feature/*
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - main
       - release/*
-      - feature/*
   schedule:
     - cron: '0 17 * * 1'
 


### PR DESCRIPTION
They work during development, but once PR's start it becomes a problem. Its easy enough to manually trigger a build, so not worth having