### PR TITLE
Reduce minimum MTU to 1248

### DIFF
--- a/src/core/mtu_discovery.c
+++ b/src/core/mtu_discovery.c
@@ -81,6 +81,15 @@ QuicGetNextProbeSize(
     // depends on that behavior.
     //
 
+    //
+    // Jump automatically to 1280 to return algorithm to ideal case. 1280 should
+    // be supported in most scenarios. With minimum being 1248, this will always
+    // be less then a full increment.
+    //
+    if (Path->Mtu < 1280) {
+        return 1280;
+    }
+
     uint16_t Mtu = Path->Mtu + QUIC_DPLPMTUD_INCREMENT;
     if (Mtu > MtuDiscovery->MaxMtu) {
         Mtu = MtuDiscovery->MaxMtu;

--- a/src/core/mtu_discovery.c
+++ b/src/core/mtu_discovery.c
@@ -87,7 +87,7 @@ QuicGetNextProbeSize(
     // be less then a full increment.
     //
     if (Path->Mtu < 1280) {
-        return 1280;
+        return min(1280, MtuDiscovery->MaxMtu);
     }
 
     uint16_t Mtu = Path->Mtu + QUIC_DPLPMTUD_INCREMENT;

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -246,10 +246,9 @@ CXPLAT_STATIC_ASSERT(IS_POWER_OF_TWO(QUIC_MAX_RANGE_DECODE_ACKS), L"Must be powe
                                                 CXPLAT_UDP_HEADER_SIZE)
 
 //
-// The minimum IP MTU DPLPMTUD will use by default. Slightly larger than
-// absolute minimum to allow a larger allowance.
+// The minimum IP MTU DPLPMTUD will use by default.
 //
-#define QUIC_DPLPMUTD_DEFAULT_MIN_MTU           1280    // TODO - Use QUIC_DPLPMUTD_MIN_MTU instead
+#define QUIC_DPLPMUTD_DEFAULT_MIN_MTU           QUIC_DPLPMUTD_MIN_MTU
 
 //
 // The maximum IP MTU DPLPMTUD will use by default.

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -238,7 +238,7 @@ QuicTestMtuDiscovery(
     MsQuicRegistration Registration;
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
-    const uint16_t MinimumMtu = RaiseMinimumMtu ? 1360 : 1280;
+    const uint16_t MinimumMtu = RaiseMinimumMtu ? 1360 : 1248;
     const uint16_t MaximumMtu = 1500;
 
     MsQuicAlpn Alpn("MsQuicTest");


### PR DESCRIPTION
For tunnelling scenarios, we want to lower the starting MTU. DPLPMTUD support made minimum MTU user configurable, so applications can enforce a higher minimum if requested

Our DPLPMTUD algorithm required 1280 at a starting point for ideal increments. This adds a special case where 1280 will always be selected as the first probe value.

closes #1216 