### PR TITLE
Decrement Ref Count before Uninitializing Binding

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1569,6 +1569,7 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 *NewBinding,
                 "Binding ephemeral port reuse encountered");
+            (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);
             *NewBinding = NULL;
             Status = QUIC_STATUS_INTERNAL_ERROR;
@@ -1579,6 +1580,7 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 Binding,
                 "Binding already in use");
+            (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);
             *NewBinding = NULL;
             Status = QUIC_STATUS_ADDRESS_IN_USE;


### PR DESCRIPTION
Fixes #1685 (minor debug assert regression from #1621) by making sure to decrement the ref count before uninitializing, so the following assert won't fire:
```c
_IRQL_requires_max_(PASSIVE_LEVEL)
void
QuicBindingUninitialize(
    _In_ QUIC_BINDING* Binding
    )
{
    QuicTraceEvent(
        BindingCleanup,
        "[bind][%p] Cleaning up",
        Binding);

    CXPLAT_TEL_ASSERT(Binding->RefCount == 0);  <====== HERE
```

