### PR TITLE
Don't allow stream to be enabled when stop sending has been set

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -46,7 +46,6 @@ QuicStreamRecvShutdown(
     if (Stream->Flags.RemoteCloseAcked ||
         Stream->Flags.RemoteCloseFin ||
         Stream->Flags.RemoteCloseReset) {
-        CXPLAT_TEL_ASSERT(!Stream->Flags.ReceiveEnabled);
         //
         // The peer already closed (graceful or abortive). Nothing else to be
         // done.

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -46,6 +46,7 @@ QuicStreamRecvShutdown(
     if (Stream->Flags.RemoteCloseAcked ||
         Stream->Flags.RemoteCloseFin ||
         Stream->Flags.RemoteCloseReset) {
+        CXPLAT_TEL_ASSERT(!Stream->Flags.ReceiveEnabled);
         //
         // The peer already closed (graceful or abortive). Nothing else to be
         // done.
@@ -703,6 +704,7 @@ QuicStreamRecvFlush(
 
     BOOLEAN FlushRecv = TRUE;
     while (FlushRecv) {
+        CXPLAT_DBG_ASSERT(!Stream->Flags.SentStopSending);
 
         QUIC_BUFFER RecvBuffers[2];
         QUIC_STREAM_EVENT Event = {0};
@@ -792,6 +794,7 @@ QuicStreamRecvFlush(
         }
 
         if (Status == QUIC_STATUS_CONTINUE) {
+            CXPLAT_DBG_ASSERT(!Stream->Flags.SentStopSending);
             //
             // The app has explicitly indicated it wants to continue to
             // receive callbacks, even if all the data wasn't drained.
@@ -872,6 +875,7 @@ QuicStreamReceiveComplete(
     }
 
     if (BufferLength == Stream->RecvPendingLength) {
+        CXPLAT_DBG_ASSERT(!Stream->Flags.SentStopSending);
         //
         // All data was drained from the callback, so additional callbacks can
         // continue to be delivered.
@@ -951,11 +955,13 @@ QuicStreamRecvSetEnabledState(
 {
     if (Stream->Flags.RemoteNotAllowed ||
         Stream->Flags.RemoteCloseFin ||
-        Stream->Flags.RemoteCloseReset) {
+        Stream->Flags.RemoteCloseReset ||
+        Stream->Flags.SentStopSending) {
         return QUIC_STATUS_INVALID_STATE;
     }
 
     if (Stream->Flags.ReceiveEnabled != NewRecvEnabled) {
+        CXPLAT_DBG_ASSERT(!Stream->Flags.SentStopSending);
         Stream->Flags.ReceiveEnabled = NewRecvEnabled;
 
         if (Stream->Flags.Started && NewRecvEnabled) {

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -208,7 +208,7 @@ QUIC_STATUS QUIC_API SpinQuicHandleStreamEvent(HQUIC Stream, void * /* Context *
             MsQuic->SetContext(Stream, (void*)Event->RECEIVE.TotalBufferLength);
             return QUIC_STATUS_PENDING; // Pend the receive, to be completed later.
         } else if (Random == 1 && Event->RECEIVE.TotalBufferLength > 0) {
-            Event->RECEIVE.TotalBufferLength = GetRandom(Event->RECEIVE.TotalBufferLength); // Partially consume the data.
+            Event->RECEIVE.TotalBufferLength = GetRandom(Event->RECEIVE.TotalBufferLength + 1); // Partially (or fully) consume the data.
             if (GetRandom(10) == 0) {
                 return QUIC_STATUS_CONTINUE; // Don't pause receive callbacks.
             }


### PR DESCRIPTION
Its possible the stream enabled flag would be triggered after stream shutdown, causing a telemetry assert

Also adds some new asserts to ensure enabled is never set to true after the send shutdown is set.

Additionally updates spinquic to possibly return continue while draining the whole receive queue.

Closes #1667 