### PR TITLE
add basic packaging script

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -20,7 +20,7 @@ if [ "$OS" == 'Linux' ]; then
         LIBDIR="lib64"
     else
         ARCH=x86
-        LIBDUR="lib"
+        LIBDIR="lib"
     fi
 else
     echo Only Linux packaging is supported at the moment.

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+OS=$(uname)
+ARCH=$(uname -m)
+FPM=`which fpm` 2>/dev/null
+CONFIG=Release
+VER_MAJOR=$(cat ./src/inc/msquic.ver | grep 'define VER_MAJOR'| cut -d ' ' -f 3)
+VER_MINOR=$(cat ./src/inc/msquic.ver | grep 'define VER_MINOR'| cut -d ' ' -f 3)
+VER_PATCH=$(cat ./src/inc/msquic.ver | grep 'define VER_PATCH'| cut -d ' ' -f 3)
+
+if [ -z "$FPM" ]; then
+  echo Install 'fpm'
+  exit 1
+fi
+
+if [ "$OS" == 'Linux' ]; then
+    OS=linux
+    if [ "$ARCH" == 'x86_64' ]; then
+        ARCH='x64'
+        LIBDIR="lib64"
+    else
+        ARCH=x86
+        LIBDUR="lib"
+    fi
+else
+    echo Only Linux packaging is supported at the moment.
+    exit 1
+fi
+
+ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
+if [ ! -e "$ARTIFACTS/libmsquic.so" ]; then
+    echo "$ARTIFACTS/libmsquic.so" does not exist. Run build first.
+    exit 1
+fi
+OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_openssl"
+mkdir -p ${OUTPUT}
+# RedHat/Cenoos
+fpm -f -s dir -t rpm  -n libmsquic -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
+    --package "$OUTPUT" \
+    "$ARTIFACTS/libmsquic.so"=/usr/${LIBDIR}/libmsquic.so \
+    "$ARTIFACTS/libmsquic.lttng.so"=/usr/${LIBDIR}/libmsquic.lttng.so
+
+# Debian/Ubuntu
+if [ "$LIBDIR" == 'lib64' ]; then
+    LIBDIR="lib/x86_64-linux-gnu"
+fi
+fpm -f -s dir -t deb  -n libmsquic -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
+    --package "$OUTPUT" \
+    "$ARTIFACTS/libmsquic.so"=/usr/${LIBDIR}/libmsquic.so \
+    "$ARTIFACTS/libmsquic.lttng.so"=/usr/${LIBDIR}/libmsquic.lttng.so

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -34,7 +34,8 @@ if [ ! -e "$ARTIFACTS/libmsquic.so" ]; then
 fi
 OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_openssl"
 mkdir -p ${OUTPUT}
-# RedHat/Cenoos
+
+# RedHat/CentOS
 fpm -f -s dir -t rpm  -n libmsquic -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
     --package "$OUTPUT" \
     "$ARTIFACTS/libmsquic.so"=/usr/${LIBDIR}/libmsquic.so \


### PR DESCRIPTION
Is is neither perfect not complete but this scrips adds ability to create RPM package for RedHat/Centos and deb for Ubuntu/Debian distributions. 

I used 'fpm' tool recommended by .NET infrastructure people because it allows to support multiple formats including packages for macOS (not supported yet) 

I used simple shell script for now so it is easier (for me) to iterate. We can eventually fold it to some PowerShell but it also allows to package with minimal dependencies. When executed, it will produce something like 
```
furt@ubu20:~/github/wfurt-msquic$ ls -al artifacts/packages/linux/x64_Release_openssl/libmsquic*
-rw-rw-r-- 1 furt furt 1784275 Jun  4 14:57 artifacts/packages/linux/x64_Release_openssl/libmsquic-1.5.0-1.x86_64.rpm
-rw-rw-r-- 1 furt furt 1789496 Jun  4 14:57 artifacts/packages/linux/x64_Release_openssl/libmsquic_1.5.0_amd64.deb
```  

each package includes just the two libraries. We could possibly also create package(s) with other executable but that is not needed IMHO at the moment. Other file to consider may be the sidecar so one can convert lilting logs. 

This PR is mostly meant to iterate on content and locations and package details. 

The packages are _not_ signed at the moment. My current thinking is that once published as artifacts/distribution we would have follow-up process to pick them up, sign and publish on packages.microsoft.com for general use.    

Once base script is in, I will continue to work on integration with CI