### PR TITLE
Switch uses of min and max to CXPLAT_MIN and CXPLAT_MAX

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -451,7 +451,7 @@ QuicCongestionControlOnDataAcknowledged(
         // so we simplify the calculation as:
         // W_est(t) ~= WindowMax*BETA + (t/(2*RTT)).
         //
-        // Using CXPLAT_MAX(RTT, 1) prevents division by zero.
+        // Using max(RTT, 1) prevents division by zero.
         //
 
         CXPLAT_STATIC_ASSERT(TEN_TIMES_BETA_CUBIC == 7, "TEN_TIMES_BETA_CUBIC must be 7 for simplified calculation.");

--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -261,7 +261,7 @@ QuicCongestionControlOnCongestionEvent(
 
     Cc->SlowStartThreshold =
     Cc->CongestionWindow =
-        max(
+        CXPLAT_MAX(
             (uint32_t)Connection->Paths[0].Mtu * QUIC_PERSISTENT_CONGESTION_WINDOW_PACKETS,
             Cc->CongestionWindow * TEN_TIMES_BETA_CUBIC / 10);
 }
@@ -451,20 +451,20 @@ QuicCongestionControlOnDataAcknowledged(
         // so we simplify the calculation as:
         // W_est(t) ~= WindowMax*BETA + (t/(2*RTT)).
         //
-        // Using max(RTT, 1) prevents division by zero.
+        // Using CXPLAT_MAX(RTT, 1) prevents division by zero.
         //
 
         CXPLAT_STATIC_ASSERT(TEN_TIMES_BETA_CUBIC == 7, "TEN_TIMES_BETA_CUBIC must be 7 for simplified calculation.");
 
         int64_t AimdWindow =
             Cc->WindowMax * TEN_TIMES_BETA_CUBIC / 10 +
-            TimeInCongAvoid * Connection->Paths[0].Mtu / (2 * max(1, US_TO_MS(SmoothedRtt)));
+            TimeInCongAvoid * Connection->Paths[0].Mtu / (2 * CXPLAT_MAX(1, US_TO_MS(SmoothedRtt)));
 
         //
         // Use the cubic or AIMD window, whichever is larger.
         //
         if (AimdWindow > CubicWindow) {
-            Cc->CongestionWindow = (uint32_t)max(AimdWindow, Cc->CongestionWindow + 1);
+            Cc->CongestionWindow = (uint32_t)CXPLAT_MAX(AimdWindow, Cc->CongestionWindow + 1);
         } else {
             //
             // Here we increment by a fraction of the difference, per the spec,
@@ -473,7 +473,7 @@ QuicCongestionControlOnDataAcknowledged(
             // the cubic window may be significantly different from SlowStartThreshold.
             //
             Cc->CongestionWindow +=
-                (uint32_t)max(
+                (uint32_t)CXPLAT_MAX(
                     ((CubicWindow - Cc->CongestionWindow) * Connection->Paths[0].Mtu) / Cc->CongestionWindow,
                     1);
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1511,7 +1511,7 @@ QuicConnTryClose(
             QuicConnTimerSet(
                 Connection,
                 QUIC_CONN_TIMER_SHUTDOWN,
-                max(15, US_TO_MS(Connection->Paths[0].SmoothedRtt * 2)));
+                CXPLAT_MAX(15, US_TO_MS(Connection->Paths[0].SmoothedRtt * 2)));
 
             QuicSendSetSendFlag(
                 &Connection->Send,
@@ -1574,7 +1574,7 @@ QuicConnTryClose(
             QuicConnTimerSet(
                 Connection,
                 QUIC_CONN_TIMER_SHUTDOWN,
-                max(15, US_TO_MS(Connection->Paths[0].SmoothedRtt * 2)));
+                CXPLAT_MAX(15, US_TO_MS(Connection->Paths[0].SmoothedRtt * 2)));
         }
 
         IsFirstCloseForConnection = FALSE;

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1442,7 +1442,7 @@ QuicConnGetMaxMtuForPath(
                 (uint16_t)Connection->PeerTransportParams.MaxUdpPayloadSize);
     }
     uint16_t SettingsMtu = Connection->Settings.MaximumMtu;
-    return min(min(LocalMtu, RemoteMtu), SettingsMtu);
+    return CXPLAT_MIN(CXPLAT_MIN(LocalMtu, RemoteMtu), SettingsMtu);
 }
 
 //

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -318,7 +318,7 @@ MsQuicLibraryInitialize(
     }
     MsQuicLib.ProcessorCount = (uint16_t)CxPlatProcActiveCount();
     CXPLAT_FRE_ASSERT(MsQuicLib.ProcessorCount > 0);
-    MsQuicLib.PartitionCount = (uint16_t)min(MsQuicLib.ProcessorCount, DefaultMaxPartitionCount);
+    MsQuicLib.PartitionCount = (uint16_t)CXPLAT_MIN(MsQuicLib.ProcessorCount, DefaultMaxPartitionCount);
 
     MsQuicCalculatePartitionMask();
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -924,7 +924,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
         //
         // Remove "suspect" packets inferred lost from out-of-order ACKs.
         // The spec has:
-        // kTimeThreshold * CXPLAT_MAX(SRTT, latest_RTT, kGranularity),
+        // kTimeThreshold * max(SRTT, latest_RTT, kGranularity),
         // where kGranularity is the system timer granularity.
         // This implementation excludes kGranularity from the calculation,
         // because it is not needed to keep timers from firing early.

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -312,7 +312,7 @@ QuicLossDetectionUpdateTimer(
         // If it expires, we'll consider the packet lost.
         //
         TimeoutType = LOSS_TIMER_RACK;
-        uint32_t RttUs = max(Path->SmoothedRtt, Path->LatestRttSample);
+        uint32_t RttUs = CXPLAT_MAX(Path->SmoothedRtt, Path->LatestRttSample);
         TimeFires = OldestPacket->SentTime + QUIC_TIME_REORDER_THRESHOLD(RttUs);
 
     } else if (!Path->GotFirstRttSample) {
@@ -784,7 +784,7 @@ QuicLossDetectionRetransmitFrames(
                 uint32_t TimeNow = CxPlatTimeUs32();
                 CXPLAT_DBG_ASSERT(Connection->Configuration != NULL);
                 uint32_t ValidationTimeout =
-                    max(QuicLossDetectionComputeProbeTimeout(LossDetection, Path, 3),
+                    CXPLAT_MAX(QuicLossDetectionComputeProbeTimeout(LossDetection, Path, 3),
                         6 * MS_TO_US(Connection->Settings.InitialRttMs));
                 if (CxPlatTimeDiff32(Path->PathValidationStartTime, TimeNow) > ValidationTimeout) {
                     QuicTraceLogConnInfo(
@@ -924,13 +924,13 @@ QuicLossDetectionDetectAndHandleLostPackets(
         //
         // Remove "suspect" packets inferred lost from out-of-order ACKs.
         // The spec has:
-        // kTimeThreshold * max(SRTT, latest_RTT, kGranularity),
+        // kTimeThreshold * CXPLAT_MAX(SRTT, latest_RTT, kGranularity),
         // where kGranularity is the system timer granularity.
         // This implementation excludes kGranularity from the calculation,
         // because it is not needed to keep timers from firing early.
         //
         const QUIC_PATH* Path = &Connection->Paths[0]; // TODO - Correct?
-        uint32_t Rtt = max(Path->SmoothedRtt, Path->LatestRttSample);
+        uint32_t Rtt = CXPLAT_MAX(Path->SmoothedRtt, Path->LatestRttSample);
         uint32_t TimeReorderThreshold = QUIC_TIME_REORDER_THRESHOLD(Rtt);
         uint64_t LargestLostPacketNumber = 0;
         QUIC_SENT_PACKET_METADATA* PrevPacket = NULL;
@@ -1400,7 +1400,7 @@ QuicLossDetectionProcessAckBlocks(
             Packet->PacketNumber,
             QuicPacketTraceType(Packet));
 
-        SmallestRtt = min(SmallestRtt, PacketRtt);
+        SmallestRtt = CXPLAT_MIN(SmallestRtt, PacketRtt);
 
         QuicLossDetectionOnPacketAcknowledged(LossDetection, EncryptLevel, Packet);
     }

--- a/src/core/mtu_discovery.c
+++ b/src/core/mtu_discovery.c
@@ -87,7 +87,7 @@ QuicGetNextProbeSize(
     // be less then a full increment.
     //
     if (Path->Mtu < 1280) {
-        return min(1280, MtuDiscovery->MaxMtu);
+        return CXPLAT_MIN(1280, MtuDiscovery->MaxMtu);
     }
 
     uint16_t Mtu = Path->Mtu + QUIC_DPLPMTUD_INCREMENT;

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -560,7 +560,7 @@ QuicPacketHash(
             CxPlatToeplitzHashCompute(
                 &MsQuicLib.ToeplitzHash,
                 RemoteCid,
-                min(RemoteCidLength, QUIC_MAX_CONNECTION_ID_LENGTH_V1),
+                CXPLAT_MIN(RemoteCidLength, QUIC_MAX_CONNECTION_ID_LENGTH_V1),
                 Offset);
     }
     return Key;

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -46,7 +46,7 @@ Abstract:
     streams, and its legacy APIs don't let it pass the problem further up the
     stack to the layer that really knows.
 
-    So then, we indicate min(SendBuffer.IdealBytes, Stream.SendWindow) as the
+    So then, we indicate CXPLAT_MIN(SendBuffer.IdealBytes, Stream.SendWindow) as the
     ISB to each stream. If the app steadily sends on multiple streams, this
     means more data will be buffered than needed. But usually we expect only
     one stream to be steadily sending, in which case this scheme will

--- a/src/core/send_buffer.c
+++ b/src/core/send_buffer.c
@@ -46,7 +46,7 @@ Abstract:
     streams, and its legacy APIs don't let it pass the problem further up the
     stack to the layer that really knows.
 
-    So then, we indicate CXPLAT_MIN(SendBuffer.IdealBytes, Stream.SendWindow) as the
+    So then, we indicate min(SendBuffer.IdealBytes, Stream.SendWindow) as the
     ISB to each stream. If the app steadily sends on multiple streams, this
     means more data will be buffered than needed. But usually we expect only
     one stream to be steadily sending, in which case this scheme will

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -296,7 +296,7 @@ QuicStreamStart(
     if (Stream->MaxAllowedSendOffset == 0) {
         Stream->OutFlowBlockedReasons |= QUIC_FLOW_BLOCKED_STREAM_FLOW_CONTROL;
     }
-    Stream->SendWindow = (uint32_t)min(Stream->MaxAllowedSendOffset, UINT32_MAX);
+    Stream->SendWindow = (uint32_t)CXPLAT_MIN(Stream->MaxAllowedSendOffset, UINT32_MAX);
 
     if (Stream->OutFlowBlockedReasons != 0) {
         QuicTraceEvent(

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -512,7 +512,7 @@ QuicStreamRecv(
             // MAX_STREAM_DATA.
             //
             Stream->SendWindow =
-                (uint32_t)min(Stream->MaxAllowedSendOffset - Stream->UnAckedOffset, UINT32_MAX);
+                (uint32_t)CXPLAT_MIN(Stream->MaxAllowedSendOffset - Stream->UnAckedOffset, UINT32_MAX);
 
             QuicSendBufferStreamAdjust(Stream);
 

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -326,7 +326,7 @@ QuicStreamSetInitializeTransportParameters(
             if (Stream->MaxAllowedSendOffset < NewMaxAllowedSendOffset) {
                 Stream->MaxAllowedSendOffset = NewMaxAllowedSendOffset;
                 FlowBlockedFlagsToRemove |= QUIC_FLOW_BLOCKED_STREAM_FLOW_CONTROL;
-                Stream->SendWindow = (uint32_t)min(Stream->MaxAllowedSendOffset, UINT32_MAX);
+                Stream->SendWindow = (uint32_t)CXPLAT_MIN(Stream->MaxAllowedSendOffset, UINT32_MAX);
             }
 
             if (FlowBlockedFlagsToRemove) {

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -289,7 +289,7 @@ IsValue(
     _In_z_ const char* toTestAgainst
     )
 {
-    return _strnicmp(name, toTestAgainst, min(strlen(name), strlen(toTestAgainst))) == 0;
+    return _strnicmp(name, toTestAgainst, CXPLAT_MIN(strlen(name), strlen(toTestAgainst))) == 0;
 }
 
 inline

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -28,6 +28,10 @@ Supported Environments:
 
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
 
+#define CXPLAT_MAX(a,b) (((a) > (b)) ? (a) : (b))
+
+#define CXPLAT_MIN(a,b) (((a) < (b)) ? (a) : (b))
+
 //
 // Time unit conversion.
 //

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -92,10 +92,6 @@ CxPlatUninitialize(
 
 #define SOCKET_ERROR (-1)
 
-#define max(a,b) (((a) > (b)) ? (a) : (b))
-
-#define min(a,b) (((a) < (b)) ? (a) : (b))
-
 #define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 
 #define UNREFERENCED_PARAMETER(P) (void)(P)

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -46,7 +46,7 @@ QuicHandleRpsClient(
     ExtraData += sizeof(CachedCompletedRequests);
     uint32_t RestOfBufferLength = Length - sizeof(RunTime) - sizeof(CachedCompletedRequests);
     RestOfBufferLength &= 0xFFFFFFFC; // Round down to nearest multiple of 4
-    uint32_t MaxCount = min(CachedCompletedRequests, RestOfBufferLength);
+    uint32_t MaxCount = CXPLAT_MIN(CachedCompletedRequests, RestOfBufferLength);
 
     uint32_t RPS = (uint32_t)((CachedCompletedRequests * 1000ull) / (uint64_t)RunTime);
     if (RPS == 0) {

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -175,7 +175,7 @@ PerfServer::StreamCallback(
             uint8_t* Dest = (uint8_t*)&Context->ResponseSize;
             uint64_t Offset = Event->RECEIVE.AbsoluteOffset;
             for (uint32_t i = 0; Offset < sizeof(uint64_t) && i < Event->RECEIVE.BufferCount; ++i) {
-                uint32_t Length = min((uint32_t)(sizeof(uint64_t) - Offset), Event->RECEIVE.Buffers[i].Length);
+                uint32_t Length = CXPLAT_MIN((uint32_t)(sizeof(uint64_t) - Offset), Event->RECEIVE.Buffers[i].Length);
                 memcpy(Dest + Offset, Event->RECEIVE.Buffers[i].Buffer, Length);
                 Offset += Length;
             }

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -398,7 +398,7 @@ protected:
                     BufferLength -= ConsumedBuffer;
                 } else {
                     ConsumedBuffer = FragmentSize * ++Count;
-                    ConsumedBuffer = min(ConsumedBuffer, BufferLength);
+                    ConsumedBuffer = CXPLAT_MIN(ConsumedBuffer, BufferLength);
                 }
 
             } while (BufferLength != 0 && !(Result & CXPLAT_TLS_RESULT_ERROR));

--- a/src/test/lib/TestStream.cpp
+++ b/src/test/lib/TestStream.cpp
@@ -124,7 +124,7 @@ TestStream::StartPing(
     BytesToSend = PayloadLength / MaxSendBuffers;
 
     do {
-        auto SendBufferLength = (uint32_t)min(BytesToSend, (int64_t)MaxSendLength);
+        auto SendBufferLength = (uint32_t)CXPLAT_MIN(BytesToSend, (int64_t)MaxSendLength);
         auto SendBuffer = new(std::nothrow) QuicSendBuffer(MaxSendBuffers, SendBufferLength);
         if (SendBuffer == nullptr) {
             TEST_FAILURE("Failed to alloc QuicSendBuffer");
@@ -277,7 +277,7 @@ TestStream::HandleStreamSendComplete(
             delete SendBuffer;
         } else {
             QUIC_SEND_FLAGS Flags = QUIC_SEND_FLAG_NONE;
-            auto SendBufferLength = (uint32_t)min(BytesToSend, (int64_t)MaxSendLength);
+            auto SendBufferLength = (uint32_t)CXPLAT_MIN(BytesToSend, (int64_t)MaxSendLength);
             for (uint32_t i = 0; i < SendBuffer->BufferCount; ++i) {
                 SendBuffer->Buffers[i].Length = SendBufferLength;
             }


### PR DESCRIPTION
The min and max macros in Windows.h are a huge pain point, however most windows libraries, including the stl, are able to handle this. However, we define these macros on posix, which most posix libraries, including the C++ standard libraries (which have min and max functions) completely breaks. Instead of defining these on posix, define a common CXPLAT_MIN and CXPLAT_MAX macro that works on all platforms, and doesn't interfere with use in posix applications and libraries.

Closes #1697 