### PR TITLE
Setting for Binding Stateless Operations

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -33,7 +33,7 @@ The following settings are available via registry as well as via [QUIC_SETTINGS]
 | Stream Receive Window              | uint32_t   | StreamRecvWindowDefault     |            32,768 | Initial stream receive window size.                                                                                           |
 | Stream Receive Buffer              | uint32_t   | StreamRecvBufferDefault     |             4,096 | Stream initial buffer size.                                                                                                   |
 | Flow Control Window                | uint32_t   | ConnFlowControlWindow       |        16,777,216 | Connection-wide flow control window.                                                                                          |
-| Max Stateless Operations           | uint32_t   | MaxStatelessOperations      |                16 | The maximum number of stateless operations that may be queued at any one time.                                                |
+| Max Stateless Operations           | uint32_t   | MaxStatelessOperations      |                16 | The maximum number of stateless operations that may be queued on a worker at any one time.                                                |
 | Initial Window                     | uint32_t   | InitialWindowPackets        |                10 | The size (in packets) of the initial congestion window for a connection.                                                      |
 | Send Idle Timeout                  | uint32_t   | SendIdleTimeoutMs           |             1,000 | Reset congestion control after being idle `SendIdleTimeoutMs` milliseconds.                                                   |
 | Initial RTT                        | uint32_t   | InitialRttMs                |               333 | Initial RTT estimate.                                                                                                         |
@@ -51,6 +51,12 @@ The following settings are available via registry as well as via [QUIC_SETTINGS]
 | Datagram Receive Support           | uint8_t    | DatagramReceiveEnabled      |         0 (FALSE) | Advertise support for QUIC datagram extension.                                                                                |
 | Server Resumption Level            | uint8_t    | ServerResumptionLevel       | 0 (No resumption) | Server only. Controls resumption tickets and/or 0-RTT server support.                                                         |
 | Version Negotiation Extension      | uint8_t    | VersionNegotiationExtEnabled|         0 (FALSE) | Controls QUIC Version Negotiation Extension support.                                                                          |
+| Minimum MTU   | uint16_t   | MinimumMtu  |            TODO | TODO |
+| Maximum MTU   | uint16_t   | MaximumMtu  |            TODO | TODO |
+| MTU Discovery Search Timeout   | uint64_t   | MtuDiscoverySearchCompleteTimeoutUs  |            TODO | TODO |
+| MTU Discovery Missing Probe Count   | uint8_t   | MtuDiscoveryMissingProbeCount  |            TODO | TODO |
+| Max Binding Stateless Operations   | uint16_t   | MaxBindingStatelessOperations  |            100 | The maximum number of stateless operations that may be queued on a binding at any one time.                                                |
+| Stateless Operation Expiration     | uint16_t   | StatelessOperationExpirationMs |            100 | The time limit between operations for the same endpoint, in milliseconds. |
 
 The types map to registry types as follows:
   - `uint64_t` is a `REG_QWORD`.

--- a/docs/api/QUIC_SETTINGS.md
+++ b/docs/api/QUIC_SETTINGS.md
@@ -11,35 +11,41 @@ typedef struct QUIC_SETTINGS {
     union {
         uint64_t IsSetFlags;
         struct {
-            uint64_t MaxBytesPerKey                 : 1;
-            uint64_t HandshakeIdleTimeoutMs         : 1;
-            uint64_t IdleTimeoutMs                  : 1;
-            uint64_t TlsClientMaxSendBuffer         : 1;
-            uint64_t TlsServerMaxSendBuffer         : 1;
-            uint64_t StreamRecvWindowDefault        : 1;
-            uint64_t StreamRecvBufferDefault        : 1;
-            uint64_t ConnFlowControlWindow          : 1;
-            uint64_t MaxWorkerQueueDelayUs          : 1;
-            uint64_t MaxStatelessOperations         : 1;
-            uint64_t InitialWindowPackets           : 1;
-            uint64_t SendIdleTimeoutMs              : 1;
-            uint64_t InitialRttMs                   : 1;
-            uint64_t MaxAckDelayMs                  : 1;
-            uint64_t DisconnectTimeoutMs            : 1;
-            uint64_t KeepAliveIntervalMs            : 1;
-            uint64_t PeerBidiStreamCount            : 1;
-            uint64_t PeerUnidiStreamCount           : 1;
-            uint64_t RetryMemoryLimit               : 1;
-            uint64_t LoadBalancingMode              : 1;
-            uint64_t MaxOperationsPerDrain          : 1;
-            uint64_t SendBufferingEnabled           : 1;
-            uint64_t PacingEnabled                  : 1;
-            uint64_t MigrationEnabled               : 1;
-            uint64_t DatagramReceiveEnabled         : 1;
-            uint64_t ServerResumptionLevel          : 1;
-            uint64_t DesiredVersionsList            : 1;
-            uint64_t VersionNegotiationExtEnabled   : 1;
-            uint64_t RESERVED                       : 36;
+            uint64_t MaxBytesPerKey                         : 1;
+            uint64_t HandshakeIdleTimeoutMs                 : 1;
+            uint64_t IdleTimeoutMs                          : 1;
+            uint64_t TlsClientMaxSendBuffer                 : 1;
+            uint64_t TlsServerMaxSendBuffer                 : 1;
+            uint64_t StreamRecvWindowDefault                : 1;
+            uint64_t StreamRecvBufferDefault                : 1;
+            uint64_t ConnFlowControlWindow                  : 1;
+            uint64_t MaxWorkerQueueDelayUs                  : 1;
+            uint64_t MaxStatelessOperations                 : 1;
+            uint64_t InitialWindowPackets                   : 1;
+            uint64_t SendIdleTimeoutMs                      : 1;
+            uint64_t InitialRttMs                           : 1;
+            uint64_t MaxAckDelayMs                          : 1;
+            uint64_t DisconnectTimeoutMs                    : 1;
+            uint64_t KeepAliveIntervalMs                    : 1;
+            uint64_t PeerBidiStreamCount                    : 1;
+            uint64_t PeerUnidiStreamCount                   : 1;
+            uint64_t RetryMemoryLimit                       : 1;
+            uint64_t LoadBalancingMode                      : 1;
+            uint64_t MaxOperationsPerDrain                  : 1;
+            uint64_t SendBufferingEnabled                   : 1;
+            uint64_t PacingEnabled                          : 1;
+            uint64_t MigrationEnabled                       : 1;
+            uint64_t DatagramReceiveEnabled                 : 1;
+            uint64_t ServerResumptionLevel                  : 1;
+            uint64_t DesiredVersionsList                    : 1;
+            uint64_t VersionNegotiationExtEnabled           : 1;
+            uint64_t MinimumMtu                             : 1;
+            uint64_t MaximumMtu                             : 1;
+            uint64_t MtuDiscoverySearchCompleteTimeoutUs    : 1;
+            uint64_t MtuDiscoveryMissingProbeCount          : 1;
+            uint64_t MaxBindingStatelessOperations          : 1;
+            uint64_t StatelessOperationExpirationMs         : 1;
+            uint64_t RESERVED                               : 30;
         } IsSet;
     };
 
@@ -61,18 +67,24 @@ typedef struct QUIC_SETTINGS {
     uint32_t KeepAliveIntervalMs;
     uint16_t PeerBidiStreamCount;
     uint16_t PeerUnidiStreamCount;
-    uint16_t RetryMemoryLimit;
-    uint16_t LoadBalancingMode;
+    uint16_t RetryMemoryLimit;                  // Global only
+    uint16_t LoadBalancingMode;                 // Global only
     uint8_t MaxOperationsPerDrain;
     uint8_t SendBufferingEnabled            : 1;
     uint8_t PacingEnabled                   : 1;
     uint8_t MigrationEnabled                : 1;
     uint8_t DatagramReceiveEnabled          : 1;
-    uint8_t ServerResumptionLevel           : 2;
+    uint8_t ServerResumptionLevel           : 2;    // QUIC_SERVER_RESUMPTION_LEVEL
     uint8_t VersionNegotiationExtEnabled    : 1;
     uint8_t RESERVED                        : 1;
     const uint32_t* DesiredVersionsList;
     uint32_t DesiredVersionsListLength;
+    uint16_t MinimumMtu;
+    uint16_t MaximumMtu;
+    uint64_t MtuDiscoverySearchCompleteTimeoutUs;
+    uint8_t MtuDiscoveryMissingProbeCount;
+    uint16_t MaxBindingStatelessOperations;
+    uint16_t StatelessOperationExpirationMs;
 
 } QUIC_SETTINGS;
 ```
@@ -139,7 +151,7 @@ The maximum queue delay (in microseconds) allowed for a worker thread. This affe
 
 `MaxStatelessOperations`
 
-The maximum number of stateless operations that may be queued at any one time.
+The maximum number of stateless operations that may be queued on a worker at any one time.
 
 **Default value:** 16
 
@@ -256,6 +268,42 @@ Only takes effect if Version Negotiation Extension is enabled. Must be set to `N
 Number of QUIC protocol versions in the DesiredVersionsList. Must be set to 0 unless `VersionNegotiationExtEnabled` is `TRUE`.
 
 **Default value:** 0
+
+`MinimumMtu`
+
+TODO
+
+**Default value:** TODO
+
+`MaximumMtu`
+
+TODO
+
+**Default value:** TODO
+
+`MtuDiscoverySearchCompleteTimeoutUs`
+
+TODO
+
+**Default value:** TODO
+
+`MtuDiscoveryMissingProbeCount`
+
+TODO
+
+**Default value:** TODO
+
+`MaxBindingStatelessOperations`
+
+The maximum number of stateless operations that may be queued on a binding at any one time.
+
+**Default value:** 100
+
+`StatelessOperationExpirationMs`
+
+The time limit between operations for the same endpoint, in milliseconds.
+
+**Default value:** 100
 
 # Remarks
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -647,7 +647,7 @@ QuicBindingCreateStatelessOperation(
                 ListEntry);
 
         if (CxPlatTimeDiff32(OldStatelessCtx->CreationTimeMs, TimeMs) <
-            QUIC_STATELESS_OPERATION_EXPIRATION_MS) {
+            (uint32_t)MsQuicLib.Settings.StatelessOperationExpirationMs) {
             break;
         }
 
@@ -672,7 +672,7 @@ QuicBindingCreateStatelessOperation(
         }
     }
 
-    if (Binding->StatelessOperCount >= QUIC_MAX_BINDING_STATELESS_OPERATIONS) {
+    if (Binding->StatelessOperCount >= (uint32_t)MsQuicLib.Settings.MaxBindingStatelessOperations) {
         QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
             "Max binding operations reached");
         goto Exit;

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -468,6 +468,8 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_SETTING_LOAD_BALANCING_MODE            "LoadBalancingMode"
 #define QUIC_SETTING_MAX_WORKER_QUEUE_DELAY         "MaxWorkerQueueDelayMs"
 #define QUIC_SETTING_MAX_STATELESS_OPERATIONS       "MaxStatelessOperations"
+#define QUIC_SETTING_MAX_BINDING_STATELESS_OPERATIONS "MaxBindingStatelessOperations"
+#define QUIC_SETTING_STATELESS_OPERATION_EXPIRATION "StatelessOperationExpirationMs"
 #define QUIC_SETTING_MAX_OPERATIONS_PER_DRAIN       "MaxOperationsPerDrain"
 
 #define QUIC_SETTING_SEND_BUFFERING_DEFAULT         "SendBufferingDefault"

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -1034,9 +1034,6 @@ QuicSettingsDumpNew(
         }
     }
     if (SETTING_HAS_FIELD(SettingsSize, MtuDiscoveryMissingProbeCount)) {
-        if (Settings->IsSet.VersionNegotiationExtEnabled) {
-            QuicTraceLogVerbose(SettingDumpVersionNegoExtEnabled,       "[sett] Version Negotiation Ext Enabled = %hhu", Settings->VersionNegotiationExtEnabled);
-        }
         if (Settings->IsSet.MinimumMtu) {
             QuicTraceLogVerbose(SettingDumpMinimumMtu,                  "[sett] MinimumMtu             = %hu", Settings->MinimumMtu);
         }

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -478,16 +478,18 @@ QuicSettingApply(
             Destination->IsSet.MtuDiscoveryMissingProbeCount = TRUE;
         }
     }
-    if (SETTING_HAS_FIELD(NewSettingsSize, MaxBindingStatelessOperations) &&
-        Source->IsSet.MaxBindingStatelessOperations && (!Destination->IsSet.MaxBindingStatelessOperations || OverWrite)) {
-        Destination->MaxBindingStatelessOperations = Source->MaxBindingStatelessOperations;
-        Destination->IsSet.MaxBindingStatelessOperations = TRUE;
+
+    if (SETTING_HAS_FIELD(NewSettingsSize, StatelessOperationExpirationMs)) {
+        if (Source->IsSet.MaxBindingStatelessOperations && (!Destination->IsSet.MaxBindingStatelessOperations || OverWrite)) {
+            Destination->MaxBindingStatelessOperations = Source->MaxBindingStatelessOperations;
+            Destination->IsSet.MaxBindingStatelessOperations = TRUE;
+        }
+        if (Source->IsSet.StatelessOperationExpirationMs && (!Destination->IsSet.StatelessOperationExpirationMs || OverWrite)) {
+            Destination->StatelessOperationExpirationMs = Source->StatelessOperationExpirationMs;
+            Destination->IsSet.StatelessOperationExpirationMs = TRUE;
+        }
     }
-    if (SETTING_HAS_FIELD(NewSettingsSize, StatelessOperationExpirationMs) &&
-        Source->IsSet.StatelessOperationExpirationMs && (!Destination->IsSet.StatelessOperationExpirationMs || OverWrite)) {
-        Destination->StatelessOperationExpirationMs = Source->StatelessOperationExpirationMs;
-        Destination->IsSet.StatelessOperationExpirationMs = TRUE;
-    }
+
     return TRUE;
 }
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -499,7 +499,9 @@ typedef struct QUIC_SETTINGS {
             uint64_t MaximumMtu                             : 1;
             uint64_t MtuDiscoverySearchCompleteTimeoutUs    : 1;
             uint64_t MtuDiscoveryMissingProbeCount          : 1;
-            uint64_t RESERVED                               : 32;
+            uint64_t MaxBindingStatelessOperations          : 1;
+            uint64_t StatelessOperationExpirationMs         : 1;
+            uint64_t RESERVED                               : 30;
         } IsSet;
     };
 
@@ -521,8 +523,8 @@ typedef struct QUIC_SETTINGS {
     uint32_t KeepAliveIntervalMs;
     uint16_t PeerBidiStreamCount;
     uint16_t PeerUnidiStreamCount;
-    uint16_t RetryMemoryLimit;              // Global only
-    uint16_t LoadBalancingMode;             // Global only
+    uint16_t RetryMemoryLimit;                  // Global only
+    uint16_t LoadBalancingMode;                 // Global only
     uint8_t MaxOperationsPerDrain;
     uint8_t SendBufferingEnabled            : 1;
     uint8_t PacingEnabled                   : 1;
@@ -537,7 +539,8 @@ typedef struct QUIC_SETTINGS {
     uint16_t MaximumMtu;
     uint64_t MtuDiscoverySearchCompleteTimeoutUs;
     uint8_t MtuDiscoveryMissingProbeCount;
-
+    uint16_t MaxBindingStatelessOperations;
+    uint16_t StatelessOperationExpirationMs;
 
 } QUIC_SETTINGS;
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -523,8 +523,8 @@ typedef struct QUIC_SETTINGS {
     uint32_t KeepAliveIntervalMs;
     uint16_t PeerBidiStreamCount;
     uint16_t PeerUnidiStreamCount;
-    uint16_t RetryMemoryLimit;                  // Global only
-    uint16_t LoadBalancingMode;                 // Global only
+    uint16_t RetryMemoryLimit;              // Global only
+    uint16_t LoadBalancingMode;             // Global only
     uint8_t MaxOperationsPerDrain;
     uint8_t SendBufferingEnabled            : 1;
     uint8_t PacingEnabled                   : 1;

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -6536,54 +6536,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "SettingMinimumMtu": {
-      "ModuleProperites": {},
-      "TraceString": "[sett] Minimum Mtu            = %hu",
-      "UniqueId": "SettingMinimumMtu",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "SettingMaximumMtu": {
-      "ModuleProperites": {},
-      "TraceString": "[sett] Maximum Mtu            = %hu",
-      "UniqueId": "SettingMaximumMtu",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "SettingMtuCompleteTimeout": {
-      "ModuleProperites": {},
-      "TraceString": "[sett] Mtu complete timeout   = %llu",
-      "UniqueId": "SettingMtuCompleteTimeout",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "SettingMtuMissingProbeCount": {
-      "ModuleProperites": {},
-      "TraceString": "[sett] Mtu probe count        = %hhu",
-      "UniqueId": "SettingMtuMissingProbeCount",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "SettingDumpDesiredVersionsListLength": {
       "ModuleProperites": {},
       "TraceString": "[sett] Desired Version length = %u",
@@ -6622,7 +6574,7 @@
     },
     "SettingDumpMinimumMtu": {
       "ModuleProperites": {},
-      "TraceString": "[sett] Minimum Mtu             = %hu",
+      "TraceString": "[sett] MinimumMtu             = %hu",
       "UniqueId": "SettingDumpMinimumMtu",
       "splitArgs": [
         {
@@ -6634,7 +6586,7 @@
     },
     "SettingDumpMaximumMtu": {
       "ModuleProperites": {},
-      "TraceString": "[sett] Maximum Mtu             = %hu",
+      "TraceString": "[sett] MaximumMtu             = %hu",
       "UniqueId": "SettingDumpMaximumMtu",
       "splitArgs": [
         {
@@ -6646,7 +6598,7 @@
     },
     "SettingDumpMtuCompleteTimeout": {
       "ModuleProperites": {},
-      "TraceString": "[sett] Mtu complete timeout   = %llu",
+      "TraceString": "[sett] MtuCompleteTimeout     = %llu",
       "UniqueId": "SettingDumpMtuCompleteTimeout",
       "splitArgs": [
         {
@@ -6658,11 +6610,35 @@
     },
     "SettingDumpMtuMissingProbeCount": {
       "ModuleProperites": {},
-      "TraceString": "[sett] Mtu probe count        = %hhu",
+      "TraceString": "[sett] MtuMissingProbeCount   = %hhu",
       "UniqueId": "SettingDumpMtuMissingProbeCount",
       "splitArgs": [
         {
           "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "SettingDumpMaxBindingStatelessOper": {
+      "ModuleProperites": {},
+      "TraceString": "[sett] MaxBindingStatelessOper= %hu",
+      "UniqueId": "SettingDumpMaxBindingStatelessOper",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "SettingDumpStatelessOperExpirMs": {
+      "ModuleProperites": {},
+      "TraceString": "[sett] StatelessOperExpirMs   = %hu",
+      "UniqueId": "SettingDumpStatelessOperExpirMs",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "hu",
           "MacroVariableName": "arg2"
         }
       ],
@@ -12412,22 +12388,6 @@
         "TraceID": "SettingDumpServerResumptionLevel"
       },
       {
-        "UniquenessHash": "5cfc25ac-dfa1-9a54-17d2-4ce6571269ed",
-        "TraceID": "SettingMinimumMtu"
-      },
-      {
-        "UniquenessHash": "ea3d9556-cb67-75dc-54ab-d483b4155090",
-        "TraceID": "SettingMaximumMtu"
-      },
-      {
-        "UniquenessHash": "723ecd2b-bc97-f800-09aa-8b0afbabf1b2",
-        "TraceID": "SettingMtuCompleteTimeout"
-      },
-      {
-        "UniquenessHash": "2c824e32-faa5-c3ff-c353-69de8545a634",
-        "TraceID": "SettingMtuMissingProbeCount"
-      },
-      {
         "UniquenessHash": "0080f5a7-d4e1-7c9d-e023-eb4dd540fffe",
         "TraceID": "SettingDumpDesiredVersionsListLength"
       },
@@ -12440,20 +12400,28 @@
         "TraceID": "SettingDumpVersionNegoExtEnabled"
       },
       {
-        "UniquenessHash": "06df85ad-1521-606b-f16e-2846609c486b",
+        "UniquenessHash": "380762fe-b4e0-231a-3107-17a5e545c780",
         "TraceID": "SettingDumpMinimumMtu"
       },
       {
-        "UniquenessHash": "3458b9f9-5880-bdc3-9828-0541357312c2",
+        "UniquenessHash": "1398ba42-f72d-dac1-4c89-f9ae626a5c7b",
         "TraceID": "SettingDumpMaximumMtu"
       },
       {
-        "UniquenessHash": "22454166-54ff-d066-4929-cdf21f7f1101",
+        "UniquenessHash": "fe0a786d-3839-19aa-8cd3-e2e1b75eb49e",
         "TraceID": "SettingDumpMtuCompleteTimeout"
       },
       {
-        "UniquenessHash": "8c10c4ab-2e33-aaf2-7cc3-d7f4e734d321",
+        "UniquenessHash": "07e96091-df10-e8a0-aae5-ed943ffea694",
         "TraceID": "SettingDumpMtuMissingProbeCount"
+      },
+      {
+        "UniquenessHash": "64337501-b792-a81e-678a-aebffa63483e",
+        "TraceID": "SettingDumpMaxBindingStatelessOper"
+      },
+      {
+        "UniquenessHash": "940f7585-40ed-60f4-0e01-fa5ef6bea02f",
+        "TraceID": "SettingDumpStatelessOperExpirMs"
       },
       {
         "UniquenessHash": "a3237095-0958-5564-417c-5a60b9db4ec1",


### PR DESCRIPTION
Adds a settings knob that can be used to tune the timeout and max count for stateless operations on Bindings.