### PR TITLE
Fix QUIC_SETTINGS Size Validation Logic

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -53,7 +53,7 @@ MsQuicConfigurationOpen(
     }
 
     if (Settings != NULL &&
-        SettingsSize < (uint32_t)FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey)) {
+        SettingsSize < (uint32_t)FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList)) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }
@@ -168,7 +168,7 @@ MsQuicConfigurationOpen(
     }
 
     if (Settings != NULL && Settings->IsSetFlags != 0) {
-        CXPLAT_DBG_ASSERT(SettingsSize >= (uint32_t)FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey));
+        CXPLAT_DBG_ASSERT(SettingsSize >= (uint32_t)FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList));
         if (!QuicSettingApply(
                 &Configuration->Settings,
                 TRUE,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -49,7 +49,7 @@ QuicConnApplyNewSettings(
     _In_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN OverWrite,
     _In_ BOOLEAN CopyExternalToInternal,
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t NewSettingsSize,
     _In_reads_bytes_(NewSettingsSize)
         const QUIC_SETTINGS* NewSettings
@@ -6427,7 +6427,7 @@ QuicConnApplyNewSettings(
     _In_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN OverWrite,
     _In_ BOOLEAN CopyExternalToInternal,
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t NewSettingsSize,
     _In_reads_bytes_(NewSettingsSize)
         const QUIC_SETTINGS* NewSettings

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -217,6 +217,9 @@ QuicSettingsCopy(
     }
 }
 
+#define SETTING_HAS_FIELD(Size, Field) \
+    (Size >= (FIELD_OFFSET(QUIC_SETTINGS, Field) + sizeof(((QUIC_SETTINGS*)0)->Field)))
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicSettingApply(
@@ -224,15 +227,12 @@ QuicSettingApply(
     _In_ BOOLEAN OverWrite,
     _In_ BOOLEAN CopyExternalToInternal,
     _In_ BOOLEAN AllowMtuChanges,
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t NewSettingsSize,
     _In_reads_bytes_(NewSettingsSize)
         const QUIC_SETTINGS* Source
     )
 {
-    // TODO - Input validation
-    UNREFERENCED_PARAMETER(NewSettingsSize); // TODO - Use to validate new settings
-
     if (Source->IsSet.SendBufferingEnabled && (!Destination->IsSet.SendBufferingEnabled || OverWrite)) {
         Destination->SendBufferingEnabled = Source->SendBufferingEnabled;
         Destination->IsSet.SendBufferingEnabled = TRUE;
@@ -365,7 +365,13 @@ QuicSettingApply(
         Destination->VersionNegotiationExtEnabled = Source->VersionNegotiationExtEnabled;
         Destination->IsSet.VersionNegotiationExtEnabled = TRUE;
     }
-    if (Source->IsSet.DesiredVersionsList) {
+
+    //
+    // All new settings MUST explicitly validate they are within NewSettingsSize.
+    //
+
+    if (SETTING_HAS_FIELD(NewSettingsSize, DesiredVersionsListLength) &&
+        Source->IsSet.DesiredVersionsList) {
         if (Destination->IsSet.DesiredVersionsList &&
             (OverWrite || Source->DesiredVersionsListLength == 0)) {
             CXPLAT_FREE(Destination->DesiredVersionsList, QUIC_POOL_DESIRED_VER_LIST);
@@ -417,46 +423,48 @@ QuicSettingApply(
         }
     }
 
-    if (AllowMtuChanges) {
-        uint16_t MinimumMtu = Destination->MinimumMtu;
-        uint16_t MaximumMtu = Destination->MaximumMtu;
-        if (Source->IsSet.MinimumMtu && (!Destination->IsSet.MinimumMtu || OverWrite)) {
-            MinimumMtu = Source->MinimumMtu;
-            if (MinimumMtu < QUIC_DPLPMUTD_MIN_MTU) {
-                MinimumMtu = QUIC_DPLPMUTD_MIN_MTU;
-            } else if (MinimumMtu > CXPLAT_MAX_MTU) {
-                MinimumMtu = CXPLAT_MAX_MTU;
+    if (SETTING_HAS_FIELD(NewSettingsSize, MtuDiscoveryMissingProbeCount)) {
+        if (AllowMtuChanges) {
+            uint16_t MinimumMtu = Destination->MinimumMtu;
+            uint16_t MaximumMtu = Destination->MaximumMtu;
+            if (Source->IsSet.MinimumMtu && (!Destination->IsSet.MinimumMtu || OverWrite)) {
+                MinimumMtu = Source->MinimumMtu;
+                if (MinimumMtu < QUIC_DPLPMUTD_MIN_MTU) {
+                    MinimumMtu = QUIC_DPLPMUTD_MIN_MTU;
+                } else if (MinimumMtu > CXPLAT_MAX_MTU) {
+                    MinimumMtu = CXPLAT_MAX_MTU;
+                }
             }
-        }
-        if (Source->IsSet.MaximumMtu && (!Destination->IsSet.MaximumMtu || OverWrite)) {
-            MaximumMtu = Source->MaximumMtu;
-            if (MaximumMtu < QUIC_DPLPMUTD_MIN_MTU) {
-                MaximumMtu = QUIC_DPLPMUTD_MIN_MTU;
-            } else if (MaximumMtu > CXPLAT_MAX_MTU) {
-                MaximumMtu = CXPLAT_MAX_MTU;
+            if (Source->IsSet.MaximumMtu && (!Destination->IsSet.MaximumMtu || OverWrite)) {
+                MaximumMtu = Source->MaximumMtu;
+                if (MaximumMtu < QUIC_DPLPMUTD_MIN_MTU) {
+                    MaximumMtu = QUIC_DPLPMUTD_MIN_MTU;
+                } else if (MaximumMtu > CXPLAT_MAX_MTU) {
+                    MaximumMtu = CXPLAT_MAX_MTU;
+                }
             }
-        }
-        if (MinimumMtu > MaximumMtu) {
+            if (MinimumMtu > MaximumMtu) {
+                return FALSE;
+            }
+            if (Destination->MinimumMtu != MinimumMtu) {
+                Destination->IsSet.MinimumMtu = TRUE;
+            }
+            if (Destination->MaximumMtu != MaximumMtu) {
+                Destination->IsSet.MaximumMtu = TRUE;
+            }
+            Destination->MinimumMtu = MinimumMtu;
+            Destination->MaximumMtu = MaximumMtu;
+        } else if (Source->IsSet.MinimumMtu || Source->IsSet.MaximumMtu) {
             return FALSE;
         }
-        if (Destination->MinimumMtu != MinimumMtu) {
-            Destination->IsSet.MinimumMtu = TRUE;
+        if (Source->IsSet.MtuDiscoverySearchCompleteTimeoutUs && (!Destination->IsSet.MtuDiscoverySearchCompleteTimeoutUs || OverWrite)) {
+            Destination->MtuDiscoverySearchCompleteTimeoutUs = Source->MtuDiscoverySearchCompleteTimeoutUs;
+            Destination->IsSet.MtuDiscoverySearchCompleteTimeoutUs = TRUE;
         }
-        if (Destination->MaximumMtu != MaximumMtu) {
-            Destination->IsSet.MaximumMtu = TRUE;
+        if (Source->IsSet.MtuDiscoveryMissingProbeCount && (!Destination->IsSet.MtuDiscoveryMissingProbeCount || OverWrite)) {
+            Destination->MtuDiscoveryMissingProbeCount = Source->MtuDiscoveryMissingProbeCount;
+            Destination->IsSet.MtuDiscoveryMissingProbeCount = TRUE;
         }
-        Destination->MinimumMtu = MinimumMtu;
-        Destination->MaximumMtu = MaximumMtu;
-    } else if (Source->IsSet.MinimumMtu || Source->IsSet.MaximumMtu) {
-        return FALSE;
-    }
-    if (Source->IsSet.MtuDiscoverySearchCompleteTimeoutUs && (!Destination->IsSet.MtuDiscoverySearchCompleteTimeoutUs || OverWrite)) {
-        Destination->MtuDiscoverySearchCompleteTimeoutUs = Source->MtuDiscoverySearchCompleteTimeoutUs;
-        Destination->IsSet.MtuDiscoverySearchCompleteTimeoutUs = TRUE;
-    }
-    if (Source->IsSet.MtuDiscoveryMissingProbeCount && (!Destination->IsSet.MtuDiscoveryMissingProbeCount || OverWrite)) {
-        Destination->MtuDiscoveryMissingProbeCount = Source->MtuDiscoveryMissingProbeCount;
-        Destination->IsSet.MtuDiscoveryMissingProbeCount = TRUE;
     }
     return TRUE;
 }
@@ -870,7 +878,7 @@ QuicSettingsDump(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicSettingsDumpNew(
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t SettingsSize,
     _In_reads_bytes_(SettingsSize)
         const QUIC_SETTINGS* Settings
@@ -956,25 +964,34 @@ QuicSettingsDumpNew(
     if (Settings->IsSet.ServerResumptionLevel) {
         QuicTraceLogVerbose(SettingDumpServerResumptionLevel,       "[sett] ServerResumptionLevel  = %hhu", Settings->ServerResumptionLevel);
     }
-    if (Settings->IsSet.DesiredVersionsList) {
-        QuicTraceLogVerbose(SettingDumpDesiredVersionsListLength,   "[sett] Desired Version length = %u", Settings->DesiredVersionsListLength);
-        if (Settings->DesiredVersionsListLength > 0) {
-            QuicTraceLogVerbose(SettingDumpDesiredVersionsList,     "[sett] Desired Version[0]     = 0x%x", Settings->DesiredVersionsList[0]);
+
+    //
+    // All new settings MUST explicitly validate they are within SettingsSize.
+    //
+
+    if (SETTING_HAS_FIELD(SettingsSize, DesiredVersionsListLength)) {
+        if (Settings->IsSet.DesiredVersionsList) {
+            QuicTraceLogVerbose(SettingDumpDesiredVersionsListLength,   "[sett] Desired Version length = %u", Settings->DesiredVersionsListLength);
+            if (Settings->DesiredVersionsListLength > 0) {
+                QuicTraceLogVerbose(SettingDumpDesiredVersionsList,     "[sett] Desired Version[0]     = 0x%x", Settings->DesiredVersionsList[0]);
+            }
+        }
+        if (Settings->IsSet.VersionNegotiationExtEnabled) {
+            QuicTraceLogVerbose(SettingDumpVersionNegoExtEnabled,       "[sett] Version Negotiation Ext Enabled = %hhu", Settings->VersionNegotiationExtEnabled);
         }
     }
-    if (Settings->IsSet.VersionNegotiationExtEnabled) {
-        QuicTraceLogVerbose(SettingDumpVersionNegoExtEnabled,       "[sett] Version Negotiation Ext Enabled = %hhu", Settings->VersionNegotiationExtEnabled);
-    }
-    if (Settings->IsSet.MinimumMtu) {
-        QuicTraceLogVerbose(SettingDumpMinimumMtu,                  "[sett] Minimum Mtu             = %hu", Settings->MinimumMtu);
-    }
-    if (Settings->IsSet.MaximumMtu) {
-        QuicTraceLogVerbose(SettingDumpMaximumMtu,                  "[sett] Maximum Mtu             = %hu", Settings->MaximumMtu);
-    }
-    if (Settings->IsSet.MtuDiscoverySearchCompleteTimeoutUs) {
-        QuicTraceLogVerbose(SettingDumpMtuCompleteTimeout,          "[sett] Mtu complete timeout   = %llu", Settings->MtuDiscoverySearchCompleteTimeoutUs);
-    }
-    if (Settings->IsSet.MtuDiscoveryMissingProbeCount) {
-        QuicTraceLogVerbose(SettingDumpMtuMissingProbeCount,        "[sett] Mtu probe count        = %hhu", Settings->MtuDiscoveryMissingProbeCount);
+    if (SETTING_HAS_FIELD(SettingsSize, MtuDiscoveryMissingProbeCount)) {
+        if (Settings->IsSet.MinimumMtu) {
+            QuicTraceLogVerbose(SettingDumpMinimumMtu,                  "[sett] Minimum Mtu             = %hu", Settings->MinimumMtu);
+        }
+        if (Settings->IsSet.MaximumMtu) {
+            QuicTraceLogVerbose(SettingDumpMaximumMtu,                  "[sett] Maximum Mtu             = %hu", Settings->MaximumMtu);
+        }
+        if (Settings->IsSet.MtuDiscoverySearchCompleteTimeoutUs) {
+            QuicTraceLogVerbose(SettingDumpMtuCompleteTimeout,          "[sett] Mtu complete timeout   = %llu", Settings->MtuDiscoverySearchCompleteTimeoutUs);
+        }
+        if (Settings->IsSet.MtuDiscoveryMissingProbeCount) {
+            QuicTraceLogVerbose(SettingDumpMtuMissingProbeCount,        "[sett] Mtu probe count        = %hhu", Settings->MtuDiscoveryMissingProbeCount);
+        }
     }
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -35,7 +35,7 @@ QuicSettingApply(
     _In_ BOOLEAN OverWrite,
     _In_ BOOLEAN CopyExternalToInternal,
     _In_ BOOLEAN AllowMtuChanges,
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t NewSettingsSize,
     _In_reads_bytes_(NewSettingsSize)
         const QUIC_SETTINGS* Source
@@ -72,7 +72,7 @@ QuicSettingsDump(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicSettingsDumpNew(
-    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, MaxBytesPerKey), UINT32_MAX)
+    _In_range_(FIELD_OFFSET(QUIC_SETTINGS, DesiredVersionsList), UINT32_MAX)
         uint32_t SettingsSize,
     _In_reads_bytes_(SettingsSize)
         const QUIC_SETTINGS* Settings


### PR DESCRIPTION
While writing up #1723, I noticed the logic (and SAL) was wrong/missing for validating input size for new fields in QUIC_SETTING ([since v1.0](https://github.com/microsoft/msquic/blob/v1.0.0-129524/src/inc/msquic.h#L368)). This updates the annotations and logic (borrowing some code from #1723).

This is only a problem if the app code is compiled for an older version of MsQuic, but uses a newer MsQuic binary.