### PR TITLE
Always force inline the shim MsQuicOpen function

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1307,7 +1307,7 @@ MsQuicOpen(
 
 #else
 
-#define MsQuicOpen(QuicApi) MsQuicOpenVersion((const void**)QuicApi, 1)
+#define MsQuicOpen(QuicApi) MsQuicOpenVersion(1, (const void**)QuicApi)
 
 #endif // defined(__cplusplus) || defined(WIN32)
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1293,9 +1293,7 @@ MsQuicOpenVersion(
 #if defined(__cplusplus) || defined(WIN32)
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-#ifdef WIN32
-__forceinline
-#else
+#ifndef WIN32
 __attribute__((always_inline))
 #endif
 inline

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1293,6 +1293,11 @@ MsQuicOpenVersion(
 #if defined(__cplusplus) || defined(WIN32)
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+#ifdef WIN32
+__forceinline
+#else
+__attribute__((always_inline))
+#endif
 inline
 QUIC_STATUS
 MsQuicOpen(


### PR DESCRIPTION
On linux, if optimization is completely turned off (can't happen with our normal build, but can with modifications that make testing easier), the linker might choose the inline definition of MsQuicOpen, which will then cause an infinite loop upon open. The solution to this is to force inline the inline function, which causes the out of line definition to never be generated.