### PR TITLE
Free DefaultCompatibilityList on initialization failure

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -543,6 +543,7 @@ MsQuicLibraryUninitialize(
     QuicSettingsCleanup(&MsQuicLib.Settings);
 
     CXPLAT_FREE(MsQuicLib.DefaultCompatibilityList, QUIC_POOL_DEFAULT_COMPAT_VER_LIST);
+    MsQuicLib.DefaultCompatibilityList = NULL;
 
     QuicTraceEvent(
         LibraryUninitialized,

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -433,6 +433,10 @@ Error:
             CxPlatStorageClose(MsQuicLib.Storage);
             MsQuicLib.Storage = NULL;
         }
+        if (MsQuicLib.DefaultCompatibilityList != NULL) {
+            CXPLAT_FREE(MsQuicLib.DefaultCompatibilityList, QUIC_POOL_DEFAULT_COMPAT_VER_LIST);
+            MsQuicLib.DefaultCompatibilityList = NULL;
+        }
         if (PlatformInitialized) {
             CxPlatUninitialize();
         }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -896,6 +896,10 @@ main(int argc, char **argv)
             // This may fail on subsequent iterations, but not on the first.
             //
             CXPLAT_DBG_ASSERT(i > 0);
+            for (size_t j = 0; j < BufferCount; ++j) {
+                free(Buffers[j].Buffer);
+                Buffers[j].Buffer = nullptr;
+            }
             continue;
         }
 


### PR DESCRIPTION
If the library fails to initialized after the list allocation, the list will leak.