### PR TITLE
Ignore Retry packets when connection is shutting down.

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3994,6 +3994,11 @@ QuicConnRecvFrames(
     uint16_t PayloadLength = Packet->PayloadLength;
     uint64_t RecvTime = CxPlatTimeUs64();
 
+    if (!QuicConnIsServer(Connection) &&
+        !Connection->State.GotFirstServerResponse) {
+        Connection->State.GotFirstServerResponse = TRUE;
+    }
+
     uint16_t Offset = 0;
     while (Offset < PayloadLength) {
 
@@ -4814,11 +4819,6 @@ QuicConnRecvFrames(
     }
 
 Done:
-
-    if (!QuicConnIsServer(Connection) &&
-        !Connection->State.GotFirstServerResponse) {
-        Connection->State.GotFirstServerResponse = TRUE;
-    }
 
     if (UpdatedFlowControl) {
         QuicConnLogOutFlowStats(Connection);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3157,7 +3157,7 @@ QuicConnRecvRetry(
     // Make sure the connection is still active
     //
     if (Connection->State.ClosedLocally || Connection->State.ClosedRemotely) {
-        QuicPacketLogDrop(Connection, Packet, "Connection is shutting down");
+        QuicPacketLogDrop(Connection, Packet, "Retry while shutting down");
         return;
     }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3154,6 +3154,14 @@ QuicConnRecvRetry(
     }
 
     //
+    // Make sure the connection is still active
+    //
+    if (Connection->State.ClosedLocally || Connection->State.ClosedRemotely) {
+        QuicPacketLogDrop(Connection, Packet, "Connection is shutting down");
+        return;
+    }
+
+    //
     // Decode and validate the Retry packet.
     //
 


### PR DESCRIPTION
If a connection hasn't completed a handshake and is shutting down, but receives a retry packet after processing some data from the server, the connection hits an assert in QuicCryptoReset. The connection has already processed some of the server's flight, so it's too late for the server to send a retry packet. The connection is already shutting down, so there's no reason to retry.
This change skips the retry logic in this case.
Fixes #1767 