### PR TITLE
Fix compilation on newer windows SDKs (1.1) (#1772)

### DIFF
--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -544,7 +544,6 @@ typedef HANDLE CXPLAT_EVENT;
 // resolution.
 //
 __kernel_entry
-NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtQueryTimerResolution(
@@ -743,17 +742,18 @@ CxPlatProcCurrentNumber(
 //
 // This is the undocumented interface for setting a thread's name. This is
 // essentially what SetThreadDescription does, but that is not available in
-// older versions of Windows.
+// older versions of Windows. These API's are suffixed _PRIVATE in order
+// to not colide with the built in windows definitions, which are not gated
+// behind any preprocessor macros
 //
 #if !defined(QUIC_UWP_BUILD)
-#define ThreadNameInformation ((THREADINFOCLASS)38)
+#define ThreadNameInformationPrivate ((THREADINFOCLASS)38)
 
-typedef struct _THREAD_NAME_INFORMATION {
+typedef struct _THREAD_NAME_INFORMATION_PRIVATE {
     UNICODE_STRING ThreadName;
-} THREAD_NAME_INFORMATION, *PTHREAD_NAME_INFORMATION;
+} THREAD_NAME_INFORMATION_PRIVATE, *PTHREAD_NAME_INFORMATION_PRIVATE;
 
 __kernel_entry
-NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtSetInformationThread(
@@ -874,11 +874,11 @@ CxPlatThreadCreate(
 #if defined(QUIC_UWP_BUILD)
         SetThreadDescription(*Thread, WideName);
 #else
-        THREAD_NAME_INFORMATION ThreadNameInfo;
+        THREAD_NAME_INFORMATION_PRIVATE ThreadNameInfo;
         RtlInitUnicodeString(&ThreadNameInfo.ThreadName, WideName);
         NtSetInformationThread(
             *Thread,
-            ThreadNameInformation,
+            ThreadNameInformationPrivate,
             &ThreadNameInfo,
             sizeof(ThreadNameInfo));
 #endif

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -935,12 +935,12 @@ CxPlatDataPathInitialize(
 #ifdef QUIC_UWP_BUILD
         SetThreadDescription(Datapath->Processors[i].CompletionThread, L"cxplat_datapath");
 #else
-        THREAD_NAME_INFORMATION ThreadNameInfo;
+        THREAD_NAME_INFORMATION_PRIVATE ThreadNameInfo;
         RtlInitUnicodeString(&ThreadNameInfo.ThreadName, L"cxplat_datapath");
         NTSTATUS NtStatus =
             NtSetInformationThread(
                 Datapath->Processors[i].CompletionThread,
-                ThreadNameInformation,
+                ThreadNameInformationPrivate,
                 &ThreadNameInfo,
                 sizeof(ThreadNameInfo));
         if (!NT_SUCCESS(NtStatus)) {


### PR DESCRIPTION
* Fix compilation on newer windows SDKs

Newer SDKs define some of the APIs we use to set thread information that we used to define locally. However, these APIs are not gated behind any version macros in the SDK headers, so we can't just conditionally check for the existance of them in the preprocessor. The solution is to rename the local versions of the struct and enum definition to not colide. Additionally, NtSetInformationThread needed its signature slightly changed to be compatible with the SDK

Cherry picked from #1772 