### PR TITLE
Stream Priority Support

### DIFF
--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -1,17 +1,9 @@
 <#
 
 .SYNOPSIS
-This updates/regenerates the CLOG sidecar file.
-
-.PARAMETER Clean
-    Deletes the old sidecar file first.
+This regenerates the CLOG sidecar file.
 
 #>
-
-param (
-    [Parameter(Mandatory = $false)]
-    [switch]$Clean = $false
-)
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
@@ -35,9 +27,7 @@ $ConfigFile = Join-Path $SrcDir "manifest" "msquic.clog_config"
 $OutputDir = Join-Path $RootDir "build" "tmp"
 New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
-if ($Clean) {
-    Remove-Item $Sidecar -Force -ErrorAction Ignore | Out-Null
-}
+Remove-Item $Sidecar -Force -ErrorAction Ignore | Out-Null
 
 foreach ($File in $Files) {
     clog -p windows --scopePrefix "QUIC" -s $Sidecar -c $ConfigFile -i $File --outputDirectory "$OutputDir"

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1614,7 +1614,6 @@ QuicCryptoCustomCertValidationComplete(
     _In_ BOOLEAN Result
     )
 {
-    CXPLAT_TEL_ASSERT(Crypto->CertValidationPending);
     if (!Crypto->CertValidationPending) {
         return;
     }

--- a/src/core/send.h
+++ b/src/core/send.h
@@ -313,6 +313,16 @@ QuicSendQueueFlushForStream(
     );
 
 //
+// Updates the stream's order in response to a priority change.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicSendUpdateStreamPriority(
+    _In_ QUIC_SEND* Send,
+    _In_ QUIC_STREAM* Stream
+    );
+
+//
 // Tries to drain all queued data that needs to be sent. Returns TRUE if all the
 // data was drained.
 //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -542,6 +542,12 @@ QuicStreamParamSet(
     QUIC_STATUS Status;
 
     switch (Param) {
+    case QUIC_PARAM_STREAM_ID:
+    case QUIC_PARAM_STREAM_0RTT_LENGTH:
+    case QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE:
+        Status = QUIC_STATUS_INVALID_PARAMETER;
+        break;
+
     case QUIC_PARAM_STREAM_PRIORITY:
 
         if (BufferLength != sizeof(Stream->SendPriority)) {

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -51,6 +51,8 @@ typedef struct QUIC_CONNECTION QUIC_CONNECTION;
     QUIC_SEND_FLAG_BUFFERED \
 )
 
+#define QUIC_STREAM_PRIORITY_DEFAULT 0x7FFF // Medium priority by default
+
 //
 // Tracks the data queued up for sending by an application.
 //
@@ -341,6 +343,12 @@ typedef struct QUIC_STREAM {
     // The ACK ranges greater than 'UnAckedOffset', with holes between them.
     //
     QUIC_RANGE SparseAckRanges;
+
+    //
+    // The relative priority between the different streams that determines the
+    // order that queued data will be sent out.
+    //
+    uint16_t SendPriority;
 
     //
     // Recv State

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -667,6 +667,7 @@ typedef struct QUIC_SCHANNEL_CONTEXT_ATTRIBUTE_W {
 #define QUIC_PARAM_STREAM_ID                            0x1C000000   // QUIC_UINT62
 #define QUIC_PARAM_STREAM_0RTT_LENGTH                   0x1C000001   // uint64_t
 #define QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE        0x1C000002   // uint64_t - bytes
+#define QUIC_PARAM_STREAM_PRIORITY                      0x1C000003   // uint16_t - 0 (low) to 0xFFFF (high) - 0x7FFF (default)
 
 typedef
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1105,6 +1105,29 @@ struct MsQuicStream {
         return MsQuic->StreamReceiveSetEnabled(Handle, IsEnabled ? TRUE : FALSE);
     }
 
+    QUIC_STATUS
+    SetPriority(_In_ uint16_t Priority) noexcept {
+        return
+            MsQuic->SetParam(
+                Handle,
+                QUIC_PARAM_LEVEL_STREAM,
+                QUIC_PARAM_STREAM_PRIORITY,
+                sizeof(Priority),
+                &Priority);
+    }
+
+    QUIC_STATUS
+    GetPriority(_Out_ uint16_t* Priority) const noexcept {
+        uint32_t Size = sizeof(*Priority);
+        return
+            MsQuic->GetParam(
+                Handle,
+                QUIC_PARAM_LEVEL_STREAM,
+                QUIC_PARAM_STREAM_PRIORITY,
+                &Size,
+                Priority);
+    }
+
     QUIC_STATUS GetInitStatus() const noexcept { return InitStatus; }
     bool IsValid() const { return QUIC_SUCCEEDED(InitStatus); }
     MsQuicStream(MsQuicStream& other) = delete;

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1106,6 +1106,24 @@ struct MsQuicStream {
     }
 
     QUIC_STATUS
+    GetID(_Out_ QUIC_UINT62* ID) const noexcept {
+        uint32_t Size = sizeof(*ID);
+        return
+            MsQuic->GetParam(
+                Handle,
+                QUIC_PARAM_LEVEL_STREAM,
+                QUIC_PARAM_STREAM_ID,
+                &Size,
+                ID);
+    }
+
+    QUIC_UINT62 ID() const noexcept {
+        QUIC_UINT62 ID;
+        GetID(&ID);
+        return ID;
+    }
+
+    QUIC_STATUS
     SetPriority(_In_ uint16_t Priority) noexcept {
         return
             MsQuic->SetParam(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -111,6 +111,18 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "LibraryError": {
+      "ModuleProperites": {},
+      "TraceString": "[ lib] ERROR, %s.",
+      "UniqueId": "LibraryError",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "ConnError": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] ERROR, %s.",
@@ -6684,6 +6696,22 @@
       ],
       "macroName": "QuicTraceLogStreamWarning"
     },
+    "UpdatePriority": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] New send priority = %hu",
+      "UniqueId": "UpdatePriority",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamInfo"
+    },
     "IndicateStartComplete": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]",
@@ -8608,18 +8636,6 @@
         }
       ],
       "macroName": "QuicTraceLogVerbose"
-    },
-    "LibraryError": {
-      "ModuleProperites": {},
-      "TraceString": "[ lib] ERROR, %s.",
-      "UniqueId": "LibraryError",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
     },
     "TlsLogSecret": {
       "ModuleProperites": {},
@@ -10880,6 +10896,10 @@
         "TraceID": "StreamError"
       },
       {
+        "UniquenessHash": "2cbc406b-c1c0-ba4d-eee8-669f30330f4a",
+        "TraceID": "LibraryError"
+      },
+      {
         "UniquenessHash": "0ebbffbe-69d8-3f2b-949d-d93cdd7f8b99",
         "TraceID": "ConnError"
       },
@@ -12436,6 +12456,10 @@
         "TraceID": "EventSilentDiscard"
       },
       {
+        "UniquenessHash": "1b92f995-0f00-00a4-3898-3e5121f9f323",
+        "TraceID": "UpdatePriority"
+      },
+      {
         "UniquenessHash": "66dd140b-9fd3-eddc-e34c-cb81639e1aca",
         "TraceID": "IndicateStartComplete"
       },
@@ -12906,10 +12930,6 @@
       {
         "UniquenessHash": "d53212c8-2068-d598-a55f-1b238ec86ad1",
         "TraceID": "CertCapiVerify"
-      },
-      {
-        "UniquenessHash": "2cbc406b-c1c0-ba4d-eee8-669f30330f4a",
-        "TraceID": "LibraryError"
       },
       {
         "UniquenessHash": "7512a5e6-b76b-d244-25a2-f27c6b593461",

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -382,6 +382,10 @@ void
 QuicTestNthAllocFail(
     );
 
+void
+QuicTestStreamPriority(
+    );
+
 //
 // QuicDrill tests
 //
@@ -867,5 +871,9 @@ typedef struct {
 
 #define IOCTL_QUIC_RUN_VALIDATE_PARAM_API \
     QUIC_CTL_CODE(71, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // int - Family
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 71
+#define IOCTL_QUIC_RUN_STREAM_PRIORITY \
+    QUIC_CTL_CODE(72, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 72

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1404,6 +1404,15 @@ TEST(Misc, NthAllocFail) {
 }
 #endif
 
+TEST(Misc, StreamPriority) {
+    TestLogger Logger("StreamPriority");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STREAM_PRIORITY));
+    } else {
+        QuicTestStreamPriority();
+    }
+}
+
 TEST(Drill, VarIntEncoder) {
     TestLogger Logger("QuicDrillTestVarIntEncoder");
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -441,7 +441,8 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     sizeof(QUIC_RUN_MTU_DISCOVERY_PARAMS),
     sizeof(INT32),
     sizeof(INT32),
-    0
+    0,
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1076,6 +1077,10 @@ QuicTestCtlEvtIoDeviceControl(
 
     case IOCTL_QUIC_RUN_VALIDATE_PARAM_API:
         QuicTestCtlRun(QuicTestValidateParamApi());
+        break;
+
+    case IOCTL_QUIC_RUN_STREAM_PRIORITY:
+        QuicTestCtlRun(QuicTestStreamPriority());
         break;
 
     default:

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -569,6 +569,8 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
             HQUIC Stream;
             QUIC_STATUS Status = MsQuic.StreamOpen(Connection, (QUIC_STREAM_OPEN_FLAGS)GetRandom(2), SpinQuicHandleStreamEvent, nullptr, &Stream);
             if (QUIC_SUCCEEDED(Status)) {
+                SpinQuicGetRandomParam(Stream);
+                SpinQuicSetRandomStreamParam(Stream);
                 SpinQuicConnection::Get(Connection)->AddStream(Stream);
             }
             break;

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -141,6 +141,7 @@ typedef enum {
     SpinQuicAPICallStreamClose,
     SpinQuicAPICallSetParamConnection,
     SpinQuicAPICallGetParamConnection,
+    SpinQuicAPICallSetParamStream,
     SpinQuicAPICallGetParamStream,
     SpinQuicAPICallDatagramSend,
     SpinQuicAPICallStreamReceiveSetEnabled,
@@ -387,7 +388,7 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection)
 {
     SetParamHelper Helper(QUIC_PARAM_LEVEL_CONNECTION);
 
-    switch (GetRandom(22) + 1) {
+    switch (0x14000000 | (GetRandom(22) + 1)) {
     case QUIC_PARAM_CONN_QUIC_VERSION:                              // uint32_t
         // QUIC_VERSION is get-only
         break;
@@ -430,6 +431,9 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection)
     case QUIC_PARAM_CONN_RESUMPTION_TICKET:                         // uint8_t[]
         // TODO
         break;
+    case QUIC_PARAM_CONN_PEER_CERTIFICATE_VALID:                    // uint8_t (BOOLEAN)
+        Helper.SetUint8(QUIC_PARAM_CONN_PEER_CERTIFICATE_VALID, (uint8_t)GetRandom(2));
+        break;
     default:
         break;
     }
@@ -437,14 +441,35 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection)
     Helper.Apply(Connection);
 }
 
+void SpinQuicSetRandomStreamParam(HQUIC Stream)
+{
+    SetParamHelper Helper(QUIC_PARAM_LEVEL_STREAM);
+
+    switch (0x1C000000 | (GetRandom(4) + 1)) {
+    case QUIC_PARAM_STREAM_ID:                                      // QUIC_UINT62
+        break; // Get Only
+    case QUIC_PARAM_STREAM_0RTT_LENGTH:                             // QUIC_ADDR
+        break; // Get Only
+    case QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE:                  // QUIC_ADDR
+        break; // Get Only
+    case QUIC_PARAM_STREAM_PRIORITY:                                // uint16_t
+        Helper.SetUint16(QUIC_PARAM_STREAM_PRIORITY, (uint16_t)GetRandom(UINT16_MAX));
+        break;
+    default:
+        break;
+    }
+
+    Helper.Apply(Stream);
+}
+
 const uint32_t ParamCounts[] = {
     QUIC_PARAM_GLOBAL_LOAD_BALACING_MODE + 1,
     QUIC_PARAM_REGISTRATION_CID_PREFIX + 1,
     0,
     QUIC_PARAM_LISTENER_STATS + 1,
-    QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION + 1,
+    QUIC_PARAM_CONN_PEER_CERTIFICATE_VALID + 1,
     0,
-    QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE + 1
+    QUIC_PARAM_STREAM_PRIORITY + 1
 };
 
 #define GET_PARAM_LOOP_COUNT 10
@@ -453,7 +478,7 @@ void SpinQuicGetRandomParam(HQUIC Handle)
 {
     for (uint32_t i = 0; i < GET_PARAM_LOOP_COUNT; ++i) {
         QUIC_PARAM_LEVEL Level = (QUIC_PARAM_LEVEL)GetRandom(5);
-        uint32_t Param = (uint32_t)GetRandom(ParamCounts[Level] + 1);
+        uint32_t Param = (uint32_t)GetRandom((ParamCounts[Level] & 0x3FFFFF) + 1);
 
         uint8_t OutBuffer[200];
         uint32_t OutBufferLength = (uint32_t)GetRandom(sizeof(OutBuffer) + 1);
@@ -642,6 +667,28 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
             SpinQuicGetRandomParam(Connection);
             break;
         }
+        case SpinQuicAPICallSetParamStream: {
+            auto Connection = Connections.TryGetRandom();
+            BAIL_ON_NULL_CONNECTION(Connection);
+            auto ctx = SpinQuicConnection::Get(Connection);
+            {
+                std::lock_guard<std::mutex> Lock(ctx->Lock);
+                auto Stream = ctx->TryGetStream();
+                if (Stream == nullptr) continue;
+                /* TODO:
+
+                    Currently deadlocks because it makes a blocking call to wait
+                    on the QUIC worker thread, but the worker thread tries to
+                    grab the same lock when cleaning up the connections' streams.
+
+                    We're going to need some kind of ref counting solution on
+                    the stream handle instead of a lock in order to do this.
+
+                SpinQuicSetRandomStreamParam(Stream);
+                */
+            }
+            break;
+        }
         case SpinQuicAPICallGetParamStream: {
             auto Connection = Connections.TryGetRandom();
             BAIL_ON_NULL_CONNECTION(Connection);
@@ -654,7 +701,7 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
 
                     Currently deadlocks because it makes a blocking call to wait
                     on the QUIC worker thread, but the worker thread tries to
-                    grab the same log when cleaning up the connections' streams.
+                    grab the same lock when cleaning up the connections' streams.
 
                     We're going to need some kind of ref counting solution on
                     the stream handle instead of a lock in order to do this.


### PR DESCRIPTION
Adds a new (optional) parameter to set a 16-bit priority on a stream that controls the relative order between the streams to send the data out.

Still need to figure out some testing.