### PR TITLE
Fix incorrect assert in QuicPathRemove

### DIFF
--- a/src/core/path.c
+++ b/src/core/path.c
@@ -56,7 +56,8 @@ QuicPathRemove(
 
 #if DEBUG
     if (Path->DestCid) {
-        QUIC_CID_SET_PATH(Path->DestCid, NULL);
+        CXPLAT_DBG_ASSERT(Path->DestCid->AssignedPath != NULL);
+        QUIC_CID_CLEAR_PATH(Path->DestCid);
     }
 #endif
 


### PR DESCRIPTION
At this point, the path should not be null because we are setting it to null. The existing check is wrong, because it expects the path to be null.