### PR TITLE
Enable renaming the output shared binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ option(QUIC_TELEMETRY_ASSERTS "Enable telemetry asserts in release builds" OFF)
 option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
 option(QUIC_DISABLE_POSIX_GSO "Disable GSO for systems that say they support it but don't" OFF)
 set(QUIC_FOLDER_PREFIX "" CACHE STRING "Optional prefix for source group folders when using an IDE generator")
+set(QUIC_LIBRARY_NAME "msquic" CACHE STRING "Override the output library name")
 
 set(BUILD_SHARED_LIBS ${QUIC_BUILD_SHARED})
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -87,8 +87,8 @@ This script provides helpers for building msquic.
 .PARAMETER ExtraArtifactDir
     Add an extra classifier to the artifact directory to allow publishing alternate builds of same base library
 
-.PARAMETER NetLibraryRename
-    Renames the library to MsQuicNative to match what .NET expects
+.PARAMETER LibraryName
+    Renames the library to whatever is passed in
 
 .EXAMPLE
     build.ps1
@@ -185,7 +185,7 @@ param (
     [string]$ExtraArtifactDir = "",
 
     [Parameter(Mandatory = $false)]
-    [switch]$NetLibraryRename = $false
+    [string]$LibraryName = "msquic"
 )
 
 Set-StrictMode -Version 'Latest'
@@ -346,9 +346,7 @@ function CMake-Generate {
     if ($UseSystemOpenSSLCrypto) {
         $Arguments += " -DQUIC_USE_SYSTEM_LIBCRYPTO=on"
     }
-    if ($NetLibraryRename) {
-        $Arguments += " -DQUIC_LIBRARY_NAME=MsQuicNative"
-    }
+    $Arguments += " -DQUIC_LIBRARY_NAME=$LibraryName"
     $Arguments += " ../../.."
 
     CMake-Execute $Arguments
@@ -379,11 +377,7 @@ function CMake-Build {
     CMake-Execute $Arguments
 
     if ($IsWindows) {
-        if ($NetLibraryRename) {
-            Copy-Item (Join-Path $BuildDir "obj" $Config "MsQuicNative.lib") $ArtifactsDir
-        } else {
-            Copy-Item (Join-Path $BuildDir "obj" $Config "msquic.lib") $ArtifactsDir
-        }
+        Copy-Item (Join-Path $BuildDir "obj" $Config "$LibraryName.lib") $ArtifactsDir
         if ($SanitizeAddress -or ($PGO -and $Config -eq "Release")) {
             Install-Module VSSetup -Scope CurrentUser -Force -SkipPublisherCheck
             $VSInstallationPath = Get-VSSetupInstance | Select-VSSetupInstance -Latest -Require Microsoft.VisualStudio.Component.VC.Tools.x86.x64 | Select-Object -ExpandProperty InstallationPath

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 if(WIN32)
-    set(SOURCES winuser/dllmain.c winuser/msquic.rc $<TARGET_OBJECTS:MsQuicEtw_Resource>)
+    configure_file(winuser/msquic.rc.in ${CMAKE_CURRENT_BINARY_DIR}/msquic.rc )
+    configure_file(winuser/msquic.def.in ${CMAKE_CURRENT_BINARY_DIR}/msquic.def )
+    set(SOURCES winuser/dllmain.c ${CMAKE_CURRENT_BINARY_DIR}/msquic.rc $<TARGET_OBJECTS:MsQuicEtw_Resource>)
 else()
     set(SOURCES linux/init.c)
 endif()
@@ -10,6 +12,7 @@ endif()
 if(BUILD_SHARED_LIBS)
     add_library(msquic SHARED ${SOURCES})
     target_link_libraries(msquic PRIVATE core platform inc warnings)
+    set_target_properties(msquic PROPERTIES OUTPUT_NAME ${QUIC_LIBRARY_NAME})
 else()
     add_library(msquic_static STATIC static/empty.c)
     target_link_libraries(msquic_static PRIVATE core platform inc)
@@ -203,7 +206,7 @@ if(WIN32)
         target_link_libraries(msquic PUBLIC OneCoreUAP)
     endif()
     SET_TARGET_PROPERTIES(msquic
-        PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/winuser/msquic.def\"")
+        PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
 elseif (CX_PLATFORM STREQUAL "linux")
     SET_TARGET_PROPERTIES(msquic
         PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/linux/exports.txt\"")

--- a/src/bin/winuser/msquic.def.in
+++ b/src/bin/winuser/msquic.def.in
@@ -1,4 +1,4 @@
-LIBRARY msquic
+LIBRARY @QUIC_LIBRARY_NAME@
 
 EXPORTS
     MsQuicOpen

--- a/src/bin/winuser/msquic.rc.in
+++ b/src/bin/winuser/msquic.rc.in
@@ -7,6 +7,6 @@
 
 #define VER_FILETYPE                VFT_DLL
 #define VER_FILESUBTYPE             VFT2_UNKNOWN
-#define VER_ORIGINALFILENAME_STR    "msquic.dll"
+#define VER_ORIGINALFILENAME_STR    "@QUIC_LIBRARY_NAME@.dll"
 
 #include "msquic.ver"


### PR DESCRIPTION
In .NET, a different library name is preferred. This PR enables that name change to be selected at build time. .NET would prefer MsQuic.Native, but the def file errors if there is a dot in the name, so MsQuicNative is chosen.

Closes #1789 

@wfurt 