### PR TITLE
Improve Event Callback Reentrancy

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -155,7 +155,7 @@ typedef union QUIC_CONNECTION_STATE {
 
         //
         // When true, this indicates that the connection is currently executing
-        // and API call inline (from a reentrant call on a callback).
+        // an API call inline (from a reentrant call on a callback).
         //
         BOOLEAN InlineApiExecution : 1;
 

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -148,16 +148,16 @@ typedef union QUIC_CONNECTION_STATE {
         BOOLEAN ResumptionEnabled : 1;
 
         //
-        // Indicates that an app close from a non worker thread is in progress.
-        // Received by the QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event.
-        //
-        BOOLEAN AppCloseInProgress: 1;
-
-        //
         // When true, this indicates that reordering shouldn't elict an
         // immediate acknowledgement.
         //
         BOOLEAN IgnoreReordering : 1;
+
+        //
+        // When true, this indicates that the connection is currently executing
+        // and API call inline (from a reentrant call on a callback).
+        //
+        BOOLEAN InlineApiExecution : 1;
 
 #ifdef CxPlatVerifierEnabledByAddr
         //
@@ -167,6 +167,8 @@ typedef union QUIC_CONNECTION_STATE {
 #endif
     };
 } QUIC_CONNECTION_STATE;
+
+CXPLAT_STATIC_ASSERT(sizeof(QUIC_CONNECTION_STATE) == sizeof(uint32_t), "Ensure correct size/type");
 
 //
 // Different references on a connection.

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -317,6 +317,9 @@ QuicStreamClose(
     _In_ __drv_freesMem(Mem) QUIC_STREAM* Stream
     )
 {
+    CXPLAT_DBG_ASSERT(!Stream->Flags.HandleClosed);
+    Stream->Flags.HandleClosed = TRUE;
+
     if (!Stream->Flags.ShutdownComplete) {
 
         if (Stream->Flags.Started) {
@@ -352,7 +355,6 @@ QuicStreamClose(
             }
     }
 
-    Stream->Flags.HandleClosed = TRUE;
     Stream->ClientCallbackHandler = NULL;
 
     QuicStreamRelease(Stream, QUIC_STREAM_REF_APP);
@@ -388,6 +390,19 @@ QuicStreamIndicateEvent(
 {
     QUIC_STATUS Status;
     if (Stream->ClientCallbackHandler != NULL) {
+        //
+        // MsQuic shouldn't indicate reentrancy to the app when at all
+        // possible. The general exception to this rule is when the connection
+        // or stream is being closed because the API MUST block until all work
+        // is completed, so we have to execute the event callbacks inline. There
+        // is also one additional exception for start complete when StreamStart
+        // is called synchronously on an MsQuic thread.
+        //
+        CXPLAT_DBG_ASSERT(
+            !Stream->Connection->State.InlineApiExecution ||
+            Stream->Connection->State.HandleClosed ||
+            Stream->Flags.HandleClosed ||
+            Event->Type == QUIC_STREAM_EVENT_START_COMPLETE);
         Status =
             Stream->ClientCallbackHandler(
                 (HQUIC)Stream,

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -200,7 +200,7 @@ typedef union QUIC_CONNECTION_STATE {
 
         //
         // When true, this indicates that the connection is currently executing
-        // and API call inline (from a reentrant call on a callback).
+        // an API call inline (from a reentrant call on a callback).
         //
         BOOLEAN InlineApiExecution : 1;
 

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -193,10 +193,16 @@ typedef union QUIC_CONNECTION_STATE {
         BOOLEAN ResumptionEnabled : 1;
 
         //
-        // Indicates that an app close from a non worker thread is in progress.
-        // Received by the QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event.
+        // When true, this indicates that reordering shouldn't elict an
+        // immediate acknowledgement.
         //
-        BOOLEAN AppCloseInProgress: 1;
+        BOOLEAN IgnoreReordering : 1;
+
+        //
+        // When true, this indicates that the connection is currently executing
+        // and API call inline (from a reentrant call on a callback).
+        //
+        BOOLEAN InlineApiExecution : 1;
 
 #ifdef CxPlatVerifierEnabledByAddr
         //


### PR DESCRIPTION
This makes a number of changes in an attempt to improve reentrancy around MsQuic event callbacks to the app:

1. The connection now tracks if it is in a reentrant API call (e.g. the app is calling a blocking function on the MsQuic thread).
2. A couple API calls were made async, even if on the callback thread (StreamShutdown and StreamStart(async)).
3. We now debug assert if we ever try to indicate an event to the app if we are in a non-*Close reentrant API call.