### PR TITLE
Split Stream Abort Error Codes

### DIFF
--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -261,11 +261,6 @@ typedef struct QUIC_STREAM {
     //
 
     //
-    // The error code sent in either RESET_STREAM or STOP_SENDING.
-    //
-    QUIC_VAR_INT SendCloseErrorCode;
-
-    //
     // API calls to StreamSend queue the send request here and then queue the
     // send operation. That operation moves the send request onto the
     // SendRequests list.
@@ -340,6 +335,11 @@ typedef struct QUIC_STREAM {
     #define RECOV_WINDOW_OPEN(S) ((S)->RecoveryNextOffset < (S)->RecoveryEndOffset)
 
     //
+    // The error code for why the send path was shutdown.
+    //
+    QUIC_VAR_INT SendShutdownErrorCode;
+
+    //
     // The ACK ranges greater than 'UnAckedOffset', with holes between them.
     //
     QUIC_RANGE SparseAckRanges;
@@ -390,6 +390,11 @@ typedef struct QUIC_STREAM {
     // The length of the pending receive call to the app.
     //
     uint64_t RecvPendingLength;
+
+    //
+    // The error code for why the receive path was shutdown.
+    //
+    QUIC_VAR_INT RecvShutdownErrorCode;
 
     //
     // The handler for the API client's callbacks.

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -72,7 +72,7 @@ QuicStreamRecvShutdown(
         goto Exit;
     }
 
-    Stream->SendCloseErrorCode = ErrorCode;
+    Stream->RecvShutdownErrorCode = ErrorCode;
     Stream->Flags.SentStopSending = TRUE;
 
     //

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -199,7 +199,7 @@ QuicStreamSendShutdown(
         }
 
         Stream->Flags.LocalCloseReset = TRUE;
-        Stream->SendCloseErrorCode = ErrorCode;
+        Stream->SendShutdownErrorCode = ErrorCode;
 
         if (!Silent) {
             //
@@ -1048,7 +1048,7 @@ QuicStreamSendWrite(
 
     if (Stream->SendFlags & QUIC_STREAM_SEND_FLAG_SEND_ABORT) {
 
-        QUIC_RESET_STREAM_EX Frame = { Stream->ID, Stream->SendCloseErrorCode, Stream->MaxSentLength };
+        QUIC_RESET_STREAM_EX Frame = { Stream->ID, Stream->SendShutdownErrorCode, Stream->MaxSentLength };
 
         if (QuicResetStreamFrameEncode(
                 &Frame,
@@ -1067,7 +1067,7 @@ QuicStreamSendWrite(
 
     if (Stream->SendFlags & QUIC_STREAM_SEND_FLAG_RECV_ABORT) {
 
-        QUIC_STOP_SENDING_EX Frame = { Stream->ID, Stream->SendCloseErrorCode };
+        QUIC_STOP_SENDING_EX Frame = { Stream->ID, Stream->RecvShutdownErrorCode };
 
         if (QuicStopSendingFrameEncode(
                 &Frame,

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -396,6 +396,10 @@ void
 QuicTestStreamPriority(
     );
 
+void
+QuicTestStreamDifferentAbortErrors(
+    );
+
 //
 // QuicDrill tests
 //
@@ -895,4 +899,7 @@ typedef struct {
     QUIC_CTL_CODE(73, METHOD_BUFFERED, FILE_WRITE_DATA)
     // int - Family
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 73
+#define IOCTL_QUIC_RUN_STREAM_DIFFERENT_ABORT_ERRORS \
+    QUIC_CTL_CODE(74, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 74

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1456,6 +1456,15 @@ TEST(Misc, StreamPriority) {
     }
 }
 
+TEST(Misc, StreamDifferentAbortErrors) {
+    TestLogger Logger("StreamDifferentAbortErrors");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STREAM_DIFFERENT_ABORT_ERRORS));
+    } else {
+        QuicTestStreamDifferentAbortErrors();
+    }
+}
+
 TEST(Drill, VarIntEncoder) {
     TestLogger Logger("QuicDrillTestVarIntEncoder");
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -444,6 +444,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     sizeof(INT32),
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1090,6 +1091,10 @@ QuicTestCtlEvtIoDeviceControl(
     case IOCTL_QUIC_RUN_CLIENT_LOCAL_PATH_CHANGES:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestLocalPathChanges(Params->Family));
+        break;
+
+    case IOCTL_QUIC_RUN_STREAM_DIFFERENT_ABORT_ERRORS:
+        QuicTestCtlRun(QuicTestStreamDifferentAbortErrors());
         break;
 
     default:

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2421,7 +2421,7 @@ struct StreamDifferentAbortErrors {
     QUIC_UINT62 PeerRecvAbortErrorCode {0};
     CxPlatEvent StreamShutdownComplete;
 
-    static QUIC_STATUS StreamCallback(_In_ MsQuicStream* Stream, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+    static QUIC_STATUS StreamCallback(_In_ MsQuicStream*, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
         auto TestContext = (StreamDifferentAbortErrors*)Context;
         if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
             TestContext->PeerRecvAbortErrorCode = Event->PEER_RECEIVE_ABORTED.ErrorCode;

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2425,7 +2425,7 @@ struct StreamDifferentAbortErrors {
         auto TestContext = (StreamDifferentAbortErrors*)Context;
         if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
             TestContext->PeerRecvAbortErrorCode = Event->PEER_RECEIVE_ABORTED.ErrorCode;
-        } else if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
+        } else if (Event->Type == QUIC_STREAM_EVENT_PEER_SEND_ABORTED) {
             TestContext->PeerSendAbortErrorCode = Event->PEER_SEND_ABORTED.ErrorCode;
         } else if (Event->Type == QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE) {
             TestContext->StreamShutdownComplete.Set();

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2415,3 +2415,69 @@ QuicTestStreamPriority(
     TEST_TRUE(Context.ReceiveEvents[1] == Stream3.ID());
     TEST_TRUE(Context.ReceiveEvents[2] == Stream1.ID());
 }
+
+struct StreamDifferentAbortErrors {
+    QUIC_UINT62 PeerSendAbortErrorCode {0};
+    QUIC_UINT62 PeerRecvAbortErrorCode {0};
+    CxPlatEvent StreamShutdownComplete;
+
+    static QUIC_STATUS StreamCallback(_In_ MsQuicStream* Stream, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (StreamDifferentAbortErrors*)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
+            TestContext->PeerRecvAbortErrorCode = Event->PEER_RECEIVE_ABORTED.ErrorCode;
+        } else if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
+            TestContext->PeerSendAbortErrorCode = Event->PEER_SEND_ABORTED.ErrorCode;
+        } else if (Event->Type == QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE) {
+            TestContext->StreamShutdownComplete.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            new(std::nothrow) MsQuicStream(Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete, StreamCallback, Context);
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+
+void
+QuicTestStreamDifferentAbortErrors(
+    )
+{
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", MsQuicSettings().SetPeerBidiStreamCount(1), ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    StreamDifferentAbortErrors Context;
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, StreamDifferentAbortErrors::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+
+    const QUIC_UINT62 RecvShutdownErrorCode = 0x1234567890;
+    const QUIC_UINT62 SendShutdownErrorCode = 0x9876543210;
+
+    MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE);
+    TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Stream.Start());
+    TEST_QUIC_SUCCEEDED(Stream.Shutdown(RecvShutdownErrorCode, QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE));
+    TEST_QUIC_SUCCEEDED(Stream.Shutdown(SendShutdownErrorCode, QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND));
+
+    TEST_QUIC_SUCCEEDED(Connection.StartLocalhost(ClientConfiguration, ServerLocalAddr));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+
+    TEST_TRUE(Context.StreamShutdownComplete.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Context.PeerRecvAbortErrorCode == RecvShutdownErrorCode);
+    TEST_TRUE(Context.PeerSendAbortErrorCode == SendShutdownErrorCode);
+}


### PR DESCRIPTION
Fixes #1807. Splits the internally tracked error code for sending out the stream shutdown related frames. While HTTP/3 generally uses the same error codes when aborting both directions, per spec, they are independent error codes, and an application should be  able to simultaneously abort both directions with different error codes.