### PR TITLE
Fix queuing 0-RTT data during handshake

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -106,6 +106,10 @@ QuicSendCanSendFlagsNow(
 {
     QUIC_CONNECTION* Connection = QuicSendGetConnection(Send);
     if (Connection->Crypto.TlsState.WriteKey < QUIC_PACKET_KEY_1_RTT) {
+        if (Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_0_RTT] != NULL &&
+            CxPlatListIsEmpty(&Send->SendStreams)) {
+            return TRUE;
+        }
         if ((!Connection->State.Started && !QuicConnIsServer(Connection)) ||
             !(Send->SendFlags & QUIC_CONN_SEND_FLAG_ALLOWED_HANDSHAKE)) {
             return FALSE;
@@ -1090,8 +1094,6 @@ QuicSendFlush(
     if (Send->SendFlags == 0 && CxPlatListIsEmpty(&Send->SendStreams)) {
         return TRUE;
     }
-
-    CXPLAT_DBG_ASSERT(QuicSendCanSendFlagsNow(Send));
 
     QUIC_SEND_RESULT Result = QUIC_SEND_INCOMPLETE;
     QUIC_STREAM* Stream = NULL;


### PR DESCRIPTION
Previously, if 0-RTT data was queued during the handshake, it has the potential to not queue the flush send. This makes it so if we have 0-RTT flags and sends are queued, we'll allow them to be flushed.

Also, there are cases where we could end up with stream data but no flags, which if this occured during the handshake would hit an assert. This assert is only there to tell if we're going to do no work, but this would only be a slight perf penalty when it does happen, so its not a valid assert

Fixes https://github.com/microsoft/msquic/issues/1749.