### PR TITLE
Increase Send Deadlock Detection Threshold

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1283,7 +1283,7 @@ QuicSendFlush(
         }
 
 #if DEBUG
-        CXPLAT_DBG_ASSERT(++DeadlockDetection < 100);
+        CXPLAT_DBG_ASSERT(++DeadlockDetection < 1000);
         UNREFERENCED_PARAMETER(PrevPrevSendFlags); // Used in debugging only
         PrevPrevSendFlags = PrevSendFlags;
         PrevSendFlags = SendFlags;


### PR DESCRIPTION
Under certain circumstances (lots of streams with small payloads) the deadlock detection can hit incorrectly. Theoretically, the loop could legally run `QUIC_MAX_FRAMES_PER_PACKET` * `QUIC_MAX_DATAGRAMS_PER_SEND` which is just under 500 right now. We'll double that for good measure.

cc @wfurt