### PR TITLE
Binding Ref Count Fixes in Error Paths

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -61,7 +61,7 @@ QuicBindingInitialize(
         goto Error;
     }
 
-    Binding->RefCount = 1;
+    Binding->RefCount = 0; // No refs until it's added to the library's list
     Binding->Exclusive = !ShareBinding;
     Binding->ServerOwned = ServerOwned;
     Binding->Connected = RemoteAddress == NULL ? FALSE : TRUE;

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1629,6 +1629,7 @@ NewBinding:
                 &NewLocalAddress,
                 NULL);
     }
+
     if (Binding != NULL) {
         if (!PortUnspecified && !Binding->Exclusive) {
             //
@@ -1648,6 +1649,7 @@ NewBinding:
                 "[ lib] Now in use.");
             MsQuicLib.InUse = TRUE;
         }
+        (*NewBinding)->RefCount++;
         CxPlatListInsertTail(&MsQuicLib.Bindings, &(*NewBinding)->Link);
     }
 
@@ -1665,7 +1667,6 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 *NewBinding,
                 "Binding ephemeral port reuse encountered");
-            (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);
             *NewBinding = NULL;
 
@@ -1688,7 +1689,6 @@ NewBinding:
                 "[bind][%p] ERROR, %s.",
                 Binding,
                 "Binding already in use");
-            (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);
             *NewBinding = NULL;
 #ifdef QUIC_SHARED_EPHEMERAL_WORKAROUND
@@ -1701,7 +1701,6 @@ NewBinding:
             Status = QUIC_STATUS_ADDRESS_IN_USE;
 
         } else {
-            (*NewBinding)->RefCount--;
             QuicBindingUninitialize(*NewBinding);
             *NewBinding = Binding;
             Status = QUIC_STATUS_SUCCESS;


### PR DESCRIPTION
When looking through the binding initialization code path I noticed there was a possible race condition with a packet getting received and processed for a binding that ultimately was getting destroyed. The fix is to just not increment the ref count until it's actually added to the library's list, so that if we happen to receive a packet that creates a new connection before that happens, it would just be dropped/ignored.