### PR TITLE
Add more path tracing to destination CIDs

### DIFF
--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -146,13 +146,27 @@ typedef struct QUIC_CID_LIST_ENTRY {
 } QUIC_CID_LIST_ENTRY;
 
 #if DEBUG
-#define QUIC_CID_SET_PATH(Cid, Path) CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL); Cid->AssignedPath = Path
+#define QUIC_CID_SET_PATH(Conn, Cid, Path)                                      \
+    do {                                                                        \
+        CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL); Cid->AssignedPath = Path; \
+        for (uint8_t PathIdx = Conn->PathsCount - 1; PathIdx > 0; PathIdx--) {  \
+            if (Path != &Conn->Paths[PathIdx])                                  \
+                CXPLAT_DBG_ASSERT(Conn->Paths[PathIdx].DestCid != Cid);         \
+            }                                                                   \
+        }                                                                       \
+    while (0)
 #define QUIC_CID_CLEAR_PATH(Cid) Cid->AssignedPath = NULL
-#define QUIC_CID_VALIDATE_NULL(Cid) CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL)
+#define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                       \
+    do {                                                                        \
+        CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL);                           \
+        for (uint8_t PathIdx = Conn->PathsCount - 1; PathIdx > 0; PathIdx--) {  \
+            CXPLAT_DBG_ASSERT(Conn->Paths[PathIdx].DestCid != Cid);             \
+        }                                                                       \
+    } while (0)    
 #else
 #define QUIC_CID_SET_PATH(Cid, Path) UNREFERENCED_PARAMETER(Cid)
 #define QUIC_CID_CLEAR_PATH(Cid) UNREFERENCED_PARAMETER(Cid)
-#define QUIC_CID_VALIDATE_NULL(Cid) UNREFERENCED_PARAMETER(Cid)
+#define QUIC_CID_VALIDATE_NULL(Conn, Cid) UNREFERENCED_PARAMETER(Cid)
 #endif
 
 typedef struct QUIC_CID_HASH_ENTRY {

--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -164,7 +164,7 @@ typedef struct QUIC_CID_LIST_ENTRY {
         }                                                                       \
     } while (0)    
 #else
-#define QUIC_CID_SET_PATH(Cid, Path) UNREFERENCED_PARAMETER(Cid)
+#define QUIC_CID_SET_PATH(Conn, Cid, Path) UNREFERENCED_PARAMETER(Cid)
 #define QUIC_CID_CLEAR_PATH(Cid) UNREFERENCED_PARAMETER(Cid)
 #define QUIC_CID_VALIDATE_NULL(Conn, Cid) UNREFERENCED_PARAMETER(Cid)
 #endif

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -581,7 +581,7 @@ QuicLossDetectionOnPacketAcknowledged(
             if (DestCid != NULL) {
 #pragma prefast(suppress:6001, "TODO - Why does compiler think: Using uninitialized memory '*DestCid'")
                 CXPLAT_DBG_ASSERT(DestCid->CID.Retired);
-                QUIC_CID_VALIDATE_NULL(DestCid);
+                QUIC_CID_VALIDATE_NULL(Connection, DestCid);
                 CXPLAT_FREE(DestCid, QUIC_POOL_CIDLIST);
             }
             break;
@@ -767,7 +767,7 @@ QuicLossDetectionRetransmitFrames(
                     FALSE);
             if (DestCid != NULL) {
                 CXPLAT_DBG_ASSERT(DestCid->CID.Retired);
-                QUIC_CID_VALIDATE_NULL(DestCid);
+                QUIC_CID_VALIDATE_NULL(Connection, DestCid);
                 DestCid->CID.NeedsToSend = TRUE;
                 NewDataQueued |=
                     QuicSendSetSendFlag(


### PR DESCRIPTION
To make it easier to debug destination CID issues, extend the tracing done when cids are added and removed from path.