### PR TITLE
Add support for building openssl with jom

### DIFF
--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -47,12 +47,12 @@ jobs:
       filePath: scripts/prepare-machine.ps1
       arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -FailOnError -Extra '${{ parameters.extraBuildArgs }}'
 
-  - task: Cache@2
-    inputs:
-      key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_14" | .gitmodules'
-      path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
-    displayName: Cache OpenSSL
-    condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'), not(${{ parameters.skipOpenSSLCache }}))
+  # - task: Cache@2
+  #   inputs:
+  #     key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_14" | .gitmodules'
+  #     path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
+  #   displayName: Cache OpenSSL
+  #   condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'), not(${{ parameters.skipOpenSSLCache }}))
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -9,7 +9,6 @@ parameters:
   config: 'Debug,Release'
   extraBuildArgs: ''
   skipArtifacts: false
-  skipOpenSSLCache: false
   extraName: ''
   ubuntuVersion: 20.04
 
@@ -46,13 +45,6 @@ jobs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
       arguments: -Configuration Build -InitSubmodules -Tls ${{ parameters.tls }} -FailOnError -Extra '${{ parameters.extraBuildArgs }}'
-
-  # - task: Cache@2
-  #   inputs:
-  #     key:  '"${{ parameters.platform }}_${{ parameters.arch }}_${{ parameters.tls }}_${{ parameters.extraName }}_${{ parameters.config }}_14" | .gitmodules'
-  #     path: build/${{ parameters.platform }}/${{ parameters.arch }}_${{ parameters.tls }}/openssl
-  #   displayName: Cache OpenSSL
-  #   condition: and(succeeded(), eq('${{ parameters.tls }}', 'openssl'), not(${{ parameters.skipOpenSSLCache }}))
 
   - task: PowerShell@2
     displayName: Build Source Code (Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,6 @@ option(QUIC_SOURCE_LINK "Enables source linking on MSVC" ON)
 option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)
 option(QUIC_CODE_CHECK "Run static code checkers" OFF)
 option(QUIC_OPTIMIZE_LOCAL "Optimize code for local machine architecture" OFF)
-option(QUIC_CI "CI Specific build optimizations" OFF)
 option(QUIC_TLS_SECRETS_SUPPORT "Enable export of TLS secrets" OFF)
 option(QUIC_TELEMETRY_ASSERTS "Enable telemetry asserts in release builds" OFF)
 option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
@@ -400,58 +399,21 @@ endif()
 
 if(QUIC_TLS STREQUAL "openssl")
     if (WIN32)
-
-        set(OPENSSL_DIR ${QUIC_BUILD_DIR}/openssl)
-        set(LIBSSL_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
-        set(LIBCRYPTO_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX})
-        set(LIBSSL_PATH ${OPENSSL_DIR}/release/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
-        set(LIBCRYPTO_PATH ${OPENSSL_DIR}/release/lib/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-        add_library(OpenSSL_Crypto STATIC IMPORTED)
-        set_property(TARGET OpenSSL_Crypto PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
-        set_target_properties(OpenSSL_Crypto PROPERTIES
-            IMPORTED_LOCATION_DEBUG ${LIBCRYPTO_DEBUG_PATH}
-            IMPORTED_LOCATION_RELEASE ${LIBCRYPTO_PATH}
-            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-            MAP_IMPORTED_CONFIG_MINSIZEREL RELEASE
-            MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)
-
-        add_library(OpenSSL_SSL STATIC IMPORTED)
-        set_property(TARGET OpenSSL_SSL PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
-        set_target_properties(OpenSSL_SSL PROPERTIES
-            IMPORTED_LOCATION_DEBUG ${LIBSSL_DEBUG_PATH}
-            IMPORTED_LOCATION_RELEASE ${LIBSSL_PATH}
-            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-            MAP_IMPORTED_CONFIG_MINSIZEREL RELEASE
-            MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)
-
         add_library(OpenSSL INTERFACE)
 
-        target_include_directories(OpenSSL INTERFACE
-            $<$<CONFIG:Debug>:${OPENSSL_DIR}/debug/include>
-            $<$<NOT:$<CONFIG:Debug>>:${OPENSSL_DIR}/release/include>)
+        include(FetchContent)
 
-        if (QUIC_CI AND QUIC_CI_CONFIG STREQUAL "Release" AND EXISTS ${LIBCRYPTO_PATH})
-            message(STATUS "Found existing OpenSSL Release cache, skipping openssl build")
-            target_link_libraries(OpenSSL INTERFACE OpenSSL_SSL OpenSSL_Crypto)
-        elseif (QUIC_CI AND QUIC_CI_CONFIG STREQUAL "Debug" AND EXISTS ${LIBCRYPTO_DEBUG_PATH})
-            message(STATUS "Found existing OpenSSL Debug cache, skipping openssl build")
-            target_link_libraries(OpenSSL INTERFACE OpenSSL_SSL OpenSSL_Crypto)
-        else()
-            include(FetchContent)
+        FetchContent_Declare(
+            OpenSSLQuic
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/submodules
+            CMAKE_ARGS "-DQUIC_BUILD_DIR=${QUIC_BUILD_DIR}"
+        )
+        FetchContent_MakeAvailable(OpenSSLQuic)
 
-            FetchContent_Declare(
-                OpenSSLQuic
-                SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/submodules
-                CMAKE_ARGS "-DQUIC_BUILD_DIR=${QUIC_BUILD_DIR}"
-            )
-            FetchContent_MakeAvailable(OpenSSLQuic)
-
-            target_link_libraries(OpenSSL
-                INTERFACE
-                OpenSSLQuic::OpenSSLQuic
-            )
-        endif()
+        target_link_libraries(OpenSSL
+            INTERFACE
+            OpenSSLQuic::OpenSSLQuic
+        )
     else()
         # Configure and build OpenSSL.
         set(OPENSSL_DIR ${QUIC_BUILD_DIR}/openssl)

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -164,8 +164,9 @@ if ($IsWindows) {
             Expand-Archive -Path "build\nasm.zip" -DestinationPath $env:Programfiles -Force
             $CurrentSystemPath = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
             $CurrentSystemPath = "$CurrentSystemPath;$NasmPath"
+            $env:PATH = "${env:PATH};$NasmPath"
             [Environment]::SetEnvironmentVariable("PATH", $CurrentSystemPath, [System.EnvironmentVariableTarget]::Machine)
-            Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};$NasmPath"
+            Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH}"
             Write-Host "PATH has been updated. You'll need to restart your terminal for this to take affect."
         }
 
@@ -184,8 +185,9 @@ if ($IsWindows) {
             Expand-Archive -Path "build\jom.zip" -DestinationPath $JomPath -Force
             $CurrentSystemPath = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
             $CurrentSystemPath = "$CurrentSystemPath;$JomPath"
+            $env:PATH = "${env:PATH};$JomPath"
             [Environment]::SetEnvironmentVariable("PATH", $CurrentSystemPath, [System.EnvironmentVariableTarget]::Machine)
-            Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};$JomPath"
+            Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH}"
             Write-Host "PATH has been updated. You'll need to restart your terminal for this to take affect."
         }
     }

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -168,6 +168,26 @@ if ($IsWindows) {
             Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};$NasmPath"
             Write-Host "PATH has been updated. You'll need to restart your terminal for this to take affect."
         }
+
+        $JomVersion = "1_1_3"
+        $JomPath = Join-Path $env:Programfiles "jom_$JomVersion"
+        $JomExe = Join-Path $JomPath "jom.exe"
+        if (!(Test-Path $JomExe)) {
+            New-Item -Path .\build -ItemType Directory -Force
+            try {
+                Invoke-WebRequest -Uri "https://qt.mirror.constant.com/official_releases/jom/jom_$JomVersion.zip" -OutFile "build\jom.zip"
+                
+            } catch {
+                Invoke-WebRequest -Uri "https://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_$JomVersion.zip" -OutFile "build\jom.zip"
+            }
+            New-Item -Path $JomPath -ItemType Directory -Force
+            Expand-Archive -Path "build\jom.zip" -DestinationPath $JomPath -Force
+            $CurrentSystemPath = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
+            $CurrentSystemPath = "$CurrentSystemPath;$JomPath"
+            [Environment]::SetEnvironmentVariable("PATH", $CurrentSystemPath, [System.EnvironmentVariableTarget]::Machine)
+            Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};$JomPath"
+            Write-Host "PATH has been updated. You'll need to restart your terminal for this to take affect."
+        }
     }
 
     if (($Configuration -eq "Dev") -or ($Configuration -eq "Test")) {

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -177,7 +177,7 @@ if ($IsWindows) {
             New-Item -Path .\build -ItemType Directory -Force
             try {
                 Invoke-WebRequest -Uri "https://qt.mirror.constant.com/official_releases/jom/jom_$JomVersion.zip" -OutFile "build\jom.zip"
-                
+
             } catch {
                 Invoke-WebRequest -Uri "https://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_$JomVersion.zip" -OutFile "build\jom.zip"
             }

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -132,5 +132,4 @@ target_link_libraries(
     $<$<NOT:$<CONFIG:Debug>>:${LIBCRYPTO_PATH}>
 )
 
-# Target to export to parent project
 add_library(OpenSSLQuic::OpenSSLQuic ALIAS OpenSSLQuic)

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -51,6 +51,17 @@ else()
     endif()
 endif()
 
+find_program(JOM_EXE jom)
+if (JOM_EXE)
+    set(OPENSSL_EXTRA_CONFIGURE_ARGS /FS)
+    include(ProcessorCount)
+    ProcessorCount(NPROCS)
+    set(OPENSSL_RUN_COMMAND "${JOM_EXE}" -j${NPROCS})
+else()
+    set(OPENSSL_EXTRA_CONFIGURE_ARGS)
+    set(OPENSSL_RUN_COMMAND nmake)
+endif()
+
 set(OPENSSL_CONFIG_FLAGS
     enable-tls1_3 no-makedepend no-dgram no-ssl3 no-psk no-srp
 
@@ -63,7 +74,7 @@ set(OPENSSL_CONFIG_FLAGS
     no-tls1 no-tls1_1 no-tls1_2 no-dtls no-dtls1 no-dtls1_2 no-ssl
     no-ssl3-method no-tls1-method no-tls1_1-method no-tls1_2-method no-dtls1-method no-dtls1_2-method
     no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt
-    no-weak-ssl-ciphers no-shared no-tests ${QUIC_OPENSSL_WIN_ARCH})
+    no-weak-ssl-ciphers no-shared no-tests ${QUIC_OPENSSL_WIN_ARCH} ${OPENSSL_EXTRA_CONFIGURE_ARGS})
 
 if (QUIC_UWP_BUILD)
     list(APPEND OPENSSL_CONFIG_FLAGS no-async)
@@ -95,7 +106,7 @@ add_custom_command(
     BYPRODUCTS ${LIBCRYPTO_DEBUG_PATH}
     DEPENDS ${QUIC_BUILD_DIR}/submodules/openssl/debug/makefile
     WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/debug
-    COMMAND nmake install_dev
+    COMMAND ${OPENSSL_RUN_COMMAND} install_dev
     COMMENT "OpenSSL debug build"
 )
 add_custom_command(
@@ -103,7 +114,7 @@ add_custom_command(
     BYPRODUCTS ${LIBCRYPTO_PATH}
     DEPENDS ${QUIC_BUILD_DIR}/submodules/openssl/release/makefile
     WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/release
-    COMMAND nmake install_dev
+    COMMAND ${OPENSSL_RUN_COMMAND} install_dev
     COMMENT "OpenSSL release build"
 )
 

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -88,34 +88,20 @@ file(MAKE_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/release)
 
 # Configure steps for debug and release variants
 add_custom_command(
-    WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/debug
-    OUTPUT ${QUIC_BUILD_DIR}/submodules/openssl/debug/makefile
-    COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/openssl/Configure ${OPENSSL_CONFIG_FLAGS} --debug --prefix=${OPENSSL_DIR}/debug
-    COMMENT "OpenSSL debug configure"
-)
-add_custom_command(
-    WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/release
-    OUTPUT ${QUIC_BUILD_DIR}/submodules/openssl/release/makefile
-    COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/openssl/Configure ${OPENSSL_CONFIG_FLAGS} --prefix=${OPENSSL_DIR}/release
-    COMMENT "OpenSSL release configure"
+    WORKING_DIRECTORY $<IF:$<CONFIG:Debug>,${QUIC_BUILD_DIR}/submodules/openssl/debug,${QUIC_BUILD_DIR}/submodules/openssl/release>
+    OUTPUT $<IF:$<CONFIG:Debug>,${QUIC_BUILD_DIR}/submodules/openssl/debug/makefile,${QUIC_BUILD_DIR}/submodules/openssl/release/makefile>
+    COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/openssl/Configure ${OPENSSL_CONFIG_FLAGS} $<$<CONFIG:Debug>:--debug> $<$<CONFIG:Debug>:--prefix=${OPENSSL_DIR}/debug> $<$<NOT:$<CONFIG:Debug>>:--prefix=${OPENSSL_DIR}/release>
+
+    COMMENT "OpenSSL configure"
 )
 
 # Compile/install commands for debug and release variants
 add_custom_command(
-    OUTPUT ${LIBSSL_DEBUG_PATH}
-    BYPRODUCTS ${LIBCRYPTO_DEBUG_PATH}
-    DEPENDS ${QUIC_BUILD_DIR}/submodules/openssl/debug/makefile
-    WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/debug
+    OUTPUT $<IF:$<CONFIG:Debug>,${LIBSSL_DEBUG_PATH},${LIBSSL_PATH}>
+    DEPENDS $<IF:$<CONFIG:Debug>,${QUIC_BUILD_DIR}/submodules/openssl/debug/makefile,${QUIC_BUILD_DIR}/submodules/openssl/release/makefile>
+    WORKING_DIRECTORY $<IF:$<CONFIG:Debug>,${QUIC_BUILD_DIR}/submodules/openssl/debug,${QUIC_BUILD_DIR}/submodules/openssl/release>
     COMMAND ${OPENSSL_RUN_COMMAND} install_dev
-    COMMENT "OpenSSL debug build"
-)
-add_custom_command(
-    OUTPUT ${LIBSSL_PATH}
-    BYPRODUCTS ${LIBCRYPTO_PATH}
-    DEPENDS ${QUIC_BUILD_DIR}/submodules/openssl/release/makefile
-    WORKING_DIRECTORY ${QUIC_BUILD_DIR}/submodules/openssl/release
-    COMMAND ${OPENSSL_RUN_COMMAND} install_dev
-    COMMENT "OpenSSL release build"
+    COMMENT "OpenSSL build"
 )
 
 # Named target depending on the final lib artifacts produced by custom commands
@@ -129,7 +115,8 @@ set_property(TARGET OpenSSL_Target PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}helpers
 
 # Target to export to parent project
 add_library(OpenSSLQuic INTERFACE)
-add_dependencies(OpenSSLQuic OpenSSL_Target)
+add_dependencies(OpenSSLQuic
+    OpenSSL_Target)
 target_include_directories(
     OpenSSLQuic
     INTERFACE
@@ -144,5 +131,6 @@ target_link_libraries(
     $<$<NOT:$<CONFIG:Debug>>:${LIBSSL_PATH}>
     $<$<NOT:$<CONFIG:Debug>>:${LIBCRYPTO_PATH}>
 )
-add_library(OpenSSLQuic::OpenSSLQuic ALIAS OpenSSLQuic)
 
+# Target to export to parent project
+add_library(OpenSSLQuic::OpenSSLQuic ALIAS OpenSSLQuic)

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -11,8 +11,8 @@ cmake_minimum_required(VERSION 3.16)
 # This file is intended to be included in the parent msquic project via FetchContent
 project(OpenSSLQuic)
 
-option(QUIC_BUILD_DIR "QUIC build directory" ${CMAKE_CURRENT_BINARY_DIR})
-option(OPENSSL_DIR "OpenSSL build directory" ${QUIC_BUILD_DIR}/openssl)
+set(QUIC_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE STRING "QUIC build directory")
+set(OPENSSL_DIR ${QUIC_BUILD_DIR}/openssl CACHE STRING "OpenSSL build directory")
 
 set(LIBSSL_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
 set(LIBCRYPTO_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX})


### PR DESCRIPTION
Jom is a QT NMAKE replacement which supports parallel builds. Its done as an optional dependency to make builds still work without it installed. This should massively drop compile times for OpenSSL builds.