### PR TITLE
Support ConnectionClose in NEW_CONNECTION Event

### DIFF
--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -497,6 +497,7 @@ QuicListenerClaimConnection(
     //
 
     Connection->State.ListenerAccepted = TRUE;
+    Connection->State.ExternalOwner = TRUE;
 
     QUIC_LISTENER_EVENT Event;
     Event.Type = QUIC_LISTENER_EVENT_NEW_CONNECTION;
@@ -516,6 +517,10 @@ QuicListenerClaimConnection(
     QuicListenerDetachSilo();
 
     if (QUIC_FAILED(Status)) {
+        CXPLAT_FRE_ASSERTMSG(
+            !Connection->State.HandleClosed,
+            "App MUST not close and reject connection!");
+        Connection->State.ExternalOwner = FALSE;
         QuicTraceEvent(
             ListenerErrorStatus,
             "[list][%p] ERROR, %u, %s.",
@@ -529,17 +534,16 @@ QuicListenerClaimConnection(
     }
 
     //
-    // The application layer has accepted the connection and provided a server
-    // certificate.
+    // The application layer has accepted the connection.
     //
     CXPLAT_FRE_ASSERTMSG(
+        Connection->State.HandleClosed ||
         Connection->ClientCallbackHandler != NULL,
-        "App MUST set callback handler!");
+        "App MUST set callback handler or close connection!");
 
-    Connection->State.ExternalOwner = TRUE;
     Connection->State.UpdateWorker = TRUE;
 
-    return TRUE;
+    return !Connection->State.HandleClosed;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -39,6 +39,11 @@ void QuicTestDesiredVersionSettings();
 void QuicTestValidateParamApi();
 
 //
+// Rejection Tests
+//
+void QuicTestConnectionRejection(bool RejectByClosing);
+
+//
 // Event Validation Tests
 //
 
@@ -902,4 +907,8 @@ typedef struct {
 #define IOCTL_QUIC_RUN_STREAM_DIFFERENT_ABORT_ERRORS \
     QUIC_CTL_CODE(74, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 74
+#define IOCTL_QUIC_RUN_CONNECTION_REJECTION \
+    QUIC_CTL_CODE(75, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // bool - RejectByClosing
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 75

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -336,6 +336,17 @@ TEST(Basic, CreateConnection) {
     }
 }
 
+TEST_P(WithBool, RejectConnection) {
+    TestLoggerT<ParamType> Logger("QuicTestConnectionRejection", GetParam());
+    if (TestingKernelMode) {
+        uint8_t Param = (uint8_t)GetParam();
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_CONNECTION_REJECTION, Param));
+    }
+    else {
+        QuicTestConnectionRejection(GetParam());
+    }
+}
+
 #ifdef QUIC_TEST_DATAPATH_HOOKS_ENABLED
 
 TEST_P(WithFamilyArgs, LocalPathChanges) {

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -341,8 +341,7 @@ TEST_P(WithBool, RejectConnection) {
     if (TestingKernelMode) {
         uint8_t Param = (uint8_t)GetParam();
         ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_CONNECTION_REJECTION, Param));
-    }
-    else {
+    } else {
         QuicTestConnectionRejection(GetParam());
     }
 }

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -445,6 +445,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     sizeof(INT32),
     0,
+    sizeof(UINT8)
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -475,6 +476,7 @@ typedef union {
     QUIC_RUN_MTU_DISCOVERY_PARAMS MtuDiscoveryParams;
     uint32_t Test;
     QUIC_RUN_REBIND_PARAMS RebindParams;
+    UINT8 RejectByClosing;
 
 } QUIC_IOCTL_PARAMS;
 
@@ -1095,6 +1097,11 @@ QuicTestCtlEvtIoDeviceControl(
 
     case IOCTL_QUIC_RUN_STREAM_DIFFERENT_ABORT_ERRORS:
         QuicTestCtlRun(QuicTestStreamDifferentAbortErrors());
+        break;
+
+    case IOCTL_QUIC_RUN_CONNECTION_REJECTION:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(QuicTestConnectionRejection(Params->RejectByClosing));
         break;
 
     default:

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -445,7 +445,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     sizeof(INT32),
     0,
-    sizeof(UINT8)
+    sizeof(UINT8),
 };
 
 CXPLAT_STATIC_ASSERT(


### PR DESCRIPTION
Fixes #1647. Correctly handles the case where the app accepts the connection (returns success) but closes the connection. Adds an additional assert to make sure the app doesn't both reject (return failure) and close the connection.