### PR TITLE
improve packaging

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -24,6 +24,7 @@ fi
 
 if [ "$OS" == 'Linux' ]; then
     OS=linux
+    LIBEXT=so
     if [ "$ARCH" == 'x86_64' ]; then
         ARCH='x64'
         LIBDIR="lib64"
@@ -32,8 +33,14 @@ if [ "$OS" == 'Linux' ]; then
         LIBDIR="lib"
     fi
 else
-    echo Only Linux packaging is supported at the moment.
+  if [ "$OS" == 'Darwin' ]; then
+    OS=macos
+    ARCH=x64
+    LIBEXT=dylib
+  else
+    echo Only Linux and macOS packaging is supported at the moment.
     exit 1
+  fi
 fi
 
 # process arguments and allow to override default values
@@ -44,10 +51,6 @@ while :; do
 
     lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
     case $lowerI in
-         -?|-h|--help)
-            usage
-            exit 1
-            ;;
         -d|-debug|--debug)
             CONFIG=Debug
             ;;
@@ -58,6 +61,10 @@ while :; do
         -o|-output|--output)
             shift
             OUTPUT=$1
+            ;;
+       -\?|-h|--help)
+            usage
+            exit 1
             ;;
         *)
             echo unknown argument
@@ -75,8 +82,8 @@ else
 fi
 
 ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
-if [ ! -e "$ARTIFACTS/libmsquic.so" ]; then
-    echo "$ARTIFACTS/libmsquic.so" does not exist. Run build first.
+if [ ! -e "$ARTIFACTS/libmsquic.${LIBEXT}" ]; then
+    echo "$ARTIFACTS/libmsquic.${LIBEXT}" does not exist. Run build first.
     exit 1
 fi
 
@@ -86,23 +93,38 @@ fi
 
 mkdir -p ${OUTPUT}
 
-# RedHat/CentOS
-fpm -f -s dir -t rpm  -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
+if [ "$OS" == "linux" ]; then
+  # RedHat/CentOS
+  FILES="${ARTIFACTS}/libmsquic.${LIBEXT}=/usr/${LIBDIR}/libmsquic.${LIBEXT}"
+  if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}" ]; then
+     FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}"
+  fi
+  fpm -f -s dir -t rpm  -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
     --package "$OUTPUT" --log error \
     --description "${DESCRIPTION}" \
     --provides libmsquic.so \
     ${CONFLICTS} \
-    "$ARTIFACTS/libmsquic.so"=/usr/${LIBDIR}/libmsquic.so \
-    "$ARTIFACTS/libmsquic.lttng.so"=/usr/${LIBDIR}/libmsquic.lttng.so
+    ${FILES}
 
-# Debian/Ubuntu
-if [ "$LIBDIR" == 'lib64' ]; then
-    LIBDIR="lib/x86_64-linux-gnu"
-fi
-fpm -f -s dir -t deb  -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
+  # Debian/Ubuntu
+  if [ "$LIBDIR" == 'lib64' ]; then
+      LIBDIR="lib/x86_64-linux-gnu"
+  fi
+  FILES="${ARTIFACTS}/libmsquic.${LIBEXT}=/usr/${LIBDIR}/libmsquic.${LIBEXT}"
+  if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}" ]; then
+     FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}"
+  fi
+  fpm -f -s dir -t deb  -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
     --package "$OUTPUT" --log error \
     --description "${DESCRIPTION}" \
     --provides libmsquic.so \
     ${CONFLICTS} \
-    "$ARTIFACTS/libmsquic.so"=/usr/${LIBDIR}/libmsquic.so \
-    "$ARTIFACTS/libmsquic.lttng.so"=/usr/${LIBDIR}/libmsquic.lttng.so
+    ${FILES}
+fi
+if [ "$OS" == "macos" ]; then
+  fpm -f -s dir -t osxpkg -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
+    --package "$OUTPUT" --log error \
+    --description "${DESCRIPTION}" \
+    --provides libmsquic.dylib \
+    "$ARTIFACTS/libmsquic.dylib"=/usr/local/lib/libmsquic.dylib
+fi


### PR DESCRIPTION
this change has three parts:
1) add support for macOS
```
gem install fpm

Shining:wfurt-msquic furt$ ./scripts/make-packages.sh
Created package {:path=>"artifacts/packages/macos/x64_Release_openssl/libmsquic-1.6.0.pkg"}

sudo installer -pkg libmsquic-1.6.0.pkg  -target /
```

2) make packaging of `libmsquic.lttng.so` optional. 
I hit issue on some platforms and since this is not critical packaging would work with or without tracing e.g. follow `-DisableLog`

3)  #1830 regressed short options. 
The `-?` will match as one character wildcard and it will also incorrectly match `-o`. I fix that by escaping as well as moved the help to the bottom so more important parts are first.  