### PR TITLE
Enable spectre and guard:cf for windows user mode builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,19 @@ set(QUIC_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/inc)
 if (WIN32)
     set(QUIC_WARNING_FLAGS /WX /W4 /sdl CACHE INTERNAL "")
     set(QUIC_COMMON_FLAGS "")
+
+    include(CheckCCompilerFlag)
+
+    check_c_compiler_flag(/Qspectre HAS_SPECTRE)
+    if(HAS_SPECTRE)
+        list(APPEND QUIC_COMMON_FLAGS /Qspectre)
+    endif()
+
+    check_c_compiler_flag(/guard:cf HAS_GUARDCF)
+    if(HAS_GUARDCF)
+        list(APPEND QUIC_COMMON_FLAGS /guard:cf)
+    endif()
+
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         list(APPEND QUIC_COMMON_FLAGS /MP)
     endif()
@@ -611,6 +624,16 @@ if(QUIC_BUILD_TEST)
 
     set_property(TARGET gtest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
     set_property(TARGET gtest_main PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+
+    if (HAS_SPECTRE)
+        target_compile_options(gtest PRIVATE /Qspectre)
+        target_compile_options(gtest_main PRIVATE /Qspectre)
+    endif()
+
+    if (HAS_GUARDCF)
+        target_compile_options(gtest PRIVATE /guard:cf)
+        target_compile_options(gtest_main PRIVATE /guard:cf)
+    endif()
 
     add_subdirectory(src/core/unittest)
     add_subdirectory(src/platform/unittest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,9 @@ if (WIN32)
 
     include(CheckCCompilerFlag)
 
-    check_c_compiler_flag(/Qspectre HAS_SPECTRE)
+    if(NOT QUIC_ENABLE_SANITIZERS)
+        check_c_compiler_flag(/Qspectre HAS_SPECTRE)
+    endif()
     if(HAS_SPECTRE)
         list(APPEND QUIC_COMMON_FLAGS /Qspectre)
     endif()

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -14,6 +14,10 @@ target_include_directories(inc INTERFACE ${QUIC_INCLUDE_DIR})
 target_compile_features(inc INTERFACE cxx_std_17)
 target_compile_features(inc INTERFACE c_std_11)
 
+if (HAS_GUARDCF)
+    target_link_options(inc INTERFACE /guard:cf /DYNAMICBASE)
+endif()
+
 if (NOT MSVC AND QUIC_ENABLE_SANITIZERS)
     target_link_libraries(inc INTERFACE -fsanitize=address,leak,undefined)
 endif()

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -14,6 +14,11 @@ set_property(TARGET msquictest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
 
 target_link_libraries(msquictest msquic testlib platform inc gtest logging)
 
+# At least /W3 must be used on all windows builds to pass compliance
+if(MSVC)
+    target_compile_options(msquictest PRIVATE /W3)
+endif()
+
 add_test(NAME msquictest
          COMMAND msquictest
          WORKING_DIRECTORY ${QUIC_OUTPUT_DIR})

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -51,14 +51,24 @@ else()
     endif()
 endif()
 
+set(OPENSSL_EXTRA_CONFIGURE_ARGS "")
+
+if(HAS_SPECTRE)
+    list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /Qspectre)
+endif()
+
+if(HAS_GUARDCF)
+    list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /guard:cf)
+endif()
+
 find_program(JOM_EXE jom)
 if (JOM_EXE)
-    set(OPENSSL_EXTRA_CONFIGURE_ARGS /FS)
+    list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /FS)
     include(ProcessorCount)
     ProcessorCount(NPROCS)
     set(OPENSSL_RUN_COMMAND "${JOM_EXE}" -j${NPROCS})
 else()
-    set(OPENSSL_EXTRA_CONFIGURE_ARGS)
+    
     set(OPENSSL_RUN_COMMAND nmake)
 endif()
 

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -57,9 +57,11 @@ if(HAS_SPECTRE)
     list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /Qspectre)
 endif()
 
-if(HAS_GUARDCF)
-    list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /guard:cf)
-endif()
+# guard:cf does not work on OpenSSL
+# https://github.com/openssl/openssl/issues/16147
+# if(HAS_GUARDCF)
+#     list(APPEND OPENSSL_EXTRA_CONFIGURE_ARGS /guard:cf)
+# endif()
 
 find_program(JOM_EXE jom)
 if (JOM_EXE)
@@ -68,7 +70,7 @@ if (JOM_EXE)
     ProcessorCount(NPROCS)
     set(OPENSSL_RUN_COMMAND "${JOM_EXE}" -j${NPROCS})
 else()
-    
+
     set(OPENSSL_RUN_COMMAND nmake)
 endif()
 


### PR DESCRIPTION
Will be required for compliance reasons in the near future.