### PR TITLE
Add notes for targeting Windows ARM64 OpenSSL

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -102,10 +102,12 @@ Note at minimum CMake 3.16 is required. Instructions for installing the newest v
 
 ### Additional Requirements on Windows
 
-  * [CMake](https://cmake.org/)
+  * [CMake](https://cmake.org/) (available in "Developer Command Prompt for VS 2019" when "C++ CMake tools for Windows" are installed)
   * [Perl](https://www.perl.org/get.html) optional (required for OpenSSL build)
-  * [Visual Studio 2019](https://www.visualstudio.com/vs/) or higher
-  * Latest [Windows Insider](https://insider.windows.com/en-us/) builds
+  * [Visual Studio 2019](https://www.visualstudio.com/vs/) (or Build Tools for Visual Studio 2019) with
+    - C++ CMake tools for Windows
+    - MSVC v142 - VS 2019 C++ (_Arch_) build tools
+  * Latest [Windows Insider](https://insider.windows.com/en-us/) builds (required for SChannel build)
 
 ## Running a Build
 
@@ -195,6 +197,7 @@ xcode-select --install
 
 ### Windows
 
+Ensure the corresponding "MSVC v142 - VS 2019 C++ (_Arch_) build tools" are installed for the target arch, e.g. selecting "Desktop development with C++" only include x64/x86 but not ARM64 by default.
 ```
 mkdir build && cd build
 cmake -g 'Visual Studio 16 2019' -A x64 ..

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -197,7 +197,7 @@ xcode-select --install
 
 ### Windows
 
-Ensure the corresponding "MSVC v142 - VS 2019 C++ (_Arch_) build tools" are installed for the target arch, e.g. selecting "Desktop development with C++" only include x64/x86 but not ARM64 by default.
+Ensure the corresponding "MSVC v142 - VS 2019 C++ (_Arch_) build tools" are installed for the target arch, e.g. selecting "Desktop development with C++" only includes x64/x86 but not ARM64 by default.
 ```
 mkdir build && cd build
 cmake -g 'Visual Studio 16 2019' -A x64 ..


### PR DESCRIPTION
Selecting "Desktop development with C++" for "Build Tools for Visual Studio 2019" (or installed as part of node.js native tools) only includes "MSVC v142 - VS 2019 C++ x64/x86 build tools". To target ARM64, select also "MSVC v142 - VS 2019 C++ ARM64 build tools" in "Individual components".
This also enable using GUI tools in Visual Studio 2019/2022 to configure and build with VS 2019 CMake tools without using the command line at all.