### PR TITLE
General build cleanups and speedups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,19 +598,25 @@ if(QUIC_BUILD_TEST)
     # Enforce static builds for test artifacts
     set(PREV_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS} CACHE INTERNAL "")
     set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+    set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
+    set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)")
+    if(WIN32 AND QUIC_STATIC_LINK_CRT)
+        option(gtest_force_shared_crt "Use shared (DLL) run-time lib even when Google Test is built as static lib." ON)
+    endif()
     FetchContent_Declare(
         googletest
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/submodules/googletest
-        CMAKE_ARGS "-DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -Dgtest_force_shared_crt=ON"
     )
     FetchContent_MakeAvailable(googletest)
     set(BUILD_SHARED_LIBS ${PREV_BUILD_SHARED_LIBS} CACHE INTERNAL "")
 
     set_property(TARGET gtest PROPERTY CXX_STANDARD 17)
-    set_property(TARGET gtest_main PROPERTY CXX_STANDARD 17)
-
     set_property(TARGET gtest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+
+    set_property(TARGET gtest_main PROPERTY CXX_STANDARD 17)
     set_property(TARGET gtest_main PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+    set_property(TARGET gtest_main PROPERTY EXCLUDE_FROM_ALL ON)
+    set_property(TARGET gtest_main PROPERTY EXCLUDE_FROM_DEFAULT_BUILD ON)
 
     add_subdirectory(src/core/unittest)
     add_subdirectory(src/platform/unittest)

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -279,12 +279,17 @@ function CMake-Generate {
     }
 
     if ($IsWindows) {
-        $Arguments += " $Generator -A "
-        switch ($Arch) {
-            "x86"   { $Arguments += "Win32" }
-            "x64"   { $Arguments += "x64" }
-            "arm"   { $Arguments += "arm" }
-            "arm64" { $Arguments += "arm64" }
+        if ($Generator.Contains("Visual Studio")) {
+            $Arguments += " $Generator -A "
+            switch ($Arch) {
+                "x86"   { $Arguments += "Win32" }
+                "x64"   { $Arguments += "x64" }
+                "arm"   { $Arguments += "arm" }
+                "arm64" { $Arguments += "arm64" }
+            }
+        } else {
+            Write-Host "Non VS based generators must be run from a Visual Studio Developer Powershell Prompt matching the passed in architecture"
+            $Arguments += " $Generator"
         }
     } elseif ($IsMacOS) {
         $Arguments += " $Generator"

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -170,7 +170,6 @@ else()
         DEPENDS ${QUIC_DEPS_FILE}
     )
     add_dependencies(msquic_linker_inputs msquic_static)
-    message(STATUS "${QUIC_DEPS_FILE}")
     set_property(TARGET msquic_linker_inputs PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
 
     # Run archiver tool (lib.exe) on our generated linker args


### PR DESCRIPTION
Remove excess prints from static builds
Remove gmock and gtest_main from builds
Allow using alternate build systems on windows builds with warning about dev command promt
Tested with VS 2022. Default is still 2019. Might add an option later to automatically detect 2022