### PR TITLE
Add minimum compiler requirements for CI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,8 @@ if (WIN32)
     set(QUIC_COMMON_DEFINES WIN32_LEAN_AND_MEAN SECURITY_WIN32)
 else()
 
-    # Check for GSO and RSS support in CI
-    if(QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS AND CX_PLATFORM STREQUAL "linux")
-        include(CheckCCompilerFlag)
+    if (CX_PLATFORM STREQUAL "linux)
+    include(CheckCCompilerFlag)
         check_c_source_compiles(
             "
             #include <netinet/udp.h>
@@ -233,8 +232,9 @@ else()
             "
             HAS_UDP_SEGMENT)
         if (NOT HAS_UDP_SEGMENT)
-            message(FATAL_ERROR "UDP_SEGMENT must exist for CI builds")
+            message(STATUS "UDP_SEGMENT is missing. Send performance will be reduced")
         endif()
+
         check_c_source_compiles(
             "
             #include <sys/socket.h>
@@ -242,10 +242,20 @@ else()
             "
             HAS_SO_ATTACH_REUSEPORT_CBPF)
         if (NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
-            message(FATAL_ERROR "SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
+            message(STATUS "HAS_SO_ATTACH_REUSEPORT_CBPF is missing. Server receive performance will be reduced")
+        endif()
+
+        # Error if flags are missing in CI
+        if(QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS)
+            if (NOT HAS_UDP_SEGMENT)
+                message(FATAL_ERROR "UDP_SEGMENT must exist for CI builds")
+            endif()
+
+            if (NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
+                message(FATAL_ERROR "SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
+            endif()
         endif()
     endif()
-
 
     set(QUIC_COMMON_FLAGS "")
     set(QUIC_COMMON_DEFINES _GNU_SOURCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,8 @@ option(QUIC_SOURCE_LINK "Enables source linking on MSVC" ON)
 option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)
 option(QUIC_CODE_CHECK "Run static code checkers" OFF)
 option(QUIC_OPTIMIZE_LOCAL "Optimize code for local machine architecture" OFF)
+option(QUIC_CI "CI Specific build" OFF)
+option(QUIC_SKIP_CI_CHECKS "Disable CI specific build checks" OFF)
 option(QUIC_TLS_SECRETS_SUPPORT "Enable export of TLS secrets" OFF)
 option(QUIC_TELEMETRY_ASSERTS "Enable telemetry asserts in release builds" OFF)
 option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
@@ -205,11 +207,33 @@ if (WIN32)
         list(APPEND QUIC_COMMON_FLAGS /guard:cf)
     endif()
 
+    # Require /Qspectre and /guard:cf in CI builds
+    if((QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS) AND (NOT HAS_SPECTRE OR NOT HAS_GUARDCF))
+        message(FATAL_ERROR "/Qspectre and /guard:cf must exist for CI builds")
+    endif()
+
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         list(APPEND QUIC_COMMON_FLAGS /MP)
     endif()
     set(QUIC_COMMON_DEFINES WIN32_LEAN_AND_MEAN SECURITY_WIN32)
 else()
+
+    # Check for GSO and RSS support in CI
+    if(QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS AND CX_PLATFORM STREQUAL "linux")
+        include(CheckCCompilerFlag)
+        check_c_source_compiles(
+            "
+            #include <netinet/udp.h>
+            #include <sys/socket.h>
+            int main() {int a = UDP_SEGMENT; int b = SO_ATTACH_REUSEPORT_CBPF; return a | b; }
+            "
+            HAS_REQUIRED_INCLUDES)
+        if (NOT HAS_REQUIRED_INCLUDES)
+            message(FATAL_ERROR "UDP_SEGMENT and SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
+        endif()
+    endif()
+
+
     set(QUIC_COMMON_FLAGS "")
     set(QUIC_COMMON_DEFINES _GNU_SOURCE)
     set(QUIC_WARNING_FLAGS -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,8 +223,8 @@ if (WIN32)
     set(QUIC_COMMON_DEFINES WIN32_LEAN_AND_MEAN SECURITY_WIN32)
 else()
 
-    if (CX_PLATFORM STREQUAL "linux)
-    include(CheckCCompilerFlag)
+    if (CX_PLATFORM STREQUAL "linux")
+        include(CheckCCompilerFlag)
         check_c_source_compiles(
             "
             #include <netinet/udp.h>
@@ -241,8 +241,8 @@ else()
             int main() { return SO_ATTACH_REUSEPORT_CBPF; }
             "
             HAS_SO_ATTACH_REUSEPORT_CBPF)
-        if (NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
-            message(STATUS "HAS_SO_ATTACH_REUSEPORT_CBPF is missing. Server receive performance will be reduced")
+        if(NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
+            message(STATUS "SO_ATTACH_REUSEPORT_CBPF is missing. Server receive performance will be reduced")
         endif()
 
         # Error if flags are missing in CI
@@ -251,8 +251,25 @@ else()
                 message(FATAL_ERROR "UDP_SEGMENT must exist for CI builds")
             endif()
 
-            if (NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
+            if(NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
                 message(FATAL_ERROR "SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
+            endif()
+        endif()
+
+        # Check to see if lttng will work
+        if(QUIC_ENABLE_LOGGING)
+            check_c_source_compiles(
+                "
+                #include <lttng/ust-config.h>
+                #ifdef LTTNG_UST_HAVE_SDT_INTEGRATION
+                #error \"SDT is enabled\"
+                #endif
+                int main() { return 0; }
+                "
+                HAS_LTTNG_WITHOUT_SDT)
+            if(NOT HAS_LTTNG_WITHOUT_SDT)
+                message(WARNING "LTTng with SDT integration does not work. Disabling logging")
+                set(QUIC_ENABLE_LOGGING OFF)
             endif()
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,8 +208,13 @@ if (WIN32)
     endif()
 
     # Require /Qspectre and /guard:cf in CI builds
-    if((QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS) AND (NOT HAS_SPECTRE OR NOT HAS_GUARDCF))
-        message(FATAL_ERROR "/Qspectre and /guard:cf must exist for CI builds")
+    if(QUIC_CI AND NOT QUIC_SKIP_CI_CHECKS)
+        if(NOT HAS_GUARDCF)
+            message(FATAL_ERROR "/guard:cf must exist for CI builds")
+        endif()
+        if(NOT HAS_SPECTRE AND NOT QUIC_ENABLE_SANITIZERS AND NOT QUIC_UWP_BUILD)
+            message(FATAL_ERROR "/Qspectre must exist for CI builds")
+        endif()
     endif()
 
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -224,12 +229,20 @@ else()
         check_c_source_compiles(
             "
             #include <netinet/udp.h>
-            #include <sys/socket.h>
-            int main() {int a = UDP_SEGMENT; int b = SO_ATTACH_REUSEPORT_CBPF; return a | b; }
+            int main() { return UDP_SEGMENT; }
             "
-            HAS_REQUIRED_INCLUDES)
-        if (NOT HAS_REQUIRED_INCLUDES)
-            message(FATAL_ERROR "UDP_SEGMENT and SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
+            HAS_UDP_SEGMENT)
+        if (NOT HAS_UDP_SEGMENT)
+            message(FATAL_ERROR "UDP_SEGMENT must exist for CI builds")
+        endif()
+        check_c_source_compiles(
+            "
+            #include <sys/socket.h>
+            int main() { return SO_ATTACH_REUSEPORT_CBPF; }
+            "
+            HAS_SO_ATTACH_REUSEPORT_CBPF)
+        if (NOT HAS_SO_ATTACH_REUSEPORT_CBPF)
+            message(FATAL_ERROR "SO_ATTACH_REUSEPORT_CBPF must exist for CI builds")
         endif()
     endif()
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -346,7 +346,9 @@ function CMake-Generate {
     }
     if ($CI) {
         $Arguments += " -DQUIC_CI=ON"
-        $Arguments += " -DQUIC_CI_CONFIG=$Config"
+        if ($Platform -eq "android" -or $ToolchainFile -ne "") {
+            $Arguments += " -DQUIC_SKIP_CI_CHECKS=ON"
+        }
         $Arguments += " -DQUIC_VER_BUILD_ID=$env:BUILD_BUILDID"
         $Arguments += " -DQUIC_VER_SUFFIX=-official"
     }

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -117,32 +117,6 @@ else()
 
     flatten_link_dependencies(msquic_static)
 
-    if(QUIC_CI AND QUIC_CI_CONFIG AND QUIC_TLS STREQUAL "openssl")
-        # CI builds may have a cached OpenSSL library available for use.
-        # Inject them directly to the dependency list if so.
-        # Again, leading spaces are important.
-        # NOTE: CI builds are single configuration only so each build variant
-        # is tested separately as opposed to using a generator expression in
-        # this case.
-        if(QUIC_CI_CONFIG STREQUAL "Release" AND EXISTS ${LIBCRYPTO_PATH})
-            set_property(
-                GLOBAL
-                APPEND
-                APPEND_STRING
-                PROPERTY QUIC_STATIC_LIBS
-                " ${LIBCRYPTO_PATH} ${LIBSSL_PATH}"
-            )
-        elseif(QUIC_CI_CONFIG STREQUAL "Debug" AND EXISTS ${LIBCRYPTO_DEBUG_PATH})
-            set_property(
-                GLOBAL
-                APPEND
-                APPEND_STRING
-                PROPERTY QUIC_STATIC_LIBS
-                " ${LIBCRYPTO_DEBUG_PATH} ${LIBSSL_DEBUG_PATH}"
-            )
-        endif()
-    endif()
-
     get_property(DEPS GLOBAL PROPERTY QUIC_STATIC_LIBS)
     # Uncomment to analyze which dependencies were traversed
     # message(STATUS "DEPS: ${DEPS}, ${QUIC_BUILD_DIR}")


### PR DESCRIPTION
For builds coming out of our CI, we want a minimum set up required flags and definitions, both for compliance and performance reasons. On linux, these checks are properly handled if missing at runtime, but we want them there in the binaries we build