### PR TITLE
Bump GNU toolchains minimum cmake version to 3.6

### DIFF
--- a/cmake/toolchains/gnu.toolchain.cmake
+++ b/cmake/toolchains/gnu.toolchain.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.6)
 
 # load settings in case of "try compile"
 set(TOOLCHAIN_CONFIG_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/toolchain.config.cmake")


### PR DESCRIPTION
Removes a warning that currently exists during the raspberry pi build