### PR TITLE
Reset distribution stages to what worked before separate pipeline testing

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -107,3 +107,10 @@ extends:
           config: Debug
           tls: openssl
           platform: UWP
+
+    - stage: package
+      displayName: Package
+      dependsOn:
+      - build
+      jobs:
+      - template: .azure/obtemplates/build-distribution.yml@self

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -101,3 +101,10 @@ extends:
           config: Debug
           tls: openssl
           platform: UWP
+
+    - stage: package
+      displayName: Package
+      dependsOn:
+      - build
+      jobs:
+      - template: .azure/obtemplates/build-distribution.yml@self

--- a/.azure/obtemplates/build-distribution.yml
+++ b/.azure/obtemplates/build-distribution.yml
@@ -1,98 +1,52 @@
-# This template contains steps to merge all builds into a single set of files to distribute.
-
 jobs:
 - job: distribution
   displayName: Distribution
-  variables:
-  - name: runCodesignValidationInjection
-    value: false
-  - name: skipComponentGovernanceDetection
-    value: true
   pool:
-    vmImage: windows-latest
+    type: windows
+  variables:
+    ob_outputDirectory: $(Build.SourcesDirectory)\artifacts\dist
   steps:
   - checkout: self
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
+      # Leaving this, as I know this works and it wasn't well documented
+      # source: specific
+      # project: $(resources.pipeline.onebranch.projectID)
+      # pipeline: $(resources.pipeline.onebranch.pipelineID)
+      # preferTriggeringPipeline: true
+      # runVersion: specific
+      # runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_windows_schannel_Release
       path: $(Build.SourcesDirectory)\artifacts\bin\windows
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_windows_openssl_Release
       path: $(Build.SourcesDirectory)\artifacts\bin\windows
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_windows_schannel_Debug
       path: $(Build.SourcesDirectory)\artifacts\bin\windows
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_windows_openssl_Debug
       path: $(Build.SourcesDirectory)\artifacts\bin\windows
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_UWP_schannel_Release
       path: $(Build.SourcesDirectory)\artifacts\bin\uwp
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_UWP_openssl_Release
       path: $(Build.SourcesDirectory)\artifacts\bin\uwp
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_UWP_schannel_Debug
       path: $(Build.SourcesDirectory)\artifacts\bin\uwp
   - task: DownloadPipelineArtifact@2
     inputs:
-      source: specific
-      project: $(resources.pipeline.onebranch.projectID)
-      pipeline: $(resources.pipeline.onebranch.pipelineID)
-      preferTriggeringPipeline: true
-      runVersion: specific
-      runId: $(resources.pipeline.onebranch.runID)
       artifact: drop_build_build_UWP_openssl_Debug
       path: $(Build.SourcesDirectory)\artifacts\bin\uwp
 
@@ -101,16 +55,3 @@ jobs:
     inputs:
       pwsh: false
       filePath: scripts/package-distribution.ps1
-
-  - task: CopyFiles@2
-    displayName: Move Distribution
-    inputs:
-      sourceFolder: artifacts/dist
-      targetFolder: $(Build.ArtifactStagingDirectory)
-
-  - task: PublishBuildArtifacts@1
-    displayName: Upload Distribution
-    inputs:
-      artifactName: distribution
-      pathToPublish: $(Build.ArtifactStagingDirectory)
-      parallel: true


### PR DESCRIPTION
This way onebranch builds will still build distributions