### PR TITLE
Fix third party notices missing from OpenSSL packaging

### DIFF
--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -127,7 +127,7 @@ foreach ($Build in $AllBuilds) {
 
     # Copy License
     Copy-Item -Path (Join-Path $RootDir "LICENSE") -Destination $TempDir
-    if (!$BuildBaseName -like "*schannel*") {
+    if (!($BuildBaseName -like "*schannel*")) {
         # Only need license, no 3rd party code
         Copy-Item -Path (Join-Path $RootDir "THIRD-PARTY-NOTICES") -Destination $TempDir
     }


### PR DESCRIPTION
Regression in https://github.com/microsoft/msquic/commit/801132a6cf3f9c12afe87ba5605203fffbab50c3