### PR TITLE
Fix official onebranch builds failing distribution stage

### DIFF
--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -25,6 +25,9 @@ $AllBuilds = @()
 foreach ($Platform in $Platforms) {
     $PlatBuilds = Get-ChildItem -Path $Platform.FullName
     foreach ($PlatBuild in $PlatBuilds) {
+        if (!(Test-Path $PlatBuild -PathType Container)) {
+            continue;
+        }
         $AllBuilds += $PlatBuild
         if ($Platform.Name -eq "windows") {
             $WindowsBuilds += $PlatBuild


### PR DESCRIPTION
An extra file path is included in the official builds because of signing, which breaks the existing scripts