### PR TITLE
Fix QNS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,12 +138,6 @@ set(QUIC_LIBRARY_NAME "msquic" CACHE STRING "Override the output library name")
 
 set(BUILD_SHARED_LIBS ${QUIC_BUILD_SHARED})
 
-# FindLTTngUST does not exist before CMake 3.6, so disable logging for older cmake versions
-if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
-    message(WARNING "Logging unsupported on this version of CMake. Please upgrade to 3.6 or later.")
-    set(QUIC_ENABLE_LOGGING OFF)
-endif()
-
 if (QUIC_PDBALTPATH AND MSVC)
 #    Disabled in all cases because generation is broken.
 #    file(READ ${CMAKE_CURRENT_LIST_DIR}/cmake/PdbAltPath.txt PDBALTPATH)
@@ -485,7 +479,7 @@ if(QUIC_TLS STREQUAL "openssl")
 
     target_link_libraries(OpenSSL
         INTERFACE
-        OpenSSLQuic::OpenSSLQuic
+        OpenSSLQuic
     )
 endif()
 

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -149,8 +149,6 @@ if (WIN32)
         $<$<NOT:$<CONFIG:Debug>>:${LIBCRYPTO_PATH}>
     )
 
-    add_library(OpenSSLQuic::OpenSSLQuic ALIAS OpenSSLQuic)
-
 else()
 
     set(LIBSSL_PATH ${OPENSSL_DIR}/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
@@ -266,7 +264,5 @@ else()
             ${LIBCRYPTO_PATH}
         )
     endif()
-
-    add_library(OpenSSLQuic::OpenSSLQuic ALIAS OpenSSLQuic)
 
 endif()


### PR DESCRIPTION
ALIAS targets only work in 3.18. Instead of bumping the requirement, remove the ALIAS target from OpenSSL