### PR TITLE
Add proper CI versioning to nuget

### DIFF
--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -17,7 +17,10 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("schannel", "openssl")]
-    [string]$Tls = "openssl"
+    [string]$Tls = "openssl",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$ReleaseBuild = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -124,4 +127,19 @@ $DistDir = Join-Path $BaseArtifactsDir "dist"
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
 $RepoRemote = Get-GitRemote -RepoDir $RootDir
 
-nuget.exe pack (Join-Path $PackagingDir "Microsoft.Native.Quic.MsQuic.$Tls.nuspec") -OutputDirectory $DistDir -p CommitHash=$CurrentCommitHash -p RepoRemote=$RepoRemote
+$Version = "1.8.0"
+
+$BuildId = $env:BUILD_BUILDID
+if ($null -ne $BuildId) {
+    if ($ReleaseBuild) {
+        $Version += "+$BuildId"
+    } else {
+        $Version += "-ci.$BuildId"
+    }
+} else {
+    $Version += "-local"
+}
+
+Write-Host $Version
+
+nuget.exe pack (Join-Path $PackagingDir "Microsoft.Native.Quic.MsQuic.$Tls.nuspec") -OutputDirectory $DistDir -p CommitHash=$CurrentCommitHash -p RepoRemote=$RepoRemote -Version $Version

--- a/scripts/update-version.ps1
+++ b/scripts/update-version.ps1
@@ -27,8 +27,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $MsQuicVerFilePath = Join-Path $RootDir "src" "inc" "msquic.ver"
 $CreatePackageFilePath = Join-Path $RootDir ".azure" "templates" "create-package.yml"
 $QnsFilePath = Join-Path $RootDir ".azure" "azure-pipelines.qns.yml"
-$NuspecOpenSSLFilePath = Join-Path $RootDir "src" "nuget" "msquic-openssl.nuspec"
-$NuspecSchannelFilePath = Join-Path $RootDir "src" "nuget" "msquic-schannel.nuspec"
+$NugetPackageFile = Join-Path $RootDir "scripts" "package-nuget.ps1"
 
 # Get the current version number from the msquic.ver file.
 $VerMajor = (Select-String -Path $MsQuicVerFilePath "#define VER_MAJOR (.*)" -AllMatches).Matches[0].Groups[1].Value
@@ -62,9 +61,6 @@ Write-Host "    New version: $NewVerMajor.$NewVerMinor.$NewVerPatch"
 (Get-Content $QnsFilePath) `
     -replace "$VerMajor.$VerMinor.$VerPatch", "$NewVerMajor.$NewVerMinor.$NewVerPatch" |`
     Out-File $QnsFilePath
-(Get-Content $NuspecOpenSSLFilePath) `
+(Get-Content $NugetPackageFile) `
     -replace "$VerMajor.$VerMinor.$VerPatch", "$NewVerMajor.$NewVerMinor.$NewVerPatch" |`
-    Out-File $NuspecOpenSSLFilePath
-(Get-Content $NuspecSchannelFilePath) `
-    -replace "$VerMajor.$VerMinor.$VerPatch", "$NewVerMajor.$NewVerMinor.$NewVerPatch" |`
-    Out-File $NuspecSchannelFilePath
+    Out-File $NugetPackageFile

--- a/src/nuget/Microsoft.Native.Quic.MsQuic.OpenSSL.nuspec
+++ b/src/nuget/Microsoft.Native.Quic.MsQuic.OpenSSL.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Native.Quic.MsQuic.OpenSSL</id>
-    <version>1.8.0</version>
+    <version>0.0.0</version>
     <title>MsQuic (OpenSSL)</title>
     <authors>Microsoft</authors>
     <license type="expression">MIT AND Apache-2.0</license>

--- a/src/nuget/Microsoft.Native.Quic.MsQuic.Schannel.nuspec
+++ b/src/nuget/Microsoft.Native.Quic.MsQuic.Schannel.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Native.Quic.MsQuic.Schannel</id>
-    <version>1.8.0</version>
+    <version>0.0.0</version>
     <title>MsQuic (Schannel)</title>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>


### PR DESCRIPTION
Right now we don't have a way to trigger a release, so all builds will show up as a prerelease. That is a next step we need to work through.