### PR TITLE
Don't allow stateless operations on a binding until fully initialized

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -166,10 +166,7 @@ QuicBindingInitialize(
 
     *NewBinding = Binding;
     Status = QUIC_STATUS_SUCCESS;
-
-    CxPlatDispatchLockAcquire(&Binding->StatelessOperLock);
-    Binding->Initialized = TRUE;
-    CxPlatDispatchLockRelease(&Binding->StatelessOperLock);
+    InterlockedIncrement16(&Binding->Initialized);
 
 Error:
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -167,6 +167,10 @@ QuicBindingInitialize(
     *NewBinding = Binding;
     Status = QUIC_STATUS_SUCCESS;
 
+    CxPlatDispatchLockAcquire(&Binding->StatelessOperLock);
+    Binding->Initialized = TRUE;
+    CxPlatDispatchLockRelease(&Binding->StatelessOperLock);
+
 Error:
 
     if (QUIC_FAILED(Status)) {
@@ -630,6 +634,10 @@ QuicBindingCreateStatelessOperation(
     QUIC_STATELESS_CONTEXT* StatelessCtx = NULL;
 
     CxPlatDispatchLockAcquire(&Binding->StatelessOperLock);
+
+    if (!Binding->Initialized) {
+        goto Exit;
+    }
 
     //
     // Age out all expired operation contexts.

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -166,7 +166,6 @@ QuicBindingInitialize(
 
     *NewBinding = Binding;
     Status = QUIC_STATUS_SUCCESS;
-    InterlockedIncrement16(&Binding->Initialized);
 
 Error:
 
@@ -632,7 +631,7 @@ QuicBindingCreateStatelessOperation(
 
     CxPlatDispatchLockAcquire(&Binding->StatelessOperLock);
 
-    if (!Binding->Initialized) {
+    if (Binding->RefCount == 0) {
         goto Exit;
     }
 

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -190,7 +190,7 @@ typedef struct QUIC_BINDING {
     // Indicates that the binding is fully initialized. Not as part of the above
     // bitfield as its accessed from multiple threads.
     //
-    uint16_t Initialized;
+    int16_t Initialized;
 
     //
     // Number of (connection and listener) references to the binding.

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -187,12 +187,6 @@ typedef struct QUIC_BINDING {
     BOOLEAN Connected : 1;
 
     //
-    // Indicates that the binding is fully initialized. Not as part of the above
-    // bitfield as its accessed from multiple threads.
-    //
-    int16_t Initialized;
-
-    //
     // Number of (connection and listener) references to the binding.
     //
     uint32_t RefCount;

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -187,9 +187,10 @@ typedef struct QUIC_BINDING {
     BOOLEAN Connected : 1;
 
     //
-    // Indicates that the binding is fully initialized.
+    // Indicates that the binding is fully initialized. Not as part of the above
+    // bitfield as its accessed from multiple threads.
     //
-    BOOLEAN Initialized : 1;
+    uint16_t Initialized;
 
     //
     // Number of (connection and listener) references to the binding.

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -187,6 +187,11 @@ typedef struct QUIC_BINDING {
     BOOLEAN Connected : 1;
 
     //
+    // Indicates that the binding is fully initialized.
+    //
+    BOOLEAN Initialized : 1;
+
+    //
     // Number of (connection and listener) references to the binding.
     //
     uint32_t RefCount;


### PR DESCRIPTION
A small race condition exists if a server binding is created and runs out of memory at a specific point in the process. If the socket and at least 1 receive buffer gets allocated, a packet can be received on that receive queue. This receive can post a stateless operation, even if one of the later receive buffers fails to allocate, and cause the socket and binding to be cleaned up early. During binding cleanup, there will be a stateless operation in the binding queue, causing an assertion to be hit. 

The solution to this is to not allow a stateless operation to queue until the binding has been fully initialized. The packet will be dropped instead, which is fine.