### PR TITLE
Change congestion control api to use "TimeNow" in microsecond

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -330,12 +330,13 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicCongestionControlOnDataAcknowledged(
     _In_ QUIC_CONGESTION_CONTROL* Cc,
-    _In_ uint64_t TimeNow, // millisec
+    _In_ uint64_t TimeNow, // microsecond
     _In_ uint64_t LargestPacketNumberAcked,
     _In_ uint32_t NumRetransmittableBytes,
     _In_ uint32_t SmoothedRtt
     )
 {
+    TimeNow = US_TO_MS(TimeNow);
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     BOOLEAN PreviousCanSendState = QuicCongestionControlCanSend(Cc);
 

--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -158,7 +158,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicCongestionControlOnDataAcknowledged(
     _In_ QUIC_CONGESTION_CONTROL* Cc,
-    _In_ uint64_t TimeNow, // millisec
+    _In_ uint64_t TimeNow, // microsecond
     _In_ uint64_t LargestPacketNumberAcked,
     _In_ uint32_t NumRetransmittableBytes,
     _In_ uint32_t SmoothedRtt

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1153,7 +1153,7 @@ QuicLossDetectionDiscardPackets(
         const QUIC_PATH* Path = &Connection->Paths[0]; // TODO - Correct?
         if (QuicCongestionControlOnDataAcknowledged(
                 &Connection->CongestionControl,
-                US_TO_MS(TimeNow),
+                TimeNow,
                 LossDetection->LargestAck,
                 AckedRetransmittableBytes,
                 Path->SmoothedRtt)) {
@@ -1434,7 +1434,7 @@ QuicLossDetectionProcessAckBlocks(
     if (NewLargestAck || AckedRetransmittableBytes > 0) {
         if (QuicCongestionControlOnDataAcknowledged(
                 &Connection->CongestionControl,
-                US_TO_MS(TimeNow),
+                TimeNow,
                 LossDetection->LargestAck,
                 AckedRetransmittableBytes,
                 Connection->Paths[0].SmoothedRtt)) {


### PR DESCRIPTION
We may lost the precision of the `TimeNow` timestamp if we do the `US_TO_MS` convertion in `loss_detection` layer, and this may not be compatible with other congestion control algorithm.
