### PR TITLE
Configure openssl certificate dir correctly during build

### DIFF
--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -32,9 +32,8 @@ set(OPENSSL_CONFIG_FLAGS
 if (WIN32)
 
     if (DEFINED ENV{CommonProgramFiles})
-        message(STATUS "Setting dir to $ENV{CommonProgramFiles}\\SSL")
+        message(STATUS "Setting openssldir to $ENV{CommonProgramFiles}\\SSL")
         list(APPEND OPENSSL_CONFIG_FLAGS --openssldir=\"$ENV{CommonProgramFiles}\\SSL\")
-        message(STATUS "${OPENSSL_CONFIG_FLAGS}")
     endif()
 
     set(LIBSSL_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -31,6 +31,12 @@ set(OPENSSL_CONFIG_FLAGS
 
 if (WIN32)
 
+    if (DEFINED ENV{CommonProgramFiles})
+        message(STATUS "Setting dir to $ENV{CommonProgramFiles}\\SSL")
+        list(APPEND OPENSSL_CONFIG_FLAGS --openssldir=\"$ENV{CommonProgramFiles}\\SSL\")
+        message(STATUS "${OPENSSL_CONFIG_FLAGS}")
+    endif()
+
     set(LIBSSL_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
     set(LIBCRYPTO_DEBUG_PATH ${OPENSSL_DIR}/debug/lib/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX})
     set(LIBSSL_PATH ${OPENSSL_DIR}/release/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
@@ -155,6 +161,27 @@ else()
 
     set(LIBSSL_PATH ${OPENSSL_DIR}/lib/libssl${CMAKE_STATIC_LIBRARY_SUFFIX})
     set(LIBCRYPTO_PATH ${OPENSSL_DIR}/lib/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+    # Figure out the default cert directory
+    execute_process(
+        COMMAND openssl version -d
+        RESULT_VARIABLE OPENSSL_VERSION_RESULT
+        OUTPUT_VARIABLE FULL_OPENSSL_CERT_DIR)
+
+    if (OPENSSL_VERSION_RESULT STREQUAL 0)
+        # PARSE OPENSSLDIR
+        string(REGEX MATCH "OPENSSLDIR:.*\"(.+)\"" OPENSSL_CERT_MATCH_VAR ${FULL_OPENSSL_CERT_DIR})
+        if (CMAKE_MATCH_COUNT EQUAL 1)
+            message(STATUS "Setting openssldir to ${CMAKE_MATCH_1}")
+            list(APPEND OPENSSL_CONFIG_FLAGS --openssldir=\"${CMAKE_MATCH_1}\")
+            set(CONFIGURED_OPENSSL_CERT_DIR TRUE)
+        endif()
+    endif()
+
+    if (NOT CONFIGURED_OPENSSL_CERT_DIR)
+        message(STATUS "Setting openssldir to default /usr/local/ssl")
+        list(APPEND OPENSSL_CONFIG_FLAGS --openssldir=/usr/local/ssl)
+    endif()
 
     list(APPEND OPENSSL_CONFIG_FLAGS --prefix=${OPENSSL_DIR})
 


### PR DESCRIPTION
By default, if a prefix is specified during the openssl build, that directory is used for the certificate store. However, in our build that directory is in the build dir, so is completely wrong. This makes it so that by default its impossible for OpenSSL that don't use the built in TLS provider to validate certificates without doing custom certificate validation (This is why .NET doesnt see this issue). This changes the cert directory during the build to point to the built in certificate store. 

We ideally should look at adding a test to ensure certificate validation against a valid remote server works.