### PR TITLE
fix compilatin issue on macOS 10.15

### DIFF
--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -93,7 +93,8 @@ class CxPlatWatchdog {
     }
 public:
     CxPlatWatchdog(uint32_t WatchdogTimeoutMs) : TimeoutMs(WatchdogTimeoutMs) {
-        CXPLAT_THREAD_CONFIG Config = { 0 };
+        CXPLAT_THREAD_CONFIG Config;
+        memset(&Config, 0, sizeof(CXPLAT_THREAD_CONFIG));
         Config.Name = "cxplat_watchdog";
         Config.Callback = WatchdogThreadCallback;
         Config.Context = this;


### PR DESCRIPTION
similar to previous changes.
```
cd /Users/furt/github/wfurt-msquic/build/macos/x64_openssl/src/test/bin && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DCX_PLATFORM_DARWIN -DQUIC_DISABLE_CLIENT_CERT_TESTS -DQUIC_DISABLE_DEFERRED_CERT_TESTS -DQUIC_DISABLE_SHARED_PORT_TESTS -DQUIC_EVENTS_STUB -DQUIC_LOGS_STUB -DQUIC_TEST_OPENSSL_FLAGS=1 -DVER_BUILD_ID=0 -DVER_SUFFIX=-private -D_GNU_SOURCE -I/Users/furt/github/wfurt-msquic/src/test -I/Users/furt/github/wfurt-msquic/src/bin/../inc -I/Users/furt/github/wfurt-msquic/src/inc -I/Users/furt/github/wfurt-msquic/build/macos/x64_openssl/_deps/opensslquic-build/openssl/include -isystem /Users/furt/github/wfurt-msquic/submodules/googletest/googletest/include -isystem /Users/furt/github/wfurt-msquic/submodules/googletest/googletest -Og -gdwarf -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.15 -fms-extensions -fPIC -Wno-microsoft-anon-tag -Wno-tautological-constant-out-of-range-compare -Wmissing-field-initializers -std=gnu++17 -MD -MT src/test/bin/CMakeFiles/msquictest.dir/quic_gtest.cpp.o -MF CMakeFiles/msquictest.dir/quic_gtest.cpp.o.d -o CMakeFiles/msquictest.dir/quic_gtest.cpp.o -c /Users/furt/github/wfurt-msquic/src/test/bin/quic_gtest.cpp
In file included from /Users/furt/github/wfurt-msquic/src/test/bin/quic_gtest.cpp:8:
In file included from /Users/furt/github/wfurt-msquic/src/test/bin/quic_gtest.h:11:
In file included from /Users/furt/github/wfurt-msquic/src/test/MsQuicTests.h:12:
/Users/furt/github/wfurt-msquic/src/bin/../inc/msquic.hpp:96:43: warning: missing field 'IdealProcessor' initializer [-Wmissing-field-initializers]
        CXPLAT_THREAD_CONFIG Config = { 0 };
                                          ^
```

seems like it is ignored and my local build would finish but the warning breaks our CI pipeline in dotnet/msquic.

