### PR TITLE
Add GameCore build platform to MSQUIC

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -212,6 +212,13 @@ stages:
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-latest
+      platform: gamecore
+      arch: x64
+      tls: schannel
+      extraBuildArgs: -DisableTools -DisableTest -EnableTelemetryAsserts
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-latest
       platform: windows
       arch: arm64
       tls: openssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ option(QUIC_ENABLE_LOGGING "Enables logging" OFF)
 option(QUIC_ENABLE_SANITIZERS "Enables sanitizers" OFF)
 option(QUIC_STATIC_LINK_CRT "Statically links the C runtime" ON)
 option(QUIC_UWP_BUILD "Build for UWP" OFF)
+option(QUIC_GAMECORE_BUILD "Build for GameCore" OFF)
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 option(QUIC_SOURCE_LINK "Enables source linking on MSVC" ON)
 option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)
@@ -368,6 +369,10 @@ if(WIN32)
 
     if (QUIC_UWP_BUILD)
         list(APPEND QUIC_COMMON_DEFINES WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP QUIC_UWP_BUILD)
+    endif()
+
+    if (QUIC_GAMECORE_BUILD)
+        list(APPEND QUIC_COMMON_DEFINES WINAPI_FAMILY=WINAPI_FAMILY_GAMES QUIC_GAMECORE_BUILD)
     endif()
 
     if(QUIC_ENABLE_LOGGING)

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -108,7 +108,7 @@ param (
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("uwp", "windows", "linux", "macos", "android", "ios")] # For future expansion
+    [ValidateSet("gamecore", "uwp", "windows", "linux", "macos", "android", "ios")] # For future expansion
     [string]$Platform = "",
 
     [Parameter(Mandatory = $false)]
@@ -216,6 +216,16 @@ if ($Generator -eq "") {
 
 if (!$IsWindows -And $Platform -eq "uwp") {
     Write-Error "[$(Get-Date)] Cannot build uwp on non windows platforms"
+    exit
+}
+
+if (!$IsWindows -And $Platform -eq "gamecore") {
+    Write-Error "[$(Get-Date)] Cannot build gamecore on non windows platforms"
+    exit
+}
+
+if ($Arch -ne "x64" -And $Platform -eq "gamecore") {
+    Write-Error "[$(Get-Date)] Cannot build gamecore for non-x64 platforms"
     exit
 }
 
@@ -342,6 +352,9 @@ function CMake-Generate {
     }
     if ($Platform -eq "uwp") {
         $Arguments += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10 -DQUIC_UWP_BUILD=on -DQUIC_STATIC_LINK_CRT=Off"
+    }
+    if ($Platform -eq "gamecore") {
+        $Arguments += " -DQUIC_GAMECORE_BUILD=on"
     }
     if ($ToolchainFile -ne "") {
         $Arguments += " -DCMAKE_TOOLCHAIN_FILE=""$ToolchainFile"""

--- a/scripts/get-buildconfig.ps1
+++ b/scripts/get-buildconfig.ps1
@@ -30,7 +30,7 @@ param (
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("uwp", "windows", "linux", "macos", "android", "ios", "")] # For future expansion
+    [ValidateSet("gamecore", "uwp", "windows", "linux", "macos", "android", "ios", "")] # For future expansion
     [string]$Platform = "",
 
     [Parameter(Mandatory = $false)]

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -33,6 +33,11 @@ Environment:
 #define WINAPI_FAMILY WINAPI_FAMILY_DESKTOP_APP
 #endif
 
+#ifdef QUIC_GAMECORE_BUILD
+#undef WINAPI_FAMILY
+#define WINAPI_FAMILY WINAPI_FAMILY_GAMES
+#endif
+
 #pragma warning(push) // Don't care about OACR warnings in publics
 #pragma warning(disable:26036)
 #pragma warning(disable:28251)
@@ -396,12 +401,24 @@ typedef SRWLOCK CXPLAT_DISPATCH_RW_LOCK;
 #define QuicIncrementLongPtrNoFence InterlockedIncrementNoFence64
 #define QuicDecrementLongPtrRelease InterlockedDecrementRelease64
 #define QuicCompareExchangeLongPtrNoFence InterlockedCompareExchangeNoFence64
+
+#ifdef QUIC_GAMECORE_BUILD
+#define QuicReadLongPtrNoFence(p) ((LONG64)(*p))
+#else
 #define QuicReadLongPtrNoFence ReadNoFence64
+#endif
+
 #else
 #define QuicIncrementLongPtrNoFence InterlockedIncrementNoFence
 #define QuicDecrementLongPtrRelease InterlockedDecrementRelease
 #define QuicCompareExchangeLongPtrNoFence InterlockedCompareExchangeNoFence
+
+#ifdef QUIC_GAMECORE_BUILD
+#define QuicReadLongPtrNoFence(p) ((LONG)(*p))
+#else
 #define QuicReadLongPtrNoFence ReadNoFence
+#endif
+
 #endif
 
 typedef LONG_PTR CXPLAT_REF_COUNT;
@@ -685,7 +702,7 @@ extern CXPLAT_PROCESSOR_INFO* CxPlatProcessorInfo;
 extern uint64_t* CxPlatNumaMasks;
 extern uint32_t* CxPlatProcessorGroupOffsets;
 
-#ifdef QUIC_UWP_BUILD
+#if defined(QUIC_UWP_BUILD) || defined(QUIC_GAMECORE_BUILD)
 DWORD CxPlatProcMaxCount();
 DWORD CxPlatProcActiveCount();
 #else

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -33,11 +33,6 @@ Environment:
 #define WINAPI_FAMILY WINAPI_FAMILY_DESKTOP_APP
 #endif
 
-#ifdef QUIC_GAMECORE_BUILD
-#undef WINAPI_FAMILY
-#define WINAPI_FAMILY WINAPI_FAMILY_GAMES
-#endif
-
 #pragma warning(push) // Don't care about OACR warnings in publics
 #pragma warning(disable:26036)
 #pragma warning(disable:28251)

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -611,7 +611,7 @@ CxPlatGetAllocFailDenominator(
 }
 #endif
 
-#ifdef QUIC_UWP_BUILD
+#if defined(QUIC_UWP_BUILD) || defined(QUIC_GAMECORE_BUILD)
 DWORD
 CxPlatProcActiveCount(
     )


### PR DESCRIPTION
GameCore supports only a subset of the Windows SDK API surface similarly to UWP, so add a new build flavor and adjust a couple of platform implementations accordingly.