### PR TITLE
bugfix: create new source CID in handshake retry

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2308,7 +2308,11 @@ QuicConnGenerateLocalTransportParameters(
             Connection->OrigDestCID = NULL;
 
             if (Connection->State.HandshakeUsedRetryPacket) {
-                CXPLAT_DBG_ASSERT(SourceCid->Link.Next != NULL);
+                if (SourceCid->Link.Next == NULL) {
+                    if (!QuicConnGenerateNewSourceCid(Connection, FALSE)) {
+                        return QUIC_STATUS_INTERNAL_ERROR;
+                    }
+                }
                 const QUIC_CID_HASH_ENTRY* PrevSourceCid =
                     CXPLAT_CONTAINING_RECORD(
                         SourceCid->Link.Next,


### PR DESCRIPTION
fix issue: microsoft#1938

During the connection handshake, server side has only one source CID in the
CID set. More CIDs will be added to CID set only when the connection is
connected (TLS handshake complete).

If the server needs to send a 'Quic Retry Packet', it runs out of CID and
cause segfault (next source CID, NULL Pointer) because RFC 9000 requires
to use a new source CID.

This commit attempts to fix the issue by creating a new CID when there is no
free CID in the CID set of the connection.
bugfix: create new source CID in handshake retry