### PR TITLE
Switch lowercase usages of true in c to TRUE

### DIFF
--- a/src/platform/darwin_openssl.c
+++ b/src/platform/darwin_openssl.c
@@ -123,7 +123,7 @@ CxPlatTlsVerifyCertificate(
         goto Exit;
     }
 
-    SSLPolicy = SecPolicyCreateSSL(true, SNIString);
+    SSLPolicy = SecPolicyCreateSSL(TRUE, SNIString);
     if (SSLPolicy == NULL) {
         QuicTraceEvent(
             LibraryError,

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -615,7 +615,7 @@ CxPlatProcessorContextInitialize(
         goto Exit;
     }
 
-    ThreadCreated = true;
+    ThreadCreated = TRUE;
 
 Exit:
 


### PR DESCRIPTION
In new compilers the lowercase usages are fine but not what we use in the rest of the code base and we want to be standardized.
