### PR TITLE
Don't Reset BytesInFlight on Path Change

### DIFF
--- a/src/core/congestion_control.c
+++ b/src/core/congestion_control.c
@@ -47,10 +47,11 @@ QuicCongestionControlInitialize(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicCongestionControlReset(
-    _In_ QUIC_CONGESTION_CONTROL* Cc
+    _In_ QUIC_CONGESTION_CONTROL* Cc,
+    _In_ BOOLEAN FullReset
     )
 {
-    Cc->QuicCongestionControlReset(Cc);
+    Cc->QuicCongestionControlReset(Cc, FullReset);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -9,7 +9,7 @@
 
 typedef union QUIC_CONGESTION_CONTROL_CONTEXT {
     QUIC_CONGESTION_CONTROL_CUBIC CubicCtx;
-    
+
     //
     // Add new congestion control context here
     //
@@ -22,7 +22,7 @@ typedef struct QUIC_CONGESTION_CONTROL {
     // Name of congestion control algorithm
     //
     const char* Name;
-    
+
     BOOLEAN (*QuicCongestionControlCanSend)(
         _In_ struct QUIC_CONGESTION_CONTROL* Cc
         );
@@ -38,7 +38,8 @@ typedef struct QUIC_CONGESTION_CONTROL {
         );
 
     void (*QuicCongestionControlReset)(
-        _In_ struct QUIC_CONGESTION_CONTROL* Cc
+        _In_ struct QUIC_CONGESTION_CONTROL* Cc,
+        _In_ BOOLEAN FullReset
         );
 
     uint32_t (*QuicCongestionControlGetSendAllowance)(
@@ -132,7 +133,8 @@ QuicCongestionControlInitialize(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicCongestionControlReset(
-    _In_ QUIC_CONGESTION_CONTROL* Cc
+    _In_ QUIC_CONGESTION_CONTROL* Cc,
+    _In_ BOOLEAN FullReset
     );
 
 //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1964,7 +1964,7 @@ QuicConnRestart(
         QuicPacketSpaceReset(Connection->Packets[i]);
     }
 
-    QuicCongestionControlReset(&Connection->CongestionControl);
+    QuicCongestionControlReset(&Connection->CongestionControl, TRUE);
     QuicSendReset(&Connection->Send);
     QuicLossDetectionReset(&Connection->LossDetection);
     QuicCryptoTlsCleanupTransportParameters(&Connection->PeerTransportParams);

--- a/src/core/cubic_impl.c
+++ b/src/core/cubic_impl.c
@@ -125,7 +125,8 @@ CubicCongestionControlInitialize(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 CubicCongestionControlReset(
-    _In_ QUIC_CONGESTION_CONTROL* Cc
+    _In_ QUIC_CONGESTION_CONTROL* Cc,
+    _In_ BOOLEAN FullReset
     )
 {
     QUIC_CONGESTION_CONTROL_CUBIC* Ctx = (QUIC_CONGESTION_CONTROL_CUBIC*)&Cc->Ctx;
@@ -136,7 +137,9 @@ CubicCongestionControlReset(
     Ctx->HasHadCongestionEvent = FALSE;
     Ctx->CongestionWindow = Connection->Paths[0].Mtu * Ctx->InitialWindowPackets;
     Ctx->BytesInFlightMax = Ctx->CongestionWindow / 2;
-    Ctx->BytesInFlight = 0;
+    if (FullReset) {
+        Ctx->BytesInFlight = 0;
+    }
     QuicConnLogOutFlowStats(Connection);
     QuicConnLogCubic(Connection);
 }
@@ -617,7 +620,7 @@ CubicCongestionControlLogOutFlowStatus(
     QUIC_CONGESTION_CONTROL_CUBIC* Ctx = (QUIC_CONGESTION_CONTROL_CUBIC*)&Cc->Ctx;
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
-    
+
     const QUIC_PATH* Path = &Connection->Paths[0];
     UNREFERENCED_PARAMETER(Path);
 

--- a/src/core/cubic_impl.h
+++ b/src/core/cubic_impl.h
@@ -38,7 +38,8 @@ CubicCongestionControlInitialize(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 CubicCongestionControlReset(
-    _In_ QUIC_CONGESTION_CONTROL* Cc
+    _In_ QUIC_CONGESTION_CONTROL* Cc,
+    _In_ BOOLEAN FullReset
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -283,6 +283,6 @@ QuicPathSetActive(
         UdpPortChangeOnly);
 
     if (!UdpPortChangeOnly) {
-        QuicCongestionControlReset(&Connection->CongestionControl);
+        QuicCongestionControlReset(&Connection->CongestionControl, FALSE);
     }
 }


### PR DESCRIPTION
When a new path becomes active it resets congestion control (because you don't know anything about the new path's network characteristics yet). That was resetting BytesInFlight too. That shouldn't have been reset because you still can have packets in flight that might get ACK'ed.

Fixes https://github.com/microsoft/msquic/issues/1975.