### PR TITLE
Publish separate vpacks for each configuration and architecture

### DIFF
--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -43,6 +43,7 @@ jobs:
       sourceDirectory: $(Build.ArtifactStagingDirectory)
       description: msquic.$(Build.SourceBranchName)
       pushPkgName: msquic
+      multiarchitecture: true
       owner: quicdev@microsoft.com
       vpackToken: $(VPACK_PAT)
       majorVer: 1

--- a/scripts/prepare-package.ps1
+++ b/scripts/prepare-package.ps1
@@ -60,4 +60,12 @@ foreach ($Config in $Configs) {
         Force-Copy (Join-Path $InputDir "secnetperfdrv.sys") (Join-Path $PlatformPackageDir "bin/kernel")
         Force-Copy (Join-Path $InputDir "secnetperfdrv.pdb") (Join-Path $PlatformPackageDir "bin/kernel")
     }
+
+    # Special case chpe
+    $ChpePackageDir = Join-Path $PackageDir "chpe$($Config.Item2)"
+    foreach ($File in $IncFiles) {
+        Force-Copy (Join-Path $RootDir "src/inc/$File") $ChpePackageDir
+    }
+    Force-Copy (Join-Path $RootDir "src/manifest/MsQuic.wprp") $ChpePackageDir
+    Force-Copy (Join-Path $RootDir "src/manifest/MsQuicEtw.man") $ChpePackageDir
 }

--- a/scripts/prepare-package.ps1
+++ b/scripts/prepare-package.ps1
@@ -21,6 +21,10 @@ $ArtifactsDir = Join-Path $RootDir "artifacts"
 # Output directory for all package files.
 $PackageDir = Join-Path $ArtifactsDir "package"
 
+$Configs = [System.Tuple]::Create("Debug","chk"), [System.Tuple]::Create("Release","fre")
+$Archs = [System.Tuple]::Create("ARM","arm","arm"), [System.Tuple]::Create("ARM64","arm64","arm64"), `
+         [System.Tuple]::Create("Win32","x86","x86"), [System.Tuple]::Create("x64","x64","amd64")
+
 function Force-Copy($Source, $Destination) {
     New-Item -Path $Destination -ItemType Directory -Force | Out-Null
     Copy-Item $Source $Destination -Force | Out-Null
@@ -28,42 +32,32 @@ function Force-Copy($Source, $Destination) {
 
 # Package up all necessary header and manifest files.
 $IncFiles = "msquic.h", "msquicp.h", "msquic_winkernel.h", "msquic_winuser.h"
-foreach ($File in $IncFiles) {
-    Force-Copy (Join-Path $RootDir "src/inc/$File") $PackageDir
-}
-Force-Copy (Join-Path $RootDir "src/manifest/MsQuic.wprp") $PackageDir
-Force-Copy (Join-Path $RootDir "src/manifest/MsQuicEtw.man") $PackageDir
 
-# Package up all the user mode binary files.
-$Configs = [System.Tuple]::Create("Debug","chk"), [System.Tuple]::Create("Release","fre")
-$Archs = [System.Tuple]::Create("arm","arm","arm"), [System.Tuple]::Create("arm64","arm64","arm64"), `
-         [System.Tuple]::Create("x86","x86","i386"), [System.Tuple]::Create("x64","amd64","amd64")
 foreach ($Config in $Configs) {
     foreach ($Arch in $Archs) {
-        $InputDir = Join-Path $ArtifactsDir "bin/windows/$($Arch.Item1)_$($Config.Item1)_schannel"
-        Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "msquic.dll") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "msquictest.exe") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "msquictest.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "secnetperf.exe") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-        Force-Copy (Join-Path $InputDir "secnetperf.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/user")
-    }
-}
+        $PlatformPackageDir = Join-Path $PackageDir "$($Arch.Item3)$($Config.Item2)"
+        foreach ($File in $IncFiles) {
+            Force-Copy (Join-Path $RootDir "src/inc/$File") $PlatformPackageDir
+        }
+        Force-Copy (Join-Path $RootDir "src/manifest/MsQuic.wprp") $PlatformPackageDir
+        Force-Copy (Join-Path $RootDir "src/manifest/MsQuicEtw.man") $PlatformPackageDir
 
-# Package up all the kernel mode binary files.
-$Configs = [System.Tuple]::Create("Debug","chk"), [System.Tuple]::Create("Release","fre")
-$Archs = [System.Tuple]::Create("ARM","arm","arm"), [System.Tuple]::Create("ARM64","arm64","arm64"), `
-         [System.Tuple]::Create("Win32","x86","i386"), [System.Tuple]::Create("x64","amd64","amd64")
-foreach ($Config in $Configs) {
-    foreach ($Arch in $Archs) {
+        $InputDir = Join-Path $ArtifactsDir "bin/windows/$($Arch.Item2)_$($Config.Item1)_schannel"
+        Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PlatformPackageDir "lib/user")
+        Force-Copy (Join-Path $InputDir "msquic.dll") (Join-Path $PlatformPackageDir "bin/user")
+        Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PlatformPackageDir "bin/user")
+        Force-Copy (Join-Path $InputDir "msquictest.exe") (Join-Path $PlatformPackageDir "bin/user")
+        Force-Copy (Join-Path $InputDir "msquictest.pdb") (Join-Path $PlatformPackageDir "bin/user")
+        Force-Copy (Join-Path $InputDir "secnetperf.exe") (Join-Path $PlatformPackageDir "bin/user")
+        Force-Copy (Join-Path $InputDir "secnetperf.pdb") (Join-Path $PlatformPackageDir "bin/user")
+
         $InputDir = Join-Path $ArtifactsDir "bin/winkernel/$($Arch.Item1)_$($Config.Item1)_schannel"
-        Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PackageDir "lib/$($Arch.Item2)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "msquic.sys") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "msquictest.sys") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "msquictest.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "secnetperfdrv.sys") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
-        Force-Copy (Join-Path $InputDir "secnetperfdrv.pdb") (Join-Path $PackageDir "bin/$($Arch.Item3)$($Config.Item2)/kernel")
+        Force-Copy (Join-Path $InputDir "msquic.lib") (Join-Path $PlatformPackageDir "lib/kernel")
+        Force-Copy (Join-Path $InputDir "msquic.sys") (Join-Path $PlatformPackageDir "bin/kernel")
+        Force-Copy (Join-Path $InputDir "msquic.pdb") (Join-Path $PlatformPackageDir "bin/kernel")
+        Force-Copy (Join-Path $InputDir "msquictest.sys") (Join-Path $PlatformPackageDir "bin/kernel")
+        Force-Copy (Join-Path $InputDir "msquictest.pdb") (Join-Path $PlatformPackageDir "bin/kernel")
+        Force-Copy (Join-Path $InputDir "secnetperfdrv.sys") (Join-Path $PlatformPackageDir "bin/kernel")
+        Force-Copy (Join-Path $InputDir "secnetperfdrv.pdb") (Join-Path $PlatformPackageDir "bin/kernel")
     }
 }


### PR DESCRIPTION
This is a redo of #1940 

There was nothing inherently wrong with the original PR, it just needed to be reverted until we were at a point to take this into windows again. That break did reveal we need a special chpe vpack. That vpack has no binaries, but just headers.