### PR TITLE
Bypass TDI to make IP_PKTINFO work properly

### DIFF
--- a/src/generated/linux/datapath_winkernel.c.clog.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h
@@ -536,6 +536,28 @@ tracepoint(CLOG_DATAPATH_WINKERNEL_C, LibraryErrorStatus , arg2, arg3);\
             LibraryErrorStatus,
             "[ lib] ERROR, %u, %s.",
             Status,
+            "WskControlClient WSK_TDI_BEHAVIOR");
+// arg2 = arg2 = Status
+// arg3 = arg3 = "WskControlClient WSK_TDI_BEHAVIOR"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryErrorStatus
+// [ lib] ERROR, %u, %s.
+// QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
             "WskControlClient WSK_SET_STATIC_EVENT_CALLBACKS");
 // arg2 = arg2 = Status
 // arg3 = arg3 = "WskControlClient WSK_SET_STATIC_EVENT_CALLBACKS"

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -837,6 +837,7 @@ CxPlatDataPathInitialize(
         &NPI_WSK_INTERFACE_ID,
         WSK_EVENT_RECEIVE_FROM
     };
+    ULONG NoTdi = WSK_TDI_BEHAVIOR_BYPASS_TDI;
 
     UNREFERENCED_PARAMETER(TcpCallbacks);
     if (NewDataPath == NULL) {
@@ -960,6 +961,27 @@ CxPlatDataPathInitialize(
             Status,
             "WskCaptureProviderNPI");
         goto Error;
+    }
+
+    Status =
+        Datapath->WskProviderNpi.Dispatch->
+        WskControlClient(
+            Datapath->WskProviderNpi.Client,
+            WSK_TDI_BEHAVIOR,
+            sizeof(NoTdi),
+            &NoTdi,
+            0,
+            NULL,
+            NULL,
+            NULL);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "WskControlClient WSK_TDI_BEHAVIOR");
+        // We don't "goto Error;" here, because MSDN says that this may be removed
+        // in the future, at which point it presumably won't be needed.
     }
 
     Status =


### PR DESCRIPTION
TDI/TDX only examines the cmsghdr of TDI IRPs from the
Options/OptionsLength fields if UserBuffer==(PVOID)8937731. This was
never documented and will probably never change, which in turn means
that TDI drivers that filter and reinject packets will strip the cmsghdr
unknowingly. TDI is a dead technology anyway, and bypassing it shouldn't
interfere with reasonable systems.

This mirrors https://git.zx2c4.com/wireguard-nt/commit/?id=c331ee4f18e98b7063dc74e3d8b0ab556cff3a96