### PR TITLE
Fix gamecore on older windows sdk, require a minimum gdk, remove scarlett

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,12 +404,7 @@ if(WIN32)
 
         set(Console_ArchOptions /favor:AMD64)
 
-        if (QUIC_SCARLETT_BUILD)
-            list(APPEND Console_ArchOptions /arch:AVX2 /d2vzeroupper)
-            set(Console_ArchOptions_LTCG /d2:-vzeroupper)
-        else()
-            list(APPEND Console_ArchOptions /arch:AVX)
-        endif()
+        list(APPEND Console_ArchOptions /arch:AVX)
 
         # Locate Software Development Kits
         get_filename_component(Console_SdkRoot "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\GDK;InstallPath]" ABSOLUTE CACHE)
@@ -432,8 +427,9 @@ if(WIN32)
                         set(GxdkRuntimeLib "${GxdkLibDirectory}/xgameplatform.lib")
                         if (EXISTS ${GxdkRuntimeLib})
                             get_filename_component(PotentialXdkEditionTarget ${GdkFolder} NAME)
-                            # Always select lowest version
-                            if (PotentialXdkEditionTarget LESS XdkEditionTarget)
+                            # Always select lowest version equal or higher than 211000
+                            if (PotentialXdkEditionTarget LESS XdkEditionTarget AND
+                                PotentialXdkEditionTarget GREATER_EQUAL 211000)
                                 set(XdkEditionTarget ${PotentialXdkEditionTarget})
                                 set(Console_EndpointLibRoot "${GxdkLibDirectory}")
                             endif()
@@ -474,8 +470,8 @@ if(WIN32)
     # These cannot be updated until CMake 3.13
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /GL /Zi")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL /Zi")
-    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 ${Console_ArchOptions_LTCG} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 ${Console_ArchOptions_LTCG} /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 /DEBUG /OPT:REF /OPT:ICF")
 
     # Configure PGO linker flags.
     set(QUIC_PGO_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/bin/winuser/pgo_${SYSTEM_PROCESSOR}/msquic.pgd")

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -108,7 +108,7 @@ param (
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("gamecore-durango", "gamecore-scarlett", "uwp", "windows", "linux", "macos", "android", "ios")] # For future expansion
+    [ValidateSet("gamecore-console", "uwp", "windows", "linux", "macos", "android", "ios")] # For future expansion
     [string]$Platform = "",
 
     [Parameter(Mandatory = $false)]
@@ -219,12 +219,12 @@ if (!$IsWindows -And $Platform -eq "uwp") {
     exit
 }
 
-if (!$IsWindows -And ($Platform -eq "gamecore-durango" -or $Platform -eq "gamecore-scarlett")) {
+if (!$IsWindows -And ($Platform -eq "gamecore-console")) {
     Write-Error "[$(Get-Date)] Cannot build gamecore on non windows platforms"
     exit
 }
 
-if ($Arch -ne "x64" -And ($Platform -eq "gamecore-durango" -or $Platform -eq "gamecore-scarlett")) {
+if ($Arch -ne "x64" -And ($Platform -eq "gamecore-console")) {
     Write-Error "[$(Get-Date)] Cannot build gamecore for non-x64 platforms"
     exit
 }
@@ -354,11 +354,8 @@ function CMake-Generate {
         $Arguments += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10 -DQUIC_UWP_BUILD=on -DQUIC_STATIC_LINK_CRT=Off"
     }
     # On gamecore, only the main binary can be built.
-    if ($Platform -eq "gamecore-durango") {
+    if ($Platform -eq "gamecore-console") {
         $Arguments += " -DQUIC_GAMECORE_BUILD=on -DQUIC_STATIC_LINK_CRT=Off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_PERF=off"
-    }
-    if ($Platform -eq "gamecore-scarlett") {
-        $Arguments += " -DQUIC_GAMECORE_BUILD=on -DQUIC_SCARLETT_BUILD=on -DQUIC_STATIC_LINK_CRT=Off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_PERF=off"
     }
     if ($ToolchainFile -ne "") {
         $Arguments += " -DCMAKE_TOOLCHAIN_FILE=""$ToolchainFile"""

--- a/scripts/get-buildconfig.ps1
+++ b/scripts/get-buildconfig.ps1
@@ -30,7 +30,7 @@ param (
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("gamecore-durango", "gamecore-scarlett", "uwp", "windows", "linux", "macos", "android", "ios", "")] # For future expansion
+    [ValidateSet("gamecore-console", "uwp", "windows", "linux", "macos", "android", "ios", "")] # For future expansion
     [string]$Platform = "",
 
     [Parameter(Mandatory = $false)]

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -317,12 +317,15 @@ typedef struct _SecPkgContext_ConnectionInfo
 
 #define SCHANNEL_USE_BLACKLISTS
 
-#ifdef QUIC_GAMECORE_BUILD
+#if (defined(QUIC_GAMECORE_BUILD))
+#include <sdkddkver.h>
+#ifdef NTDDI_WIN10_CO
 typedef struct _UNICODE_STRING {
     USHORT Length;
     USHORT MaximumLength;
     PWSTR Buffer;
 } UNICODE_STRING, *PUNICODE_STRING;
+#endif
 #endif
 
 #include <schannel.h>


### PR DESCRIPTION
Many xbox devs have older windows SDKs which have issues with UNICODE_STRING. Found a workaround to detect newer SDKs. For some of the functions, there is a minimum GDK version, so enforce that. Scarlett doesn't add any capabilities for our code, so move to 1 gamecore build.