### PR TITLE
Push individual vpacks rather than multiarchitecture flag

### DIFF
--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -40,10 +40,144 @@ jobs:
     inputs:
       vPackCmd: push
       versionAs: parts
-      sourceDirectory: $(Build.ArtifactStagingDirectory)
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/amd64chk
       description: msquic.$(Build.SourceBranchName)
-      pushPkgName: msquic
-      multiarchitecture: true
+      pushPkgName: msquic.amd64chk
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/amd64fre
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.amd64fre
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/arm64chk
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.arm64chk
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/arm64fre
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.arm64fre
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/armchk
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.armchk
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/armfre
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.armfre
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/chpechk
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.chpechk
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/chpefre
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.chpefre
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/x86chk
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.x86chk
+      owner: quicdev@microsoft.com
+      vpackToken: $(VPACK_PAT)
+      majorVer: 1
+      minorVer: 9
+      patchVer: 0
+      prereleaseVer: $(Build.BuildId)
+
+  - task: PkgESVPack@12
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    inputs:
+      vPackCmd: push
+      versionAs: parts
+      sourceDirectory: $(Build.ArtifactStagingDirectory)/x86fre
+      description: msquic.$(Build.SourceBranchName)
+      pushPkgName: msquic.x86fre
       owner: quicdev@microsoft.com
       vpackToken: $(VPACK_PAT)
       majorVer: 1


### PR DESCRIPTION
Multiarchitecture flag is missing provenance, which is required to ingest into windows