### PR TITLE
Don't wrap all headers in extern C

### DIFF
--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -10,6 +10,10 @@ Abstract:
 
 --*/
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 //
 // Set of callbacks for TLS.
 //
@@ -395,3 +399,7 @@ QuicCryptoDecodeClientTicket(
     _Out_ uint32_t* ServerTicketLength,
     _Out_ uint32_t* QuicVersion
     );
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -9,6 +9,10 @@
 // QUIC Transport Error codes defined by the QUIC Transport RFC.
 //
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 //
 // An endpoint uses this with CONNECTION_CLOSE to signal that the connection
 // is being closed abruptly in the absence of any error.
@@ -899,3 +903,7 @@ QuicFrameLogAll(
         const uint8_t * const Packet,
     _In_ uint16_t Offset
     );
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -5,6 +5,10 @@
 
 --*/
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 //
 // The different possible types of handles.
 //
@@ -583,3 +587,7 @@ QuicLibraryGenerateStatelessResetToken(
     _Out_writes_all_(QUIC_STATELESS_RESET_TOKEN_LENGTH)
         uint8_t* ResetToken
     );
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/core/precomp.h
+++ b/src/core/precomp.h
@@ -36,10 +36,6 @@
 #define QUIC_VERSION_ONLY 1
 #include "msquic.ver"
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 //
 // Internal Core Headers.
 //
@@ -78,7 +74,3 @@ extern "C" {
 #include "packet_builder.h"
 #include "listener.h"
 #include "cubic.h"
-
-#if defined(__cplusplus)
-}
-#endif

--- a/src/core/range.h
+++ b/src/core/range.h
@@ -5,6 +5,10 @@
 
 --*/
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #define QUIC_RANGE_NO_MAX_ALLOC_SIZE    UINT32_MAX
 #define QUIC_RANGE_USE_BINARY_SEARCH    1
 
@@ -374,3 +378,7 @@ QuicRangeGetMaxSafe(
     _In_ QUIC_RANGE* Range,
     _Out_ uint64_t* Value
     );
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/core/transport_params.h
+++ b/src/core/transport_params.h
@@ -9,6 +9,10 @@ Abstract:
 
 --*/
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #define QUIC_TP_FLAG_INITIAL_MAX_DATA                       0x00000001
 #define QUIC_TP_FLAG_INITIAL_MAX_STRM_DATA_BIDI_LOCAL       0x00000002
 #define QUIC_TP_FLAG_INITIAL_MAX_STRM_DATA_BIDI_REMOTE      0x00000004
@@ -234,3 +238,7 @@ void
 QuicCryptoTlsCleanupTransportParameters(
     _In_ QUIC_TRANSPORT_PARAMETERS* TransportParams
     );
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/core/version_neg.h
+++ b/src/core/version_neg.h
@@ -11,6 +11,10 @@ Abstract:
 
 #pragma once
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 //
 // This list is the versions that the server advertises support for.
 //
@@ -77,3 +81,7 @@ QuicVersionNegotiationExtEncodeVersionInfo(
     _In_ QUIC_CONNECTION* Connection,
     _Out_ uint32_t* VerInfoLength
     );
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
Newer versions of lltng have templates, which don't properly work if extern C has been used around lttng headers. The fix to this is to not have a global extern C, but instead have it in individual headers.

Closes #2026 