### PR TITLE
Fix Flow Control Assert

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -409,7 +409,7 @@ QuicStreamProcessStreamFrame(
         // Keep track of the total ordered bytes received.
         //
         Stream->Connection->Send.OrderedStreamBytesReceived += WriteLength;
-        CXPLAT_DBG_ASSERT(Stream->Connection->Send.OrderedStreamBytesReceived < Stream->Connection->Send.MaxData);
+        CXPLAT_DBG_ASSERT(Stream->Connection->Send.OrderedStreamBytesReceived <= Stream->Connection->Send.MaxData);
         CXPLAT_DBG_ASSERT(Stream->Connection->Send.OrderedStreamBytesReceived >= WriteLength);
 
         if (QuicRecvBufferGetTotalLength(&Stream->RecvBuffer) == Stream->MaxAllowedRecvOffset) {


### PR DESCRIPTION
Uncovered by .NET testing, we had an incorrect assert (should be `<=` instead of `<`) when doing some stream/connection flow control validation.

cc @ManickaP