### PR TITLE
Enable Linux Signing Preview

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -58,6 +58,8 @@ extends:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.azure\openssl.gdnsuppress
+    featureFlags:
+      linuxEsrpSigningPreview: true
 
     stages:
     - stage: build_winkernel


### PR DESCRIPTION
An attempt to fix the following errors that are showing up in the internal pipeline:
```
##[error]OneBranch Pipeline's prerequisites were not set. Please check https://aka.ms/obpipelines/signing or contact OneBranch Support https://aka.ms/onebranchsup
```