### PR TITLE
Only Return TRUE in QuicSendWriteFrames if Data Written

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -771,7 +771,7 @@ QuicSendWriteFrames(
             if (!HasMoreCidsToSend) {
                 Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_NEW_CONNECTION_ID;
             }
-            if (MaxFrameLimitHit || RanOutOfRoom) {
+            if (MaxFrameLimitHit) {
                 return TRUE;
             }
         }
@@ -822,7 +822,7 @@ QuicSendWriteFrames(
             if (!HasMoreCidsToSend) {
                 Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_RETIRE_CONNECTION_ID;
             }
-            if (MaxFrameLimitHit || RanOutOfRoom) {
+            if (MaxFrameLimitHit) {
                 return TRUE;
             }
         }


### PR DESCRIPTION
Found a couple places in `QuicSendWriteFrames` where data could not be written, but the function still returned `TRUE` indicating frames were written. This can lead to infinite loops in the worst case scenario.