### PR TITLE
Disable ASAN SpinQuic on Windows

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -688,16 +688,12 @@ stages:
       platform: windows
       tls: schannel
       allocFail: 100
-      extraArtifactDir: '_Sanitize'
-      extraArgs: -ExtraArtifactDir Sanitize
   - template: ./templates/run-spinquic.yml
     parameters:
       pool: MsQuic-Win-Latest
       platform: windows
       tls: schannel
       allocFail: 100
-      extraArtifactDir: '_Sanitize'
-      extraArgs: -ExtraArtifactDir Sanitize
   - template: ./templates/run-spinquic.yml
     parameters:
       image: windows-2019


### PR DESCRIPTION
Closes #1933. Stops using ASAN on Windows until it can be used reliably.