### PR TITLE
Fix wraparound bug in CxPlatSocketPoolGetNextLocalPort

### DIFF
--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -199,7 +199,7 @@ CxPlatSocketCreateUdp(
             Config->LocalAddress->Ipv4.sin_port;
     } else {
         (*NewSocket)->LocalAddress.Ipv4.sin_port =
-            CxPlatByteSwapUint16(CxPlatSocketPoolGetNextLocalPort(&Datapath->SocketPool));
+            CxPlatByteSwapUint16(CxPlatSockPoolGetNextLocalPort(&Datapath->SocketPool));
     }
 
     if (!CxPlatTryAddSocket(&Datapath->SocketPool, *NewSocket)) {

--- a/src/platform/datapath_raw.h
+++ b/src/platform/datapath_raw.h
@@ -169,14 +169,10 @@ CxPlatSockPoolUninitialize(
     _Inout_ CXPLAT_SOCKET_POOL* Pool
     );
 
-inline
 uint16_t // Host byte order
-CxPlatSocketPoolGetNextLocalPort(
+CxPlatSockPoolGetNextLocalPort(
     _Inout_ CXPLAT_SOCKET_POOL* Pool
-    )
-{
-    return InterlockedIncrement16((short*)&Pool->NextLocalPort);
-}
+    );
 
 CXPLAT_SOCKET*
 CxPlatGetSocket(


### PR DESCRIPTION
Reset NextLocalPort back to the (currently hardcoded) start port when it wraps.
Otherwise we'll use port 0, which is invalid, or a low reserved port number.
CxPlatSocketPoolGetNextLocalPort is also renamed to CxPlatSockPoolGetNextLocalPort
for consistency with sibling functions.

Synchronization is changed from interlocked to use of the RW lock. On this note,
probably we should make a future change to select the port in CxPlatTryAddSocket
while we already hold the lock; that function is called right after this one currently.