### PR TITLE
Filter for remote address for connected sockets in CxPlatGetSocket

### DIFF
--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -299,7 +299,11 @@ CxPlatDpRawRxEthernet(
         CXPLAT_DBG_ASSERT(Packet->Next == NULL);
 
         if (Packet->Reserved == L4_TYPE_UDP) {
-            CXPLAT_SOCKET* Socket = CxPlatGetSocket(&Datapath->SocketPool, &Packet->Tuple->LocalAddress);
+            CXPLAT_SOCKET* Socket =
+                CxPlatGetSocket(
+                    &Datapath->SocketPool,
+                    &Packet->Tuple->LocalAddress,
+                    &Packet->Tuple->RemoteAddress);
             if (Socket) {
                 QuicTraceEvent(
                     DatapathRecv,

--- a/src/platform/datapath_raw.h
+++ b/src/platform/datapath_raw.h
@@ -178,10 +178,14 @@ CxPlatSocketPoolGetNextLocalPort(
     return InterlockedIncrement16((short*)&Pool->NextLocalPort);
 }
 
+//
+// Finds a socket to deliver received packets with the given addresses.
+//
 CXPLAT_SOCKET*
 CxPlatGetSocket(
     _In_ CXPLAT_SOCKET_POOL* Pool,
-    _In_ const QUIC_ADDR* LocalAddress
+    _In_ const QUIC_ADDR* LocalAddress,
+    _In_ const QUIC_ADDR* RemoteAddress
     );
 
 BOOLEAN

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -56,7 +56,7 @@ CxPlatGetSocket(
     while (Entry != NULL) {
         CXPLAT_SOCKET* Temp = CONTAINING_RECORD(Entry, CXPLAT_SOCKET, Entry);
         if (QuicAddrCompareIp(&Temp->LocalAddress, LocalAddress) &&
-            (!Temp->Connected || QuicAddrCompareIp(&Temp->RemoteAddress, RemoteAddress))) {
+            (!Temp->Connected || QuicAddrCompare(&Temp->RemoteAddress, RemoteAddress))) {
             if (CxPlatRundownAcquire(&Temp->Rundown)) {
                 Socket = Temp;
             }

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -44,7 +44,8 @@ CxPlatSockPoolUninitialize(
 CXPLAT_SOCKET*
 CxPlatGetSocket(
     _In_ CXPLAT_SOCKET_POOL* Pool,
-    _In_ const QUIC_ADDR* LocalAddress
+    _In_ const QUIC_ADDR* LocalAddress,
+    _In_ const QUIC_ADDR* RemoteAddress
     )
 {
     CXPLAT_SOCKET* Socket = NULL;
@@ -54,7 +55,8 @@ CxPlatGetSocket(
     Entry = CxPlatHashtableLookup(&Pool->Sockets, LocalAddress->Ipv4.sin_port, &Context);
     while (Entry != NULL) {
         CXPLAT_SOCKET* Temp = CONTAINING_RECORD(Entry, CXPLAT_SOCKET, Entry);
-        if (QuicAddrCompareIp(&Temp->LocalAddress, LocalAddress)) {
+        if (QuicAddrCompareIp(&Temp->LocalAddress, LocalAddress) &&
+            (!Temp->Connected || QuicAddrCompareIp(&Temp->RemoteAddress, RemoteAddress))) {
             if (CxPlatRundownAcquire(&Temp->Rundown)) {
                 Socket = Temp;
             }


### PR DESCRIPTION
Adds a RemoteAddress parameter to CxPlatGetSocket so that only traffic matching
the socket's remote address will be delivered to a connected socket.
