### PR TITLE
Fix leak in OpenSSL PKCS12 parsing.

### DIFF
--- a/scripts/install-test-certificates.ps1
+++ b/scripts/install-test-certificates.ps1
@@ -170,8 +170,8 @@ $Collection = [System.Security.Cryptography.X509Certificates.X509Certificate2Col
 
 $Collection.Add($Leaf[1]) # TODO(AnRossi):Why is $Leaf an array of an Int and the Cert?
 #Export the intermediate and root certs and then import them to drop their private keys.
-$Collection.Import($IntermediateSigner.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::SerializedCert))
-$Collection.Import($Root.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::SerializedCert))
+$Collection.Import($IntermediateSigner.rawData)
+$Collection.Import($Root.rawData)
 
 $Pfx = $Collection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, "PLACEHOLDER");
 

--- a/scripts/install-test-certificates.ps1
+++ b/scripts/install-test-certificates.ps1
@@ -15,52 +15,170 @@ param (
     [Parameter(Mandatory = $true)]
     [string]$OutputFile = ""
 )
-
-$Subject = [X500DistinguishedName]::new("CN=localhost")
 [System.DateTimeOffset]$NotBefore = [System.DateTimeOffset]::Now.AddDays(-1)
 [System.DateTimeOffset]$NotAfter = [System.DateTimeOffset]::Now.AddDays(365)
 
-# EKU
-$EkuOidCollection = [System.Security.Cryptography.OidCollection]::new()
-$EkuOidCollection.Add([System.Security.Cryptography.Oid]::new("1.3.6.1.5.5.7.3.1", "Server Authentication"))
-$EnhancedKeyUsages = [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]::new($EkuOidCollection, <# critical #> $false)
+function CreateRootCertificate() {
+    $Subject = [X500DistinguishedName]::new("CN=MsQuicPkcs12Root")
 
-# Create Basic Constraints
-$BasicConstraints = [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new(
-    <# certificateAuthority #> $false,
-    <# hasPathLengthConstraint #> $false,
-    <# pathLengthConstraint #> 0,
-    <# critical #> $false)
+    # KU
+    $KeyUsage = [System.Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new(
+        [System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DigitalSignature +
+        [System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::KeyCertSign,
+        $true)
 
-$Extensions = [System.Collections.Generic.List[System.Security.Cryptography.X509Certificates.X509Extension]]::new()
-$Extensions.Add($EnhancedKeyUsages)
-$Extensions.Add($BasicConstraints)
+    # Create Basic Constraints
+    $BasicConstraints = [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new(
+        <# certificateAuthority #> $true,
+        <# hasPathLengthConstraint #> $true,
+        <# pathLengthConstraint #> 1,
+        <# critical #> $true)
 
-$PrivateKey = [System.Security.Cryptography.RSA]::Create(2048)
+    $Extensions = [System.Collections.Generic.List[System.Security.Cryptography.X509Certificates.X509Extension]]::new()
+    $Extensions.Add($KeyUsage)
+    $Extensions.Add($BasicConstraints)
 
-# Create Certificate Request
-$CertRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-            $Subject,
-            $PrivateKey,
-            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
-            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    $PrivateKey = [System.Security.Cryptography.RSA]::Create(2048)
 
- # Create the Subject Key Identifier extension
-$SubjectKeyIdentifier = [System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension]::new(
-            $CertRequest.PublicKey,
-            <# critical #> $false)
-$Extensions.Add($SubjectKeyIdentifier)
+    # Create Certificate Request
+    $CertRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                $Subject,
+                $PrivateKey,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
 
-foreach ($Extension in $Extensions)
-{
-    $CertRequest.CertificateExtensions.Add($Extension)
+     # Create the Subject Key Identifier extension
+    $SubjectKeyIdentifier = [System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension]::new(
+                $CertRequest.PublicKey,
+                <# critical #> $false)
+    $Extensions.Add($SubjectKeyIdentifier)
+
+    foreach ($Extension in $Extensions)
+    {
+        $CertRequest.CertificateExtensions.Add($Extension)
+    }
+
+    $CertificateWithKey = $CertRequest.CreateSelfSigned($NotBefore, $NotAfter)
+    return $CertificateWithKey
 }
 
-$CertificateWithKey = $CertRequest.CreateSelfSigned($NotBefore, $NotAfter)
+function CreateIntermediateCertificate($RootCert) {
+    $Subject = [X500DistinguishedName]::new("CN=MsQuicPkcs12Intermediate")
 
-$Pfx = $CertificateWithKey.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, "PLACEHOLDER");
+    # KU
+    $KeyUsage = [System.Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new(
+        [System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DigitalSignature +
+        [System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::KeyCertSign,
+        $true)
+
+    # Create Basic Constraints
+    $BasicConstraints = [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new(
+        <# certificateAuthority #> $true,
+        <# hasPathLengthConstraint #> $true,
+        <# pathLengthConstraint #> 0,
+        <# critical #> $true)
+
+    $Extensions = [System.Collections.Generic.List[System.Security.Cryptography.X509Certificates.X509Extension]]::new()
+    $Extensions.Add($KeyUsage)
+    $Extensions.Add($BasicConstraints)
+
+    $PrivateKey = [System.Security.Cryptography.RSA]::Create(2048)
+
+    # Create Certificate Request
+    $CertRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                $Subject,
+                $PrivateKey,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+
+     # Create the Subject Key Identifier extension
+    $SubjectKeyIdentifier = [System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension]::new(
+                $CertRequest.PublicKey,
+                <# critical #> $false)
+    $Extensions.Add($SubjectKeyIdentifier)
+
+    foreach ($Extension in $Extensions)
+    {
+        $CertRequest.CertificateExtensions.Add($Extension)
+    }
+
+    $Serial = [byte[]]::new(16)
+    $Random = [System.Random]::new()
+    $Random.NextBytes($Serial)
+
+    $Cert = $CertRequest.Create($RootCert, $NotBefore, $NotAfter, $Serial)
+    return [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::CopyWithPrivateKey($Cert, $PrivateKey)
+}
+
+function CreateLeafCert($Signer) {
+    $Subject = [X500DistinguishedName]::new("CN=localhost")
+
+    # EKU
+    $EkuOidCollection = [System.Security.Cryptography.OidCollection]::new()
+    $EkuOidCollection.Add([System.Security.Cryptography.Oid]::new("1.3.6.1.5.5.7.3.1", "Server Authentication"))
+    $EnhancedKeyUsages = [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]::new($EkuOidCollection, <# critical #> $true)
+
+    $KeyUsage = [System.Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new(
+        [System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DigitalSignature,
+        $true)
+
+    # Create Basic Constraints
+    $BasicConstraints = [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new(
+        <# certificateAuthority #> $false,
+        <# hasPathLengthConstraint #> $false,
+        <# pathLengthConstraint #> 0,
+        <# critical #> $true)
+
+    $Extensions = [System.Collections.Generic.List[System.Security.Cryptography.X509Certificates.X509Extension]]::new()
+    $Extensions.Add($KeyUsage)
+    $Extensions.Add($EnhancedKeyUsages)
+    $Extensions.Add($BasicConstraints)
+
+    $PrivateKey = [System.Security.Cryptography.RSA]::Create(2048)
+
+    # Create Certificate Request
+    $CertRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                $Subject,
+                $PrivateKey,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+
+     # Create the Subject Key Identifier extension
+    $SubjectKeyIdentifier = [System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension]::new(
+                $CertRequest.PublicKey,
+                <# critical #> $false)
+    $Extensions.Add($SubjectKeyIdentifier)
+
+    foreach ($Extension in $Extensions)
+    {
+        $CertRequest.CertificateExtensions.Add($Extension)
+    }
+
+    $Serial = [byte[]]::new(16)
+    $Random = [System.Random]::new()
+    $Random.NextBytes($Serial)
+
+    $Cert = $CertRequest.Create($Signer, $NotBefore, $NotAfter, $Serial)
+    return [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::CopyWithPrivateKey($Cert, $PrivateKey)
+}
+
+$Root = CreateRootCertificate
+$IntermediateSigner = CreateIntermediateCertificate $Root
+$Leaf = CreateLeafCert $IntermediateSigner
+
+$Collection = [System.Security.Cryptography.X509Certificates.X509Certificate2Collection]::new()
+
+$Collection.Add($Leaf[1]) # TODO(AnRossi):Why is $Leaf an array of an Int and the Cert?
+#Export the intermediate and root certs and then import them to drop their private keys.
+$Collection.Import($IntermediateSigner.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::SerializedCert))
+$Collection.Import($Root.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::SerializedCert))
+
+$Pfx = $Collection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, "PLACEHOLDER");
 
 Set-Content $OutputFile -Value $Pfx -AsByteStream
 
 Write-Output "Generated $OutputFile"
 
+# Clean up the signer's private keys
+$Root.PrivateKey.Clear()
+$IntermediateSigner.PrivateKey.Clear()

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1383,6 +1383,7 @@ CxPlatTlsSecConfigCreate(
                 //
                 SSL_CTX_add_extra_chain_cert(SecurityConfig->SSLCtx, CaCert);
             }
+            sk_X509_free(CaCertificates);
         }
         if (Pkcs12) {
             PKCS12_free(Pkcs12);


### PR DESCRIPTION
When parsing a PKCS12 that includes a certificate chain, OpenSSL wasn't freeing the certificate chain memory, and introduced a leak.
This change fixes that by freeing the certificate chain when done adding the certificates to `SSL_CTX`.
Signed-off-by: Anthony Rossi <anrossi@microsoft.com>