### PR TITLE
Support multiple XDP queues

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -247,7 +247,7 @@ CxPlatDpRawInitialize(
         goto Error;
     }
 
-    ZeroMemory(Xdp->Queues, Xdp->QueueCount * sizeof(*Xdp->Queues));
+    CxPlatZeroMemory(Xdp->Queues, Xdp->QueueCount * sizeof(*Xdp->Queues));
 
     for (uint32_t QueueIndex = 0; QueueIndex < Xdp->QueueCount; QueueIndex++) {
         XDP_QUEUE* Queue = &Xdp->Queues[QueueIndex];
@@ -257,7 +257,7 @@ CxPlatDpRawInitialize(
         CxPlatLockInitialize(&Queue->TxLock);
         CxPlatListInitializeHead(&Queue->TxQueue);
         CxPlatListInitializeHead(&Queue->WorkerTxQueue);
-        Queue->WorkerRxPool.Next = NULL;
+        CxPlatZeroMemory(&Queue->WorkerRxPool, sizeof(Queue->WorkerRxPool));
 
         //
         // RX datapath.

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -23,12 +23,11 @@ Abstract:
 #define RX_BATCH_SIZE 16
 #define MAX_ETH_FRAME_SIZE 1514
 
+#define QUEUE_TAG     'QpdX' // XdpQ
 #define RX_BUFFER_TAG 'RpdX' // XdpR
 #define TX_BUFFER_TAG 'TpdX' // XdpT
 
-typedef struct XDP_DATAPATH {
-    CXPLAT_DATAPATH;
-
+typedef struct _XDP_QUEUE {
     uint8_t* RxBuffers;
     HANDLE RxXsk;
     XSK_RING RxFillRing;
@@ -38,9 +37,8 @@ typedef struct XDP_DATAPATH {
     HANDLE TxXsk;
     XSK_RING TxRing;
     XSK_RING TxCompletionRing;
+    BOOL Error;
 
-    BOOLEAN Running;
-    CXPLAT_THREAD WorkerThread;
     CXPLAT_LIST_ENTRY WorkerTxQueue;
     CXPLAT_SLIST_ENTRY WorkerRxPool;
 
@@ -53,6 +51,14 @@ typedef struct XDP_DATAPATH {
     DECLSPEC_CACHEALIGN
     CXPLAT_LOCK TxLock;
     CXPLAT_LIST_ENTRY TxQueue;
+} XDP_QUEUE;
+
+typedef struct XDP_DATAPATH {
+    CXPLAT_DATAPATH;
+
+    BOOLEAN Running;
+    CXPLAT_THREAD WorkerThread;
+    XDP_QUEUE* Queues;
 
     // Constants
     DECLSPEC_CACHEALIGN
@@ -63,6 +69,7 @@ typedef struct XDP_DATAPATH {
     uint32_t RxRingSize;
     uint32_t TxBufferCount;
     uint32_t TxRingSize;
+    uint32_t QueueCount;
     BOOL Affinitize;
     BOOL TxAlwaysPoke;
 } XDP_DATAPATH;
@@ -70,7 +77,7 @@ typedef struct XDP_DATAPATH {
 typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) XDP_RX_PACKET {
     CXPLAT_RECV_DATA;
     CXPLAT_TUPLE IP;
-    XDP_DATAPATH* Xdp;
+    XDP_QUEUE* Queue;
     // Followed by:
     // uint8_t ClientContext[...];
     // uint8_t FrameBuffer[MAX_ETH_FRAME_SIZE];
@@ -78,7 +85,7 @@ typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) XDP_RX_PACKET {
 
 typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) XDP_TX_PACKET {
     CXPLAT_SEND_DATA;
-    XDP_DATAPATH* Xdp;
+    XDP_QUEUE* Queue;
     CXPLAT_LIST_ENTRY Link;
     uint8_t FrameBuffer[MAX_ETH_FRAME_SIZE];
 } XDP_TX_PACKET;
@@ -143,6 +150,8 @@ CxPlatXdpReadConfig(
     Xdp->ClientIP.si_family = AF_INET;
     Xdp->ClientIP.Ipv4.sin_addr.S_un.S_addr = 0x02FFFFFF;
 
+    Xdp->IfIndex = IFI_UNSPECIFIED;
+    Xdp->QueueCount = 1;
     Xdp->RxBufferCount = 4096;
     Xdp->RxRingSize = 128;
     Xdp->TxBufferCount = 4096;
@@ -165,7 +174,11 @@ CxPlatXdpReadConfig(
             Value[strlen(Value) - 1] = '\0';
         }
 
-        if (strcmp(Line, "ServerMac") == 0) {
+        if (strcmp(Line, "IfIndex") == 0) {
+            Xdp->IfIndex = (uint16_t)strtoul(Value, NULL, 10);
+        } else if (strcmp(Line, "QueueCount") == 0) {
+            Xdp->QueueCount = strtoul(Value, NULL, 10);
+        } else if (strcmp(Line, "ServerMac") == 0) {
             ValueToMac(Value, Xdp->ServerMac);
         } else if (strcmp(Line, "ClientMac") == 0) {
             ValueToMac(Value, Xdp->ClientMac);
@@ -179,8 +192,6 @@ CxPlatXdpReadConfig(
         } else if (strcmp(Line, "CpuNumber") == 0) {
              Xdp->DatapathCpuNumber = (uint8_t)strtoul(Value, NULL, 10);
              Xdp->Affinitize = TRUE;
-        } else if (strcmp(Line, "IfIndex") == 0) {
-            Xdp->IfIndex = (uint16_t)strtoul(Value, NULL, 10);
         } else if (strcmp(Line, "RxBufferCount") == 0) {
              Xdp->RxBufferCount = strtoul(Value, NULL, 10);
         } else if (strcmp(Line, "RxRingSize") == 0) {
@@ -221,232 +232,252 @@ CxPlatDpRawInitialize(
     const uint32_t RxPacketSize = ALIGN_UP(RxHeadroom + MAX_ETH_FRAME_SIZE, XDP_RX_PACKET);
     QUIC_STATUS Status;
 
-    InitializeSListHead(&Xdp->RxPool);
-    InitializeSListHead(&Xdp->TxPool);
-    CxPlatLockInitialize(&Xdp->TxLock);
-    CxPlatListInitializeHead(&Xdp->TxQueue);
-    CxPlatListInitializeHead(&Xdp->WorkerTxQueue);
-    Xdp->WorkerRxPool.Next = NULL;
-
     CxPlatXdpReadConfig(Xdp);
     Datapath->Cpu = Xdp->DatapathCpuNumber;
     CxPlatDpRawGenerateCpuTable(Datapath);
 
-    //
-    // RX datapath.
-    //
-
-    Xdp->RxBuffers = CxPlatAlloc(Xdp->RxBufferCount * RxPacketSize, RX_BUFFER_TAG);
-    if (Xdp->RxBuffers == NULL) {
+    Xdp->Queues = CxPlatAlloc(Xdp->QueueCount * sizeof(*Xdp->Queues), QUEUE_TAG);
+    if (Xdp->Queues == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
-            "XDP RX Buffers",
-            Xdp->RxBufferCount * RxPacketSize);
+            "XDP Queues",
+            Xdp->QueueCount * sizeof(*Xdp->Queues));
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
 
-    Status = XskCreate(&Xdp->RxXsk);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskCreate");
-        goto Error;
-    }
+    ZeroMemory(Xdp->Queues, Xdp->QueueCount * sizeof(*Xdp->Queues));
 
-    XSK_UMEM_REG RxUmem = {0};
-    RxUmem.address = Xdp->RxBuffers;
-    RxUmem.chunkSize = RxPacketSize;
-    RxUmem.headroom = RxHeadroom;
-    RxUmem.totalSize = Xdp->RxBufferCount * RxPacketSize;
+    for (uint32_t QueueIndex = 0; QueueIndex < Xdp->QueueCount; QueueIndex++) {
+        XDP_QUEUE* Queue = &Xdp->Queues[QueueIndex];
 
-    Status = XskSetSockopt(Xdp->RxXsk, XSK_SOCKOPT_UMEM_REG, &RxUmem, sizeof(RxUmem));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_UMEM_REG)");
-        goto Error;
-    }
+        InitializeSListHead(&Queue->RxPool);
+        InitializeSListHead(&Queue->TxPool);
+        CxPlatLockInitialize(&Queue->TxLock);
+        CxPlatListInitializeHead(&Queue->TxQueue);
+        CxPlatListInitializeHead(&Queue->WorkerTxQueue);
+        Queue->WorkerRxPool.Next = NULL;
 
-    Status =
-        XskSetSockopt(
-            Xdp->RxXsk, XSK_SOCKOPT_RX_FILL_RING_SIZE, &Xdp->RxRingSize, sizeof(Xdp->RxRingSize));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_RX_FILL_RING_SIZE)");
-        goto Error;
-    }
+        //
+        // RX datapath.
+        //
 
-    Status =
-        XskSetSockopt(
-            Xdp->RxXsk, XSK_SOCKOPT_RX_RING_SIZE, &Xdp->RxRingSize, sizeof(Xdp->RxRingSize));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_RX_RING_SIZE)");
-        goto Error;
-    }
+        Queue->RxBuffers = CxPlatAlloc(Xdp->RxBufferCount * RxPacketSize, RX_BUFFER_TAG);
+        if (Queue->RxBuffers == NULL) {
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "XDP RX Buffers",
+                Xdp->RxBufferCount * RxPacketSize);
+            Status = QUIC_STATUS_OUT_OF_MEMORY;
+            goto Error;
+        }
 
-    uint32_t QueueId = 0;   // TODO: support more than one RSS queue.
-    uint32_t Flags = 0;     // TODO: support native/generic forced flags.
-    Status = XskBind(Xdp->RxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskBind");
-        goto Error;
-    }
+        Status = XskCreate(&Queue->RxXsk);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskCreate");
+            goto Error;
+        }
 
-    XSK_RING_INFO_SET RxRingInfo;
-    uint32_t RxRingInfoSize = sizeof(RxRingInfo);
-    Status = XskGetSockopt(Xdp->RxXsk, XSK_SOCKOPT_RING_INFO, &RxRingInfo, &RxRingInfoSize);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskGetSockopt(XSK_SOCKOPT_RING_INFO)");
-        goto Error;
-    }
+        XSK_UMEM_REG RxUmem = {0};
+        RxUmem.address = Queue->RxBuffers;
+        RxUmem.chunkSize = RxPacketSize;
+        RxUmem.headroom = RxHeadroom;
+        RxUmem.totalSize = Xdp->RxBufferCount * RxPacketSize;
 
-    XskRingInitialize(&Xdp->RxFillRing, &RxRingInfo.fill);
-    XskRingInitialize(&Xdp->RxRing, &RxRingInfo.rx);
+        Status = XskSetSockopt(Queue->RxXsk, XSK_SOCKOPT_UMEM_REG, &RxUmem, sizeof(RxUmem));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_UMEM_REG)");
+            goto Error;
+        }
 
-    XDP_RULE RxRule = {
-        .Match = XDP_MATCH_ALL,
-        .Action = XDP_PROGRAM_ACTION_REDIRECT,
-        .Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK,
-        .Redirect.Target = Xdp->RxXsk,
-    };
+        Status =
+            XskSetSockopt(
+                Queue->RxXsk, XSK_SOCKOPT_RX_FILL_RING_SIZE, &Xdp->RxRingSize,
+                sizeof(Xdp->RxRingSize));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_RX_FILL_RING_SIZE)");
+            goto Error;
+        }
 
-    static const XDP_HOOK_ID RxHook = {
-        .Layer = XDP_HOOK_L2,
-        .Direction = XDP_HOOK_RX,
-        .SubLayer = XDP_HOOK_INSPECT,
-    };
+        Status =
+            XskSetSockopt(
+                Queue->RxXsk, XSK_SOCKOPT_RX_RING_SIZE, &Xdp->RxRingSize, sizeof(Xdp->RxRingSize));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_RX_RING_SIZE)");
+            goto Error;
+        }
 
-    Flags = 0; // TODO: support native/generic forced flags.
-    Status = XdpCreateProgram(Xdp->IfIndex, &RxHook, QueueId, Flags, &RxRule, 1, &Xdp->RxProgram);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XdpCreateProgram");
-        goto Error;
-    }
+        uint32_t QueueId = 0;   // TODO: support more than one RSS queue.
+        uint32_t Flags = 0;     // TODO: support native/generic forced flags.
+        Status = XskBind(Queue->RxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskBind");
+            goto Error;
+        }
 
-    for (uint32_t i = 0; i < Xdp->RxBufferCount; i++) {
-        InterlockedPushEntrySList(&Xdp->RxPool, (PSLIST_ENTRY)&Xdp->RxBuffers[i * RxPacketSize]);
-    }
+        XSK_RING_INFO_SET RxRingInfo;
+        uint32_t RxRingInfoSize = sizeof(RxRingInfo);
+        Status = XskGetSockopt(Queue->RxXsk, XSK_SOCKOPT_RING_INFO, &RxRingInfo, &RxRingInfoSize);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskGetSockopt(XSK_SOCKOPT_RING_INFO)");
+            goto Error;
+        }
 
-    //
-    // TX datapath.
-    //
+        XskRingInitialize(&Queue->RxFillRing, &RxRingInfo.fill);
+        XskRingInitialize(&Queue->RxRing, &RxRingInfo.rx);
 
-    Xdp->TxBuffers = CxPlatAlloc(Xdp->TxBufferCount * sizeof(XDP_TX_PACKET), TX_BUFFER_TAG);
-    if (Xdp->TxBuffers == NULL) {
-        QuicTraceEvent(
-            AllocFailure,
-            "Allocation of '%s' failed. (%llu bytes)",
-            "XDP TX Buffers",
-            Xdp->TxBufferCount * sizeof(XDP_TX_PACKET));
-        Status = QUIC_STATUS_OUT_OF_MEMORY;
-        goto Error;
-    }
+        XDP_RULE RxRule = {
+            .Match = XDP_MATCH_ALL,
+            .Action = XDP_PROGRAM_ACTION_REDIRECT,
+            .Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK,
+            .Redirect.Target = Queue->RxXsk,
+        };
 
-    Status = XskCreate(&Xdp->TxXsk);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskCreate");
-        goto Error;
-    }
+        static const XDP_HOOK_ID RxHook = {
+            .Layer = XDP_HOOK_L2,
+            .Direction = XDP_HOOK_RX,
+            .SubLayer = XDP_HOOK_INSPECT,
+        };
 
-    XSK_UMEM_REG TxUmem = {0};
-    TxUmem.address = Xdp->TxBuffers;
-    TxUmem.chunkSize = sizeof(XDP_TX_PACKET);
-    TxUmem.headroom = FIELD_OFFSET(XDP_TX_PACKET, FrameBuffer);
-    TxUmem.totalSize = Xdp->TxBufferCount * sizeof(XDP_TX_PACKET);
+        Flags = 0; // TODO: support native/generic forced flags.
+        Status =
+            XdpCreateProgram(Xdp->IfIndex, &RxHook, QueueId, Flags, &RxRule, 1, &Queue->RxProgram);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XdpCreateProgram");
+            goto Error;
+        }
 
-    Status = XskSetSockopt(Xdp->TxXsk, XSK_SOCKOPT_UMEM_REG, &TxUmem, sizeof(TxUmem));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_UMEM_REG)");
-        goto Error;
-    }
+        for (uint32_t i = 0; i < Xdp->RxBufferCount; i++) {
+            InterlockedPushEntrySList(
+                &Queue->RxPool, (PSLIST_ENTRY)&Queue->RxBuffers[i * RxPacketSize]);
+        }
 
-    Status =
-        XskSetSockopt(
-            Xdp->TxXsk, XSK_SOCKOPT_TX_RING_SIZE, &Xdp->TxRingSize, sizeof(Xdp->TxRingSize));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_TX_RING_SIZE)");
-        goto Error;
-    }
+        //
+        // TX datapath.
+        //
 
-    Status =
-        XskSetSockopt(
-            Xdp->TxXsk, XSK_SOCKOPT_TX_COMPLETION_RING_SIZE, &Xdp->TxRingSize,
-            sizeof(Xdp->TxRingSize));
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskSetSockopt(XSK_SOCKOPT_TX_COMPLETION_RING_SIZE)");
-        goto Error;
-    }
+        Queue->TxBuffers = CxPlatAlloc(Xdp->TxBufferCount * sizeof(XDP_TX_PACKET), TX_BUFFER_TAG);
+        if (Queue->TxBuffers == NULL) {
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "XDP TX Buffers",
+                Xdp->TxBufferCount * sizeof(XDP_TX_PACKET));
+            Status = QUIC_STATUS_OUT_OF_MEMORY;
+            goto Error;
+        }
 
-    Flags = 0; // TODO: support native/generic forced flags.
-    Status = XskBind(Xdp->TxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskBind");
-        goto Error;
-    }
+        Status = XskCreate(&Queue->TxXsk);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskCreate");
+            goto Error;
+        }
 
-    XSK_RING_INFO_SET TxRingInfo;
-    uint32_t TxRingInfoSize = sizeof(TxRingInfo);
-    Status = XskGetSockopt(Xdp->TxXsk, XSK_SOCKOPT_RING_INFO, &TxRingInfo, &TxRingInfoSize);
-    if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "XskGetSockopt(XSK_SOCKOPT_RING_INFO)");
-        goto Error;
-    }
+        XSK_UMEM_REG TxUmem = {0};
+        TxUmem.address = Queue->TxBuffers;
+        TxUmem.chunkSize = sizeof(XDP_TX_PACKET);
+        TxUmem.headroom = FIELD_OFFSET(XDP_TX_PACKET, FrameBuffer);
+        TxUmem.totalSize = Xdp->TxBufferCount * sizeof(XDP_TX_PACKET);
 
-    XskRingInitialize(&Xdp->TxRing, &TxRingInfo.tx);
-    XskRingInitialize(&Xdp->TxCompletionRing, &TxRingInfo.completion);
+        Status = XskSetSockopt(Queue->TxXsk, XSK_SOCKOPT_UMEM_REG, &TxUmem, sizeof(TxUmem));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_UMEM_REG)");
+            goto Error;
+        }
 
-    for (uint32_t i = 0; i < Xdp->TxBufferCount; i++) {
-        InterlockedPushEntrySList(
-            &Xdp->TxPool, (PSLIST_ENTRY)&Xdp->TxBuffers[i * sizeof(XDP_TX_PACKET)]);
+        Status =
+            XskSetSockopt(
+                Queue->TxXsk, XSK_SOCKOPT_TX_RING_SIZE, &Xdp->TxRingSize, sizeof(Xdp->TxRingSize));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_TX_RING_SIZE)");
+            goto Error;
+        }
+
+        Status =
+            XskSetSockopt(
+                Queue->TxXsk, XSK_SOCKOPT_TX_COMPLETION_RING_SIZE, &Xdp->TxRingSize,
+                sizeof(Xdp->TxRingSize));
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskSetSockopt(XSK_SOCKOPT_TX_COMPLETION_RING_SIZE)");
+            goto Error;
+        }
+
+        Flags = 0; // TODO: support native/generic forced flags.
+        Status = XskBind(Queue->TxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskBind");
+            goto Error;
+        }
+
+        XSK_RING_INFO_SET TxRingInfo;
+        uint32_t TxRingInfoSize = sizeof(TxRingInfo);
+        Status = XskGetSockopt(Queue->TxXsk, XSK_SOCKOPT_RING_INFO, &TxRingInfo, &TxRingInfoSize);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "XskGetSockopt(XSK_SOCKOPT_RING_INFO)");
+            goto Error;
+        }
+
+        XskRingInitialize(&Queue->TxRing, &TxRingInfo.tx);
+        XskRingInitialize(&Queue->TxCompletionRing, &TxRingInfo.completion);
+
+        for (uint32_t i = 0; i < Xdp->TxBufferCount; i++) {
+            InterlockedPushEntrySList(
+                &Queue->TxPool, (PSLIST_ENTRY)&Queue->TxBuffers[i * sizeof(XDP_TX_PACKET)]);
+        }
     }
 
     Xdp->Running = TRUE;
@@ -483,44 +514,62 @@ CxPlatDpRawUninitialize(
         CxPlatThreadDelete(&Xdp->WorkerThread);
     }
 
-    if (Xdp->TxXsk != NULL) {
-        XSK_STATISTICS Stats;
-        uint32_t StatsSize = sizeof(Stats);
-        if (QUIC_SUCCEEDED(XskGetSockopt(Xdp->TxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize))) {
-            printf("txInvalidDescriptors: %llu\n", Stats.txInvalidDescriptors);
+    #pragma warning(push)
+    #pragma warning(disable:6001) // Using uninitialized memory
+
+    for (uint32_t i = 0; Xdp->Queues != NULL && i < Xdp->QueueCount; i++) {
+        XDP_QUEUE *Queue = &Xdp->Queues[i];
+
+        if (Queue->TxXsk != NULL) {
+            QUIC_STATUS Status;
+            XSK_STATISTICS Stats;
+            uint32_t StatsSize = sizeof(Stats);
+            Status = XskGetSockopt(Queue->TxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
+            if (QUIC_SUCCEEDED(Status)) {
+                printf("[%u]txInvalidDescriptors: %llu\n", i, Stats.txInvalidDescriptors);
+            }
+            CloseHandle(Queue->TxXsk);
         }
-        CloseHandle(Xdp->TxXsk);
-    }
 
-    if (Xdp->TxBuffers != NULL) {
-        CxPlatFree(Xdp->TxBuffers, TX_BUFFER_TAG);
-    }
-
-    if (Xdp->RxProgram != NULL) {
-        CloseHandle(Xdp->RxProgram);
-    }
-
-    if (Xdp->RxXsk != NULL) {
-        XSK_STATISTICS Stats;
-        uint32_t StatsSize = sizeof(Stats);
-        if (QUIC_SUCCEEDED(XskGetSockopt(Xdp->RxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize))) {
-            printf("rxDropped: %llu\n", Stats.rxDropped);
-            printf("rxInvalidDescriptors: %llu\n", Stats.rxInvalidDescriptors);
+        if (Queue->TxBuffers != NULL) {
+            CxPlatFree(Queue->TxBuffers, TX_BUFFER_TAG);
         }
-        CloseHandle(Xdp->RxXsk);
+
+        if (Queue->RxProgram != NULL) {
+            CloseHandle(Queue->RxProgram);
+        }
+
+        if (Queue->RxXsk != NULL) {
+            QUIC_STATUS Status;
+            XSK_STATISTICS Stats;
+            uint32_t StatsSize = sizeof(Stats);
+            Status = XskGetSockopt(Queue->RxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
+            if (QUIC_SUCCEEDED(Status)) {
+                printf("]%u]rxDropped: %llu\n", i, Stats.rxDropped);
+                printf("[%u]rxInvalidDescriptors: %llu\n", i, Stats.rxInvalidDescriptors);
+            }
+            CloseHandle(Queue->RxXsk);
+        }
+
+        if (Queue->RxBuffers != NULL) {
+            CxPlatFree(Queue->RxBuffers, RX_BUFFER_TAG);
+        }
+
+        CxPlatLockUninitialize(&Queue->TxLock);
     }
 
-    if (Xdp->RxBuffers != NULL) {
-        CxPlatFree(Xdp->RxBuffers, RX_BUFFER_TAG);
-    }
+    #pragma warning(pop)
 
-    CxPlatLockUninitialize(&Xdp->TxLock);
+    if (Xdp->Queues != NULL) {
+        CxPlatFree(Xdp->Queues, QUEUE_TAG);
+    }
 }
 
 static
 void
 CxPlatXdpRx(
-    _In_ XDP_DATAPATH* Xdp
+    _In_ XDP_DATAPATH* Xdp,
+    _In_ XDP_QUEUE *Queue
     )
 {
     CXPLAT_RECV_DATA* Buffers[RX_BATCH_SIZE];
@@ -528,12 +577,12 @@ CxPlatXdpRx(
     uint32_t FillIndex;
     uint32_t ProdCount = 0;
     uint32_t PacketCount = 0;
-    const uint32_t BuffersCount = XskRingConsumerReserve(&Xdp->RxRing, RX_BATCH_SIZE, &RxIndex);
+    const uint32_t BuffersCount = XskRingConsumerReserve(&Queue->RxRing, RX_BATCH_SIZE, &RxIndex);
 
     for (uint32_t i = 0; i < BuffersCount; i++) {
-        XSK_BUFFER_DESCRIPTOR* Buffer = XskRingGetElement(&Xdp->RxRing, RxIndex++);
+        XSK_BUFFER_DESCRIPTOR* Buffer = XskRingGetElement(&Queue->RxRing, RxIndex++);
         XDP_RX_PACKET* Packet =
-            (XDP_RX_PACKET*)(Xdp->RxBuffers + XskDescriptorGetAddress(Buffer->address));
+            (XDP_RX_PACKET*)(Queue->RxBuffers + XskDescriptorGetAddress(Buffer->address));
         uint8_t* FrameBuffer = (uint8_t*)Packet + XskDescriptorGetOffset(Buffer->address);
 
         CxPlatZeroMemory(Packet, sizeof(XDP_RX_PACKET));
@@ -547,48 +596,48 @@ CxPlatXdpRx(
 
         if (Packet->Buffer) {
             Packet->Allocated = TRUE;
-            Packet->Xdp = Xdp;
+            Packet->Queue = Queue;
             Buffers[PacketCount++] = (CXPLAT_RECV_DATA*)Packet;
         } else {
-            CxPlatListPushEntry(&Xdp->WorkerRxPool, (CXPLAT_SLIST_ENTRY*)Packet);
+            CxPlatListPushEntry(&Queue->WorkerRxPool, (CXPLAT_SLIST_ENTRY*)Packet);
         }
     }
 
     if (BuffersCount > 0) {
-        XskRingConsumerRelease(&Xdp->RxRing, BuffersCount);
+        XskRingConsumerRelease(&Queue->RxRing, BuffersCount);
     }
 
-    uint32_t FillAvailable = XskRingProducerReserve(&Xdp->RxFillRing, MAXUINT32, &FillIndex);
+    uint32_t FillAvailable = XskRingProducerReserve(&Queue->RxFillRing, MAXUINT32, &FillIndex);
     while (FillAvailable-- > 0) {
-        if (Xdp->WorkerRxPool.Next == NULL) {
-            Xdp->WorkerRxPool.Next = (CXPLAT_SLIST_ENTRY*)InterlockedFlushSList(&Xdp->RxPool);
+        if (Queue->WorkerRxPool.Next == NULL) {
+            Queue->WorkerRxPool.Next = (CXPLAT_SLIST_ENTRY*)InterlockedFlushSList(&Queue->RxPool);
         }
 
-        XDP_RX_PACKET* Packet = (XDP_RX_PACKET*)CxPlatListPopEntry(&Xdp->WorkerRxPool);
+        XDP_RX_PACKET* Packet = (XDP_RX_PACKET*)CxPlatListPopEntry(&Queue->WorkerRxPool);
         if (Packet == NULL) {
             break;
         }
 
-        uint64_t* FillDesc = XskRingGetElement(&Xdp->RxFillRing, FillIndex++);
-        *FillDesc = (uint8_t*)Packet - Xdp->RxBuffers;
+        uint64_t* FillDesc = XskRingGetElement(&Queue->RxFillRing, FillIndex++);
+        *FillDesc = (uint8_t*)Packet - Queue->RxBuffers;
         ProdCount++;
     }
 
     if (ProdCount > 0) {
-        XskRingProducerSubmit(&Xdp->RxFillRing, ProdCount);
+        XskRingProducerSubmit(&Queue->RxFillRing, ProdCount);
     }
 
     if (PacketCount > 0) {
         CxPlatDpRawRxEthernet((CXPLAT_DATAPATH*)Xdp, Buffers, (uint16_t)PacketCount);
     }
 
-    if (XskRingError(&Xdp->RxRing)) {
+    if (XskRingError(&Queue->RxRing) && !Queue->Error) {
         XSK_ERROR ErrorStatus;
         QUIC_STATUS XskStatus;
         uint32_t ErrorSize = sizeof(ErrorStatus);
-        XskStatus = XskGetSockopt(Xdp->RxXsk, XSK_SOCKOPT_RX_ERROR, &ErrorStatus, &ErrorSize);
+        XskStatus = XskGetSockopt(Queue->RxXsk, XSK_SOCKOPT_RX_ERROR, &ErrorStatus, &ErrorSize);
         printf("RX ring error: 0x%x\n", SUCCEEDED(XskStatus) ? ErrorStatus : XskStatus);
-        Xdp->Running = FALSE;
+        Queue->Error = TRUE;
     }
 }
 
@@ -608,7 +657,7 @@ CxPlatDpRawRxFree(
         PacketChain = PacketChain->Next;
         // Packet->Allocated = FALSE; (other data paths don't clear this flag?)
 
-        if (Pool != &Packet->Xdp->RxPool) {
+        if (Pool != &Packet->Queue->RxPool) {
             if (Count > 0) {
                 InterlockedPushListSList(
                     Pool, Head, CONTAINING_RECORD(Tail, SLIST_ENTRY, Next), Count);
@@ -617,7 +666,7 @@ CxPlatDpRawRxFree(
                 Count = 0;
             }
 
-            Pool = &Packet->Xdp->RxPool;
+            Pool = &Packet->Queue->RxPool;
         }
 
         *Tail = (SLIST_ENTRY*)Packet;
@@ -639,14 +688,19 @@ CxPlatDpRawTxAlloc(
     )
 {
     XDP_DATAPATH* Xdp = (XDP_DATAPATH*)Datapath;
-    XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)InterlockedPopEntrySList(&Xdp->TxPool);
     const uint16_t HeaderBackfill = 42; // Ethernet,IPv4,UDP
+
+    //
+    // TODO: TX spreading.
+    //
+    XDP_QUEUE* Queue = &Xdp->Queues[0];
+    XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)InterlockedPopEntrySList(&Queue->TxPool);
 
     UNREFERENCED_PARAMETER(ECN);
 
     if (Packet) {
         CXPLAT_DBG_ASSERT(MaxPacketSize <= sizeof(Packet->FrameBuffer) - HeaderBackfill);
-        Packet->Xdp = Xdp;
+        Packet->Queue = Queue;
         Packet->Buffer.Length = MaxPacketSize;
         Packet->Buffer.Buffer = &Packet->FrameBuffer[HeaderBackfill];
     }
@@ -661,7 +715,7 @@ CxPlatDpRawTxFree(
     )
 {
     XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)SendData;
-    InterlockedPushEntrySList(&Packet->Xdp->TxPool, (PSLIST_ENTRY)Packet);
+    InterlockedPushEntrySList(&Packet->Queue->TxPool, (PSLIST_ENTRY)Packet);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -672,15 +726,16 @@ CxPlatDpRawTxEnqueue(
 {
     XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)SendData;
 
-    CxPlatLockAcquire(&Packet->Xdp->TxLock);
-    CxPlatListInsertTail(&Packet->Xdp->TxQueue, &Packet->Link);
-    CxPlatLockRelease(&Packet->Xdp->TxLock);
+    CxPlatLockAcquire(&Packet->Queue->TxLock);
+    CxPlatListInsertTail(&Packet->Queue->TxQueue, &Packet->Link);
+    CxPlatLockRelease(&Packet->Queue->TxLock);
 }
 
 static
 void
 CxPlatXdpTx(
-    _In_ XDP_DATAPATH* Xdp
+    _In_ XDP_DATAPATH* Xdp,
+    _In_ XDP_QUEUE* Queue
     )
 {
     uint32_t ProdCount = 0;
@@ -688,60 +743,61 @@ CxPlatXdpTx(
     SLIST_ENTRY* TxCompleteHead = NULL;
     SLIST_ENTRY** TxCompleteTail = &TxCompleteHead;
 
-    if (CxPlatListIsEmpty(&Xdp->WorkerTxQueue) &&
-        ReadPointerNoFence(&Xdp->TxQueue.Flink) != &Xdp->TxQueue) {
-        CxPlatLockAcquire(&Xdp->TxLock);
-        CxPlatListMoveItems(&Xdp->TxQueue, &Xdp->WorkerTxQueue);
-        CxPlatLockRelease(&Xdp->TxLock);
+    if (CxPlatListIsEmpty(&Queue->WorkerTxQueue) &&
+        ReadPointerNoFence(&Queue->TxQueue.Flink) != &Queue->TxQueue) {
+        CxPlatLockAcquire(&Queue->TxLock);
+        CxPlatListMoveItems(&Queue->TxQueue, &Queue->WorkerTxQueue);
+        CxPlatLockRelease(&Queue->TxLock);
     }
 
     uint32_t TxIndex;
-    uint32_t TxAvailable = XskRingProducerReserve(&Xdp->TxRing, MAXUINT32, &TxIndex);
-    while (TxAvailable-- > 0 && !CxPlatListIsEmpty(&Xdp->WorkerTxQueue)) {
-        XSK_BUFFER_DESCRIPTOR* Buffer = XskRingGetElement(&Xdp->TxRing, TxIndex++);
-        CXPLAT_LIST_ENTRY* Entry = CxPlatListRemoveHead(&Xdp->WorkerTxQueue);
+    uint32_t TxAvailable = XskRingProducerReserve(&Queue->TxRing, MAXUINT32, &TxIndex);
+    while (TxAvailable-- > 0 && !CxPlatListIsEmpty(&Queue->WorkerTxQueue)) {
+        XSK_BUFFER_DESCRIPTOR* Buffer = XskRingGetElement(&Queue->TxRing, TxIndex++);
+        CXPLAT_LIST_ENTRY* Entry = CxPlatListRemoveHead(&Queue->WorkerTxQueue);
         XDP_TX_PACKET* Packet = CONTAINING_RECORD(Entry, XDP_TX_PACKET, Link);
 
-        Buffer->address = (uint8_t*)Packet - Xdp->TxBuffers;
+        Buffer->address = (uint8_t*)Packet - Queue->TxBuffers;
         XskDescriptorSetOffset(&Buffer->address, FIELD_OFFSET(XDP_TX_PACKET, FrameBuffer));
         Buffer->length = Packet->Buffer.Length;
         ProdCount++;
     }
 
     if (ProdCount > 0) {
-        XskRingProducerSubmit(&Xdp->TxRing, ProdCount);
-        if (Xdp->TxAlwaysPoke || XskRingProducerNeedPoke(&Xdp->TxRing)) {
+        XskRingProducerSubmit(&Queue->TxRing, ProdCount);
+        if (Xdp->TxAlwaysPoke || XskRingProducerNeedPoke(&Queue->TxRing)) {
             uint32_t OutFlags;
-            QUIC_STATUS Status = XskNotifySocket(Xdp->TxXsk, XSK_NOTIFY_POKE_TX, 0, &OutFlags);
+            QUIC_STATUS Status = XskNotifySocket(Queue->TxXsk, XSK_NOTIFY_POKE_TX, 0, &OutFlags);
             CXPLAT_DBG_ASSERT(QUIC_SUCCEEDED(Status));
             UNREFERENCED_PARAMETER(Status);
         }
     }
 
     uint32_t CompIndex;
-    uint32_t CompAvailable = XskRingConsumerReserve(&Xdp->TxCompletionRing, MAXUINT32, &CompIndex);
+    uint32_t CompAvailable =
+        XskRingConsumerReserve(&Queue->TxCompletionRing, MAXUINT32, &CompIndex);
     while (CompAvailable-- > 0) {
-        uint64_t* CompDesc = XskRingGetElement(&Xdp->TxCompletionRing, CompIndex++);
-        XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)(Xdp->TxBuffers + *CompDesc);
+        uint64_t* CompDesc = XskRingGetElement(&Queue->TxCompletionRing, CompIndex++);
+        XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)(Queue->TxBuffers + *CompDesc);
         *TxCompleteTail = (PSLIST_ENTRY)Packet;
         TxCompleteTail = &((PSLIST_ENTRY)Packet)->Next;
         CompCount++;
     }
 
     if (CompCount > 0) {
-        XskRingConsumerRelease(&Xdp->TxCompletionRing, CompCount);
+        XskRingConsumerRelease(&Queue->TxCompletionRing, CompCount);
         InterlockedPushListSList(
-            &Xdp->TxPool, TxCompleteHead, CONTAINING_RECORD(TxCompleteTail, SLIST_ENTRY, Next),
+            &Queue->TxPool, TxCompleteHead, CONTAINING_RECORD(TxCompleteTail, SLIST_ENTRY, Next),
             CompCount);
     }
 
-    if (XskRingError(&Xdp->TxRing)) {
+    if (XskRingError(&Queue->TxRing) && !Queue->Error) {
         XSK_ERROR ErrorStatus;
         QUIC_STATUS XskStatus;
         uint32_t ErrorSize = sizeof(ErrorStatus);
-        XskStatus = XskGetSockopt(Xdp->TxXsk, XSK_SOCKOPT_TX_ERROR, &ErrorStatus, &ErrorSize);
+        XskStatus = XskGetSockopt(Queue->TxXsk, XSK_SOCKOPT_TX_ERROR, &ErrorStatus, &ErrorSize);
         printf("TX ring error: 0x%x\n", SUCCEEDED(XskStatus) ? ErrorStatus : XskStatus);
-        Xdp->Running = FALSE;
+        Queue->Error = TRUE;
     }
 }
 
@@ -758,8 +814,12 @@ CXPLAT_THREAD_CALLBACK(CxPlatXdpWorkerThread, Context)
     }
 
     while (Xdp->Running) {
-        CxPlatXdpRx(Xdp);
-        CxPlatXdpTx(Xdp);
+        for (uint32_t i = 0; i < Xdp->QueueCount; i++) {
+            XDP_QUEUE* Queue = &Xdp->Queues[i];
+
+            CxPlatXdpRx(Xdp, Queue);
+            CxPlatXdpTx(Xdp, Queue);
+        }
     }
 
     return 0;

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -257,7 +257,6 @@ CxPlatDpRawInitialize(
         CxPlatLockInitialize(&Queue->TxLock);
         CxPlatListInitializeHead(&Queue->TxQueue);
         CxPlatListInitializeHead(&Queue->WorkerTxQueue);
-        CxPlatZeroMemory(&Queue->WorkerRxPool, sizeof(Queue->WorkerRxPool));
 
         //
         // RX datapath.


### PR DESCRIPTION
Initial support for multiple XDP queues, i.e. multiple RSS queues.

1. QUIC core and raw abstractions do not not provide a TX spreading scheme other than implicitly via worker CPU.
2. For simplicity, use only one user mode worker thread to pump all the kernel mode XDP queues.