### PR TITLE
GitHub Action for Repo Mirroring

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -826,44 +826,6 @@ stages:
       tls: openssl
 
 #
-# Mirror
-#
-
-- ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), not(eq(variables['Build.Reason'], 'Schedule'))) }}:
-  - stage: mirror
-    displayName: Mirror Branch
-    dependsOn:
-    - build_windows_release
-    - build_winkernel_release
-    - build_linux_release
-    - build_windows_debug
-    - build_winkernel_debug
-    - build_linux_debug
-    - build_windows_nontest
-    - build_winkernel_nontest
-    - build_linux_nontest
-    - build_macos_release
-    - build_macos_nontest
-    - build_macos_debug
-    - merge_darwin
-    jobs:
-    - job: mirror
-      displayName: Mirror
-      pool:
-        vmImage: windows-2019
-      steps:
-      - checkout: self
-        persistCredentials: true
-      - task: PowerShell@2
-        displayName: Sync Changes to AzDO Mirror Branch
-        inputs:
-          pwsh: true
-          filePath: scripts/sync-mirror.ps1
-          arguments: -Branch $(Build.SourceBranch)
-        env:
-          AzDO_PAT: $(AzDO_PAT)
-
-#
 # Distribution
 #
 

--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -1,0 +1,24 @@
+name: Mirror
+
+on:
+  push:
+    branches:
+    - main
+    - release/*
+    - prerelease/*
+    tags:
+    - v*
+
+jobs:
+  mirror:
+    name: Mirror
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Sync mirror
+      shell: pwsh
+      env:
+        AzDO_PAT: ${{ secrets.AZDO_PAT }}
+        Source: ${{ github.ref }} # refs/heads/<branch_name> or refs/tags/<tag_name>
+      run: scripts/sync-mirror.ps1 -Source $env:Source

--- a/scripts/sync-mirror.ps1
+++ b/scripts/sync-mirror.ps1
@@ -1,19 +1,22 @@
 <#
 
 .SYNOPSIS
-This synchronizes a branch on the current repository to the mirror repo.
+This synchronizes a branch or tag on the current repository to the mirror repo.
 
 .EXAMPLE
     sync-mirror.ps1
 
 .EXAMPLE
-    sync-mirror.ps1 -Branch refs/heads/release/xxxx
+    sync-mirror.ps1 -Source refs/heads/release/1.0.0
+
+.EXAMPLE
+    sync-mirror.ps1 -Source refs/tags/v1.0.0
 
 #>
 
 param (
     [Parameter(Mandatory = $false)]
-    [string]$Branch = "refs/heads/main"
+    [string]$Source = "refs/heads/main"
 )
 
 Set-StrictMode -Version 'Latest'
@@ -24,21 +27,37 @@ if ($null -eq $Env:AzDO_PAT -or "" -eq $Env:AzDO_PAT) {
     Write-Error "PAT for Azure DevOps Repo doesn't exist!"
 }
 
-# Remove the 'refs/heads/' prefix.
-$BranchName = $Branch.Substring(11)
+$SourceName = "" # The name of the branch or tag
 
-# Make sure we're in the correct branch.
-git checkout $BranchName
+if ($Source.StartsWith("refs/heads/")) {
+
+    # Remove the 'refs/heads/' prefix.
+    $SourceName = $Source.Substring(11)
+
+    # Make sure we're in the correct branch.
+    git checkout $SourceName
+
+    # Reset branch to origin.
+    git reset --hard origin/$SourceName
+
+} else if ($Source.StartsWith("refs/tags/")) {
+
+    # Remove the 'refs/tags/' prefix.
+    $SourceName = $Source.Substring(10)
+
+    # Make sure we're in the correct tag.
+    git checkout $SourceName
+
+} else {
+    Write-Error "Unsupported source: " + $Source
+}
 
 # Add the AzDO repo as a remote.
 git remote add azdo-mirror "https://nibanks:$Env:AzDO_PAT@mscodehub.visualstudio.com/msquic/_git/msquic"
 
-# Reset branch to origin.
-git reset --hard origin/$BranchName
-
 # Push to the AzDO repo.
 try {
-    git push azdo-mirror $BranchName
+    git push azdo-mirror $SourceName
 } catch {
     Write-Host "Supressing exception while running 'git push'"
 }


### PR DESCRIPTION
Moves the mirroring job to a GitHub Action. Also adds tag support, and now includes mirroring for prerelease branches. No longer requires that all builds complete first. This isn't really necessary any more since these consistently pass always anyways.