### PR TITLE
GitHub Action for WAN Perf

### DIFF
--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -19,10 +19,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -Configuration Build -InitSubmodules
+      run: scripts/prepare-machine.ps1 -Configuration Build -InitSubmodules -Extra "-DisableTest -DisableTools"
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/build.ps1 -Config Release
+      run: scripts/build.ps1 -Config Release -Extra "-DisableTest -DisableTools"
     - uses: actions/upload-artifact@v2
       with:
         name: bin
@@ -36,6 +36,10 @@ jobs:
     name: Run Perf Test
     runs-on: windows-2022
     needs: build
+    strategy:
+      matrix:
+        rate: [5, 10, 50, 100]
+        rtt: [5, 50, 200, 500]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -48,4 +52,4 @@ jobs:
         path: artifacts/bin
     - name: Run WAN Perf
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations 3 -BottleneckMbps 100 -BottleneckQueueRatio 1 -DurationMs 10000 -RttMs 50 -Pacing 1 -RandomLossDenominator 0 -RandomReorderDenominator 0 -ReorderDelayDeltaMs 0 -BaseRandomSeed '""' -LogProfile None -Config Release
+      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations 3 -DurationMs 10000 -Pacing 1 -BottleneckMbps ${{ matrix.rate }} -BottleneckQueueRatio 1 -RttMs ${{ matrix.rtt }} -RandomLossDenominator 0 -RandomReorderDenominator 0 -ReorderDelayDeltaMs 0

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -1,0 +1,49 @@
+name: WAN Perf
+
+on:
+  push:
+    branches:
+    - main
+    - release/*
+  pull_request:
+    branches:
+    - main
+    - release/*
+
+jobs:
+  build:
+    name: Build
+    runs-on: windows-latest
+    steps:
+    - name: Prepare Machine
+      shell: pwsh
+      run: scripts/prepare-machine.ps1 -Configuration Build -InitSubmodules
+    - name: Prepare Machine
+      shell: pwsh
+      run: scripts/build.ps1 -Config Release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: bin
+        path: |
+          artifacts/bin
+          !artifacts/bin/**/*.ilk
+          !artifacts/bin/**/*.cer
+          !artifacts/bin/**/*.exp
+          !artifacts/bin/**/*.lastcodeanalysissucceeded
+  wan-perf:
+    name: Run Perf Test
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Prepare Machine
+      shell: pwsh
+      run: scripts/prepare-machine.ps1 -Configuration Test -DuoNic
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin
+        path: artifacts/bin
+    - name: Run WAN Perf
+      shell: pwsh
+      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations 3 -BottleneckMbps 100 -BottleneckQueueRatio 1 -DurationMs 10000 -RttMs 50 -Pacing 1 -RandomLossDenominator 0 -RandomReorderDenominator 0 -ReorderDelayDeltaMs 0 -BaseRandomSeed '""' -LogProfile None -Config Release

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -15,6 +15,7 @@ env:
   iterations: 3
   duration: 10000
   pacing: 1
+  loss: "(0,1000,10000)"
   reorder: "(0,1000,10000)"
   delay: "(0,5,10)"
 
@@ -50,7 +51,6 @@ jobs:
         rate: [5, 10, 20, 50, 100, 200]
         rtt: [5, 50, 200, 500]
         queueRatio: [0.2, 1, 5]
-        loss: [0, 1000, 10000]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         path: artifacts/bin
     - name: Run WAN Perf
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
+      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ env.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
     - uses: actions/upload-artifact@v2
       with:
         name: results

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -15,6 +15,8 @@ env:
   iterations: 3
   duration: 10000
   pacing: 1
+  reorder: "(0,1000,10000)"
+  delay: "(0,5,10)"
 
 jobs:
   build:
@@ -39,16 +41,16 @@ jobs:
           !artifacts/bin/**/*.exp
           !artifacts/bin/**/*.lastcodeanalysissucceeded
   wan-perf:
-    name: Run Perf Test
+    name: Test
     runs-on: windows-2022
     needs: build
     strategy:
       fail-fast: false
       matrix:
-        rate: [5, 10, 50, 100]
+        rate: [5, 10, 20, 50, 100, 200]
         rtt: [5, 50, 200, 500]
-        queueRatio: [0.25, 1.0]
-        loss: [0, 1000]
+        queueRatio: [0.2, 1, 5]
+        loss: [0, 1000, 10000]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -61,7 +63,7 @@ jobs:
         path: artifacts/bin
     - name: Run WAN Perf
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -BaseRandomSeed ${{ env.seed }}
+      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
     - uses: actions/upload-artifact@v2
       with:
         name: results

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -5,10 +5,30 @@ on:
     branches:
     - main
     - release/*
+    paths-ignore:
+    - .azure/*
+    - docs/*
+    - src/cs/*
+    - src/distribution/*
+    - src/plugins/*
+    - src/tools/*
+    - src/lib.rs
+    - Cargo.toml
+    - README.md
   pull_request:
     branches:
     - main
     - release/*
+    paths-ignore:
+    - .azure/*
+    - docs/*
+    - src/cs/*
+    - src/distribution/*
+    - src/plugins/*
+    - src/tools/*
+    - src/lib.rs
+    - Cargo.toml
+    - README.md
 
 env:
   seed: 41473a2e60b6958500ec0add7dcfb9 # TODO - Randomize?

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build
     runs-on: windows-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -Configuration Build -InitSubmodules
@@ -32,7 +34,7 @@ jobs:
           !artifacts/bin/**/*.lastcodeanalysissucceeded
   wan-perf:
     name: Run Perf Test
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: build
     steps:
     - name: Checkout repository

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -108,7 +108,3 @@ jobs:
     - name: Merge Data Files
       shell: pwsh
       run: scripts/emulated-performance.ps1 -MergeDataFiles
-    - uses: actions/upload-artifact@v2
-      with:
-        name: results
-        path: artifacts/PerfDataResults/WanPerf.html

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -Configuration Test -DuoNic
+      run: scripts/prepare-machine.ps1 -Configuration Test -DuoNic -NoCodeCoverage
     - uses: actions/download-artifact@v2
       with:
         name: bin

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -10,6 +10,12 @@ on:
     - main
     - release/*
 
+env:
+  seed: 41473a2e60b6958500ec0add7dcfb9
+  iterations: 3
+  duration: 10000
+  pacing: 1
+
 jobs:
   build:
     name: Build
@@ -37,9 +43,12 @@ jobs:
     runs-on: windows-2022
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         rate: [5, 10, 50, 100]
         rtt: [5, 50, 200, 500]
+        queueRatio: [0.25, 1.0]
+        loss: [0, 1000]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -52,4 +61,4 @@ jobs:
         path: artifacts/bin
     - name: Run WAN Perf
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations 3 -DurationMs 10000 -Pacing 1 -BottleneckMbps ${{ matrix.rate }} -BottleneckQueueRatio 1 -RttMs ${{ matrix.rtt }} -RandomLossDenominator 0 -RandomReorderDenominator 0 -ReorderDelayDeltaMs 0
+      run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -BaseRandomSeed ${{ env.seed }}

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -40,8 +40,8 @@ env:
   delay: "(0,5,10)"
 
 jobs:
-  build:
-    name: Build
+  build-perf:
+    name: Build Perf
     runs-on: windows-latest
     steps:
     - name: Checkout repository
@@ -64,9 +64,9 @@ jobs:
           !artifacts/bin/**/*.pgd
           !artifacts/bin/**/*.lib
   wan-perf:
-    name: Test
+    name: Run Tests
     runs-on: windows-2022
-    needs: build
+    needs: build-perf
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -62,3 +62,7 @@ jobs:
     - name: Run WAN Perf
       shell: pwsh
       run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -BaseRandomSeed ${{ env.seed }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: results
+        path: artifacts/PerfDataResults/windows/x64_Release_schannel/WAN/*.json

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -94,4 +94,21 @@ jobs:
       with:
         name: data
         path: artifacts/PerfDataResults/windows/x64_Release_schannel/WAN/*.json
-  # TODO - Download and merge data files
+  merge-data:
+    name: Merge Results
+    runs-on: windows-2022
+    needs: wan-perf
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: data
+        path: artifacts/PerfDataResults/windows/x64_Release_schannel/WAN
+    - name: Merge Data Files
+      shell: pwsh
+      run: scripts/emulated-performance.ps1 -MergeDataFiles
+    - uses: actions/upload-artifact@v2
+      with:
+        name: results
+        path: artifacts/PerfDataResults/WanPerf.html

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -11,7 +11,7 @@ on:
     - release/*
 
 env:
-  seed: 41473a2e60b6958500ec0add7dcfb9
+  seed: 41473a2e60b6958500ec0add7dcfb9 # TODO - Randomize?
   iterations: 3
   duration: 10000
   pacing: 1
@@ -41,6 +41,8 @@ jobs:
           !artifacts/bin/**/*.cer
           !artifacts/bin/**/*.exp
           !artifacts/bin/**/*.lastcodeanalysissucceeded
+          !artifacts/bin/**/*.pgd
+          !artifacts/bin/**/*.lib
   wan-perf:
     name: Test
     runs-on: windows-2022
@@ -51,6 +53,10 @@ jobs:
         rate: [5, 10, 20, 50, 100, 200]
         rtt: [5, 50, 200, 500]
         queueRatio: [0.2, 1, 5]
+        exclude:
+        - rate: 5
+          rtt: 5
+          queueRatio: 0.2 # Results in sub-packet limit
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -66,5 +72,6 @@ jobs:
       run: scripts/emulated-performance.ps1 -Protocol quic -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ env.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
     - uses: actions/upload-artifact@v2
       with:
-        name: results
+        name: data
         path: artifacts/PerfDataResults/windows/x64_Release_schannel/WAN/*.json
+  # TODO - Download and merge data files

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -22,7 +22,7 @@ jobs:
       run: scripts/prepare-machine.ps1 -Configuration Build -InitSubmodules -Extra "-DisableTest -DisableTools"
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/build.ps1 -Config Release -Extra "-DisableTest -DisableTools"
+      run: scripts/build.ps1 -Config Release -DisableTest -DisableTools
     - uses: actions/upload-artifact@v2
       with:
         name: bin

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -271,23 +271,23 @@ if (![string]::IsNullOrWhiteSpace($ForceBranchName)) {
 
 } elseif (![string]::IsNullOrWhiteSpace($env:SYSTEM_PULLREQUEST_TARGETBRANCH)) {
     # We are in a (AZP) pull request build.
-    Write-Host "Using $env:SYSTEM_PULLREQUEST_TARGETBRANCH to compute branch"
+    Write-Host "Using SYSTEM_PULLREQUEST_TARGETBRANCH=$env:SYSTEM_PULLREQUEST_TARGETBRANCH to compute branch"
     $BranchName = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
 
 } elseif (![string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
     # We are in a (GitHub Action) pull request build.
-    Write-Host "Using $env:GITHUB_BASE_REF to compute branch"
-    $BranchName = $env:GITHUB_BASE_REF.Substring(11)
+    Write-Host "Using GITHUB_BASE_REF=$env:GITHUB_BASE_REF to compute branch"
+    $BranchName = $env:GITHUB_BASE_REF
 
 } elseif (![string]::IsNullOrWhiteSpace($env:BUILD_SOURCEBRANCH)) {
     # We are in a (AZP) main build.
-    Write-Host "Using $env:BUILD_SOURCEBRANCH to compute branch"
+    Write-Host "Using BUILD_SOURCEBRANCH=$env:BUILD_SOURCEBRANCH to compute branch"
     $BranchName = $env:BUILD_SOURCEBRANCH.Substring(11)
 
 } elseif (![string]::IsNullOrWhiteSpace($env:GITHUB_REF_NAME)) {
     # We are in a (GitHub Action) main build.
-    Write-Host "Using $env:GITHUB_REF_NAME to compute branch"
-    $BranchName = $env:GITHUB_REF_NAME.Substring(11)
+    Write-Host "Using GITHUB_REF_NAME=$env:GITHUB_REF_NAME to compute branch"
+    $BranchName = $env:GITHUB_REF_NAME
 
 } else {
     # Fallback to the current branch.

--- a/scripts/emulated-performance.ps1
+++ b/scripts/emulated-performance.ps1
@@ -271,18 +271,22 @@ if (![string]::IsNullOrWhiteSpace($ForceBranchName)) {
 
 } elseif (![string]::IsNullOrWhiteSpace($env:SYSTEM_PULLREQUEST_TARGETBRANCH)) {
     # We are in a (AZP) pull request build.
+    Write-Host "Using $env:SYSTEM_PULLREQUEST_TARGETBRANCH to compute branch"
     $BranchName = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
 
 } elseif (![string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
     # We are in a (GitHub Action) pull request build.
+    Write-Host "Using $env:GITHUB_BASE_REF to compute branch"
     $BranchName = $env:GITHUB_BASE_REF.Substring(11)
 
 } elseif (![string]::IsNullOrWhiteSpace($env:BUILD_SOURCEBRANCH)) {
     # We are in a (AZP) main build.
+    Write-Host "Using $env:BUILD_SOURCEBRANCH to compute branch"
     $BranchName = $env:BUILD_SOURCEBRANCH.Substring(11)
 
 } elseif (![string]::IsNullOrWhiteSpace($env:GITHUB_REF_NAME)) {
     # We are in a (GitHub Action) main build.
+    Write-Host "Using $env:GITHUB_REF_NAME to compute branch"
     $BranchName = $env:GITHUB_REF_NAME.Substring(11)
 
 } else {

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -60,7 +60,10 @@ param (
     [switch]$SignCode,
 
     [Parameter(Mandatory = $false)]
-    [switch]$DuoNic
+    [switch]$DuoNic,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoCodeCoverage
 )
 
 #Requires -RunAsAdministrator
@@ -325,7 +328,7 @@ if ($IsWindows) {
             }
         }
         # Install OpenCppCoverage on test machines
-        if (!(Test-Path "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe")) {
+        if (!$NoCodeCoverage -and !(Test-Path "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe")) {
             # Download the installer.
             $Installer = $null
             if ([System.Environment]::Is64BitOperatingSystem) {


### PR DESCRIPTION
Starts the process of refactoring and moving WAN perf testing. Uses a matrix to run parallel jobs.

Future work:

- Remove AZP WAN perf and ensure this Action replaces all functionality.
- Periodically do even more cases (i.e. TCP)