### PR TITLE
Create CXPLAT_ROUTE to replace QUIC_PATH::LocalAddress and QUIC_PATH::RemoteAddress

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1058,10 +1058,13 @@ QuicBindingProcessStatelessOperation(
         goto Exit;
     }
 
+    CXPLAT_ROUTE Route;
+    Route.LocalAddress = RecvDatagram->Tuple->LocalAddress;
+    Route.RemoteAddress = RecvDatagram->Tuple->RemoteAddress;
+
     QuicBindingSend(
         Binding,
-        &RecvDatagram->Tuple->LocalAddress,
-        &RecvDatagram->Tuple->RemoteAddress,
+        &Route,
         SendData,
         SendDatagram->Length,
         1,
@@ -1745,8 +1748,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QuicBindingSend(
     _In_ QUIC_BINDING* Binding,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend,
@@ -1759,12 +1761,12 @@ QuicBindingSend(
     QUIC_TEST_DATAPATH_HOOKS* Hooks = MsQuicLib.TestDatapathHooks;
     if (Hooks != NULL) {
 
-        QUIC_ADDR RemoteAddressCopy = *RemoteAddress;
-        QUIC_ADDR LocalAddressCopy = *LocalAddress;
+        CXPLAT_ROUTE RouteCopy = *Route;
+
         BOOLEAN Drop =
             Hooks->Send(
-                &RemoteAddressCopy,
-                &LocalAddressCopy,
+                &RouteCopy.RemoteAddress,
+                &RouteCopy.LocalAddress,
                 SendData);
 
         if (Drop) {
@@ -1778,8 +1780,7 @@ QuicBindingSend(
             Status =
                 CxPlatSocketSend(
                     Binding->Socket,
-                    &LocalAddressCopy,
-                    &RemoteAddressCopy,
+                    &RouteCopy,
                     SendData,
                     IdealProcessor);
             if (QUIC_FAILED(Status)) {
@@ -1795,8 +1796,7 @@ QuicBindingSend(
         Status =
             CxPlatSocketSend(
                 Binding->Socket,
-                LocalAddress,
-                RemoteAddress,
+                Route,
                 SendData,
                 IdealProcessor);
         if (QUIC_FAILED(Status)) {

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -435,8 +435,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QuicBindingSend(
     _In_ QUIC_BINDING* Binding,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint32_t BytesToSend,
     _In_ uint32_t DatagramsToSend,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -181,21 +181,21 @@ QuicConnAlloc(
         Connection->Stats.QuicVersion = Packet->Invariant->LONG_HDR.Version;
         QuicConnOnQuicVersionSet(Connection);
 
-        Path->LocalAddress = Datagram->Tuple->LocalAddress;
+        Path->Route.LocalAddress = Datagram->Tuple->LocalAddress;
         Connection->State.LocalAddressSet = TRUE;
         QuicTraceEvent(
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 
-        Path->RemoteAddress = Datagram->Tuple->RemoteAddress;
+        Path->Route.RemoteAddress = Datagram->Tuple->RemoteAddress;
         Connection->State.RemoteAddressSet = TRUE;
         QuicTraceEvent(
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 
         Path->DestCid =
             QuicCidNewDestination(Packet->SourceCidLen, Packet->SourceCid);
@@ -609,14 +609,14 @@ QuicConnTraceRundownOper(
                     ConnLocalAddrAdded,
                      "[conn][%p] New Local IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].LocalAddress), &Connection->Paths[i].LocalAddress));
+                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.LocalAddress), &Connection->Paths[i].Route.LocalAddress));
             }
             if (Connection->State.RemoteAddressSet || i != 0) {
                 QuicTraceEvent(
                     ConnRemoteAddrAdded,
                     "[conn][%p] New Remote IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].RemoteAddress), &Connection->Paths[i].RemoteAddress));
+                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.RemoteAddress), &Connection->Paths[i].Route.RemoteAddress));
             }
         }
         for (CXPLAT_SLIST_ENTRY* Entry = Connection->SourceCids.Next;
@@ -1774,7 +1774,7 @@ QuicConnStart(
     if (!Connection->State.RemoteAddressSet) {
 
         CXPLAT_DBG_ASSERT(ServerName != NULL);
-        QuicAddrSetFamily(&Path->RemoteAddress, Family);
+        QuicAddrSetFamily(&Path->Route.RemoteAddress, Family);
 
 #ifdef QUIC_COMPARTMENT_ID
         BOOLEAN RevertCompartmentId = FALSE;
@@ -1800,7 +1800,7 @@ QuicConnStart(
             CxPlatDataPathResolveAddress(
                 MsQuicLib.Datapath,
                 ServerName,
-                &Path->RemoteAddress);
+                &Path->Route.RemoteAddress);
 
 #ifdef QUIC_COMPARTMENT_ID
         if (RevertCompartmentId) {
@@ -1815,18 +1815,18 @@ QuicConnStart(
         Connection->State.RemoteAddressSet = TRUE;
     }
 
-    QuicAddrSetPort(&Path->RemoteAddress, ServerPort);
+    QuicAddrSetPort(&Path->Route.RemoteAddress, ServerPort);
     QuicTraceEvent(
         ConnRemoteAddrAdded,
         "[conn][%p] New Remote IP: %!ADDR!",
         Connection,
-        CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = Connection->State.LocalAddressSet ? &Path->LocalAddress : NULL;
-    UdpConfig.RemoteAddress = &Path->RemoteAddress;
+    UdpConfig.LocalAddress = Connection->State.LocalAddressSet ? &Path->Route.LocalAddress : NULL;
+    UdpConfig.RemoteAddress = &Path->Route.RemoteAddress;
     UdpConfig.Flags = Connection->State.ShareBinding ? CXPLAT_SOCKET_FLAG_SHARE : 0;
-    UdpConfig.InterfaceIndex = Connection->State.LocalInterfaceSet ? (uint32_t)Path->LocalAddress.Ipv6.sin6_scope_id : 0, // NOLINT(google-readability-casting)
+    UdpConfig.InterfaceIndex = Connection->State.LocalInterfaceSet ? (uint32_t)Path->Route.LocalAddress.Ipv6.sin6_scope_id : 0, // NOLINT(google-readability-casting)
 #ifdef QUIC_COMPARTMENT_ID
     UdpConfig.CompartmentId = Configuration->CompartmentId;
 #endif
@@ -1883,12 +1883,12 @@ QuicConnStart(
     }
 
     Connection->State.LocalAddressSet = TRUE;
-    QuicBindingGetLocalAddress(Path->Binding, &Path->LocalAddress);
+    QuicBindingGetLocalAddress(Path->Binding, &Path->Route.LocalAddress);
     QuicTraceEvent(
         ConnLocalAddrAdded,
         "[conn][%p] New Local IP: %!ADDR!",
         Connection,
-        CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 
     //
     // Save the server name.
@@ -3534,7 +3534,7 @@ QuicConnRecvHeader(
             }
 
             CXPLAT_DBG_ASSERT(Token.Encrypted.OrigConnIdLength <= sizeof(Token.Encrypted.OrigConnId));
-            CXPLAT_DBG_ASSERT(QuicAddrCompare(&Path->RemoteAddress, &Token.Encrypted.RemoteAddress));
+            CXPLAT_DBG_ASSERT(QuicAddrCompare(&Path->Route.RemoteAddress, &Token.Encrypted.RemoteAddress));
             CXPLAT_DBG_ASSERT(Connection->OrigDestCID == NULL);
 
             Connection->OrigDestCID =
@@ -5028,11 +5028,11 @@ QuicConnRecvPostProcessing(
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].RemoteAddress), &Connection->Paths[0].RemoteAddress)); // TODO - Addr removed event?
+            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.RemoteAddress), &Connection->Paths[0].Route.RemoteAddress)); // TODO - Addr removed event?
 
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED;
-        Event.PEER_ADDRESS_CHANGED.Address = &(*Path)->RemoteAddress;
+        Event.PEER_ADDRESS_CHANGED.Address = &(*Path)->Route.RemoteAddress;
         QuicTraceLogConnVerbose(
             IndicatePeerAddrChanged,
             Connection,
@@ -5517,7 +5517,7 @@ QuicConnProcessUdpUnreachable(
             Connection,
             "Ignoring received unreachable event");
 
-    } else if (QuicAddrCompare(&Connection->Paths[0].RemoteAddress, RemoteAddress)) {
+    } else if (QuicAddrCompare(&Connection->Paths[0].Route.RemoteAddress, RemoteAddress)) {
         QuicTraceLogConnInfo(
             Unreachable,
             Connection,
@@ -5688,12 +5688,12 @@ QuicConnParamSet(
         }
 
         Connection->State.LocalAddressSet = TRUE;
-        CxPlatCopyMemory(&Connection->Paths[0].LocalAddress, Buffer, sizeof(QUIC_ADDR));
+        CxPlatCopyMemory(&Connection->Paths[0].Route.LocalAddress, Buffer, sizeof(QUIC_ADDR));
         QuicTraceEvent(
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 
         if (Connection->State.Started) {
 
@@ -5705,7 +5705,7 @@ QuicConnParamSet(
 
             CXPLAT_UDP_CONFIG UdpConfig = {0};
             UdpConfig.LocalAddress = LocalAddress;
-            UdpConfig.RemoteAddress = &Connection->Paths[0].RemoteAddress;
+            UdpConfig.RemoteAddress = &Connection->Paths[0].Route.RemoteAddress;
             UdpConfig.Flags = Connection->State.ShareBinding ? CXPLAT_SOCKET_FLAG_SHARE : 0;
             UdpConfig.InterfaceIndex = 0;
 #ifdef QUIC_COMPARTMENT_ID
@@ -5736,17 +5736,17 @@ QuicConnParamSet(
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 
             QuicBindingGetLocalAddress(
                 Connection->Paths[0].Binding,
-                &Connection->Paths[0].LocalAddress);
+                &Connection->Paths[0].Route.LocalAddress);
 
             QuicTraceEvent(
                 ConnLocalAddrAdded,
                 "[conn][%p] New Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 
             QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_PING);
         }
@@ -5773,7 +5773,7 @@ QuicConnParamSet(
         }
 
         Connection->State.RemoteAddressSet = TRUE;
-        CxPlatCopyMemory(&Connection->Paths[0].RemoteAddress, Buffer, sizeof(QUIC_ADDR));
+        CxPlatCopyMemory(&Connection->Paths[0].Route.RemoteAddress, Buffer, sizeof(QUIC_ADDR));
         //
         // Don't log new Remote address added here because it is logged when
         // the connection is started.
@@ -6006,13 +6006,13 @@ QuicConnParamSet(
         }
 
         Connection->State.LocalInterfaceSet = TRUE;
-        Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id = *(uint32_t*)Buffer;
+        Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id = *(uint32_t*)Buffer;
 
         QuicTraceLogConnInfo(
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id);
+            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
 
         Status = QUIC_STATUS_SUCCESS;
         break;
@@ -6195,7 +6195,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &Connection->Paths[0].LocalAddress,
+            &Connection->Paths[0].Route.LocalAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;
@@ -6222,7 +6222,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &Connection->Paths[0].RemoteAddress,
+            &Connection->Paths[0].Route.RemoteAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1458,7 +1458,7 @@ QuicConnGetMaxMtuForPath(
     if ((Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_MAX_UDP_PAYLOAD_SIZE)) {
         RemoteMtu =
             PacketSizeFromUdpPayloadSize(
-                QuicAddrGetFamily(&Path->RemoteAddress),
+                QuicAddrGetFamily(&Path->Route.RemoteAddress),
                 (uint16_t)Connection->PeerTransportParams.MaxUdpPayloadSize);
     }
     uint16_t SettingsMtu = Connection->Settings.MaximumMtu;

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1751,8 +1751,8 @@ QuicCryptoProcessData(
             QuicCryptoValidate(Crypto);
 
             Info.QuicVersion = Connection->Stats.QuicVersion;
-            Info.LocalAddress = &Connection->Paths[0].LocalAddress;
-            Info.RemoteAddress = &Connection->Paths[0].RemoteAddress;
+            Info.LocalAddress = &Connection->Paths[0].Route.LocalAddress;
+            Info.RemoteAddress = &Connection->Paths[0].Route.RemoteAddress;
             Info.CryptoBufferLength = Buffer.Length;
             Info.CryptoBuffer = Buffer.Buffer;
 

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -275,7 +275,7 @@ QuicDatagramOnSendStateChanged(
             const QUIC_PATH* Path = &Connection->Paths[0];
             MtuMaxSendLength =
                 QuicCalculateDatagramLength(
-                    QuicAddrGetFamily(&Path->RemoteAddress),
+                    QuicAddrGetFamily(&Path->Route.RemoteAddress),
                     Path->Mtu,
                     Path->DestCid->CID.Length);
         }

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -603,7 +603,7 @@ QuicLossDetectionOnPacketAcknowledged(
     if (Path != NULL) {
         uint16_t PacketMtu =
             PacketSizeFromUdpPayloadSize(
-                QuicAddrGetFamily(&Path->RemoteAddress),
+                QuicAddrGetFamily(&Path->Route.RemoteAddress),
                 Packet->PacketLength);
         BOOLEAN ChangedMtu = FALSE;
         if (!Path->IsMinMtuValidated &&
@@ -870,7 +870,7 @@ QuicLossDetectionOnPacketDiscarded(
             if (Path != NULL) {
                 uint16_t PacketMtu =
                     PacketSizeFromUdpPayloadSize(
-                        QuicAddrGetFamily(&Path->RemoteAddress),
+                        QuicAddrGetFamily(&Path->Route.RemoteAddress),
                         Packet->PacketLength);
                 QuicMtuDiscoveryProbePacketDiscarded(&Path->MtuDiscovery, Connection, PacketMtu);
             }

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -247,7 +247,7 @@ QuicPacketBuilderPrepare(
                     IsPathMtuDiscovery ?
                         0 :
                         MaxUdpPayloadSizeForFamily(
-                            QuicAddrGetFamily(&Builder->Path->RemoteAddress),
+                            QuicAddrGetFamily(&Builder->Path->Route.RemoteAddress),
                             DatagramSize));
             if (Builder->SendData == NULL) {
                 QuicTraceEvent(
@@ -262,7 +262,7 @@ QuicPacketBuilderPrepare(
 
         uint16_t NewDatagramLength =
             MaxUdpPayloadSizeForFamily(
-                QuicAddrGetFamily(&Builder->Path->RemoteAddress),
+                QuicAddrGetFamily(&Builder->Path->Route.RemoteAddress),
                 IsPathMtuDiscovery ? Builder->Path->MtuDiscovery.ProbeSize : DatagramSize);
         if ((Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_MAX_UDP_PAYLOAD_SIZE) &&
             NewDatagramLength > Connection->PeerTransportParams.MaxUdpPayloadSize) {
@@ -313,7 +313,7 @@ QuicPacketBuilderPrepare(
             //
             Builder->MinimumDatagramLength =
                 MaxUdpPayloadSizeForFamily(
-                    QuicAddrGetFamily(&Builder->Path->RemoteAddress),
+                    QuicAddrGetFamily(&Builder->Path->Route.RemoteAddress),
                     Builder->Path->Mtu);
 
             if ((uint32_t)Builder->MinimumDatagramLength > Builder->Datagram->Length) {
@@ -971,8 +971,8 @@ QuicPacketBuilderSendBatch(
 
     QuicBindingSend(
         Builder->Path->Binding,
-        &Builder->Path->LocalAddress,
-        &Builder->Path->RemoteAddress,
+        &Builder->Path->Route.LocalAddress,
+        &Builder->Path->Route.RemoteAddress,
         Builder->SendData,
         Builder->TotalDatagramsLength,
         Builder->TotalCountDatagrams,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -971,8 +971,7 @@ QuicPacketBuilderSendBatch(
 
     QuicBindingSend(
         Builder->Path->Binding,
-        &Builder->Path->Route.LocalAddress,
-        &Builder->Path->Route.RemoteAddress,
+        &Builder->Path->Route,
         Builder->SendData,
         Builder->TotalDatagramsLength,
         Builder->TotalCountDatagrams,

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -179,10 +179,10 @@ QuicConnGetPathForDatagram(
     for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
         if (!QuicAddrCompare(
                 &Datagram->Tuple->LocalAddress,
-                &Connection->Paths[i].LocalAddress) ||
+                &Connection->Paths[i].Route.LocalAddress) ||
             !QuicAddrCompare(
                 &Datagram->Tuple->RemoteAddress,
-                &Connection->Paths[i].RemoteAddress)) {
+                &Connection->Paths[i].Route.RemoteAddress)) {
             if (!Connection->State.HandshakeConfirmed) {
                 //
                 // Ignore packets on any other paths until connected/confirmed.
@@ -203,9 +203,9 @@ QuicConnGetPathForDatagram(
         //
         for (uint8_t i = Connection->PathsCount - 1; i > 0; i--) {
             if (!Connection->Paths[i].IsActive
-                && QuicAddrGetFamily(&Datagram->Tuple->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].RemoteAddress)
-                && QuicAddrCompareIp(&Datagram->Tuple->RemoteAddress, &Connection->Paths[i].RemoteAddress)
-                && QuicAddrCompare(&Datagram->Tuple->LocalAddress, &Connection->Paths[i].LocalAddress)) {
+                && QuicAddrGetFamily(&Datagram->Tuple->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompareIp(&Datagram->Tuple->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompare(&Datagram->Tuple->LocalAddress, &Connection->Paths[i].Route.LocalAddress)) {
                 QuicPathRemove(Connection, i);
             }
         }
@@ -237,8 +237,8 @@ QuicConnGetPathForDatagram(
         Path->DestCid = Connection->Paths[0].DestCid; // TODO - Copy instead?
     }
     Path->Binding = Connection->Paths[0].Binding;
-    Path->LocalAddress = Datagram->Tuple->LocalAddress;
-    Path->RemoteAddress = Datagram->Tuple->RemoteAddress;
+    Path->Route.LocalAddress = Datagram->Tuple->LocalAddress;
+    Path->Route.RemoteAddress = Datagram->Tuple->RemoteAddress;
     QuicPathValidate(Path);
 
     return Path;
@@ -258,8 +258,8 @@ QuicPathSetActive(
     } else {
         CXPLAT_DBG_ASSERT(Path->DestCid != NULL);
         UdpPortChangeOnly =
-            QuicAddrGetFamily(&Path->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[0].RemoteAddress) &&
-            QuicAddrCompareIp(&Path->RemoteAddress, &Connection->Paths[0].RemoteAddress);
+            QuicAddrGetFamily(&Path->Route.RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[0].Route.RemoteAddress) &&
+            QuicAddrCompareIp(&Path->Route.RemoteAddress, &Connection->Paths[0].Route.RemoteAddress);
 
         QUIC_PATH PrevActivePath = Connection->Paths[0];
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -88,14 +88,9 @@ typedef struct QUIC_PATH {
     QUIC_BINDING* Binding;
 
     //
-    // The locally bound source IP address.
+    // The network route.
     //
-    QUIC_ADDR LocalAddress;
-
-    //
-    // The peer's source IP address.
-    //
-    QUIC_ADDR RemoteAddress;
+    CXPLAT_ROUTE Route;
 
     //
     // The destination CID used for sending on this path.

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1020,7 +1020,7 @@ QuicSendPathChallenges(
             //
             Builder.MinimumDatagramLength =
                 MaxUdpPayloadSizeForFamily(
-                    QuicAddrGetFamily(&Builder.Path->RemoteAddress),
+                    QuicAddrGetFamily(&Builder.Path->Route.RemoteAddress),
                     Builder.Path->Mtu);
 
             if ((uint32_t)Builder.MinimumDatagramLength > Builder.Datagram->Length) {

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -878,9 +878,9 @@ tracepoint(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme , arg1, arg3);\
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id);
+            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection
-// arg3 = arg3 = Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id
+// arg3 = arg3 = Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id
 ----------------------------------------------------------*/
 #define _clog_4_ARGS_TRACE_LocalInterfaceSet(uniqueId, arg1, encoded_arg_string, arg3)\
 tracepoint(CLOG_CONNECTION_C, LocalInterfaceSet , arg1, arg3);\
@@ -1720,9 +1720,9 @@ tracepoint(CLOG_CONNECTION_C, ConnCreated , arg2, arg3, arg4);\
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 tracepoint(CLOG_CONNECTION_C, ConnLocalAddrAdded , arg2, arg3_len, arg3);\
@@ -1743,9 +1743,9 @@ tracepoint(CLOG_CONNECTION_C, ConnLocalAddrAdded , arg2, arg3_len, arg3);\
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnRemoteAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 tracepoint(CLOG_CONNECTION_C, ConnRemoteAddrAdded , arg2, arg3_len, arg3);\
@@ -2108,9 +2108,9 @@ tracepoint(CLOG_CONNECTION_C, ConnVersionSet , arg2, arg3);\
                     ConnLocalAddrAdded,
                      "[conn][%p] New Local IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].LocalAddress), &Connection->Paths[i].LocalAddress));
+                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.LocalAddress), &Connection->Paths[i].Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].LocalAddress), &Connection->Paths[i].LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.LocalAddress), &Connection->Paths[i].Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -2130,9 +2130,9 @@ tracepoint(CLOG_CONNECTION_C, ConnVersionSet , arg2, arg3);\
                     ConnRemoteAddrAdded,
                     "[conn][%p] New Remote IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].RemoteAddress), &Connection->Paths[i].RemoteAddress));
+                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.RemoteAddress), &Connection->Paths[i].Route.RemoteAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].RemoteAddress), &Connection->Paths[i].RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.RemoteAddress), &Connection->Paths[i].Route.RemoteAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnRemoteAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -2567,9 +2567,9 @@ tracepoint(CLOG_CONNECTION_C, ConnErrorStatus , arg2, arg3, arg4);\
         ConnRemoteAddrAdded,
         "[conn][%p] New Remote IP: %!ADDR!",
         Connection,
-        CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnRemoteAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -2613,9 +2613,9 @@ tracepoint(CLOG_CONNECTION_C, ConnErrorStatus , arg2, arg3, arg4);\
         ConnLocalAddrAdded,
         "[conn][%p] New Local IP: %!ADDR!",
         Connection,
-        CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -3838,9 +3838,9 @@ tracepoint(CLOG_CONNECTION_C, ConnPacketRecv , arg2, arg3, arg4, arg5);\
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].RemoteAddress), &Connection->Paths[0].RemoteAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.RemoteAddress), &Connection->Paths[0].Route.RemoteAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].RemoteAddress), &Connection->Paths[0].RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.RemoteAddress), &Connection->Paths[0].Route.RemoteAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnRemoteAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -3860,9 +3860,9 @@ tracepoint(CLOG_CONNECTION_C, ConnPacketRecv , arg2, arg3, arg4, arg5);\
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 
@@ -3882,9 +3882,9 @@ tracepoint(CLOG_CONNECTION_C, ConnPacketRecv , arg2, arg3, arg4, arg5);\
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrRemoved(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 tracepoint(CLOG_CONNECTION_C, ConnLocalAddrRemoved , arg2, arg3_len, arg3);\
@@ -3905,9 +3905,9 @@ tracepoint(CLOG_CONNECTION_C, ConnLocalAddrRemoved , arg2, arg3_len, arg3);\
                 ConnLocalAddrAdded,
                 "[conn][%p] New Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_ConnLocalAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
 

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -814,9 +814,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme,
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id);
+            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection
-// arg3 = arg3 = Connection->Paths[0].LocalAddress.Ipv6.sin6_scope_id
+// arg3 = arg3 = Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, LocalInterfaceSet,
     TP_ARGS(
@@ -1628,9 +1628,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnCreated,
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->LocalAddress), &Path->LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress)
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnLocalAddrAdded,
     TP_ARGS(
@@ -1653,9 +1653,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnLocalAddrAdded,
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress));
+            CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->RemoteAddress), &Path->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress)
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnRemoteAddrAdded,
     TP_ARGS(
@@ -2182,9 +2182,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnPacketRecv,
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress));
+                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
 // arg2 = arg2 = Connection
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].LocalAddress), &Connection->Paths[0].LocalAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress)
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnLocalAddrRemoved,
     TP_ARGS(

--- a/src/generated/linux/datapath_winkernel.c.clog.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h
@@ -1292,14 +1292,14 @@ tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathRecv , arg2, arg3, arg4, arg5_len,
         SendData->TotalSize,
         SendData->WskBufferCount,
         SendData->SegmentSize,
-        CASTED_CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress),
-        CASTED_CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress));
 // arg2 = arg2 = Binding
 // arg3 = arg3 = SendData->TotalSize
 // arg4 = arg4 = SendData->WskBufferCount
 // arg5 = arg5 = SendData->SegmentSize
-// arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress)
-// arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress)
+// arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress)
+// arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress)
 ----------------------------------------------------------*/
 #define _clog_10_ARGS_TRACE_DatapathSend(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg6_len, arg7, arg7_len)\
 tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathSend , arg2, arg3, arg4, arg5, arg6_len, arg6, arg7_len, arg7);\

--- a/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
@@ -586,14 +586,14 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathRecv,
         SendData->TotalSize,
         SendData->WskBufferCount,
         SendData->SegmentSize,
-        CASTED_CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress),
-        CASTED_CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress));
 // arg2 = arg2 = Binding
 // arg3 = arg3 = SendData->TotalSize
 // arg4 = arg4 = SendData->WskBufferCount
 // arg5 = arg5 = SendData->SegmentSize
-// arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress)
-// arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress)
+// arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress)
+// arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress)
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathSend,
     TP_ARGS(

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -613,8 +613,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t PartitionId
     );

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -142,6 +142,16 @@ typedef struct CXPLAT_SEND_DATA CXPLAT_SEND_DATA;
 typedef struct QUIC_BUFFER QUIC_BUFFER;
 
 //
+// Structure to represent a network route.
+//
+typedef struct CXPLAT_ROUTE {
+
+    QUIC_ADDR RemoteAddress;
+    QUIC_ADDR LocalAddress;
+
+} CXPLAT_ROUTE;
+
+//
 // Structure to represent data buffers received.
 //
 typedef struct CXPLAT_TUPLE {

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -522,8 +522,11 @@ void TcpConnection::Process()
         }
     }
     if (BatchedSendData) {
+        CXPLAT_ROUTE Route;
+        Route.LocalAddress = LocalAddress;
+        Route.RemoteAddress = RemoteAddress;
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
+            CxPlatSocketSend(Socket, &Route, BatchedSendData, PartitionIndex))) {
             IndicateDisconnect = true;
         }
         BatchedSendData = nullptr;
@@ -905,8 +908,11 @@ bool TcpConnection::FinalizeSendBuffer(QUIC_BUFFER* SendBuffer)
     TotalSendOffset += SendBuffer->Length;
     if (SendBuffer->Length != TLS_BLOCK_SIZE ||
         CxPlatSendDataIsFull(BatchedSendData)) {
+        CXPLAT_ROUTE Route;
+        Route.LocalAddress = LocalAddress;
+        Route.RemoteAddress = RemoteAddress;
         if (QUIC_FAILED(
-            CxPlatSocketSend(Socket, &LocalAddress, &RemoteAddress, BatchedSendData, PartitionIndex))) {
+            CxPlatSocketSend(Socket, &Route, BatchedSendData, PartitionIndex))) {
             WriteOutput("CxPlatSocketSend FAILED\n");
             return false;
         }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2690,8 +2690,7 @@ Exit:
 QUIC_STATUS
 CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t IdealProcessor
     )
@@ -2700,8 +2699,8 @@ CxPlatSocketSend(
     QUIC_STATUS Status =
         CxPlatSocketSendInternal(
             Socket,
-            LocalAddress,
-            RemoteAddress,
+            &Route->LocalAddress,
+            &Route->RemoteAddress,
             SendData,
             FALSE);
     if (Status == QUIC_STATUS_PENDING) {

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2236,8 +2236,7 @@ Exit:
 QUIC_STATUS
 CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t IdealProcessor
     )
@@ -2246,8 +2245,8 @@ CxPlatSocketSend(
     QUIC_STATUS Status =
         CxPlatSocketSendInternal(
             Socket,
-            LocalAddress,
-            RemoteAddress,
+            &Route->LocalAddress,
+            &Route->RemoteAddress,
             SendData,
             FALSE);
     if (Status == QUIC_STATUS_PENDING) {

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2957,8 +2957,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Binding,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t IdealProcessor
     )
@@ -2968,8 +2967,7 @@ CxPlatSocketSend(
 
     UNREFERENCED_PARAMETER(IdealProcessor);
     CXPLAT_DBG_ASSERT(
-        Binding != NULL && LocalAddress != NULL &&
-        RemoteAddress != NULL && SendData != NULL);
+        Binding != NULL && Route != NULL && SendData != NULL);
 
     //
     // Initialize IRP and MDLs for sending.
@@ -2985,14 +2983,14 @@ CxPlatSocketSend(
         SendData->TotalSize,
         SendData->WskBufferCount,
         SendData->SegmentSize,
-        CASTED_CLOG_BYTEARRAY(sizeof(*RemoteAddress), RemoteAddress),
-        CASTED_CLOG_BYTEARRAY(sizeof(*LocalAddress), LocalAddress));
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress));
 
     //
     // Map V4 address to dual-stack socket format.
     //
     SOCKADDR_INET MappedAddress = { 0 };
-    CxPlatConvertToMappedV6(RemoteAddress, &MappedAddress);
+    CxPlatConvertToMappedV6(&Route->RemoteAddress, &MappedAddress);
 
     //
     // Build up message header to indicate local address to send from.
@@ -3004,7 +3002,7 @@ CxPlatSocketSend(
     // TODO - Use SendData->ECN if not CXPLAT_ECN_NON_ECT
 
     if (!Binding->Connected) {
-        if (LocalAddress->si_family == QUIC_ADDRESS_FAMILY_INET) {
+        if (Route->LocalAddress.si_family == QUIC_ADDRESS_FAMILY_INET) {
             CMsgLen += WSA_CMSG_SPACE(sizeof(IN_PKTINFO));
 
             CMsg->cmsg_level = IPPROTO_IP;
@@ -3012,8 +3010,8 @@ CxPlatSocketSend(
             CMsg->cmsg_len = WSA_CMSG_LEN(sizeof(IN_PKTINFO));
 
             PIN_PKTINFO PktInfo = (PIN_PKTINFO)WSA_CMSG_DATA(CMsg);
-            PktInfo->ipi_ifindex = LocalAddress->Ipv6.sin6_scope_id;
-            PktInfo->ipi_addr = LocalAddress->Ipv4.sin_addr;
+            PktInfo->ipi_ifindex = Route->LocalAddress.Ipv6.sin6_scope_id;
+            PktInfo->ipi_addr = Route->LocalAddress.Ipv4.sin_addr;
 
         } else {
             CMsgLen += WSA_CMSG_SPACE(sizeof(IN6_PKTINFO));
@@ -3023,8 +3021,8 @@ CxPlatSocketSend(
             CMsg->cmsg_len = WSA_CMSG_LEN(sizeof(IN6_PKTINFO));
 
             PIN6_PKTINFO PktInfo6 = (PIN6_PKTINFO)WSA_CMSG_DATA(CMsg);
-            PktInfo6->ipi6_ifindex = LocalAddress->Ipv6.sin6_scope_id;
-            PktInfo6->ipi6_addr = LocalAddress->Ipv6.sin6_addr;
+            PktInfo6->ipi6_ifindex = Route->LocalAddress.Ipv6.sin6_scope_id;
+            PktInfo6->ipi6_addr = Route->LocalAddress.Ipv6.sin6_addr;
         }
     }
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3958,16 +3958,14 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 CxPlatSocketSend(
     _In_ CXPLAT_SOCKET* Socket,
-    _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
+    _In_ const CXPLAT_ROUTE* Route,
     _In_ CXPLAT_SEND_DATA* SendData,
     _In_ uint16_t IdealProcessor
     )
 {
     CXPLAT_DBG_ASSERT(
-        Socket != NULL && LocalAddress != NULL &&
-        RemoteAddress != NULL && SendData != NULL &&
-        SendData->WsaBufferCount != 0);
+        Socket != NULL && Route != NULL &&
+        SendData != NULL && SendData->WsaBufferCount != 0);
 
     CXPLAT_DATAPATH* Datapath = Socket->Datapath;
     CXPLAT_SOCKET_PROC* SocketProc =
@@ -3988,20 +3986,20 @@ CxPlatSocketSend(
         return
             CxPlatSocketSendInline(
                 SocketProc,
-                LocalAddress,
-                RemoteAddress,
+                &Route->LocalAddress,
+                &Route->RemoteAddress,
                 SendData);
     }
 
     CxPlatCopyMemory(
         &SendData->LocalAddress,
-        LocalAddress,
-        sizeof(*LocalAddress));
+        &Route->LocalAddress,
+        sizeof(Route->LocalAddress));
 
     CxPlatCopyMemory(
         &SendData->RemoteAddress,
-        RemoteAddress,
-        sizeof(*RemoteAddress));
+        &Route->RemoteAddress,
+        sizeof(Route->RemoteAddress));
 
     RtlZeroMemory(&SendData->Overlapped, sizeof(OVERLAPPED));
     BOOL Result =
@@ -4029,8 +4027,8 @@ CxPlatSocketSend(
     return
         CxPlatSocketSendInline(
             SocketProc,
-            LocalAddress,
-            RemoteAddress,
+            &Route->LocalAddress,
+            &Route->RemoteAddress,
             SendData);
 
 #endif // CXPLAT_DATAPATH_QUEUE_SENDS

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -422,11 +422,13 @@ CxPlatPcpSendMapRequestInternal(
         Request->MAP.SuggestedExternalIpAddress,
         sizeof(Request->MAP.SuggestedExternalIpAddress));
 
+    CXPLAT_ROUTE Route;
+    Route.LocalAddress = LocalAddress;
+    Route.RemoteAddress = RemoteAddress;
     QUIC_STATUS Status =
         CxPlatSocketSend(
             Socket,
-            &LocalAddress,
-            &RemoteAddress,
+            &Route,
             SendData,
             (uint16_t)CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {
@@ -528,11 +530,13 @@ CxPlatPcpSendPeerRequestInternal(
         sizeof(Request->PEER.RemotePeerIpAddress));
     Request->PEER.RemotePeerPort = RemotePeerMappedAddress.Ipv6.sin6_port;
 
+    CXPLAT_ROUTE Route;
+    Route.LocalAddress = LocalAddress;
+    Route.RemoteAddress = RemoteAddress;
     QUIC_STATUS Status =
         CxPlatSocketSend(
             Socket,
-            &LocalAddress,
-            &RemoteAddress,
+            &Route,
             SendData,
             (uint16_t)CxPlatProcCurrentNumber());
     if (QUIC_FAILED(Status)) {

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -382,12 +382,12 @@ CxPlatPcpSendMapRequestInternal(
     _In_ uint32_t Lifetime          // Zero indicates delete Nonce must match.
     )
 {
-    QUIC_ADDR LocalAddress, RemoteAddress;
-    CxPlatSocketGetLocalAddress(Socket, &LocalAddress);
-    CxPlatSocketGetRemoteAddress(Socket, &RemoteAddress);
+    CXPLAT_ROUTE Route;
+    CxPlatSocketGetLocalAddress(Socket, &Route.LocalAddress);
+    CxPlatSocketGetRemoteAddress(Socket, &Route.RemoteAddress);
 
     QUIC_ADDR LocalMappedAddress;
-    CxPlatConvertToMappedV6(&LocalAddress, &LocalMappedAddress);
+    CxPlatConvertToMappedV6(&Route.LocalAddress, &LocalMappedAddress);
 
     CXPLAT_SEND_DATA* SendData =
         CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE);
@@ -422,9 +422,6 @@ CxPlatPcpSendMapRequestInternal(
         Request->MAP.SuggestedExternalIpAddress,
         sizeof(Request->MAP.SuggestedExternalIpAddress));
 
-    CXPLAT_ROUTE Route;
-    Route.LocalAddress = LocalAddress;
-    Route.RemoteAddress = RemoteAddress;
     QUIC_STATUS Status =
         CxPlatSocketSend(
             Socket,

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -242,11 +242,13 @@ protected:
                 ASSERT_NE(nullptr, ServerBuffer);
                 memcpy(ServerBuffer->Buffer, RecvData->Buffer, RecvData->BufferLength);
 
+                CXPLAT_ROUTE Route;
+                Route.LocalAddress = RecvData->Tuple->LocalAddress;
+                Route.RemoteAddress = RecvData->Tuple->RemoteAddress;
                 VERIFY_QUIC_SUCCESS(
                     CxPlatSocketSend(
                         Socket,
-                        &RecvData->Tuple->LocalAddress,
-                        &RecvData->Tuple->RemoteAddress,
+                        &Route,
                         ServerSendData,
                         0));
 
@@ -506,11 +508,13 @@ struct CxPlatSocket {
         _In_ uint16_t PartitionId = 0
         ) const noexcept
     {
+        CXPLAT_ROUTE Route;
+        Route.LocalAddress = LocalAddress;
+        Route.RemoteAddress = RemoteAddress;
         return
             CxPlatSocketSend(
                 Socket,
-                &LocalAddress,
-                &RemoteAddress,
+                &Route,
                 SendData,
                 PartitionId);
     }
@@ -924,14 +928,14 @@ TEST_P(DataPathTest, TcpDataServer)
     ASSERT_NE(nullptr, SendBuffer);
     memcpy(SendBuffer->Buffer, ExpectedData, ExpectedDataSize);
 
-    QUIC_ADDR ServerAddress = Listener.GetLocalAddress();
-    QUIC_ADDR ClientAddress = Client.GetLocalAddress();
+    CXPLAT_ROUTE Route;
+    Route.LocalAddress = Listener.GetLocalAddress();
+    Route.RemoteAddress = Client.GetLocalAddress();
 
     VERIFY_QUIC_SUCCESS(
         CxPlatSocketSend(
             ListenerContext.Server,
-            &ServerAddress,
-            &ClientAddress,
+            &Route,
             SendData, 0));
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ClientContext.ReceiveEvent, 100));
 }

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -194,6 +194,10 @@ struct DrillSender {
         CXPLAT_FRE_ASSERT(PacketBuffer->size() <= UINT16_MAX);
         const uint16_t DatagramLength = (uint16_t) PacketBuffer->size();
 
+        CXPLAT_ROUTE Route;
+        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+        Route.RemoteAddress = ServerAddress;
+
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
                 Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
@@ -211,10 +215,6 @@ struct DrillSender {
         // Copy test packet into SendBuffer.
         //
         memcpy(SendBuffer->Buffer, PacketBuffer->data(), DatagramLength);
-
-        CXPLAT_ROUTE Route;
-        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
-        Route.RemoteAddress = ServerAddress;
 
         Status =
             CxPlatSocketSend(

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -194,9 +194,6 @@ struct DrillSender {
         CXPLAT_FRE_ASSERT(PacketBuffer->size() <= UINT16_MAX);
         const uint16_t DatagramLength = (uint16_t) PacketBuffer->size();
 
-        QUIC_ADDR LocalAddress;
-        CxPlatSocketGetLocalAddress(Binding, &LocalAddress);
-
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
                 Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
@@ -215,11 +212,14 @@ struct DrillSender {
         //
         memcpy(SendBuffer->Buffer, PacketBuffer->data(), DatagramLength);
 
+        CXPLAT_ROUTE Route;
+        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+        Route.RemoteAddress = ServerAddress;
+
         Status =
             CxPlatSocketSend(
                 Binding,
-                &LocalAddress,
-                &ServerAddress,
+                &Route,
                 SendData,
                 0);
 

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -106,6 +106,10 @@ UdpUnreachCallback(
 
 void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 {
+    CXPLAT_ROUTE Route;
+    CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+    Route.RemoteAddress = ServerAddress;
+
     uint64_t ConnectionId = 0;
     CxPlatRandom(sizeof(ConnectionId), &ConnectionId);
 
@@ -152,10 +156,6 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             InterlockedExchangeAdd64(&TotalByteCount, Length);
         }
 
-        CXPLAT_ROUTE Route;
-        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
-        Route.RemoteAddress = ServerAddress;
-
         VERIFY(
         QUIC_SUCCEEDED(
         CxPlatSocketSend(
@@ -184,6 +184,10 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
     const StrBuffer InitialSalt("afbfec289993d24c9e9786f19c6111e04390a899");
     const uint16_t DatagramLength = QUIC_MIN_INITIAL_LENGTH;
     const uint64_t PacketNumber = 0;
+
+    CXPLAT_ROUTE Route;
+    CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+    Route.RemoteAddress = ServerAddress;
 
     uint8_t Packet[512] = {0};
     uint16_t PacketLength, HeaderLength;
@@ -282,10 +286,6 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             InterlockedExchangeAdd64(&TotalPacketCount, 1);
             InterlockedExchangeAdd64(&TotalByteCount, DatagramLength);
         }
-
-        CXPLAT_ROUTE Route;
-        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
-        Route.RemoteAddress = ServerAddress;
 
         VERIFY(
         QUIC_SUCCEEDED(

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -106,9 +106,6 @@ UdpUnreachCallback(
 
 void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 {
-    QUIC_ADDR LocalAddress;
-    CxPlatSocketGetLocalAddress(Binding, &LocalAddress);
-
     uint64_t ConnectionId = 0;
     CxPlatRandom(sizeof(ConnectionId), &ConnectionId);
 
@@ -155,12 +152,15 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
             InterlockedExchangeAdd64(&TotalByteCount, Length);
         }
 
+        CXPLAT_ROUTE Route;
+        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+        Route.RemoteAddress = ServerAddress;
+
         VERIFY(
         QUIC_SUCCEEDED(
         CxPlatSocketSend(
             Binding,
-            &LocalAddress,
-            &ServerAddress,
+            &Route,
             SendData,
             (uint16_t)CxPlatProcCurrentNumber())));
     }
@@ -184,9 +184,6 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
     const StrBuffer InitialSalt("afbfec289993d24c9e9786f19c6111e04390a899");
     const uint16_t DatagramLength = QUIC_MIN_INITIAL_LENGTH;
     const uint64_t PacketNumber = 0;
-
-    QUIC_ADDR LocalAddress;
-    CxPlatSocketGetLocalAddress(Binding, &LocalAddress);
 
     uint8_t Packet[512] = {0};
     uint16_t PacketLength, HeaderLength;
@@ -286,12 +283,15 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
             InterlockedExchangeAdd64(&TotalByteCount, DatagramLength);
         }
 
+        CXPLAT_ROUTE Route;
+        CxPlatSocketGetLocalAddress(Binding, &Route.LocalAddress);
+        Route.RemoteAddress = ServerAddress;
+
         VERIFY(
         QUIC_SUCCEEDED(
         CxPlatSocketSend(
             Binding,
-            &LocalAddress,
-            &ServerAddress,
+            &Route,
             SendData,
             (uint16_t)CxPlatProcCurrentNumber())));
     }

--- a/src/tools/lb/loadbalancer.cpp
+++ b/src/tools/lb/loadbalancer.cpp
@@ -61,6 +61,9 @@ struct LbInterface {
             CxPlatSocketGetRemoteAddress(Socket, &RemoteAddress);
             PeerAddress = &RemoteAddress;
         }
+        CXPLAT_ROUTE Route;
+        Route.LocalAddress = LocalAddress;
+        Route.RemoteAddress = *PeerAddress;
         CXPLAT_SEND_DATA* Send = nullptr;
         while (RecvDataChain) {
             if (!Send) {
@@ -69,7 +72,7 @@ struct LbInterface {
             if (Send) {
                 auto Buffer = CxPlatSendDataAllocBuffer(Send, MAX_UDP_PAYLOAD_LENGTH);
                 if (!Buffer) {
-                    (void)CxPlatSocketSend(Socket, &LocalAddress, PeerAddress, Send, 0);
+                    (void)CxPlatSocketSend(Socket, &Route, Send, 0);
                     Send = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, MAX_UDP_PAYLOAD_LENGTH);
                     if (Send) {
                         Buffer = CxPlatSendDataAllocBuffer(Send, MAX_UDP_PAYLOAD_LENGTH);
@@ -83,7 +86,7 @@ struct LbInterface {
             RecvDataChain = RecvDataChain->Next;
         }
         if (Send) {
-            (void)CxPlatSocketSend(Socket, &LocalAddress, PeerAddress, Send, 0);
+            (void)CxPlatSocketSend(Socket, &Route, Send, 0);
         }
     }
 };


### PR DESCRIPTION
The signature of CxPlatSocketSend is updated so that a pointer to the QUIC_PATH's CXPLAT_ROUTE is passed instead of pointers to its LocalAddress and RemoteAddress. This enables additional state (specifically the next hop for the selected route) to be stored in QUIC_PATH and passed to the datapath layer without massive plumbing.