### PR TITLE
Change CXPLAT_TUPLE field of CXPLAT_RECV_DATA to CXPLAT_ROUTE

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1058,13 +1058,9 @@ QuicBindingProcessStatelessOperation(
         goto Exit;
     }
 
-    CXPLAT_ROUTE Route;
-    Route.LocalAddress = RecvDatagram->Route->LocalAddress;
-    Route.RemoteAddress = RecvDatagram->Route->RemoteAddress;
-
     QuicBindingSend(
         Binding,
-        &Route,
+        RecvDatagram->Route,
         SendData,
         SendDatagram->Length,
         1,

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -625,7 +625,7 @@ QuicBindingCreateStatelessOperation(
     )
 {
     uint32_t TimeMs = CxPlatTimeMs32();
-    const QUIC_ADDR* RemoteAddress = &Datagram->Tuple->RemoteAddress;
+    const QUIC_ADDR* RemoteAddress = &Datagram->Route->RemoteAddress;
     uint32_t Hash = QuicAddrHash(RemoteAddress);
     QUIC_STATELESS_CONTEXT* StatelessCtx = NULL;
 
@@ -992,7 +992,7 @@ QuicBindingProcessStatelessOperation(
         QUIC_RETRY_TOKEN_CONTENTS Token = { 0 };
         Token.Authenticated.Timestamp = CxPlatTimeEpochMs64();
 
-        Token.Encrypted.RemoteAddress = RecvDatagram->Tuple->RemoteAddress;
+        Token.Encrypted.RemoteAddress = RecvDatagram->Route->RemoteAddress;
         CxPlatCopyMemory(Token.Encrypted.OrigConnId, RecvPacket->DestCid, RecvPacket->DestCidLen);
         Token.Encrypted.OrigConnIdLength = RecvPacket->DestCidLen;
 
@@ -1059,8 +1059,8 @@ QuicBindingProcessStatelessOperation(
     }
 
     CXPLAT_ROUTE Route;
-    Route.LocalAddress = RecvDatagram->Tuple->LocalAddress;
-    Route.RemoteAddress = RecvDatagram->Tuple->RemoteAddress;
+    Route.LocalAddress = RecvDatagram->Route->LocalAddress;
+    Route.RemoteAddress = RecvDatagram->Route->RemoteAddress;
 
     QuicBindingSend(
         Binding,
@@ -1245,7 +1245,7 @@ QuicBindingValidateRetryToken(
 
     const CXPLAT_RECV_DATA* Datagram =
         CxPlatDataPathRecvPacketToRecvData(Packet);
-    if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Datagram->Tuple->RemoteAddress)) {
+    if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Datagram->Route->RemoteAddress)) {
         QuicPacketLogDrop(Binding, Packet, "Retry Token Addr Mismatch");
         return FALSE;
     }
@@ -1360,7 +1360,7 @@ QuicBindingCreateConnection(
     if (!QuicLookupAddRemoteHash(
             &Binding->Lookup,
             NewConnection,
-            &Datagram->Tuple->RemoteAddress,
+            &Datagram->Route->RemoteAddress,
             Packet->SourceCidLen,
             Packet->SourceCid,
             &Connection)) {
@@ -1472,7 +1472,7 @@ QuicBindingDeliverDatagrams(
         Connection =
             QuicLookupFindConnectionByRemoteHash(
                 &Binding->Lookup,
-                &DatagramChain->Tuple->RemoteAddress,
+                &DatagramChain->Route->RemoteAddress,
                 Packet->SourceCidLen,
                 Packet->SourceCid);
     }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -165,15 +165,15 @@ QuicConnAlloc(
         Connection->Type = QUIC_HANDLE_TYPE_CONNECTION_SERVER;
         if (MsQuicLib.Settings.LoadBalancingMode == QUIC_LOAD_BALANCING_SERVER_ID_IP) {
             CxPlatRandom(1, Connection->ServerID); // Randomize the first byte.
-            if (QuicAddrGetFamily(&Datagram->Tuple->LocalAddress) == QUIC_ADDRESS_FAMILY_INET) {
+            if (QuicAddrGetFamily(&Datagram->Route->LocalAddress) == QUIC_ADDRESS_FAMILY_INET) {
                 CxPlatCopyMemory(
                     Connection->ServerID + 1,
-                    &Datagram->Tuple->LocalAddress.Ipv4.sin_addr,
+                    &Datagram->Route->LocalAddress.Ipv4.sin_addr,
                     4);
             } else {
                 CxPlatCopyMemory(
                     Connection->ServerID + 1,
-                    ((uint8_t*)&Datagram->Tuple->LocalAddress.Ipv6.sin6_addr) + 12,
+                    ((uint8_t*)&Datagram->Route->LocalAddress.Ipv6.sin6_addr) + 12,
                     4);
             }
         }
@@ -181,7 +181,7 @@ QuicConnAlloc(
         Connection->Stats.QuicVersion = Packet->Invariant->LONG_HDR.Version;
         QuicConnOnQuicVersionSet(Connection);
 
-        Path->Route.LocalAddress = Datagram->Tuple->LocalAddress;
+        Path->Route.LocalAddress = Datagram->Route->LocalAddress;
         Connection->State.LocalAddressSet = TRUE;
         QuicTraceEvent(
             ConnLocalAddrAdded,
@@ -189,7 +189,7 @@ QuicConnAlloc(
             Connection,
             CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.LocalAddress), &Path->Route.LocalAddress));
 
-        Path->Route.RemoteAddress = Datagram->Tuple->RemoteAddress;
+        Path->Route.RemoteAddress = Datagram->Route->RemoteAddress;
         Connection->State.RemoteAddressSet = TRUE;
         QuicTraceEvent(
             ConnRemoteAddrAdded,

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -711,8 +711,8 @@ QuicPacketLogDrop(
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
     } else {
         InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
@@ -720,8 +720,8 @@ QuicPacketLogDrop(
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
     }
     QuicPerfCounterIncrement(QUIC_PERF_COUNTER_PKTS_DROPPED);
@@ -746,8 +746,8 @@ QuicPacketLogDropWithValue(
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
     } else {
         InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
@@ -756,8 +756,8 @@ QuicPacketLogDropWithValue(
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
     }
     QuicPerfCounterIncrement(QUIC_PERF_COUNTER_PKTS_DROPPED);

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -178,10 +178,10 @@ QuicConnGetPathForDatagram(
 {
     for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
         if (!QuicAddrCompare(
-                &Datagram->Tuple->LocalAddress,
+                &Datagram->Route->LocalAddress,
                 &Connection->Paths[i].Route.LocalAddress) ||
             !QuicAddrCompare(
-                &Datagram->Tuple->RemoteAddress,
+                &Datagram->Route->RemoteAddress,
                 &Connection->Paths[i].Route.RemoteAddress)) {
             if (!Connection->State.HandshakeConfirmed) {
                 //
@@ -203,9 +203,9 @@ QuicConnGetPathForDatagram(
         //
         for (uint8_t i = Connection->PathsCount - 1; i > 0; i--) {
             if (!Connection->Paths[i].IsActive
-                && QuicAddrGetFamily(&Datagram->Tuple->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
-                && QuicAddrCompareIp(&Datagram->Tuple->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
-                && QuicAddrCompare(&Datagram->Tuple->LocalAddress, &Connection->Paths[i].Route.LocalAddress)) {
+                && QuicAddrGetFamily(&Datagram->Route->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompareIp(&Datagram->Route->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompare(&Datagram->Route->LocalAddress, &Connection->Paths[i].Route.LocalAddress)) {
                 QuicPathRemove(Connection, i);
             }
         }
@@ -237,8 +237,8 @@ QuicConnGetPathForDatagram(
         Path->DestCid = Connection->Paths[0].DestCid; // TODO - Copy instead?
     }
     Path->Binding = Connection->Paths[0].Binding;
-    Path->Route.LocalAddress = Datagram->Tuple->LocalAddress;
-    Path->Route.RemoteAddress = Datagram->Tuple->RemoteAddress;
+    Path->Route.LocalAddress = Datagram->Route->LocalAddress;
+    Path->Route.RemoteAddress = Datagram->Route->RemoteAddress;
     QuicPathValidate(Path);
 
     return Path;

--- a/src/generated/linux/packet.c.clog.h
+++ b/src/generated/linux/packet.c.clog.h
@@ -276,12 +276,12 @@ tracepoint(CLOG_PACKET_C, AllocFailure , arg2, arg3);\
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg5 = arg5 = Reason
 ----------------------------------------------------------*/
 #define _clog_8_ARGS_TRACE_ConnDropPacket(uniqueId, encoded_arg_string, arg2, arg3, arg3_len, arg4, arg4_len, arg5)\
@@ -303,12 +303,12 @@ tracepoint(CLOG_PACKET_C, ConnDropPacket , arg2, arg3_len, arg3, arg4_len, arg4,
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg5 = arg5 = Reason
 ----------------------------------------------------------*/
 #define _clog_8_ARGS_TRACE_BindingDropPacket(uniqueId, encoded_arg_string, arg2, arg3, arg3_len, arg4, arg4_len, arg5)\
@@ -331,13 +331,13 @@ tracepoint(CLOG_PACKET_C, BindingDropPacket , arg2, arg3_len, arg3, arg4_len, ar
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
 // arg3 = arg3 = Value
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg6 = arg6 = Reason
 ----------------------------------------------------------*/
 #define _clog_9_ARGS_TRACE_ConnDropPacketEx(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg4_len, arg5, arg5_len, arg6)\
@@ -360,13 +360,13 @@ tracepoint(CLOG_PACKET_C, ConnDropPacketEx , arg2, arg3, arg4_len, arg4, arg5_le
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
 // arg3 = arg3 = Value
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg6 = arg6 = Reason
 ----------------------------------------------------------*/
 #define _clog_9_ARGS_TRACE_BindingDropPacketEx(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg4_len, arg5, arg5_len, arg6)\

--- a/src/generated/linux/packet.c.clog.h.lttng.h
+++ b/src/generated/linux/packet.c.clog.h.lttng.h
@@ -308,12 +308,12 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, AllocFailure,
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg5 = arg5 = Reason
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacket,
@@ -343,12 +343,12 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacket,
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg5 = arg5 = Reason
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacket,
@@ -379,13 +379,13 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacket,
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
 // arg3 = arg3 = Value
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg6 = arg6 = Reason
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacketEx,
@@ -418,13 +418,13 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacketEx,
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner
 // arg3 = arg3 = Value
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->LocalAddress), &Datagram->Tuple->LocalAddress)
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Tuple->RemoteAddress), &Datagram->Tuple->RemoteAddress)
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress)
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress)
 // arg6 = arg6 = Reason
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacketEx,

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -152,16 +152,6 @@ typedef struct CXPLAT_ROUTE {
 } CXPLAT_ROUTE;
 
 //
-// Structure to represent data buffers received.
-//
-typedef struct CXPLAT_TUPLE {
-
-    QUIC_ADDR RemoteAddress;
-    QUIC_ADDR LocalAddress;
-
-} CXPLAT_TUPLE;
-
-//
 // Structure to represent received UDP datagrams or TCP data.
 //
 typedef struct CXPLAT_RECV_DATA {

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -172,9 +172,9 @@ typedef struct CXPLAT_RECV_DATA {
     struct CXPLAT_RECV_DATA* Next;
 
     //
-    // Contains the 4 tuple.
+    // Contains the network route.
     //
-    CXPLAT_TUPLE* Tuple;
+    CXPLAT_ROUTE* Route;
 
     //
     // The data buffer containing the received bytes.

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -91,10 +91,9 @@ typedef struct CXPLAT_DATAPATH_RECV_BLOCK {
     CXPLAT_RECV_DATA RecvPacket;
 
     //
-    // Represents the address (source and destination) information of the
-    // packet.
+    // Represents the network route.
     //
-    CXPLAT_TUPLE Tuple;
+    CXPLAT_ROUTE Route;
 
     //
     // Buffer that actually stores the UDP payload.
@@ -1422,10 +1421,10 @@ CxPlatSocketContextPrepareReceive(
 
         SocketContext->RecvIov[i].iov_base = CurrentBlock->RecvPacket.Buffer;
         CurrentBlock->RecvPacket.BufferLength = SocketContext->RecvIov[i].iov_len;
-        CurrentBlock->RecvPacket.Tuple = &CurrentBlock->Tuple;
+        CurrentBlock->RecvPacket.Route = &CurrentBlock->Route;
 
-        MsgHdr->msg_name = &CurrentBlock->RecvPacket.Tuple->RemoteAddress;
-        MsgHdr->msg_namelen = sizeof(CurrentBlock->RecvPacket.Tuple->RemoteAddress);
+        MsgHdr->msg_name = &CurrentBlock->RecvPacket.Route->RemoteAddress;
+        MsgHdr->msg_namelen = sizeof(CurrentBlock->RecvPacket.Route->RemoteAddress);
         MsgHdr->msg_iov = &SocketContext->RecvIov[i];
         MsgHdr->msg_iovlen = 1;
         MsgHdr->msg_control = &SocketContext->RecvMsgControl[i].Data;
@@ -1514,11 +1513,11 @@ CxPlatSocketContextRecvComplete(
 
         BOOLEAN FoundLocalAddr = FALSE;
         BOOLEAN FoundTOS = FALSE;
-        QUIC_ADDR* LocalAddr = &RecvPacket->Tuple->LocalAddress;
+        QUIC_ADDR* LocalAddr = &RecvPacket->Route->LocalAddress;
         if (LocalAddr->Ipv6.sin6_family == AF_INET6) {
             LocalAddr->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
         }
-        QUIC_ADDR* RemoteAddr = &RecvPacket->Tuple->RemoteAddress;
+        QUIC_ADDR* RemoteAddr = &RecvPacket->Route->RemoteAddress;
         if (RemoteAddr->Ipv6.sin6_family == AF_INET6) {
             RemoteAddr->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
         }

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -54,10 +54,9 @@ typedef struct CXPLAT_DATAPATH_RECV_BLOCK {
     CXPLAT_RECV_DATA RecvPacket;
 
     //
-    // Represents the address (source and destination) information of the
-    // packet.
+    // Represents the network route.
     //
-    CXPLAT_TUPLE Tuple;
+    CXPLAT_ROUTE Route;
 
     //
     // Buffer that actually stores the UDP payload.
@@ -1112,13 +1111,13 @@ CxPlatSocketContextPrepareReceive(
 
     SocketContext->RecvIov.iov_base = SocketContext->CurrentRecvBlock->RecvPacket.Buffer;
     SocketContext->CurrentRecvBlock->RecvPacket.BufferLength = SocketContext->RecvIov.iov_len;
-    SocketContext->CurrentRecvBlock->RecvPacket.Tuple = &SocketContext->CurrentRecvBlock->Tuple;
+    SocketContext->CurrentRecvBlock->RecvPacket.Route = &SocketContext->CurrentRecvBlock->Route;
 
     CxPlatZeroMemory(&SocketContext->RecvMsgHdr, sizeof(SocketContext->RecvMsgHdr));
     CxPlatZeroMemory(&SocketContext->RecvMsgControl, sizeof(SocketContext->RecvMsgControl));
 
-    SocketContext->RecvMsgHdr.msg_name = &SocketContext->CurrentRecvBlock->RecvPacket.Tuple->RemoteAddress;
-    SocketContext->RecvMsgHdr.msg_namelen = sizeof(SocketContext->CurrentRecvBlock->RecvPacket.Tuple->RemoteAddress);
+    SocketContext->RecvMsgHdr.msg_name = &SocketContext->CurrentRecvBlock->RecvPacket.Route->RemoteAddress;
+    SocketContext->RecvMsgHdr.msg_namelen = sizeof(SocketContext->CurrentRecvBlock->RecvPacket.Route->RemoteAddress);
     SocketContext->RecvMsgHdr.msg_iov = &SocketContext->RecvIov;
     SocketContext->RecvMsgHdr.msg_iovlen = 1;
     SocketContext->RecvMsgHdr.msg_control = SocketContext->RecvMsgControl;
@@ -1191,11 +1190,11 @@ CxPlatSocketContextRecvComplete(
 
     BOOLEAN FoundLocalAddr = FALSE;
     BOOLEAN FoundTOS = FALSE;
-    QUIC_ADDR* LocalAddr = &RecvPacket->Tuple->LocalAddress;
+    QUIC_ADDR* LocalAddr = &RecvPacket->Route->LocalAddress;
     if (LocalAddr->Ipv6.sin6_family == AF_INET6) {
         LocalAddr->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
     }
-    QUIC_ADDR* RemoteAddr = &RecvPacket->Tuple->RemoteAddress;
+    QUIC_ADDR* RemoteAddr = &RecvPacket->Route->RemoteAddress;
     if (RemoteAddr->Ipv6.sin6_family == AF_INET6) {
         RemoteAddr->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
         CxPlatConvertFromMappedV6(RemoteAddr, RemoteAddr);

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2372,7 +2372,7 @@ CxPlatDataPathSocketReceive(
             }
 
             Datagram->BufferLength = MessageLength;
-            Datagram->Tuple = &RecvContext->Tuple;
+            Datagram->Route = &RecvContext->Route;
 
             //
             // Add the datagram to the end of the current chain.

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -129,9 +129,9 @@ typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
     ULONG ReferenceCount;
 
     //
-    // Contains the 4 tuple.
+    // Contains the network route.
     //
-    CXPLAT_TUPLE Tuple;
+    CXPLAT_ROUTE Route;
 
     int32_t DataIndicationSize;
 
@@ -2347,8 +2347,8 @@ CxPlatDataPathSocketReceive(
 
                 RecvContext->Binding = Binding;
                 RecvContext->ReferenceCount = 0;
-                RecvContext->Tuple.LocalAddress = LocalAddr;
-                RecvContext->Tuple.RemoteAddress = RemoteAddr;
+                RecvContext->Route.LocalAddress = LocalAddr;
+                RecvContext->Route.RemoteAddress = RemoteAddr;
                 Datagram = (CXPLAT_RECV_DATA*)(RecvContext + 1);
             }
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3253,7 +3253,7 @@ CxPlatDataPathUdpRecvComplete(
             Datagram->Next = NULL;
             Datagram->Buffer = RecvPayload;
             Datagram->BufferLength = MessageLength;
-            Datagram->Tuple = &RecvContext->Tuple;
+            Datagram->Route = &RecvContext->Route;
             Datagram->PartitionIndex = DatapathProc->Index;
             Datagram->TypeOfService = (uint8_t)ECN;
             Datagram->Allocated = TRUE;
@@ -3414,7 +3414,7 @@ CxPlatDataPathTcpRecvComplete(
         Data->Next = NULL;
         Data->Buffer = ((PUCHAR)RecvContext) + Datapath->RecvPayloadOffset;
         Data->BufferLength = NumberOfBytesTransferred;
-        Data->Tuple = &RecvContext->Tuple;
+        Data->Route = &RecvContext->Route;
         Data->PartitionIndex = DatapathProc->Index;
         Data->TypeOfService = 0;
         Data->Allocated = TRUE;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -126,9 +126,9 @@ typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
     ULONG ReferenceCount;
 
     //
-    // Contains the 4 tuple.
+    // Contains the network route.
     //
-    CXPLAT_TUPLE Tuple;
+    CXPLAT_ROUTE Route;
 
 } CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT;
 
@@ -2950,7 +2950,7 @@ CxPlatSocketHandleUnreachableError(
     )
 {
     PSOCKADDR_INET RemoteAddr =
-        &SocketProc->CurrentRecvContext->Tuple.RemoteAddress;
+        &SocketProc->CurrentRecvContext->Route.RemoteAddress;
     UNREFERENCED_PARAMETER(ErrorCode);
 
     CxPlatConvertFromMappedV6(RemoteAddr, RemoteAddr);
@@ -3014,9 +3014,9 @@ CxPlatSocketStartReceive(
         sizeof(SocketProc->RecvWsaMsgHdr));
 
     SocketProc->RecvWsaMsgHdr.name =
-        (PSOCKADDR)&SocketProc->CurrentRecvContext->Tuple.RemoteAddress;
+        (PSOCKADDR)&SocketProc->CurrentRecvContext->Route.RemoteAddress;
     SocketProc->RecvWsaMsgHdr.namelen =
-        sizeof(SocketProc->CurrentRecvContext->Tuple.RemoteAddress);
+        sizeof(SocketProc->CurrentRecvContext->Route.RemoteAddress);
 
     SocketProc->RecvWsaMsgHdr.lpBuffers = &SocketProc->RecvWsaBuf;
     SocketProc->RecvWsaMsgHdr.dwBufferCount = 1;
@@ -3112,8 +3112,8 @@ CxPlatDataPathUdpRecvComplete(
         SocketProc->CurrentRecvContext = NULL;
     }
 
-    PSOCKADDR_INET RemoteAddr = &RecvContext->Tuple.RemoteAddress;
-    PSOCKADDR_INET LocalAddr = &RecvContext->Tuple.LocalAddress;
+    PSOCKADDR_INET RemoteAddr = &RecvContext->Route.RemoteAddress;
+    PSOCKADDR_INET LocalAddr = &RecvContext->Route.LocalAddress;
 
     if (IoResult == WSAENOTSOCK || IoResult == WSA_OPERATION_ABORTED) {
         //
@@ -3360,8 +3360,8 @@ CxPlatDataPathTcpRecvComplete(
         SocketProc->CurrentRecvContext = NULL;
     }
 
-    PSOCKADDR_INET RemoteAddr = &RecvContext->Tuple.RemoteAddress;
-    PSOCKADDR_INET LocalAddr = &RecvContext->Tuple.LocalAddress;
+    PSOCKADDR_INET RemoteAddr = &RecvContext->Route.RemoteAddress;
+    PSOCKADDR_INET LocalAddr = &RecvContext->Route.LocalAddress;
 
     if (IoResult == WSAENOTSOCK ||
         IoResult == WSA_OPERATION_ABORTED ||
@@ -4254,13 +4254,13 @@ CxPlatFuzzerReceiveInject(
         return;
     }
 
-    RecvContext->Tuple.RemoteAddress = *SourceAddress;
+    RecvContext->Route.RemoteAddress = *SourceAddress;
 
     CXPLAT_RECV_DATA* Datagram = (CXPLAT_RECV_DATA*)(RecvContext + 1);
 
     Datagram->Next = NULL;
     Datagram->BufferLength = PacketLength;
-    Datagram->Tuple = &RecvContext->Tuple;
+    Datagram->Route = &RecvContext->Route;
     Datagram->Allocated = TRUE;
     Datagram->QueuedOnConnection = FALSE;
     Datagram->Buffer = ((PUCHAR)RecvContext) + Socket->Socket->Datapath->RecvPayloadOffset;

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -268,7 +268,7 @@ CxPlatPcpProcessDatagram(
     CXPLAT_PCP_EVENT Event = {0};
     CxPlatCopyMemory(Event.FAILURE.Nonce, Response->MAP.MappingNonce, CXPLAT_PCP_NONCE_LENGTH);
     QUIC_ADDR InternalAddress;
-    CxPlatCopyMemory(&InternalAddress, &Datagram->Tuple->LocalAddress, sizeof(QUIC_ADDR));
+    CxPlatCopyMemory(&InternalAddress, &Datagram->Route->LocalAddress, sizeof(QUIC_ADDR));
     InternalAddress.Ipv6.sin6_port = Response->MAP.InternalPort;
     QUIC_ADDR ExternalAddress = {0};
     QUIC_ADDR RemotePeerAddress = {0};

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -232,7 +232,7 @@ protected:
             ASSERT_EQ(RecvData->BufferLength, ExpectedDataSize);
             ASSERT_EQ(0, memcmp(RecvData->Buffer, ExpectedData, ExpectedDataSize));
 
-            if (RecvData->Tuple->LocalAddress.Ipv4.sin_port == RecvContext->DestinationAddress.Ipv4.sin_port) {
+            if (RecvData->Route->LocalAddress.Ipv4.sin_port == RecvContext->DestinationAddress.Ipv4.sin_port) {
 
                 ASSERT_EQ((CXPLAT_ECN_TYPE)RecvData->TypeOfService, RecvContext->EcnType);
 
@@ -242,17 +242,14 @@ protected:
                 ASSERT_NE(nullptr, ServerBuffer);
                 memcpy(ServerBuffer->Buffer, RecvData->Buffer, RecvData->BufferLength);
 
-                CXPLAT_ROUTE Route;
-                Route.LocalAddress = RecvData->Tuple->LocalAddress;
-                Route.RemoteAddress = RecvData->Tuple->RemoteAddress;
                 VERIFY_QUIC_SUCCESS(
                     CxPlatSocketSend(
                         Socket,
-                        &Route,
+                        RecvData->Route,
                         ServerSendData,
                         0));
 
-            } else if (RecvData->Tuple->RemoteAddress.Ipv4.sin_port == RecvContext->DestinationAddress.Ipv4.sin_port) {
+            } else if (RecvData->Route->RemoteAddress.Ipv4.sin_port == RecvContext->DestinationAddress.Ipv4.sin_port) {
                 CxPlatEventSet(RecvContext->ClientCompletion);
 
             } else {

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -506,14 +506,14 @@ struct MtuDropHelper : public DatapathHook
         ) {
         uint16_t PacketMtu =
             PacketSizeFromUdpPayloadSize(
-                QuicAddrGetFamily(&Datagram->Tuple->RemoteAddress),
+                QuicAddrGetFamily(&Datagram->Route->RemoteAddress),
                 Datagram->BufferLength);
         if (ServerDropPacketSize != 0 && PacketMtu > ServerDropPacketSize &&
-            QuicAddrGetPort(&Datagram->Tuple->RemoteAddress) == ServerDropPort) {
+            QuicAddrGetPort(&Datagram->Route->RemoteAddress) == ServerDropPort) {
             return TRUE;
         }
         if (ClientDropPacketSize != 0 && PacketMtu > ClientDropPacketSize &&
-            QuicAddrGetPort(&Datagram->Tuple->RemoteAddress) != ServerDropPort) {
+            QuicAddrGetPort(&Datagram->Route->RemoteAddress) != ServerDropPort) {
             return TRUE;
         }
         return FALSE;
@@ -548,9 +548,9 @@ struct ReplaceAddressHelper : public DatapathHook
         _Inout_ struct CXPLAT_RECV_DATA* Datagram
         ) {
         if (QuicAddrCompare(
-                &Datagram->Tuple->RemoteAddress,
+                &Datagram->Route->RemoteAddress,
                 &Original)) {
-            Datagram->Tuple->RemoteAddress = New;
+            Datagram->Route->RemoteAddress = New;
             QuicTraceLogVerbose(
                 TestHookReplaceAddrRecv,
                 "[test][hook] Recv Addr :%hu => :%hu",
@@ -601,7 +601,7 @@ struct ReplaceAddressThenDropHelper : public DatapathHook
         _Inout_ struct CXPLAT_RECV_DATA* Datagram
         ) {
         if (QuicAddrCompare(
-                &Datagram->Tuple->RemoteAddress,
+                &Datagram->Route->RemoteAddress,
                 &Original)) {
             if (AllowPacketCount == 0) {
                 QuicTraceLogVerbose(
@@ -610,7 +610,7 @@ struct ReplaceAddressThenDropHelper : public DatapathHook
                 return TRUE; // Drop
             }
             AllowPacketCount--;
-            Datagram->Tuple->RemoteAddress = New;
+            Datagram->Route->RemoteAddress = New;
             QuicTraceLogVerbose(
                 TestHookReplaceAddrRecv,
                 "[test][hook] Recv Addr :%hu => :%hu",
@@ -708,9 +708,9 @@ struct LoadBalancerHelper : public DatapathHook
         ) {
         for (uint32_t i = 0; i < PrivateAddressesCount; ++i) {
             if (QuicAddrCompare(
-                    &Datagram->Tuple->RemoteAddress,
+                    &Datagram->Route->RemoteAddress,
                     &PrivateAddresses[i])) {
-                Datagram->Tuple->RemoteAddress = PublicAddress;
+                Datagram->Route->RemoteAddress = PublicAddress;
                 QuicTraceLogVerbose(
                     TestHookReplaceAddrRecv,
                     "[test][hook] Recv Addr :%hu => :%hu",

--- a/src/tools/lb/loadbalancer.cpp
+++ b/src/tools/lb/loadbalancer.cpp
@@ -151,8 +151,8 @@ struct LbPublicInterface : public LbInterface {
     void Receive(_In_ CXPLAT_RECV_DATA* RecvDataChain) {
         auto PrivateInterface =
             GetPrivateInterface(
-                &RecvDataChain->Tuple->LocalAddress,
-                &RecvDataChain->Tuple->RemoteAddress);
+                &RecvDataChain->Route->LocalAddress,
+                &RecvDataChain->Route->RemoteAddress);
         PrivateInterface->Send(RecvDataChain);
     }
 


### PR DESCRIPTION
In addition to QUIC_PATHs having a "route", now CXPLAT_RECV_DATAs (which represent received packets) also have one. This enables the route of the received packet which triggered a stateless operation to be directly passed to QuicBindingSend in QuicBindingProcessStatelessOperation.

The idea here is that LoLa can potentially skip route lookup and ARP when sending stateless replies on the dpdk or xdp datapath.
