### PR TITLE
Xsum in forward direction and a knob to skip xsum for testing

### DIFF
--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -351,7 +351,7 @@ CxPlatFramingChecksum(
     )
 {
     //
-    // Checksum is calculated in reverse order.
+    // Add up all bytes in 3 steps:
     // 1. Add the odd byte to the checksum if the length is odd.
     // 2. If the length is divisible by 2 but not 4, add the last 2 bytes.
     // 3. Sum up the rest as 32-bit words.

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -367,9 +367,8 @@ CxPlatFramingChecksum(
         InitialChecksum += *((uint16_t*)(&Data[Length]));
     }
 
-    while (Length != 0) {
-        Length -= 4;
-        InitialChecksum += *((uint32_t*)(&Data[Length]));
+    for (uint32_t i = 0; i < Length; i += 4) {
+        InitialChecksum += *((uint32_t*)(&Data[i]));
     }
 
     //

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -202,6 +202,13 @@ CxPlatXdpReadConfig(
              Xdp->TxRingSize = strtoul(Value, NULL, 10);
         } else if (strcmp(Line, "TxAlwaysPoke") == 0) {
              Xdp->TxAlwaysPoke = !!strtoul(Value, NULL, 10);
+        } else if (strcmp(Line, "SkipXsum") == 0) {
+            BOOLEAN State = !!strtoul(Value, NULL, 10);
+            Xdp->OffloadStatus.Transmit.NetworkLayerXsum = State;
+            Xdp->OffloadStatus.Transmit.TransportLayerXsum = State;
+            Xdp->OffloadStatus.Receive.NetworkLayerXsum = State;
+            Xdp->OffloadStatus.Receive.TransportLayerXsum = State;
+            printf("Checksums will not be calculated\n");
         }
     }
 

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -208,7 +208,7 @@ CxPlatXdpReadConfig(
             Xdp->OffloadStatus.Transmit.TransportLayerXsum = State;
             Xdp->OffloadStatus.Receive.NetworkLayerXsum = State;
             Xdp->OffloadStatus.Receive.TransportLayerXsum = State;
-            printf("Checksums will not be calculated\n");
+            printf("SkipXsum: %u\n", State);
         }
     }
 


### PR DESCRIPTION
Only very slight difference between xsum on and off during my testing.

.\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536

These 2 metrics are consistently different between the xsum on and off. So, with xsum, min is smaller but 99th is larger. The variance in long tails are huge so I am not looking at them.

Xsum On: 
Min: 197, 99th: 238

Xsum Off:
Min: 203, 99th: 217


```
> # no xsum
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4716 RPS, Min: 204, Max: 6082, 50th: 207.000000, 90th: 209.000000, 99th: 217.000000, 99.9th: 260.000000, 99.99th: 852.000000, 99.999th: 6082.000000, 99.9999th: 6082.000000, StdErr: 0.134733
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4713 RPS, Min: 204, Max: 473, 50th: 208.000000, 90th: 209.000000, 99th: 217.000000, 99.9th: 239.000000, 99.99th: 332.000000, 99.999th: 473.000000, 99.9999th: 473.000000, StdErr: 0.014235
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4724 RPS, Min: 204, Max: 2800, 50th: 207.000000, 90th: 209.000000, 99th: 217.000000, 99.9th: 237.000000, 99.99th: 373.000000, 99.999th: 2800.000000, 99.9999th: 2800.000000, StdErr: 0.056907
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4718 RPS, Min: 204, Max: 1459, 50th: 207.000000, 90th: 209.000000, 99th: 217.000000, 99.9th: 242.000000, 99.99th: 396.000000, 99.999th: 1459.000000, 99.9999th: 1459.000000, StdErr: 0.039185
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4712 RPS, Min: 203, Max: 4030, 50th: 207.000000, 90th: 209.000000, 99th: 217.000000, 99.9th: 237.000000, 99.99th: 385.000000, 99.999th: 4030.000000, 99.9999th: 4030.000000, StdErr: 0.095515
> # xsum on
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4760 RPS, Min: 197, Max: 5507, 50th: 205.000000, 90th: 208.000000, 99th: 234.000000, 99.9th: 255.000000, 99.99th: 306.000000, 99.999th: 5507.000000, 99.9999th: 5507.000000, StdErr: 0.113869
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4762 RPS, Min: 197, Max: 1958, 50th: 205.000000, 90th: 208.000000, 99th: 236.000000, 99.9th: 258.000000, 99.99th: 343.000000, 99.999th: 1958.000000, 99.9999th: 1958.000000, StdErr: 0.045181
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4767 RPS, Min: 197, Max: 596, 50th: 204.000000, 90th: 208.000000, 99th: 236.000000, 99.9th: 260.000000, 99.99th: 325.000000, 99.999th: 596.000000, 99.9999th: 596.000000, StdErr: 0.028323
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4767 RPS, Min: 197, Max: 702, 50th: 204.000000, 90th: 208.000000, 99th: 241.000000, 99.9th: 261.000000, 99.99th: 361.000000, 99.999th: 702.000000, 99.9999th: 702.000000, StdErr: 0.030179
> .\xdp\secnetperf.exe -test:rps -target:quic-server -bind:192.168.77.31 -conns:1 -requests:1 -request:512 -response:65536
Result: 4743 RPS, Min: 197, Max: 2566, 50th: 205.000000, 90th: 209.000000, 99th: 246.000000, 99.9th: 273.000000, 99.99th: 464.000000, 99.999th: 2566.000000, 99.9999th: 2566.000000, StdErr: 0.080162
```



