### PR TITLE
Add support for building arm64ec binaries

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -198,6 +198,13 @@ stages:
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-2019
+      platform: windows
+      arch: arm64ec
+      tls: schannel
+      extraBuildArgs: -EnableTelemetryAsserts
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: windows-2019
       platform: uwp
       arch: x64
       tls: schannel

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -197,7 +197,7 @@ stages:
       extraBuildArgs: -EnableTelemetryAsserts
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-2019
+      image: windows-2022
       platform: windows
       arch: arm64ec
       tls: schannel

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -229,8 +229,6 @@ if ($Arch -ne "x64" -And ($Platform -eq "gamecore_console")) {
     exit
 }
 
-
-
 if ($Arch -eq "arm64ec") {
     if (!$IsWindows) {
         Write-Error "Arm64EC is only supported on Windows"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -104,7 +104,7 @@ param (
     [string]$Config = "Debug",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("x86", "x64", "arm", "arm64")]
+    [ValidateSet("x86", "x64", "arm", "arm64", "arm64ec")]
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]
@@ -229,6 +229,17 @@ if ($Arch -ne "x64" -And ($Platform -eq "gamecore_console")) {
     exit
 }
 
+
+
+if ($Arch -eq "arm64ec") {
+    if (!$IsWindows) {
+        Write-Error "Arm64EC is only supported on Windows"
+    }
+    if ($Tls -eq "openssl") {
+        Write-Error "Arm64EC does not support openssl"
+    }
+}
+
 if ($Platform -eq "ios" -and !$Static) {
     $Static = $true
     Write-Host "iOS can only be built as static"
@@ -296,6 +307,7 @@ function CMake-Generate {
                 "x64"   { $Arguments += "x64" }
                 "arm"   { $Arguments += "arm" }
                 "arm64" { $Arguments += "arm64" }
+                "arm64ec" { $Arguments += "arm64ec" }
             }
         } else {
             Write-Host "Non VS based generators must be run from a Visual Studio Developer Powershell Prompt matching the passed in architecture"

--- a/scripts/get-buildconfig.ps1
+++ b/scripts/get-buildconfig.ps1
@@ -26,7 +26,7 @@ param (
     [string]$Config = "Debug",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("x86", "x64", "arm", "arm64", "universal", "")]
+    [ValidateSet("x86", "x64", "arm", "arm64", "arm64ec", "universal", "")]
     [string]$Arch = "",
 
     [Parameter(Mandatory = $false)]

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -43,6 +43,9 @@ endif()
 
 if(WIN32)
     target_link_libraries(base_link INTERFACE ws2_32 schannel ntdll bcrypt ncrypt crypt32 iphlpapi advapi32)
+    if (_MSVC_CXX_ARCHITECTURE_FAMILY STREQUAL "ARM64EC")
+        target_link_libraries(base_link INTERFACE softintrin)
+    endif()
 endif()
 
 add_library(warnings INTERFACE)


### PR DESCRIPTION
Arm64ec is an emulation compatible arm64 calling convention. It allows x64 and arm64 code to mix in the same exectable. This is great for a program that uses plugins, as it can use exisiting x64 plugins but run most of its code as arm code.

Only supports schannel, as openssl would require changes to their assembly files, which they do not have any interest in doing.