### PR TITLE
Fix memory leak when indicated certificate is rejected by app

### DIFF
--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -276,7 +276,7 @@ This event indicates a certificate has been received from the peer.
 
 `Certificate`
 
-Pointer to a platform/TLS specific certificate. Valid only during the callback.
+Pointer to a platform/TLS specific certificate. Valid only during the callback. Can be NULL on error.
 
 `DeferredErrorFlags`
 
@@ -288,7 +288,7 @@ Most severe error status when doing deferred validation of the certificate. Vali
 
 `Chain`
 
-Pointer to a platform/TLS specific certificate chain. Valid only during the callback.
+Pointer to a platform/TLS specific certificate chain. Valid only during the callback. Can be NULL on error.
 
 # See Also
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2882,8 +2882,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicConnPeerCertReceived(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_CERTIFICATE* Certificate,
-    _In_ QUIC_CERTIFICATE_CHAIN* Chain,
+    _In_opt_ QUIC_CERTIFICATE* Certificate,
+    _In_opt_ QUIC_CERTIFICATE_CHAIN* Chain,
     _In_ uint32_t DeferredErrorFlags,
     _In_ QUIC_STATUS DeferredStatus
     )

--- a/src/generated/linux/tls_schannel.c.clog.h
+++ b/src/generated/linux/tls_schannel.c.clog.h
@@ -899,6 +899,53 @@ tracepoint(CLOG_TLS_SCHANNEL_C, TlsError , arg2, arg3);\
 // Decoder Ring for TlsErrorStatus
 // [ tls][%p] ERROR, %u, %s.
 // QuicTraceEvent(
+            TlsErrorStatus,
+            "[ tls][%p] ERROR, %u, %s.",
+            TlsContext->Connection,
+            SecStatus,
+            "Query peer cert");
+// arg2 = arg2 = TlsContext->Connection
+// arg3 = arg3 = SecStatus
+// arg4 = arg4 = "Query peer cert"
+----------------------------------------------------------*/
+#define _clog_5_ARGS_TRACE_TlsErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
+tracepoint(CLOG_TLS_SCHANNEL_C, TlsErrorStatus , arg2, arg3, arg4);\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_TlsError
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for TlsError
+// [ tls][%p] ERROR, %s.
+// QuicTraceEvent(
+            TlsError,
+            "[ tls][%p] ERROR, %s.",
+            TlsContext->Connection,
+            "Indicate certificate received failed");
+// arg2 = arg2 = TlsContext->Connection
+// arg3 = arg3 = "Indicate certificate received failed"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_TlsError(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_5_ARGS_TRACE_TlsErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for TlsErrorStatus
+// [ tls][%p] ERROR, %u, %s.
+// QuicTraceEvent(
                     TlsErrorStatus,
                     "[ tls][%p] ERROR, %u, %s.",
                     TlsContext->Connection,
@@ -909,7 +956,6 @@ tracepoint(CLOG_TLS_SCHANNEL_C, TlsError , arg2, arg3);\
 // arg4 = arg4 = "Convert SNI to unicode"
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_TlsErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
-tracepoint(CLOG_TLS_SCHANNEL_C, TlsErrorStatus , arg2, arg3, arg4);\
 
 #endif
 
@@ -1074,52 +1120,6 @@ tracepoint(CLOG_TLS_SCHANNEL_C, TlsErrorStatus , arg2, arg3, arg4);\
 // arg4 = arg4 = "query session info"
 ----------------------------------------------------------*/
 #define _clog_5_ARGS_TRACE_TlsErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
-
-#endif
-
-
-
-
-#ifndef _clog_5_ARGS_TRACE_TlsErrorStatus
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for TlsErrorStatus
-// [ tls][%p] ERROR, %u, %s.
-// QuicTraceEvent(
-                        TlsErrorStatus,
-                        "[ tls][%p] ERROR, %u, %s.",
-                        TlsContext->Connection,
-                        SecStatus,
-                        "Query peer cert");
-// arg2 = arg2 = TlsContext->Connection
-// arg3 = arg3 = SecStatus
-// arg4 = arg4 = "Query peer cert"
-----------------------------------------------------------*/
-#define _clog_5_ARGS_TRACE_TlsErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
-
-#endif
-
-
-
-
-#ifndef _clog_4_ARGS_TRACE_TlsError
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for TlsError
-// [ tls][%p] ERROR, %s.
-// QuicTraceEvent(
-                        TlsError,
-                        "[ tls][%p] ERROR, %s.",
-                        TlsContext->Connection,
-                        "Indicate certificate received failed");
-// arg2 = arg2 = TlsContext->Connection
-// arg3 = arg3 = "Indicate certificate received failed"
-----------------------------------------------------------*/
-#define _clog_4_ARGS_TRACE_TlsError(uniqueId, encoded_arg_string, arg2, arg3)\
 
 #endif
 

--- a/src/generated/linux/tls_schannel.c.clog.h.lttng.h
+++ b/src/generated/linux/tls_schannel.c.clog.h.lttng.h
@@ -482,14 +482,14 @@ TRACEPOINT_EVENT(CLOG_TLS_SCHANNEL_C, TlsError,
 // Decoder Ring for TlsErrorStatus
 // [ tls][%p] ERROR, %u, %s.
 // QuicTraceEvent(
-                    TlsErrorStatus,
-                    "[ tls][%p] ERROR, %u, %s.",
-                    TlsContext->Connection,
-                    Status,
-                    "Convert SNI to unicode");
+            TlsErrorStatus,
+            "[ tls][%p] ERROR, %u, %s.",
+            TlsContext->Connection,
+            SecStatus,
+            "Query peer cert");
 // arg2 = arg2 = TlsContext->Connection
-// arg3 = arg3 = Status
-// arg4 = arg4 = "Convert SNI to unicode"
+// arg3 = arg3 = SecStatus
+// arg4 = arg4 = "Query peer cert"
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_TLS_SCHANNEL_C, TlsErrorStatus,
     TP_ARGS(

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -963,10 +963,10 @@ typedef struct QUIC_CONNECTION_EVENT {
             const uint8_t* ResumptionTicket;
         } RESUMPTION_TICKET_RECEIVED;
         struct {
-            QUIC_CERTIFICATE* Certificate;      // Peer certificate (platform specific). Valid only during QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED callback.
+            QUIC_CERTIFICATE* Certificate;      // Peer certificate (platform specific). Valid only during QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED callback. Can be NULL on error.
             uint32_t DeferredErrorFlags;        // Bit flag of errors (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION) - Schannel only, zero otherwise.
             QUIC_STATUS DeferredStatus;         // Most severe error status (only valid with QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)
-            QUIC_CERTIFICATE_CHAIN* Chain;      // Peer certificate chain (platform specific). Valid only during QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED callback.
+            QUIC_CERTIFICATE_CHAIN* Chain;      // Peer certificate chain (platform specific). Valid only during QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED callback. Can be NULL on error.
         } PEER_CERTIFICATE_RECEIVED;
     };
 } QUIC_CONNECTION_EVENT;

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -109,8 +109,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 (CXPLAT_TLS_PEER_CERTIFICATE_RECEIVED_CALLBACK)(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_CERTIFICATE* Certificate,
-    _In_ QUIC_CERTIFICATE_CHAIN* Chain,
+    _In_opt_ QUIC_CERTIFICATE* Certificate,
+    _In_opt_ QUIC_CERTIFICATE_CHAIN* Chain,
     _In_ uint32_t DeferredErrorFlags,
     _In_ QUIC_STATUS DeferredStatus
     );


### PR DESCRIPTION
When indicate certificate is set and the certificate is rejected, we would leak the cert context. Also if the cert context failed to be grabbed we'd deref a null pointer. Both issues are fixed