### PR TITLE
Pass Route into CxPlatSocketCreateUdp instead of Addresses

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -109,6 +109,8 @@ QuicBindingInitialize(
         UdpConfigCopy.Route = &RouteCopy;
         UdpConfigCopy.CallbackContext = Binding;
 
+        Hooks->Create(&RouteCopy);
+
         Status =
             CxPlatSocketCreateUdp(
                 MsQuicLib.Datapath,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1823,8 +1823,7 @@ QuicConnStart(
         CASTED_CLOG_BYTEARRAY(sizeof(Path->Route.RemoteAddress), &Path->Route.RemoteAddress));
 
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = Connection->State.LocalAddressSet ? &Path->Route.LocalAddress : NULL;
-    UdpConfig.RemoteAddress = &Path->Route.RemoteAddress;
+    UdpConfig.Route = &Path->Route;
     UdpConfig.Flags = Connection->State.ShareBinding ? CXPLAT_SOCKET_FLAG_SHARE : 0;
     UdpConfig.InterfaceIndex = Connection->State.LocalInterfaceSet ? (uint32_t)Path->Route.LocalAddress.Ipv6.sin6_scope_id : 0, // NOLINT(google-readability-casting)
 #ifdef QUIC_COMPARTMENT_ID
@@ -5704,8 +5703,7 @@ QuicConnParamSet(
             QUIC_BINDING* OldBinding = Connection->Paths[0].Binding;
 
             CXPLAT_UDP_CONFIG UdpConfig = {0};
-            UdpConfig.LocalAddress = LocalAddress;
-            UdpConfig.RemoteAddress = &Connection->Paths[0].Route.RemoteAddress;
+            UdpConfig.Route = &Connection->Paths[0].Route;
             UdpConfig.Flags = Connection->State.ShareBinding ? CXPLAT_SOCKET_FLAG_SHARE : 0;
             UdpConfig.InterfaceIndex = 0;
 #ifdef QUIC_COMPARTMENT_ID

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -165,7 +165,7 @@ MsQuicListenerStart(
     uint8_t* AlpnList;
     uint32_t AlpnListLength;
     BOOLEAN PortUnspecified;
-    QUIC_ADDR BindingLocalAddress = {0};
+    CXPLAT_ROUTE Route = {0};
 
     QuicTraceEvent(
         ApiEnter,
@@ -249,8 +249,8 @@ MsQuicListenerStart(
     // (if available) UDP port and then manually filter on the specific address
     // (if available) at the QUIC layer.
     //
-    QuicAddrSetFamily(&BindingLocalAddress, QUIC_ADDRESS_FAMILY_INET6);
-    QuicAddrSetPort(&BindingLocalAddress,
+    QuicAddrSetFamily(&Route.LocalAddress, QUIC_ADDRESS_FAMILY_INET6);
+    QuicAddrSetPort(&Route.LocalAddress,
         PortUnspecified ? 0 : QuicAddrGetPort(LocalAddress));
 
     if (!QuicLibraryOnListenerRegistered(Listener)) {
@@ -259,8 +259,7 @@ MsQuicListenerStart(
     }
 
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = &BindingLocalAddress;
-    UdpConfig.RemoteAddress = NULL;
+    UdpConfig.Route = &Route;
     UdpConfig.Flags = CXPLAT_SOCKET_FLAG_SHARE | CXPLAT_SOCKET_SERVER_OWNED; // Listeners always share the binding.
     UdpConfig.InterfaceIndex = 0;
 #ifdef QUIC_COMPARTMENT_ID
@@ -299,10 +298,10 @@ MsQuicListenerStart(
     }
 
     if (PortUnspecified) {
-        QuicBindingGetLocalAddress(Listener->Binding, &BindingLocalAddress);
+        QuicBindingGetLocalAddress(Listener->Binding, &Route.LocalAddress);
         QuicAddrSetPort(
             &Listener->LocalAddress,
-            QuicAddrGetPort(&BindingLocalAddress));
+            QuicAddrGetPort(&Route.LocalAddress));
     }
 
     QuicTraceEvent(

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -22,13 +22,13 @@ extern "C" {
 
 typedef struct CXPLAT_RECV_DATA CXPLAT_RECV_DATA;
 typedef struct CXPLAT_SEND_DATA CXPLAT_SEND_DATA;
+typedef struct CXPLAT_ROUTE CXPLAT_ROUTE;
 
 typedef
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 (QUIC_API * QUIC_TEST_DATAPATH_CREATE_HOOK)(
-    _Inout_opt_ QUIC_ADDR* RemoteAddress,
-    _Inout_opt_ QUIC_ADDR* LocalAddress
+    _Inout_ CXPLAT_ROUTE* Route
     );
 
 typedef

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -440,8 +440,7 @@ CxPlatDataPathGetGatewayAddresses(
 #define CXPLAT_SOCKET_SERVER_OWNED  0x00000004  // Indicates socket is a listener socket
 
 typedef struct CXPLAT_UDP_CONFIG {
-    const QUIC_ADDR* LocalAddress;      // optional
-    const QUIC_ADDR* RemoteAddress;     // optional
+    CXPLAT_ROUTE* Route;                // in/out
     uint32_t Flags;                     // CXPLAT_SOCKET_FLAG_*
     uint32_t InterfaceIndex;            // 0 means any/all
     void* CallbackContext;              // optional

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -136,8 +136,9 @@ QuicMainStart(
 
         QuicAddr LocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
         CXPLAT_UDP_CONFIG UdpConfig = {0};
-        UdpConfig.LocalAddress = &LocalAddress.SockAddr;
-        UdpConfig.RemoteAddress = nullptr;
+        CXPLAT_ROUTE Route = {0};
+        Route.LocalAddress = LocalAddress.SockAddr;
+        UdpConfig.Route = &Route;
         UdpConfig.Flags = 0;
         UdpConfig.InterfaceIndex = 0;
         UdpConfig.CallbackContext = StopEvent;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -985,8 +985,8 @@ CxPlatSocketContextInitialize(
     int Option = 0;
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
-    const BOOLEAN HasRemoteAddr = RemoteAddress->si_family != AF_UNSPEC;
-    const BOOLEAN HasLocalAddr = LocalAddress->si_family != AF_UNSPEC || LocalAddress->Ipv4.sin_port != 0;
+    const BOOLEAN HasRemoteAddr = RemoteAddress->Ip.sa_family != AF_UNSPEC;
+    const BOOLEAN HasLocalAddr = LocalAddress->Ip.sa_family != AF_UNSPEC || LocalAddress->Ipv4.sin_port != 0;
 
     CXPLAT_SOCKET* Binding = SocketContext->Binding;
 
@@ -1834,8 +1834,8 @@ CxPlatSocketCreateUdp(
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const CXPLAT_ROUTE* Route = Config->Route;
-    const BOOLEAN HasRemoteAddr = Route->RemoteAddress.si_family != AF_UNSPEC;
-    const BOOLEAN HasLocalAddr = Route->LocalAddress.si_family != AF_UNSPEC || Route->LocalAddress.Ipv4.sin_port != 0;
+    const BOOLEAN HasRemoteAddr = Route->RemoteAddress.Ip.sa_family != AF_UNSPEC;
+    const BOOLEAN HasLocalAddr = Route->LocalAddress.Ip.sa_family != AF_UNSPEC || Route->LocalAddress.Ipv4.sin_port != 0;
     BOOLEAN IsServerSocket = !HasRemoteAddr;
     int32_t SuccessfulStartReceives = -1;
 
@@ -1873,8 +1873,8 @@ CxPlatSocketCreateUdp(
     Binding->HasFixedRemoteAddress = HasRemoteAddr;
     Binding->Mtu = CXPLAT_MAX_MTU;
     CxPlatRundownInitialize(&Binding->Rundown);
-    if (Config->LocalAddress) {
-        CxPlatConvertToMappedV6(Config->LocalAddress, &Binding->LocalAddress);
+    if (HasLocalAddr) {
+        CxPlatConvertToMappedV6(&Route->LocalAddress, &Binding->LocalAddress);
     } else {
         Binding->LocalAddress.Ip.sa_family = QUIC_ADDRESS_FAMILY_INET6;
     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -986,6 +986,7 @@ CxPlatSocketContextInitialize(
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
     const BOOLEAN HasRemoteAddr = RemoteAddress->Ip.sa_family != AF_UNSPEC;
+    const BOOLEAN HasLocalAddr = LocalAddress->Ip.sa_family != AF_UNSPEC || LocalAddress->Ipv4.sin_port != 0;
 
     CXPLAT_SOCKET* Binding = SocketContext->Binding;
 
@@ -1338,7 +1339,7 @@ CxPlatSocketContextInitialize(
         CXPLAT_DBG_ASSERT(Binding->LocalAddress.Ipv4.sin_port != RemoteAddress->Ipv4.sin_port);
     }
 #else
-    UNREFERENCED_PARAMETER(LocalAddress);
+    UNREFERENCED_PARAMETER(HasLocalAddr);
 #endif
 
     if (Binding->LocalAddress.Ipv6.sin6_family == AF_INET6) {

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -986,7 +986,6 @@ CxPlatSocketContextInitialize(
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
     const BOOLEAN HasRemoteAddr = RemoteAddress->Ip.sa_family != AF_UNSPEC;
-    const BOOLEAN HasLocalAddr = LocalAddress->Ip.sa_family != AF_UNSPEC || LocalAddress->Ipv4.sin_port != 0;
 
     CXPLAT_SOCKET* Binding = SocketContext->Binding;
 

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1440,8 +1440,8 @@ CxPlatSocketCreateUdp(
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const CXPLAT_ROUTE* Route = Config->Route;
-    const BOOLEAN HasRemoteAddr = Route->RemoteAddress.si_family != AF_UNSPEC;
-    const BOOLEAN HasLocalAddr = Route->LocalAddress.si_family != AF_UNSPEC || Route->LocalAddress.Ipv4.sin_port != 0;
+    const BOOLEAN HasRemoteAddr = Route->RemoteAddress.Ip.sa_family != AF_UNSPEC;
+    const BOOLEAN HasLocalAddr = Route->LocalAddress.Ip.sa_family != AF_UNSPEC || Route->LocalAddress.Ipv4.sin_port != 0;
     const BOOLEAN IsServerSocket = !HasRemoteAddr;
     int32_t SuccessfulStartReceives = -1;
 

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -179,14 +179,15 @@ CxPlatPcpInitialize(
     PcpContext->GatewayCount = GatewayAddressesCount;
 
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = NULL;
+    CXPLAT_ROUTE Route = {0};
+    UdpConfig.Route = &Route;
     UdpConfig.Flags = CXPLAT_SOCKET_FLAG_PCP;
     UdpConfig.InterfaceIndex = 0;
     UdpConfig.CallbackContext = PcpContext;
 
     for (uint32_t i = 0; i < GatewayAddressesCount; ++i) {
         QuicAddrSetPort(&GatewayAddresses[i], CXPLAT_PCP_PORT);
-        UdpConfig.RemoteAddress = &GatewayAddresses[i];
+        Route.RemoteAddress = GatewayAddresses[i];
         Status =
             CxPlatSocketCreateUdp(
                 Datapath,

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -436,8 +436,14 @@ struct CxPlatSocket {
         ) noexcept
     {
         CXPLAT_UDP_CONFIG UdpConfig = {0};
-        UdpConfig.LocalAddress = LocalAddress;
-        UdpConfig.RemoteAddress = RemoteAddress;
+        CXPLAT_ROUTE Route = {0};
+        if (LocalAddress) {
+            Route.LocalAddress = *LocalAddress;
+        }
+        if (RemoteAddress) {
+            Route.RemoteAddress = *RemoteAddress;
+        }
+        UdpConfig.Route = &Route;
         UdpConfig.Flags = InternalFlags;
         UdpConfig.InterfaceIndex = 0;
         UdpConfig.CallbackContext = CallbackContext;

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -165,8 +165,9 @@ struct DrillSender {
         }
 
         CXPLAT_UDP_CONFIG UdpConfig = {0};
-        UdpConfig.LocalAddress = nullptr;
-        UdpConfig.RemoteAddress = &ServerAddress;
+        CXPLAT_ROUTE Route = {0};
+        Route.RemoteAddress = ServerAddress;
+        UdpConfig.Route = &Route;
         UdpConfig.Flags = 0;
         UdpConfig.InterfaceIndex = 0;
         UdpConfig.CallbackContext = this;

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -301,8 +301,9 @@ CXPLAT_THREAD_CALLBACK(RunAttackThread, /* Context */)
 {
     CXPLAT_SOCKET* Binding;
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = nullptr;
-    UdpConfig.RemoteAddress = &ServerAddress;
+    CXPLAT_ROUTE Route = {0};
+    Route.RemoteAddress = ServerAddress;
+    UdpConfig.Route = &Route;
     UdpConfig.Flags = 0;
     UdpConfig.InterfaceIndex = 0;
     UdpConfig.CallbackContext = nullptr;

--- a/src/tools/lb/loadbalancer.cpp
+++ b/src/tools/lb/loadbalancer.cpp
@@ -30,16 +30,16 @@ struct LbInterface {
 
     LbInterface(_In_ const QUIC_ADDR* Address, bool IsPublic) : IsPublic(IsPublic) {
         CXPLAT_UDP_CONFIG UdpConfig = {0};
-        UdpConfig.LocalAddress = nullptr;
-        UdpConfig.RemoteAddress = nullptr;
+        CXPLAT_ROUTE Route = {0};
+        UdpConfig.Route = &Route;
         UdpConfig.Flags = 0;
         UdpConfig.InterfaceIndex = 0;
         UdpConfig.CallbackContext = this;
         if (IsPublic) {
-            UdpConfig.LocalAddress = Address;
+            Route.LocalAddress = *Address;
             CxPlatSocketCreateUdp(Datapath, &UdpConfig, &Socket);
         } else {
-            UdpConfig.RemoteAddress = Address;
+            Route.RemoteAddress = *Address;
             CxPlatSocketCreateUdp(Datapath, &UdpConfig, &Socket);
         }
         if (!Socket) {

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -856,7 +856,7 @@ CXPLAT_THREAD_CALLBACK(ClientSpin, Context)
     CXPLAT_THREAD_RETURN(0);
 }
 
-void QUIC_API DatapathHookCreateCallback(_Inout_opt_ QUIC_ADDR* /* RemoteAddress */, _Inout_opt_ QUIC_ADDR* /* LocalAddress */)
+void QUIC_API DatapathHookCreateCallback(_Inout_ CXPLAT_ROUTE* /* Route */)
 {
 }
 


### PR DESCRIPTION
Updates `CxPlatSocketCreateUdp` to take a `CXPLAT_ROUTE` as input instead of `QUIC_ADDR`s. This is useful if we want the `CxPlatSocketCreateUdp` function itself to modify the route (route / next hop).