### PR TITLE
Pass CXPLAT_ROUTE to CxPlatSendDataAlloc

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -813,7 +813,8 @@ QuicBindingProcessStatelessOperation(
         CxPlatSendDataAlloc(
             Binding->Socket,
             CXPLAT_ECN_NON_ECT,
-            0);
+            0,
+            RecvDatagram->Route);
     if (SendData == NULL) {
         QuicTraceEvent(
             AllocFailure,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -248,7 +248,8 @@ QuicPacketBuilderPrepare(
                         0 :
                         MaxUdpPayloadSizeForFamily(
                             QuicAddrGetFamily(&Builder->Path->Route.RemoteAddress),
-                            DatagramSize));
+                            DatagramSize),
+                    &Builder->Path->Route);
             if (Builder->SendData == NULL) {
                 QuicTraceEvent(
                     AllocFailure,

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -381,7 +381,7 @@ CxPlatDataPathResolveAddress(
     _In_z_ const char* HostName,
     _Inout_ QUIC_ADDR* Address
     );
-    
+
 //
 // Values from RFC 2863
 //
@@ -554,7 +554,8 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _Inout_ CXPLAT_ROUTE* Route
     );
 
 //

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -176,8 +176,7 @@ class TcpConnection {
     uint16_t PartitionIndex;
     CXPLAT_REF_COUNT Ref;
     CXPLAT_DISPATCH_LOCK Lock;
-    QUIC_ADDR LocalAddress;
-    QUIC_ADDR RemoteAddress;
+    CXPLAT_ROUTE Route;
     CXPLAT_SOCKET* Socket{nullptr};
     CXPLAT_SEC_CONFIG* SecConfig{nullptr};
     CXPLAT_TLS* Tls{nullptr};

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2161,9 +2161,11 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _Inout_ CXPLAT_ROUTE* Route
     )
 {
+    UNREFERENCED_PARAMETER(Route);
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1748,9 +1748,11 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _Inout_ CXPLAT_ROUTE* Route
     )
 {
+    UNREFERENCED_PARAMETER(Route);
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc =

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2542,9 +2542,11 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Binding,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ UINT16 MaxPacketSize
+    _In_ UINT16 MaxPacketSize,
+    _Inout_ CXPLAT_ROUTE* Route
     )
 {
+    UNREFERENCED_PARAMETER(Route);
     CXPLAT_DBG_ASSERT(Binding != NULL);
 
     CXPLAT_DATAPATH_PROC_CONTEXT* ProcContext =

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3500,9 +3500,11 @@ CXPLAT_SEND_DATA*
 CxPlatSendDataAlloc(
     _In_ CXPLAT_SOCKET* Socket,
     _In_ CXPLAT_ECN_TYPE ECN,
-    _In_ uint16_t MaxPacketSize
+    _In_ uint16_t MaxPacketSize,
+    _Inout_ CXPLAT_ROUTE* Route
     )
 {
+    UNREFERENCED_PARAMETER(Route);
     CXPLAT_DBG_ASSERT(Socket != NULL);
 
     CXPLAT_DATAPATH_PROC* DatapathProc =

--- a/src/platform/pcp.c
+++ b/src/platform/pcp.c
@@ -390,7 +390,7 @@ CxPlatPcpSendMapRequestInternal(
     CxPlatConvertToMappedV6(&Route.LocalAddress, &LocalMappedAddress);
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE);
+        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_MAP_REQUEST_SIZE, &Route);
     if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
@@ -479,18 +479,18 @@ CxPlatPcpSendPeerRequestInternal(
     _In_ uint32_t Lifetime          // Zero indicates delete. Nonce must match.
     )
 {
-    QUIC_ADDR LocalAddress, RemoteAddress;
-    CxPlatSocketGetLocalAddress(Socket, &LocalAddress);
-    CxPlatSocketGetRemoteAddress(Socket, &RemoteAddress);
+    CXPLAT_ROUTE Route;
+    CxPlatSocketGetLocalAddress(Socket, &Route.LocalAddress);
+    CxPlatSocketGetRemoteAddress(Socket, &Route.RemoteAddress);
 
     QUIC_ADDR LocalMappedAddress;
-    CxPlatConvertToMappedV6(&LocalAddress, &LocalMappedAddress);
+    CxPlatConvertToMappedV6(&Route.LocalAddress, &LocalMappedAddress);
 
     QUIC_ADDR RemotePeerMappedAddress;
     CxPlatConvertToMappedV6(RemotePeerAddress, &RemotePeerMappedAddress);
 
     CXPLAT_SEND_DATA* SendData =
-        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_PEER_REQUEST_SIZE);
+        CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, PCP_PEER_REQUEST_SIZE, &Route);
     if (SendData == NULL) {
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
@@ -527,9 +527,6 @@ CxPlatPcpSendPeerRequestInternal(
         sizeof(Request->PEER.RemotePeerIpAddress));
     Request->PEER.RemotePeerPort = RemotePeerMappedAddress.Ipv6.sin6_port;
 
-    CXPLAT_ROUTE Route;
-    Route.LocalAddress = LocalAddress;
-    Route.RemoteAddress = RemoteAddress;
     QUIC_STATUS Status =
         CxPlatSocketSend(
             Socket,

--- a/src/test/lib/QuicDrill.cpp
+++ b/src/test/lib/QuicDrill.cpp
@@ -200,7 +200,7 @@ struct DrillSender {
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
+                Binding, CXPLAT_ECN_NON_ECT, DatagramLength, &Route);
 
         QUIC_BUFFER* SendBuffer =
             CxPlatSendDataAllocBuffer(SendData, DatagramLength);

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -117,7 +117,7 @@ void RunAttackRandom(CXPLAT_SOCKET* Binding, uint16_t Length, bool ValidQuic)
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, Length);
+                Binding, CXPLAT_ECN_NON_ECT, Length, &Route);
         if (SendData == nullptr) {
             printf("CxPlatSendDataAlloc failed\n");
             return;
@@ -221,7 +221,7 @@ void RunAttackValidInitial(CXPLAT_SOCKET* Binding)
 
         CXPLAT_SEND_DATA* SendData =
             CxPlatSendDataAlloc(
-                Binding, CXPLAT_ECN_NON_ECT, DatagramLength);
+                Binding, CXPLAT_ECN_NON_ECT, DatagramLength, &Route);
         VERIFY(SendData);
 
         while (CxPlatTimeDiff64(TimeStart, CxPlatTimeMs64()) < TimeoutMs &&

--- a/src/tools/lb/loadbalancer.cpp
+++ b/src/tools/lb/loadbalancer.cpp
@@ -67,13 +67,13 @@ struct LbInterface {
         CXPLAT_SEND_DATA* Send = nullptr;
         while (RecvDataChain) {
             if (!Send) {
-                Send = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, MAX_UDP_PAYLOAD_LENGTH);
+                Send = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, MAX_UDP_PAYLOAD_LENGTH, &Route);
             }
             if (Send) {
                 auto Buffer = CxPlatSendDataAllocBuffer(Send, MAX_UDP_PAYLOAD_LENGTH);
                 if (!Buffer) {
                     (void)CxPlatSocketSend(Socket, &Route, Send, 0);
-                    Send = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, MAX_UDP_PAYLOAD_LENGTH);
+                    Send = CxPlatSendDataAlloc(Socket, CXPLAT_ECN_NON_ECT, MAX_UDP_PAYLOAD_LENGTH, &Route);
                     if (Send) {
                         Buffer = CxPlatSendDataAllocBuffer(Send, MAX_UDP_PAYLOAD_LENGTH);
                     }


### PR DESCRIPTION
Extracts out the change to pass the route to the send alloc function from #2165 to make that PR simpler to review.