### PR TITLE
Clean up cmake install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,45 +63,6 @@ elseif (UNIX)
 endif()
 message(STATUS "QUIC Platform: ${CX_PLATFORM}")
 
-if(WIN32)
-    # On Windows, we just need to set the destination variables
-    # This will allow the build to be picked up by other projects
-    set(msquic_dest ${CMAKE_INSTALL_PREFIX})
-    set(main_lib_dest lib)
-    set(include_dest include)
-else()
-    # On unix platforms, we need to do rpath manipulation for the shared library
-    # In addition, we install into a subfolder of install to not polute the global namespace
-
-    # Setup for Install. We set this up in here rather then in the main library folder for future use.
-    # i.e. don't skip the full RPATH for the build tree
-    #set(CMAKE_SKIP_BUILD_RPATH FALSE)
-
-    # When building, don't use the install RPATH already
-    # (but later on when installing)
-    #set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-    # Azure is not liking this argument. I think its a bug in their configuration
-    # Once this is fixed, also fix the shim in build-config-user.yml
-    #set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
-
-    #set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/msquic/lib")
-
-    # Add the automatically determined parts of the RPATH
-    # which point to directories outside the build tree to the install RPATH
-    #set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-    # The RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/msquic/lib" isSystemDir)
-    if("${isSystemDir}" STREQUAL "-1")
-    #set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/msquic/lib")
-    endif("${isSystemDir}" STREQUAL "-1")
-
-    set(msquic_dest msquic)
-    set(main_lib_dest msquic/lib)
-    set(include_dest msquic/include)
-endif()
-
 set(FILENAME_DEP_REPLACE "get_filename_component(SELF_DIR \"$\{CMAKE_CURRENT_LIST_FILE\}\" PATH)")
 set(SELF_DIR "$\{SELF_DIR\}")
 

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -5,10 +5,9 @@ use cmake::Config;
 use std::path::Path;
 
 fn main() {
-    let mut path_extra = "lib";
+    let path_extra = "lib";
     let mut logging_enabled = "off";
     if cfg!(windows) {
-        path_extra = "lib";
         logging_enabled = "on";
     }
 

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -5,7 +5,7 @@ use cmake::Config;
 use std::path::Path;
 
 fn main() {
-    let mut path_extra = "msquic/lib";
+    let mut path_extra = "lib";
     let mut logging_enabled = "off";
     if cfg!(windows) {
         path_extra = "lib";

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -262,15 +262,15 @@ set(PUBLIC_HEADERS
     ../inc/msquic_posix.h
     ../inc/quic_sal_stub.h)
 
-install(TARGETS msquic EXPORT msquic DESTINATION "${main_lib_dest}")
-install(FILES ${PUBLIC_HEADERS} DESTINATION "${include_dest}")
+install(TARGETS msquic EXPORT msquic DESTINATION lib)
+install(FILES ${PUBLIC_HEADERS} DESTINATION include)
 
 configure_file(msquic-config.cmake.in ${CMAKE_BINARY_DIR}/msquic-config.cmake)
 
-install(FILES ${CMAKE_BINARY_DIR}/msquic-config.cmake DESTINATION ${msquic_dest})
+install(FILES ${CMAKE_BINARY_DIR}/msquic-config.cmake DESTINATION share/msquic)
 
 if(BUILD_SHARED_LIBS)
-    install(EXPORT msquic DESTINATION ${msquic_dest})
+    install(EXPORT msquic DESTINATION share/msquic)
 endif()
 
 if (MSVC AND NOT QUIC_ENABLE_SANITIZERS AND BUILD_SHARED_LIBS)

--- a/src/generated/CMakeLists.txt
+++ b/src/generated/CMakeLists.txt
@@ -22,7 +22,7 @@ if(QUIC_ENABLE_LOGGING)
         target_link_libraries(msquic.lttng PRIVATE logging_inc inc)
         target_link_libraries(msquic.lttng PRIVATE ${LTTNGUST_LIBRARIES})
 
-        install(TARGETS msquic.lttng DESTINATION "${main_lib_dest}")
+        install(TARGETS msquic.lttng DESTINATION lib)
     endif()
 else()
     add_library(logging INTERFACE)


### PR DESCRIPTION
Removes /msquic from library install path, as it does make using raw gcc harder, and is non standard. Cmake install process is tested to still work

Replaces #2169 

@ami-GS the cmake target needed another change, and I realized I could remove all the boilerplate in the root cmake file, as it was completely unnecessary. I tested that both a raw gcc build and a build using cmake's find_package still work.