### PR TITLE
Fix Crypto Spelling Mistakes

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1693,7 +1693,7 @@ QuicCryptoProcessData(
         QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
 
         Buffer.Length =
-            QuicCrytpoTlsGetCompleteTlsMessagesLength(
+            QuicCryptoTlsGetCompleteTlsMessagesLength(
                 Buffer.Buffer, Buffer.Length);
         if (Buffer.Length == 0) {
             QuicTraceLogConnVerbose(

--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -273,7 +273,7 @@ QuicCryptoCustomCertValidationComplete(
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
 uint32_t
-QuicCrytpoTlsGetCompleteTlsMessagesLength(
+QuicCryptoTlsGetCompleteTlsMessagesLength(
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -576,7 +576,7 @@ QuicCryptoTlsReadClientHello(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 uint32_t
-QuicCrytpoTlsGetCompleteTlsMessagesLength(
+QuicCryptoTlsGetCompleteTlsMessagesLength(
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -17,7 +17,7 @@ Abstract:
 
 // ############################# HELPERS #############################
 
-#define FRAME_TYPE_CRYTPO   0
+#define FRAME_TYPE_CRYPTO   0
 #define FRAME_TYPE_STREAM   1
 
 #pragma pack(push)
@@ -639,7 +639,7 @@ bool TcpConnection::SendTlsData(const uint8_t* Buffer, uint16_t BufferLength, ui
     }
 
     auto Frame = (TcpFrame*)SendBuffer->Buffer;
-    Frame->FrameType = FRAME_TYPE_CRYTPO;
+    Frame->FrameType = FRAME_TYPE_CRYPTO;
     Frame->Length = BufferLength;
     Frame->KeyType = KeyType;
     CxPlatCopyMemory(Frame->Data, Buffer, BufferLength);
@@ -754,7 +754,7 @@ bool TcpConnection::ProcessReceiveFrame(TcpFrame* Frame)
     }
 
     switch (Frame->FrameType) {
-    case FRAME_TYPE_CRYTPO:
+    case FRAME_TYPE_CRYPTO:
         if (!ProcessTls(Frame->Data, Frame->Length)) {
             return false;
         }


### PR DESCRIPTION
Thanks to @wqweto for finding. `crytpo` -> `crypto`