### PR TITLE
Set release build in pwsh to relwithdbginfo on unix

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -353,7 +353,11 @@ function CMake-Generate {
         $Arguments += " -DQUIC_BUILD_PERF=off"
     }
     if (!$IsWindows) {
-        $Arguments += " -DCMAKE_BUILD_TYPE=" + $Config
+        $ConfigToBuild = $Config;
+        if ($Config -eq "Release") {
+            $ConfigToBuild = "RelWithDebInfo"
+        }
+        $Arguments += " -DCMAKE_BUILD_TYPE=" + $ConfigToBuild
     }
     if ($DynamicCRT) {
         $Arguments += " -DQUIC_STATIC_LINK_CRT=off"


### PR DESCRIPTION
Since we're open source, we don't mind having debug symbols in the object. And in release mode, debug symbols still help if crashes occur in the wild. So in pwsh builds, set release to relwithdebinfo, which will enable debug symbols for release mode.