### PR TITLE
Fix connection mishandling out of order initial packets with retrys

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3519,10 +3519,23 @@ QuicConnRecvHeader(
         }
 
         QUIC_PATH* Path = &Connection->Paths[0];
-        if (!Path->IsPeerValidated && Packet->ValidToken) {
+        if (!Path->IsPeerValidated && (Packet->ValidToken || TokenLength != 0)) {
 
-            CXPLAT_DBG_ASSERT(TokenBuffer == NULL);
-            QuicPacketDecodeRetryTokenV1(Packet, &TokenBuffer, &TokenLength);
+            if (Packet->ValidToken) {
+                CXPLAT_DBG_ASSERT(TokenBuffer == NULL);
+                CXPLAT_DBG_ASSERT(TokenLength == 0);
+                QuicPacketDecodeRetryTokenV1(Packet, &TokenBuffer, &TokenLength);
+            } else {
+                CXPLAT_DBG_ASSERT(TokenBuffer != NULL);
+                if (!QuicPacketValidateRetryToken(
+                        Connection,
+                        Packet,
+                        TokenLength,
+                        TokenBuffer)) {
+                    return FALSE;
+                }
+            }
+
             CXPLAT_DBG_ASSERT(TokenBuffer != NULL);
             CXPLAT_DBG_ASSERT(TokenLength == sizeof(QUIC_RETRY_TOKEN_CONTENTS));
 
@@ -3581,7 +3594,6 @@ QuicConnRecvHeader(
                 Connection->OrigDestCID->Data,
                 Packet->DestCid,
                 Packet->DestCidLen);
-
         }
 
         Packet->KeyType = QuicPacketTypeToKeyType(Packet->LH->Type);

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -473,6 +473,45 @@ QuicPacketDecodeRetryTokenV1(
     *TokenLength = (uint16_t)TokenLengthVarInt;
 }
 
+//
+// Returns TRUE if the retry token was successfully decrypted and validated.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+QuicPacketValidateRetryToken(
+    _In_ const void* const Owner,
+    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ uint16_t TokenLength,
+    _In_reads_(TokenLength)
+        const uint8_t* TokenBuffer
+    )
+{
+    if (TokenLength != sizeof(QUIC_RETRY_TOKEN_CONTENTS)) {
+        QuicPacketLogDrop(Owner, Packet, "Invalid Retry Token Length");
+        return FALSE;
+    }
+
+    QUIC_RETRY_TOKEN_CONTENTS Token;
+    if (!QuicRetryTokenDecrypt(Packet, TokenBuffer, &Token)) {
+        QuicPacketLogDrop(Owner, Packet, "Retry Token Decryption Failure");
+        return FALSE;
+    }
+
+    if (Token.Encrypted.OrigConnIdLength > sizeof(Token.Encrypted.OrigConnId)) {
+        QuicPacketLogDrop(Owner, Packet, "Invalid Retry Token OrigConnId Length");
+        return FALSE;
+    }
+
+    const CXPLAT_RECV_DATA* Datagram =
+        CxPlatDataPathRecvPacketToRecvData(Packet);
+    if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Datagram->Route->RemoteAddress)) {
+        QuicPacketLogDrop(Owner, Packet, "Retry Token Addr Mismatch");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -284,6 +284,16 @@ QuicPacketDecodeRetryTokenV1(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+QuicPacketValidateRetryToken(
+    _In_ const void* const Owner,
+    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ uint16_t TokenLength,
+    _In_reads_(TokenLength)
+        const uint8_t* TokenBuffer
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN
 QuicPacketValidateShortHeaderV1(


### PR DESCRIPTION
Closes #2150 

In loopback scenarios, it is possible for multiple initial packets with retry tokens to be received at the same time on different threads. If this happens, its possible for the packet that isn't creating the connection to be queued first on the connection. This packet won't have its retry token validated, causing the non retry token path to be taken through the connection code. When the packet with the validated token is then handled, its expecting different state and asserts.

The solution is to always validate the retry token if it exists in the long header packet.