### PR TITLE
XDP automatically binds to all supported interfaces at startup

### DIFF
--- a/src/generated/linux/datapath_raw_dpdk.c.clog.h
+++ b/src/generated/linux/datapath_raw_dpdk.c.clog.h
@@ -294,6 +294,28 @@ tracepoint(CLOG_DATAPATH_RAW_DPDK_C, LibraryErrorStatus , arg2, arg3);\
 // QuicTraceEvent(
             LibraryErrorStatus,
             "[ lib] ERROR, %u, %s.",
+            Status,
+            "GetIfTable2");
+// arg2 = arg2 = Status
+// arg3 = arg3 = "GetIfTable2"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryErrorStatus
+// [ lib] ERROR, %u, %s.
+// QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
             ret,
             "rte_eal_mp_remote_launch");
 // arg2 = arg2 = ret

--- a/src/generated/linux/datapath_raw_socket.c.clog.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h
@@ -259,24 +259,23 @@ tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathErrorStatus , arg2, arg3, arg4);\
 
 
 
-#ifndef _clog_5_ARGS_TRACE_DatapathErrorStatus
+#ifndef _clog_4_ARGS_TRACE_DatapathError
 
 
 
 /*----------------------------------------------------------
-// Decoder Ring for DatapathErrorStatus
-// [data][%p] ERROR, %u, %s.
+// Decoder Ring for DatapathError
+// [data][%p] ERROR, %s.
 // QuicTraceEvent(
-            DatapathErrorStatus,
-            "[data][%p] ERROR, %u, %s.",
+            DatapathError,
+            "[data][%p] ERROR, %s.",
             Socket,
-            ERROR_NOT_FOUND,
             "no matching interface");
 // arg2 = arg2 = Socket
-// arg3 = arg3 = ERROR_NOT_FOUND
-// arg4 = arg4 = "no matching interface"
+// arg3 = arg3 = "no matching interface"
 ----------------------------------------------------------*/
-#define _clog_5_ARGS_TRACE_DatapathErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
+#define _clog_4_ARGS_TRACE_DatapathError(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathError , arg2, arg3);\
 
 #endif
 

--- a/src/generated/linux/datapath_raw_socket.c.clog.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h
@@ -269,6 +269,30 @@ tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathErrorStatus , arg2, arg3, arg4);\
 // QuicTraceEvent(
             DatapathErrorStatus,
             "[data][%p] ERROR, %u, %s.",
+            Socket,
+            ERROR_NOT_FOUND,
+            "no matching interface");
+// arg2 = arg2 = Socket
+// arg3 = arg3 = ERROR_NOT_FOUND
+// arg4 = arg4 = "no matching interface"
+----------------------------------------------------------*/
+#define _clog_5_ARGS_TRACE_DatapathErrorStatus(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
+
+#endif
+
+
+
+
+#ifndef _clog_5_ARGS_TRACE_DatapathErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for DatapathErrorStatus
+// [data][%p] ERROR, %u, %s.
+// QuicTraceEvent(
+            DatapathErrorStatus,
+            "[data][%p] ERROR, %u, %s.",
             Datapath,
             Length,
             "packet is too small for an IPv4 header");

--- a/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
@@ -48,3 +48,26 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathErrorStatus,
         ctf_string(arg4, arg4)
     )
 )
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for DatapathError
+// [data][%p] ERROR, %s.
+// QuicTraceEvent(
+            DatapathError,
+            "[data][%p] ERROR, %s.",
+            Socket,
+            "no matching interface");
+// arg2 = arg2 = Socket
+// arg3 = arg3 = "no matching interface"
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathError,
+    TP_ARGS(
+        const void *, arg2,
+        const char *, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg2, arg2)
+        ctf_string(arg3, arg3)
+    )
+)

--- a/src/generated/linux/datapath_raw_xdp.c.clog.h
+++ b/src/generated/linux/datapath_raw_xdp.c.clog.h
@@ -227,28 +227,6 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
-            AllocFailure,
-            "Allocation of '%s' failed. (%llu bytes)",
-            "XDP Queues",
-            Interface->QueueCount * sizeof(*Interface->Queues));
-// arg2 = arg2 = "XDP Queues"
-// arg3 = arg3 = Interface->QueueCount * sizeof(*Interface->Queues)
-----------------------------------------------------------*/
-#define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
-
-#endif
-
-
-
-
-#ifndef _clog_4_ARGS_TRACE_AllocFailure
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for AllocFailure
-// Allocation of '%s' failed. (%llu bytes)
-// QuicTraceEvent(
                 AllocFailure,
                 "Allocation of '%s' failed. (%llu bytes)",
                 "XDP RX Buffers",
@@ -571,22 +549,22 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
 
 
 
-#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+#ifndef _clog_4_ARGS_TRACE_AllocFailure
 
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryErrorStatus
-// [ lib] ERROR, %u, %s.
+// Decoder Ring for AllocFailure
+// Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "GetIfTable2");
-// arg2 = arg2 = Status
-// arg3 = arg3 = "GetIfTable2"
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "XDP interface",
+                AdaptersBufferSize);
+// arg2 = arg2 = "XDP interface"
+// arg3 = arg3 = AdaptersBufferSize
 ----------------------------------------------------------*/
-#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+#define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
 
 #endif
 
@@ -601,10 +579,10 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
-                    AllocFailure,
-                    "Allocation of '%s' failed. (%llu bytes)",
-                    "XDP interface",
-                    sizeof(*Interface));
+                        AllocFailure,
+                        "Allocation of '%s' failed. (%llu bytes)",
+                        "XDP interface",
+                        sizeof(*Interface));
 // arg2 = arg2 = "XDP interface"
 // arg3 = arg3 = sizeof(*Interface)
 ----------------------------------------------------------*/
@@ -623,14 +601,57 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
 // Decoder Ring for LibraryErrorStatus
 // [ lib] ERROR, %u, %s.
 // QuicTraceEvent(
-                    LibraryErrorStatus,
-                    "[ lib] ERROR, %u, %s.",
-                    Status,
-                    "CxPlatDpRawInterfaceInitialize");
+                        LibraryErrorStatus,
+                        "[ lib] ERROR, %u, %s.",
+                        Status,
+                        "CxPlatDpRawInterfaceInitialize");
 // arg2 = arg2 = Status
 // arg3 = arg3 = "CxPlatDpRawInterfaceInitialize"
 ----------------------------------------------------------*/
 #define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryErrorStatus
+// [ lib] ERROR, %u, %s.
+// QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "CxPlatThreadCreate");
+// arg2 = arg2 = Status
+// arg3 = arg3 = "CxPlatThreadCreate"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_3_ARGS_TRACE_LibraryError
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "no XDP capable interface");
+// arg2 = arg2 = "no XDP capable interface"
+----------------------------------------------------------*/
+#define _clog_3_ARGS_TRACE_LibraryError(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_DATAPATH_RAW_XDP_C, LibraryError , arg2);\
 
 #endif
 

--- a/src/generated/linux/datapath_raw_xdp.c.clog.h
+++ b/src/generated/linux/datapath_raw_xdp.c.clog.h
@@ -207,12 +207,34 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, LibraryErrorStatus , arg2, arg3);\
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "XDP Queues",
-            Xdp->QueueCount * sizeof(*Xdp->Queues));
+            Interface->QueueCount * sizeof(*Interface->Queues));
 // arg2 = arg2 = "XDP Queues"
-// arg3 = arg3 = Xdp->QueueCount * sizeof(*Xdp->Queues)
+// arg3 = arg3 = Interface->QueueCount * sizeof(*Interface->Queues)
 ----------------------------------------------------------*/
 #define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
 tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_AllocFailure
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for AllocFailure
+// Allocation of '%s' failed. (%llu bytes)
+// QuicTraceEvent(
+            AllocFailure,
+            "Allocation of '%s' failed. (%llu bytes)",
+            "XDP Queues",
+            Interface->QueueCount * sizeof(*Interface->Queues));
+// arg2 = arg2 = "XDP Queues"
+// arg3 = arg3 = Interface->QueueCount * sizeof(*Interface->Queues)
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
 
 #endif
 
@@ -541,6 +563,72 @@ tracepoint(CLOG_DATAPATH_RAW_XDP_C, AllocFailure , arg2, arg3);\
                 "XskGetSockopt(XSK_SOCKOPT_RING_INFO)");
 // arg2 = arg2 = Status
 // arg3 = arg3 = "XskGetSockopt(XSK_SOCKOPT_RING_INFO)"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryErrorStatus
+// [ lib] ERROR, %u, %s.
+// QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "GetIfTable2");
+// arg2 = arg2 = Status
+// arg3 = arg3 = "GetIfTable2"
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_AllocFailure
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for AllocFailure
+// Allocation of '%s' failed. (%llu bytes)
+// QuicTraceEvent(
+                    AllocFailure,
+                    "Allocation of '%s' failed. (%llu bytes)",
+                    "XDP interface",
+                    sizeof(*Interface));
+// arg2 = arg2 = "XDP interface"
+// arg3 = arg3 = sizeof(*Interface)
+----------------------------------------------------------*/
+#define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
+
+#endif
+
+
+
+
+#ifndef _clog_4_ARGS_TRACE_LibraryErrorStatus
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryErrorStatus
+// [ lib] ERROR, %u, %s.
+// QuicTraceEvent(
+                    LibraryErrorStatus,
+                    "[ lib] ERROR, %u, %s.",
+                    Status,
+                    "CxPlatDpRawInterfaceInitialize");
+// arg2 = arg2 = Status
+// arg3 = arg3 = "CxPlatDpRawInterfaceInitialize"
 ----------------------------------------------------------*/
 #define _clog_4_ARGS_TRACE_LibraryErrorStatus(uniqueId, encoded_arg_string, arg2, arg3)\
 

--- a/src/generated/linux/datapath_raw_xdp.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_xdp.c.clog.h.lttng.h
@@ -44,3 +44,22 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_XDP_C, AllocFailure,
         ctf_integer(uint64_t, arg3, arg3)
     )
 )
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "no XDP capable interface");
+// arg2 = arg2 = "no XDP capable interface"
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_XDP_C, LibraryError,
+    TP_ARGS(
+        const char *, arg2), 
+    TP_FIELDS(
+        ctf_string(arg2, arg2)
+    )
+)

--- a/src/generated/linux/datapath_raw_xdp.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_xdp.c.clog.h.lttng.h
@@ -31,9 +31,9 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_XDP_C, LibraryErrorStatus,
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "XDP Queues",
-            Xdp->QueueCount * sizeof(*Xdp->Queues));
+            Interface->QueueCount * sizeof(*Interface->Queues));
 // arg2 = arg2 = "XDP Queues"
-// arg3 = arg3 = Xdp->QueueCount * sizeof(*Xdp->Queues)
+// arg3 = arg3 = Interface->QueueCount * sizeof(*Interface->Queues)
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_XDP_C, AllocFailure,
     TP_ARGS(

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -141,6 +141,21 @@ typedef struct CXPLAT_SEND_DATA CXPLAT_SEND_DATA;
 //
 typedef struct QUIC_BUFFER QUIC_BUFFER;
 
+typedef struct CXPLAT_INTERFACE {
+    CXPLAT_LIST_ENTRY Link;
+    uint32_t IfIndex;
+    struct {
+        struct {
+            BOOLEAN NetworkLayerXsum : 1;
+            BOOLEAN TransportLayerXsum : 1;
+        } Transmit;
+        struct {
+            BOOLEAN NetworkLayerXsum : 1;
+            BOOLEAN TransportLayerXsum : 1;
+        } Receive;
+    } OffloadStatus;
+} CXPLAT_INTERFACE;
+
 //
 // Structure to represent a network route.
 //
@@ -153,7 +168,7 @@ typedef struct CXPLAT_ROUTE {
     uint8_t NextHopLinkLayerAddress[6];
     BOOLEAN Resolved; // When TRUE, LocalLinkLayerAddress and NextHopLinkLayerAddress are valid.
     uint8_t QueueId;
-
+    CXPLAT_INTERFACE* Interface;
 } CXPLAT_ROUTE;
 
 //

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -144,6 +144,7 @@ typedef struct QUIC_BUFFER QUIC_BUFFER;
 typedef struct CXPLAT_INTERFACE {
     CXPLAT_LIST_ENTRY Link;
     uint32_t IfIndex;
+    UCHAR PhysicalAddress[6];
     struct {
         struct {
             BOOLEAN NetworkLayerXsum : 1;

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -141,21 +141,7 @@ typedef struct CXPLAT_SEND_DATA CXPLAT_SEND_DATA;
 //
 typedef struct QUIC_BUFFER QUIC_BUFFER;
 
-typedef struct CXPLAT_INTERFACE {
-    CXPLAT_LIST_ENTRY Link;
-    uint32_t IfIndex;
-    UCHAR PhysicalAddress[6];
-    struct {
-        struct {
-            BOOLEAN NetworkLayerXsum : 1;
-            BOOLEAN TransportLayerXsum : 1;
-        } Transmit;
-        struct {
-            BOOLEAN NetworkLayerXsum : 1;
-            BOOLEAN TransportLayerXsum : 1;
-        } Receive;
-    } OffloadStatus;
-} CXPLAT_INTERFACE;
+typedef struct CXPLAT_INTERFACE CXPLAT_INTERFACE;
 
 //
 // Structure to represent a network route.

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -8821,6 +8821,22 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "DatapathError": {
+      "ModuleProperites": {},
+      "TraceString": "[data][%p] ERROR, %s.",
+      "UniqueId": "DatapathError",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "DatapathOpenTcpSocketFailed": {
       "ModuleProperites": {},
       "TraceString": "[data] RSS helper socket failed to open, 0x%x",
@@ -12983,6 +12999,10 @@
       {
         "UniquenessHash": "20cf52f5-ef36-a45b-6a54-29e5eaac7f19",
         "TraceID": "DatapathSend"
+      },
+      {
+        "UniquenessHash": "2b127bfd-4623-d1ad-f438-977d808c9514",
+        "TraceID": "DatapathError"
       },
       {
         "UniquenessHash": "6eeae539-95db-bea9-7e36-8635006dae40",

--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -440,10 +440,12 @@ CxPlatSocketSend(
         CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress),
         CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress));
     CXPLAT_DBG_ASSERT(Route->Resolved);
+    CXPLAT_DBG_ASSERT(Route->Interface != NULL);
+    CXPLAT_INTERFACE* Interface = Route->Interface;
     CxPlatFramingWriteHeaders(
         Socket, Route, &SendData->Buffer,
-        Socket->Datapath->OffloadStatus.Transmit.NetworkLayerXsum,
-        Socket->Datapath->OffloadStatus.Transmit.TransportLayerXsum);
+        Interface->OffloadStatus.Transmit.NetworkLayerXsum,
+        Interface->OffloadStatus.Transmit.TransportLayerXsum);
     CxPlatDpRawTxEnqueue(SendData);
     return QUIC_STATUS_SUCCESS;
 }

--- a/src/platform/datapath_raw.h
+++ b/src/platform/datapath_raw.h
@@ -31,10 +31,12 @@ typedef struct CXPLAT_DATAPATH {
 
 } CXPLAT_DATAPATH;
 
+#define ETH_MAC_ADDR_LEN 6
+
 typedef struct CXPLAT_INTERFACE {
     CXPLAT_LIST_ENTRY Link;
     uint32_t IfIndex;
-    UCHAR PhysicalAddress[6];
+    UCHAR PhysicalAddress[ETH_MAC_ADDR_LEN];
     struct {
         struct {
             BOOLEAN NetworkLayerXsum : 1;

--- a/src/platform/datapath_raw.h
+++ b/src/platform/datapath_raw.h
@@ -31,6 +31,22 @@ typedef struct CXPLAT_DATAPATH {
 
 } CXPLAT_DATAPATH;
 
+typedef struct CXPLAT_INTERFACE {
+    CXPLAT_LIST_ENTRY Link;
+    uint32_t IfIndex;
+    UCHAR PhysicalAddress[6];
+    struct {
+        struct {
+            BOOLEAN NetworkLayerXsum : 1;
+            BOOLEAN TransportLayerXsum : 1;
+        } Transmit;
+        struct {
+            BOOLEAN NetworkLayerXsum : 1;
+            BOOLEAN TransportLayerXsum : 1;
+        } Receive;
+    } OffloadStatus;
+} CXPLAT_INTERFACE;
+
 typedef struct CXPLAT_SEND_DATA {
 
     QUIC_BUFFER Buffer;

--- a/src/platform/datapath_raw.h
+++ b/src/platform/datapath_raw.h
@@ -27,16 +27,7 @@ typedef struct CXPLAT_DATAPATH {
     uint8_t CpuTableSize;
     uint16_t CpuTable[64];
 
-    struct {
-        struct {
-            BOOLEAN NetworkLayerXsum : 1;
-            BOOLEAN TransportLayerXsum : 1;
-        } Transmit;
-        struct {
-            BOOLEAN NetworkLayerXsum : 1;
-            BOOLEAN TransportLayerXsum : 1;
-        } Receive;
-    } OffloadStatus;
+    CXPLAT_LIST_ENTRY Interfaces;
 
 } CXPLAT_DATAPATH;
 

--- a/src/platform/datapath_raw_dpdk.c
+++ b/src/platform/datapath_raw_dpdk.c
@@ -512,7 +512,7 @@ CxPlatDpdkRx(
     DPDK_RX_PACKET Packet; // Working space
     CxPlatZeroMemory(&Packet, sizeof(DPDK_RX_PACKET));
     Packet.Route = &Packet.RouteStorage;
-    Packet.Route->Interface = Interface;
+    Packet.Route->Interface = (CXPLAT_INTERFACE*)Interface;
 
     uint16_t PacketCount = 0;
     for (uint16_t i = 0; i < BuffersCount; i++) {
@@ -579,7 +579,7 @@ CxPlatDpRawTxAlloc(
     DPDK_DATAPATH* Dpdk = (DPDK_DATAPATH*)Datapath;
     DPDK_TX_PACKET* Packet = CxPlatPoolAlloc(&Dpdk->AdditionalInfoPool);
     QUIC_ADDRESS_FAMILY Family = QuicAddrGetFamily(&Route->RemoteAddress);
-    DPDK_INTERFACE* Interface = Route->Interface;
+    DPDK_INTERFACE* Interface = (DPDK_INTERFACE*)Route->Interface;
 
     if (likely(Packet)) {
         Packet->Interface = Interface;

--- a/src/platform/datapath_raw_dpdk.c
+++ b/src/platform/datapath_raw_dpdk.c
@@ -440,6 +440,7 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
             !IfRow->InterfaceAndOperStatusFlags.Paused &&
             IfRow->OperStatus == IfOperStatusUp &&
             IfRow->MediaType == NdisMedium802_3 &&
+            IfRow->PhysicalAddressLength == 6 &&
             memcmp(IfRow->PhysicalAddress, addr.addr_bytes, IfRow->PhysicalAddressLength) == 0) {
             Dpdk->Interface.IfIndex = IfRow->InterfaceIndex;
             break;

--- a/src/platform/datapath_raw_dpdk.c
+++ b/src/platform/datapath_raw_dpdk.c
@@ -36,6 +36,19 @@ Abstract:
 #define TX_BURST_SIZE 16
 #define TX_RING_SIZE 1024
 
+typedef struct DPDK_INTERFACE {
+
+    CXPLAT_INTERFACE;
+
+    uint16_t Port;
+    CXPLAT_LOCK TxLock;
+    struct rte_mempool* MemoryPool;
+    struct rte_ring* TxRingBuffer;
+
+    // Constants
+    char DeviceName[32];
+} DPDK_INTERFACE;
+
 typedef struct DPDK_DATAPATH {
 
     CXPLAT_DATAPATH;
@@ -47,13 +60,7 @@ typedef struct DPDK_DATAPATH {
 
     CXPLAT_POOL AdditionalInfoPool;
 
-    uint16_t Port;
-    CXPLAT_LOCK TxLock;
-    struct rte_mempool* MemoryPool;
-    struct rte_ring* TxRingBuffer;
-
-    // Constants
-    char DeviceName[32];
+    DPDK_INTERFACE Interface; // TODO: support multiple NIC interfaces.
 
 } DPDK_DATAPATH;
 
@@ -68,6 +75,7 @@ typedef struct DPDK_TX_PACKET {
     CXPLAT_SEND_DATA;
     struct rte_mbuf* Mbuf;
     DPDK_DATAPATH* Dpdk;
+    DPDK_INTERFACE* Interface;
 } DPDK_TX_PACKET;
 
 CXPLAT_STATIC_ASSERT(
@@ -120,7 +128,7 @@ CxPlatDpdkReadConfig(
         if (strcmp(Line, "CPU") == 0) {
              Dpdk->Cpu = (uint16_t)strtoul(Value, NULL, 10);
         } else if (strcmp(Line, "DeviceName") == 0) {
-             strcpy(Dpdk->DeviceName, Value);
+             strcpy(Dpdk->Interface.DeviceName, Value);
         }
     }
 
@@ -156,7 +164,9 @@ CxPlatDpRawInitialize(
     BOOLEAN CleanUpThread = FALSE;
     CxPlatEventInitialize(&Dpdk->StartComplete, TRUE, FALSE);
     CxPlatPoolInitialize(FALSE, AdditionalBufferSize, QUIC_POOL_DATAPATH, &Dpdk->AdditionalInfoPool);
-    CxPlatLockInitialize(&Dpdk->TxLock);
+    CxPlatLockInitialize(&Dpdk->Interface.TxLock);
+    CxPlatListInitializeHead(&Dpdk->Interfaces);
+    CxPlatListInsertTail(&Dpdk->Interfaces, &Dpdk->Interface.Link);
 
     //
     // This starts a new thread to do all the DPDK initialization because DPDK
@@ -183,7 +193,7 @@ Error:
 
     if (QUIC_FAILED(Status)) {
         if (CleanUpThread) {
-            CxPlatLockUninitialize(&Dpdk->TxLock);
+            CxPlatLockUninitialize(&Dpdk->Interface.TxLock);
             CxPlatPoolUninitialize(&Dpdk->AdditionalInfoPool);
             CxPlatThreadWait(&Dpdk->DpdkThread);
             CxPlatThreadDelete(&Dpdk->DpdkThread);
@@ -202,7 +212,7 @@ CxPlatDpRawUninitialize(
 {
     DPDK_DATAPATH* Dpdk = (DPDK_DATAPATH*)Datapath;
     Dpdk->Running = FALSE;
-    CxPlatLockUninitialize(&Dpdk->TxLock);
+    CxPlatLockUninitialize(&Dpdk->Interface.TxLock);
     CxPlatPoolUninitialize(&Dpdk->AdditionalInfoPool);
     CxPlatThreadWait(&Dpdk->DpdkThread);
     CxPlatThreadDelete(&Dpdk->DpdkThread);
@@ -254,14 +264,15 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
     }
     CleanUpRte = TRUE;
 
-    if (Dpdk->DeviceName[0] != '\0') {
-        ret = rte_eth_dev_get_port_by_name(Dpdk->DeviceName, &Port);
+    if (Dpdk->Interface.DeviceName[0] != '\0') {
+        ret = rte_eth_dev_get_port_by_name(Dpdk->Interface.DeviceName, &Port);
     } else {
         ret = rte_eth_dev_get_port_by_name("0000:81:00.0", &Port);
         if (ret < 0) {
             ret = rte_eth_dev_get_port_by_name("0000:81:00.1", &Port);
         }
     }
+
     if (ret < 0) {
         QuicTraceEvent(
             LibraryErrorStatus,
@@ -271,13 +282,13 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
         Status = QUIC_STATUS_INTERNAL_ERROR;
         goto Error;
     }
-    Dpdk->Port = Port;
 
-    Dpdk->MemoryPool =
+    Dpdk->Interface.Port = Port;
+    Dpdk->Interface.MemoryPool =
         rte_pktmbuf_pool_create(
             "MBUF_POOL", NUM_MBUFS, MBUF_CACHE_SIZE, 0,
             RTE_MBUF_DEFAULT_BUF_SIZE, rte_eth_dev_socket_id(Port));
-    if (Dpdk->MemoryPool == NULL) {
+    if (Dpdk->Interface.MemoryPool == NULL) {
         QuicTraceEvent(
             LibraryErrorStatus,
             "[ lib] ERROR, %u, %s.",
@@ -287,11 +298,11 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
         goto Error;
     }
 
-    Dpdk->TxRingBuffer =
+    Dpdk->Interface.TxRingBuffer =
         rte_ring_create(
             "TxRing", TX_RING_SIZE, rte_eth_dev_socket_id(Port),
             RING_F_MP_HTS_ENQ | RING_F_SC_DEQ);
-    if (Dpdk->TxRingBuffer == NULL) {
+    if (Dpdk->Interface.TxRingBuffer == NULL) {
         QuicTraceEvent(
             LibraryErrorStatus,
             "[ lib] ERROR, %u, %s.",
@@ -312,25 +323,27 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
         goto Error;
     }
 
+    Dpdk->Interface.IfIndex = DeviceInfo.if_index;
+
     if (DeviceInfo.tx_offload_capa & DEV_TX_OFFLOAD_IPV4_CKSUM) {
         printf("TX IPv4 Checksum Offload Enabled\n");
         PortConfig.txmode.offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
-        Dpdk->OffloadStatus.Transmit.NetworkLayerXsum = TRUE;
+        Dpdk->Interface.OffloadStatus.Transmit.NetworkLayerXsum = TRUE;
     }
     if (DeviceInfo.tx_offload_capa & DEV_TX_OFFLOAD_UDP_CKSUM) {
         printf("TX UDP Checksum Offload Enabled\n");
         PortConfig.txmode.offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
-        Dpdk->OffloadStatus.Transmit.TransportLayerXsum = TRUE;
+        Dpdk->Interface.OffloadStatus.Transmit.TransportLayerXsum = TRUE;
     }
     if (DeviceInfo.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM) {
         printf("RX IPv4 Checksum Offload Enabled\n");
         PortConfig.rxmode.offloads |= DEV_RX_OFFLOAD_IPV4_CKSUM;
-        Dpdk->OffloadStatus.Receive.NetworkLayerXsum = TRUE;
+        Dpdk->Interface.OffloadStatus.Receive.NetworkLayerXsum = TRUE;
     }
     if (DeviceInfo.rx_offload_capa & DEV_RX_OFFLOAD_UDP_CKSUM) {
         printf("RX UDP Checksum Offload Enabled\n");
         PortConfig.rxmode.offloads |= DEV_RX_OFFLOAD_UDP_CKSUM;
-        Dpdk->OffloadStatus.Receive.TransportLayerXsum = TRUE;
+        Dpdk->Interface.OffloadStatus.Receive.TransportLayerXsum = TRUE;
     }
 
     ret = rte_eth_dev_configure(Port, rx_rings, tx_rings, &PortConfig);
@@ -357,7 +370,7 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
 
     rxconf = DeviceInfo.default_rxconf;
     for (uint16_t q = 0; q < rx_rings; q++) {
-        ret = rte_eth_rx_queue_setup(Port, q, nb_rxd, rte_eth_dev_socket_id(Port), &rxconf, Dpdk->MemoryPool);
+        ret = rte_eth_rx_queue_setup(Port, q, nb_rxd, rte_eth_dev_socket_id(Port), &rxconf, Dpdk->Interface.MemoryPool);
         if (ret < 0) {
             QuicTraceEvent(
                 LibraryErrorStatus,
@@ -406,10 +419,38 @@ CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context)
         goto Error;
     }
 
-    printf("\nStarting Port %hu, %02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx\n",
-            Dpdk->Port,
-            addr.addr_bytes[0], addr.addr_bytes[1], addr.addr_bytes[2],
-            addr.addr_bytes[3], addr.addr_bytes[4], addr.addr_bytes[5]);
+    //
+    // Retrieve ifindex of the interface to which DPDK is binding.
+    //
+    MIB_IF_TABLE2* IfTable;
+    Status = GetIfTable2(&IfTable);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "GetIfTable2");
+        goto Error;
+    }
+
+    for (uint32_t i = 0; i < IfTable->NumEntries; i++) {
+        MIB_IF_ROW2* IfRow = (MIB_IF_ROW2*)&IfTable->Table[i];
+        if (!IfRow->InterfaceAndOperStatusFlags.FilterInterface &&
+            !IfRow->InterfaceAndOperStatusFlags.NotMediaConnected &&
+            !IfRow->InterfaceAndOperStatusFlags.Paused &&
+            IfRow->OperStatus == IfOperStatusUp &&
+            IfRow->MediaType == NdisMedium802_3 &&
+            memcmp(IfRow->PhysicalAddress, addr.addr_bytes, IfRow->PhysicalAddressLength) == 0) {
+            Dpdk->Interface.IfIndex = IfRow->InterfaceIndex;
+            break;
+        }
+    }
+
+    printf(
+        "\nStarting Port %hu on Interface %u, %02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx\n",
+        Dpdk->Interface.Port, Dpdk->Interface.IfIndex,
+        addr.addr_bytes[0], addr.addr_bytes[1], addr.addr_bytes[2],
+        addr.addr_bytes[3], addr.addr_bytes[4], addr.addr_bytes[5]);
 
     Dpdk->Running = TRUE;
     ret = rte_eal_mp_remote_launch(CxPlatDpdkWorkerThread, Dpdk, SKIP_MAIN);
@@ -437,12 +478,12 @@ Error:
         CxPlatEventSet(Dpdk->StartComplete);
     }
 
-    if (Dpdk->TxRingBuffer) {
-        rte_ring_free(Dpdk->TxRingBuffer);
+    if (Dpdk->Interface.TxRingBuffer) {
+        rte_ring_free(Dpdk->Interface.TxRingBuffer);
     }
 
-    if (Dpdk->MemoryPool) {
-        rte_mempool_free(Dpdk->MemoryPool);
+    if (Dpdk->Interface.MemoryPool) {
+        rte_mempool_free(Dpdk->Interface.MemoryPool);
     }
 
     if (CleanUpRte) {
@@ -456,12 +497,13 @@ static
 void
 CxPlatDpdkRx(
     _In_ DPDK_DATAPATH* Dpdk,
-    _In_ const uint16_t Core
+    _In_ const uint16_t Core,
+    _In_ DPDK_INTERFACE* Interface
     )
 {
     void* Buffers[RX_BURST_SIZE];
     const uint16_t BuffersCount =
-        rte_eth_rx_burst(Dpdk->Port, 0, (struct rte_mbuf**)Buffers, RX_BURST_SIZE);
+        rte_eth_rx_burst(Interface->Port, 0, (struct rte_mbuf**)Buffers, RX_BURST_SIZE);
     if (unlikely(BuffersCount == 0)) {
         return;
     }
@@ -469,6 +511,7 @@ CxPlatDpdkRx(
     DPDK_RX_PACKET Packet; // Working space
     CxPlatZeroMemory(&Packet, sizeof(DPDK_RX_PACKET));
     Packet.Route = &Packet.RouteStorage;
+    Packet.Route->Interface = Interface;
 
     uint16_t PacketCount = 0;
     for (uint16_t i = 0; i < BuffersCount; i++) {
@@ -487,8 +530,8 @@ CxPlatDpdkRx(
                 Buffer->ol_flags,
                 "L3/L4 checksum incorrect");
             CXPLAT_DBG_ASSERT(
-                Dpdk->OffloadStatus.Receive.NetworkLayerXsum != 0 ||
-                Dpdk->OffloadStatus.Receive.TransportLayerXsum != 0);
+                Interface->OffloadStatus.Receive.NetworkLayerXsum != 0 ||
+                Interface->OffloadStatus.Receive.TransportLayerXsum != 0);
         }
 
         DPDK_RX_PACKET* NewPacket;
@@ -535,9 +578,11 @@ CxPlatDpRawTxAlloc(
     DPDK_DATAPATH* Dpdk = (DPDK_DATAPATH*)Datapath;
     DPDK_TX_PACKET* Packet = CxPlatPoolAlloc(&Dpdk->AdditionalInfoPool);
     QUIC_ADDRESS_FAMILY Family = QuicAddrGetFamily(&Route->RemoteAddress);
+    DPDK_INTERFACE* Interface = Route->Interface;
 
     if (likely(Packet)) {
-        Packet->Mbuf = rte_pktmbuf_alloc(Dpdk->MemoryPool);
+        Packet->Interface = Interface;
+        Packet->Mbuf = rte_pktmbuf_alloc(Interface->MemoryPool);
         if (likely(Packet->Mbuf)) {
             HEADER_BACKFILL HeaderFill = CxPlatDpRawCalculateHeaderBackFill(Family);
             Packet->Dpdk = Dpdk;
@@ -572,11 +617,12 @@ CxPlatDpRawTxEnqueue(
     )
 {
     DPDK_TX_PACKET* Packet = (DPDK_TX_PACKET*)SendData;
+    DPDK_INTERFACE* Interface = Packet->Interface;
     Packet->Mbuf->data_len = (uint16_t)Packet->Buffer.Length;
     Packet->Mbuf->ol_flags = PKT_TX_IPV4 | PKT_TX_IP_CKSUM | PKT_TX_UDP_CKSUM;
 
     DPDK_DATAPATH* Dpdk = Packet->Dpdk;
-    if (unlikely(rte_ring_mp_enqueue(Dpdk->TxRingBuffer, Packet->Mbuf) != 0)) {
+    if (unlikely(rte_ring_mp_enqueue(Interface->TxRingBuffer, Packet->Mbuf) != 0)) {
         rte_pktmbuf_free(Packet->Mbuf);
         QuicTraceEvent(
             LibraryError,
@@ -590,18 +636,19 @@ CxPlatDpRawTxEnqueue(
 static
 void
 CxPlatDpdkTx(
-    _In_ DPDK_DATAPATH* Dpdk
+    _In_ DPDK_DATAPATH* Dpdk,
+    _In_ DPDK_INTERFACE* Interface
     )
 {
     struct rte_mbuf* Buffers[TX_BURST_SIZE];
     const uint16_t BufferCount =
         (uint16_t)rte_ring_sc_dequeue_burst(
-            Dpdk->TxRingBuffer, (void**)Buffers, TX_BURST_SIZE, NULL);
+            Interface->TxRingBuffer, (void**)Buffers, TX_BURST_SIZE, NULL);
     if (unlikely(BufferCount == 0)) {
         return;
     }
 
-    const uint16_t TxCount = rte_eth_tx_burst(Dpdk->Port, 0, Buffers, BufferCount);
+    const uint16_t TxCount = rte_eth_tx_burst(Interface->Port, 0, Buffers, BufferCount);
     if (unlikely(TxCount < BufferCount)) {
         for (uint16_t buf = TxCount; buf < BufferCount; buf++) {
             rte_pktmbuf_free(Buffers[buf]);
@@ -617,13 +664,16 @@ CxPlatDpdkWorkerThread(
 {
     DPDK_DATAPATH* Dpdk = (DPDK_DATAPATH*)Context;
     const uint16_t Core = (uint16_t)rte_lcore_id();
+    CXPLAT_LIST_ENTRY* Entry;
 
     printf("Core %u worker running...\n", Core);
-    if (rte_eth_dev_socket_id(Dpdk->Port) > 0 &&
-        rte_eth_dev_socket_id(Dpdk->Port) != (int)rte_socket_id()) {
-        printf("\nWARNING, port %u is on remote NUMA node to polling thread.\n"
-               "\tPerformance will not be optimal.\n\n",
-               Dpdk->Port);
+    for (Entry = Dpdk->Interfaces.Flink; Entry != &Dpdk->Interfaces; Entry = Entry->Flink) {
+        if (rte_eth_dev_socket_id(Dpdk->Interface.Port) > 0 &&
+            rte_eth_dev_socket_id(Dpdk->Interface.Port) != (int)rte_socket_id()) {
+            printf("\nWARNING, port %u is on remote NUMA node to polling thread.\n"
+                "\tPerformance will not be optimal.\n\n",
+                Dpdk->Interface.Port);
+        }
     }
 
 #ifdef QUIC_USE_EXECUTION_CONTEXTS
@@ -631,8 +681,11 @@ CxPlatDpdkWorkerThread(
 #endif
 
     while (likely(Dpdk->Running)) {
-        CxPlatDpdkRx(Dpdk, Core);
-        CxPlatDpdkTx(Dpdk);
+        for (Entry = Dpdk->Interfaces.Flink; Entry != &Dpdk->Interfaces; Entry = Entry->Flink) {
+            DPDK_INTERFACE* Interface = CONTAINING_RECORD(Entry, DPDK_INTERFACE, Link);
+            CxPlatDpdkRx(Dpdk, Core, Interface);
+            CxPlatDpdkTx(Dpdk, Interface);
+        }
 
 #ifdef QUIC_USE_EXECUTION_CONTEXTS
         (void)CxPlatRunExecutionContexts(ThreadID);

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -370,7 +370,7 @@ CxPlatResolveRoute(
     }
 
     if (Route->Interface == NULL) {
-        Status = ERROR_NOT_FOUND;
+        Status = QUIC_STATUS_NOT_FOUND;
         QuicTraceEvent(
             DatapathError,
             "[data][%p] ERROR, %s.",

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -372,10 +372,9 @@ CxPlatResolveRoute(
     if (Route->Interface == NULL) {
         Status = ERROR_NOT_FOUND;
         QuicTraceEvent(
-            DatapathErrorStatus,
-            "[data][%p] ERROR, %u, %s.",
+            DatapathError,
+            "[data][%p] ERROR, %s.",
             Socket,
-            ERROR_NOT_FOUND,
             "no matching interface");
         goto Done;
     }

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -434,7 +434,6 @@ CxPlatDpRawInterfaceUninitialize(
     _Inout_ XDP_INTERFACE* Interface
     )
 {
-
     #pragma warning(push)
     #pragma warning(disable:6001) // Using uninitialized memory
 
@@ -507,11 +506,6 @@ CxPlatDpRawInterfaceInitialize(
 
     Status = CxPlatGetInterfaceRssQueueCount(Interface->IfIndex, &Interface->QueueCount);
     if (QUIC_FAILED(Status)) {
-        QuicTraceEvent(
-            AllocFailure,
-            "Allocation of '%s' failed. (%llu bytes)",
-            "XDP Queues",
-            Interface->QueueCount * sizeof(*Interface->Queues));
         goto Error;
     }
 
@@ -828,7 +822,7 @@ CxPlatDpRawInitialize(
                     "Allocation of '%s' failed. (%llu bytes)",
                     "XDP interface",
                     sizeof(*Interface));
-                continue;
+                goto Error;
             }
 
             CxPlatZeroMemory(Interface, sizeof(*Interface));

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -24,6 +24,7 @@ Abstract:
 #define RX_BATCH_SIZE 16
 #define MAX_ETH_FRAME_SIZE 1514
 
+#define IF_TAG     'IpdX' // XdpI
 #define QUEUE_TAG     'QpdX' // XdpQ
 #define RX_BUFFER_TAG 'RpdX' // XdpR
 #define TX_BUFFER_TAG 'TpdX' // XdpT
@@ -54,27 +55,34 @@ typedef struct _XDP_QUEUE {
     CXPLAT_LIST_ENTRY TxQueue;
 } XDP_QUEUE;
 
+typedef struct XDP_INTERFACE {
+    CXPLAT_INTERFACE;
+    uint8_t QueueCount;
+    XDP_QUEUE* Queues;
+} XDP_INTERFACE;
+
 typedef struct XDP_DATAPATH {
     CXPLAT_DATAPATH;
 
     BOOLEAN Running;
     CXPLAT_THREAD WorkerThread;
     CXPLAT_THREAD ExtraWorkerThreads[64];
-    XDP_QUEUE* Queues;
 
     // Constants
     DECLSPEC_CACHEALIGN
-    uint16_t IfIndex;
     uint16_t DatapathCpuGroup;
     uint8_t DatapathCpuNumber;
+    //
+    // Currently, all XDP interfaces share the same config.
+    //
     uint32_t RxBufferCount;
     uint32_t RxRingSize;
     uint32_t TxBufferCount;
     uint32_t TxRingSize;
-    uint8_t QueueCount;
+    BOOLEAN TxAlwaysPoke;
     uint32_t ExtraThreads;
-    BOOL Affinitize;
-    BOOL TxAlwaysPoke;
+    BOOLEAN Affinitize;
+    BOOLEAN SkipXsum;
 } XDP_DATAPATH;
 
 typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) XDP_RX_PACKET {
@@ -361,8 +369,6 @@ CxPlatXdpReadConfig(
     )
 {
     // Default config
-    Xdp->IfIndex = IFI_UNSPECIFIED;
-    Xdp->QueueCount = 1;
     Xdp->RxBufferCount = 4096;
     Xdp->RxRingSize = 128;
     Xdp->TxBufferCount = 4096;
@@ -385,10 +391,7 @@ CxPlatXdpReadConfig(
             Value[strlen(Value) - 1] = '\0';
         }
 
-        if (strcmp(Line, "IfIndex") == 0) {
-            Xdp->IfIndex = (uint16_t)strtoul(Value, NULL, 10);
-            (void)CxPlatGetInterfaceRssQueueCount(Xdp->IfIndex, &Xdp->QueueCount);
-        } else if (strcmp(Line, "CpuGroup") == 0) {
+        if (strcmp(Line, "CpuGroup") == 0) {
              Xdp->DatapathCpuGroup = (uint16_t)strtoul(Value, NULL, 10);
              Xdp->Affinitize = TRUE;
         } else if (strcmp(Line, "CpuNumber") == 0) {
@@ -406,10 +409,7 @@ CxPlatXdpReadConfig(
              Xdp->TxAlwaysPoke = !!strtoul(Value, NULL, 10);
         } else if (strcmp(Line, "SkipXsum") == 0) {
             BOOLEAN State = !!strtoul(Value, NULL, 10);
-            Xdp->OffloadStatus.Transmit.NetworkLayerXsum = State;
-            Xdp->OffloadStatus.Transmit.TransportLayerXsum = State;
-            Xdp->OffloadStatus.Receive.NetworkLayerXsum = State;
-            Xdp->OffloadStatus.Receive.TransportLayerXsum = State;
+            Xdp->SkipXsum = State;
             printf("SkipXsum: %u\n", State);
         } else if (strcmp(Line, "ExtraThreads") == 0) {
             Xdp->ExtraThreads = strtoul(Value, NULL, 10);
@@ -429,39 +429,107 @@ CxPlatDpRawGetDapathSize(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+void
+CxPlatDpRawInterfaceUninitialize(
+    _Inout_ XDP_INTERFACE* Interface
+    )
+{
+
+    #pragma warning(push)
+    #pragma warning(disable:6001) // Using uninitialized memory
+
+    for (uint32_t i = 0; Interface->Queues != NULL && i < Interface->QueueCount; i++) {
+        XDP_QUEUE *Queue = &Interface->Queues[i];
+
+        if (Queue->TxXsk != NULL) {
+            QUIC_STATUS Status;
+            XSK_STATISTICS Stats;
+            uint32_t StatsSize = sizeof(Stats);
+            Status = XskGetSockopt(Queue->TxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
+            if (QUIC_SUCCEEDED(Status)) {
+                printf("[%u-%u]txInvalidDescriptors: %llu\n", Interface->IfIndex, i, Stats.txInvalidDescriptors);
+            }
+            CloseHandle(Queue->TxXsk);
+        }
+
+        if (Queue->TxBuffers != NULL) {
+            CxPlatFree(Queue->TxBuffers, TX_BUFFER_TAG);
+        }
+
+        if (Queue->RxProgram != NULL) {
+            CloseHandle(Queue->RxProgram);
+        }
+
+        if (Queue->RxXsk != NULL) {
+            QUIC_STATUS Status;
+            XSK_STATISTICS Stats;
+            uint32_t StatsSize = sizeof(Stats);
+            Status = XskGetSockopt(Queue->RxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
+            if (QUIC_SUCCEEDED(Status)) {
+                printf("[%u-%u]rxDropped: %llu\n", Interface->IfIndex, i, Stats.rxDropped);
+                printf("[%u-%u]rxInvalidDescriptors: %llu\n", Interface->IfIndex, i, Stats.rxInvalidDescriptors);
+            }
+            CloseHandle(Queue->RxXsk);
+        }
+
+        if (Queue->RxBuffers != NULL) {
+            CxPlatFree(Queue->RxBuffers, RX_BUFFER_TAG);
+        }
+
+        CxPlatLockUninitialize(&Queue->TxLock);
+    }
+
+    if (Interface->Queues != NULL) {
+        CxPlatFree(Interface->Queues, QUEUE_TAG);
+    }
+
+    #pragma warning(pop)
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
-CxPlatDpRawInitialize(
-    _Inout_ CXPLAT_DATAPATH* Datapath,
+CxPlatDpRawInterfaceInitialize(
+    _In_ XDP_DATAPATH* Xdp,
+    _Out_ XDP_INTERFACE* Interface,
+    _In_ uint32_t IfIndex,
     _In_ uint32_t ClientRecvContextLength
     )
 {
-    XDP_DATAPATH* Xdp = (XDP_DATAPATH*)Datapath;
-    CXPLAT_THREAD_CONFIG Config = {
-        0, 0, "XdpDatapathWorker", CxPlatXdpWorkerThread, Xdp
-    };
     const uint32_t RxHeadroom = sizeof(XDP_RX_PACKET) + ALIGN_UP(ClientRecvContextLength, uint32_t);
     const uint32_t RxPacketSize = ALIGN_UP(RxHeadroom + MAX_ETH_FRAME_SIZE, XDP_RX_PACKET);
     QUIC_STATUS Status;
 
-    CxPlatXdpReadConfig(Xdp);
-    Datapath->Cpu = Xdp->DatapathCpuNumber;
-    CxPlatDpRawGenerateCpuTable(Datapath);
+    Interface->IfIndex = IfIndex;
+    Interface->OffloadStatus.Receive.NetworkLayerXsum = Xdp->SkipXsum;
+    Interface->OffloadStatus.Receive.TransportLayerXsum = Xdp->SkipXsum;
+    Interface->OffloadStatus.Transmit.NetworkLayerXsum = Xdp->SkipXsum;
+    Interface->OffloadStatus.Transmit.NetworkLayerXsum = Xdp->SkipXsum;
 
-    Xdp->Queues = CxPlatAlloc(Xdp->QueueCount * sizeof(*Xdp->Queues), QUEUE_TAG);
-    if (Xdp->Queues == NULL) {
+    Status = CxPlatGetInterfaceRssQueueCount(Interface->IfIndex, &Interface->QueueCount);
+    if (QUIC_FAILED(Status)) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "XDP Queues",
-            Xdp->QueueCount * sizeof(*Xdp->Queues));
+            Interface->QueueCount * sizeof(*Interface->Queues));
+        goto Error;
+    }
+
+    Interface->Queues = CxPlatAlloc(Interface->QueueCount * sizeof(*Interface->Queues), QUEUE_TAG);
+    if (Interface->Queues == NULL) {
+        QuicTraceEvent(
+            AllocFailure,
+            "Allocation of '%s' failed. (%llu bytes)",
+            "XDP Queues",
+            Interface->QueueCount * sizeof(*Interface->Queues));
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
 
-    CxPlatZeroMemory(Xdp->Queues, Xdp->QueueCount * sizeof(*Xdp->Queues));
+    CxPlatZeroMemory(Interface->Queues, Interface->QueueCount * sizeof(*Interface->Queues));
 
-    for (uint32_t QueueIndex = 0; QueueIndex < Xdp->QueueCount; QueueIndex++) {
-        XDP_QUEUE* Queue = &Xdp->Queues[QueueIndex];
+    for (uint32_t QueueIndex = 0; QueueIndex < Interface->QueueCount; QueueIndex++) {
+        XDP_QUEUE* Queue = &Interface->Queues[QueueIndex];
 
         InitializeSListHead(&Queue->RxPool);
         InitializeSListHead(&Queue->TxPool);
@@ -537,7 +605,7 @@ CxPlatDpRawInitialize(
 
         uint32_t QueueId = QueueIndex;
         uint32_t Flags = 0;     // TODO: support native/generic forced flags.
-        Status = XskBind(Queue->RxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
+        Status = XskBind(Queue->RxXsk, Interface->IfIndex, QueueId, Flags, NULL);
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 LibraryErrorStatus,
@@ -577,7 +645,7 @@ CxPlatDpRawInitialize(
 
         Flags = 0; // TODO: support native/generic forced flags.
         Status =
-            XdpCreateProgram(Xdp->IfIndex, &RxHook, QueueId, Flags, &RxRule, 1, &Queue->RxProgram);
+            XdpCreateProgram(Interface->IfIndex, &RxHook, QueueId, Flags, &RxRule, 1, &Queue->RxProgram);
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 LibraryErrorStatus,
@@ -659,7 +727,7 @@ CxPlatDpRawInitialize(
         }
 
         Flags = 0; // TODO: support native/generic forced flags.
-        Status = XskBind(Queue->TxXsk, Xdp->IfIndex, QueueId, Flags, NULL);
+        Status = XskBind(Queue->TxXsk, Interface->IfIndex, QueueId, Flags, NULL);
         if (QUIC_FAILED(Status)) {
             QuicTraceEvent(
                 LibraryErrorStatus,
@@ -687,6 +755,81 @@ CxPlatDpRawInitialize(
         for (uint32_t i = 0; i < Xdp->TxBufferCount; i++) {
             InterlockedPushEntrySList(
                 &Queue->TxPool, (PSLIST_ENTRY)&Queue->TxBuffers[i * sizeof(XDP_TX_PACKET)]);
+        }
+    }
+
+Error:
+    if (QUIC_FAILED(Status)) {
+        CxPlatDpRawInterfaceUninitialize(Interface);
+    }
+
+    return Status;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatDpRawInitialize(
+    _Inout_ CXPLAT_DATAPATH* Datapath,
+    _In_ uint32_t ClientRecvContextLength
+    )
+{
+    XDP_DATAPATH* Xdp = (XDP_DATAPATH*)Datapath;
+    CXPLAT_THREAD_CONFIG Config = {
+        0, 0, "XdpDatapathWorker", CxPlatXdpWorkerThread, Xdp
+    };
+    QUIC_STATUS Status;
+    MIB_IF_TABLE2* IfTable;
+    MIB_IF_ROW2* IfRow;
+
+    CxPlatXdpReadConfig(Xdp);
+    Datapath->Cpu = Xdp->DatapathCpuNumber;
+    CxPlatDpRawGenerateCpuTable(Datapath);
+    CxPlatListInitializeHead(&Xdp->Interfaces);
+
+    Status = GetIfTable2(&IfTable);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "GetIfTable2");
+        goto Error;
+    }
+
+    for (uint32_t i = 0; i < IfTable->NumEntries; i++) {
+        IfRow = (MIB_IF_ROW2 *)&IfTable->Table[i];
+        if (!IfRow->InterfaceAndOperStatusFlags.FilterInterface &&
+            !IfRow->InterfaceAndOperStatusFlags.NotMediaConnected &&
+            !IfRow->InterfaceAndOperStatusFlags.Paused &&
+            IfRow->OperStatus == IfOperStatusUp &&
+            IfRow->MediaType == NdisMedium802_3) {
+            XDP_INTERFACE* Interface = CxPlatAlloc(sizeof(XDP_INTERFACE), IF_TAG);
+            if (Interface == NULL) {
+                QuicTraceEvent(
+                    AllocFailure,
+                    "Allocation of '%s' failed. (%llu bytes)",
+                    "XDP interface",
+                    sizeof(*Interface));
+                continue;
+            }
+
+            CxPlatZeroMemory(Interface, sizeof(*Interface));
+
+            Status =
+                CxPlatDpRawInterfaceInitialize(
+                    Xdp, Interface, IfRow->InterfaceIndex, ClientRecvContextLength);
+            if (QUIC_FAILED(Status)) {
+                QuicTraceEvent(
+                    LibraryErrorStatus,
+                    "[ lib] ERROR, %u, %s.",
+                    Status,
+                    "CxPlatDpRawInterfaceInitialize");
+                CxPlatFree(Interface, IF_TAG);
+                continue;
+            }
+
+            printf("Bound XDP to interface %u\n", IfRow->InterfaceIndex);
+            CxPlatListInsertTail(&Xdp->Interfaces, &Interface->Link);
         }
     }
 
@@ -737,54 +880,10 @@ CxPlatDpRawUninitialize(
         CxPlatThreadDelete(&Xdp->WorkerThread);
     }
 
-    #pragma warning(push)
-    #pragma warning(disable:6001) // Using uninitialized memory
-
-    for (uint32_t i = 0; Xdp->Queues != NULL && i < Xdp->QueueCount; i++) {
-        XDP_QUEUE *Queue = &Xdp->Queues[i];
-
-        if (Queue->TxXsk != NULL) {
-            QUIC_STATUS Status;
-            XSK_STATISTICS Stats;
-            uint32_t StatsSize = sizeof(Stats);
-            Status = XskGetSockopt(Queue->TxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
-            if (QUIC_SUCCEEDED(Status)) {
-                printf("[%u]txInvalidDescriptors: %llu\n", i, Stats.txInvalidDescriptors);
-            }
-            CloseHandle(Queue->TxXsk);
-        }
-
-        if (Queue->TxBuffers != NULL) {
-            CxPlatFree(Queue->TxBuffers, TX_BUFFER_TAG);
-        }
-
-        if (Queue->RxProgram != NULL) {
-            CloseHandle(Queue->RxProgram);
-        }
-
-        if (Queue->RxXsk != NULL) {
-            QUIC_STATUS Status;
-            XSK_STATISTICS Stats;
-            uint32_t StatsSize = sizeof(Stats);
-            Status = XskGetSockopt(Queue->RxXsk, XSK_SOCKOPT_STATISTICS, &Stats, &StatsSize);
-            if (QUIC_SUCCEEDED(Status)) {
-                printf("[%u]rxDropped: %llu\n", i, Stats.rxDropped);
-                printf("[%u]rxInvalidDescriptors: %llu\n", i, Stats.rxInvalidDescriptors);
-            }
-            CloseHandle(Queue->RxXsk);
-        }
-
-        if (Queue->RxBuffers != NULL) {
-            CxPlatFree(Queue->RxBuffers, RX_BUFFER_TAG);
-        }
-
-        CxPlatLockUninitialize(&Queue->TxLock);
-    }
-
-    #pragma warning(pop)
-
-    if (Xdp->Queues != NULL) {
-        CxPlatFree(Xdp->Queues, QUEUE_TAG);
+    while (!CxPlatListIsEmpty(&Xdp->Interfaces)) {
+        CXPLAT_LIST_ENTRY* Entry = CxPlatListRemoveHead(&Xdp->Interfaces);
+        XDP_INTERFACE* Interface = (XDP_INTERFACE*)CONTAINING_RECORD(Entry, XDP_INTERFACE, Link);
+        CxPlatDpRawInterfaceUninitialize(Interface);
     }
 }
 
@@ -792,7 +891,8 @@ static
 void
 CxPlatXdpRx(
     _In_ XDP_DATAPATH* Xdp,
-    _In_ uint8_t QueueId
+    _In_ uint8_t QueueId,
+    _In_ XDP_INTERFACE* Interface
     )
 {
     CXPLAT_RECV_DATA* Buffers[RX_BATCH_SIZE];
@@ -800,7 +900,7 @@ CxPlatXdpRx(
     uint32_t FillIndex;
     uint32_t ProdCount = 0;
     uint32_t PacketCount = 0;
-    XDP_QUEUE* Queue = &Xdp->Queues[QueueId];
+    XDP_QUEUE* Queue = &Interface->Queues[QueueId];
     const uint32_t BuffersCount = XskRingConsumerReserve(&Queue->RxRing, RX_BATCH_SIZE, &RxIndex);
 
     for (uint32_t i = 0; i < BuffersCount; i++) {
@@ -812,6 +912,7 @@ CxPlatXdpRx(
         CxPlatZeroMemory(Packet, sizeof(XDP_RX_PACKET));
         Packet->Route = &Packet->RouteStorage;
         Packet->RouteStorage.QueueId = QueueId;
+        Packet->RouteStorage.Interface = (CXPLAT_INTERFACE*)Interface;
 
         CxPlatDpRawParseEthernet(
             (CXPLAT_DATAPATH*)Xdp,
@@ -913,13 +1014,13 @@ CxPlatDpRawTxAlloc(
     _Inout_ CXPLAT_ROUTE* Route
     )
 {
-    XDP_DATAPATH* Xdp = (XDP_DATAPATH*)Datapath;
     QUIC_ADDRESS_FAMILY Family = QuicAddrGetFamily(&Route->RemoteAddress);
-
-    XDP_QUEUE* Queue = &Xdp->Queues[Route->QueueId];
+    XDP_INTERFACE* Interface = (XDP_INTERFACE*)Route->Interface;
+    XDP_QUEUE* Queue = &Interface->Queues[Route->QueueId];
     XDP_TX_PACKET* Packet = (XDP_TX_PACKET*)InterlockedPopEntrySList(&Queue->TxPool);
 
     UNREFERENCED_PARAMETER(ECN);
+    UNREFERENCED_PARAMETER(Datapath);
 
     if (Packet) {
         HEADER_BACKFILL HeaderBackfill = CxPlatDpRawCalculateHeaderBackFill(Family); // TODO - Cache in Route?
@@ -959,14 +1060,15 @@ static
 void
 CxPlatXdpTx(
     _In_ XDP_DATAPATH* Xdp,
-    _In_ uint8_t QueueId
+    _In_ uint8_t QueueId,
+    _In_ XDP_INTERFACE* Interface
     )
 {
     uint32_t ProdCount = 0;
     uint32_t CompCount = 0;
     SLIST_ENTRY* TxCompleteHead = NULL;
     SLIST_ENTRY** TxCompleteTail = &TxCompleteHead;
-    XDP_QUEUE* Queue = &Xdp->Queues[QueueId];
+    XDP_QUEUE* Queue = &Interface->Queues[QueueId];
 
     if (CxPlatListIsEmpty(&Queue->WorkerTxQueue) &&
         ReadPointerNoFence(&Queue->TxQueue.Flink) != &Queue->TxQueue) {
@@ -1029,6 +1131,7 @@ CxPlatXdpTx(
 CXPLAT_THREAD_CALLBACK(CxPlatXdpWorkerThread, Context)
 {
     XDP_DATAPATH* Xdp = (XDP_DATAPATH*)Context;
+    CXPLAT_LIST_ENTRY* Entry;
 
 #ifdef QUIC_USE_EXECUTION_CONTEXTS
     const CXPLAT_THREAD_ID ThreadID = CxPlatCurThreadID();
@@ -1043,9 +1146,12 @@ CXPLAT_THREAD_CALLBACK(CxPlatXdpWorkerThread, Context)
     }
 
     while (Xdp->Running) {
-        for (uint8_t i = 0; i < Xdp->QueueCount; i++) {
-            CxPlatXdpRx(Xdp, i);
-            CxPlatXdpTx(Xdp, i);
+        for (Entry = Xdp->Interfaces.Flink; Entry != &Xdp->Interfaces; Entry = Entry->Flink) {
+            XDP_INTERFACE* Interface = CONTAINING_RECORD(Entry, XDP_INTERFACE, Link);
+            for (uint8_t QueueId = 0; QueueId < Interface->QueueCount; QueueId++) {
+                CxPlatXdpRx(Xdp, QueueId, Interface);
+                CxPlatXdpTx(Xdp, QueueId, Interface);
+            }
         }
 
 #ifdef QUIC_USE_EXECUTION_CONTEXTS


### PR DESCRIPTION
1. Abstracted all interface related stuff into CXPLAT_INTERFACE, XDP_INTERFACE and DPDK_INTERFACE. Interfaces are chained by a linked list.
2. No support for dynamic NIC add/removal yet.
3. Tested with both XDP and DPDK.

For DPDK, rte_eth_dev_info_get doesn't give us a valid ifindex. So, the ifindex of the interface being bound is looked up by mac address via GetIfTable2.