### PR TITLE
Enable single file exe for QuicTrace

### DIFF
--- a/scripts/publish-quictrace.ps1
+++ b/scripts/publish-quictrace.ps1
@@ -32,27 +32,20 @@ foreach ($RID in $RIDs) {
 
     $FullOutputFile = Join-Path $BinFolder "Release/net6.0/$RID/publish/$ExeName"
 
-    # Publish Non Trimmed Non Single File
-    dotnet publish $ToolDir -r $RID -c Release --self-contained true
+    # Publish Non Trimmed
+    dotnet publish $ToolDir -r $RID -c Release -p:PublishSingleFile=true --self-contained true -p:EnableCompressionInSingleFile=true
 
     $ArtifactFolder = Join-Path $RootOutputFolder $RID
     if (!(Test-Path $ArtifactFolder)) { New-Item -Path $ArtifactFolder -ItemType Directory -Force | Out-Null }
     Copy-Item $FullOutputFile $ArtifactFolder
 
-    # # Publish Non Trimmed
-    # dotnet publish $ToolDir -r $RID -c Release -p:PublishSingleFile=true --self-contained true -p:EnableCompressionInSingleFile=true
+    # Clear out bin folder
+    if (Test-Path $BinFolder) { Remove-Item $BinFolder -Recurse -Force | Out-Null }
 
-    # $ArtifactFolder = Join-Path $RootOutputFolder $RID
-    # if (!(Test-Path $ArtifactFolder)) { New-Item -Path $ArtifactFolder -ItemType Directory -Force | Out-Null }
-    # Copy-Item $FullOutputFile $ArtifactFolder
+    # Publish Trimmed
+    dotnet publish $ToolDir -r $RID -c Release -p:PublishSingleFile=true --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true
 
-    # # Clear out bin folder
-    # if (Test-Path $BinFolder) { Remove-Item $BinFolder -Recurse -Force | Out-Null }
-
-    # # Publish Trimmed
-    # dotnet publish $ToolDir -r $RID -c Release -p:PublishSingleFile=true --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true
-
-    # $TrimmedArtifactFolder = Join-Path $ArtifactFolder "trimmed"
-    # if (!(Test-Path $TrimmedArtifactFolder)) { New-Item -Path $TrimmedArtifactFolder -ItemType Directory -Force | Out-Null }
-    # Copy-Item $FullOutputFile $TrimmedArtifactFolder
+    $TrimmedArtifactFolder = Join-Path $ArtifactFolder "trimmed"
+    if (!(Test-Path $TrimmedArtifactFolder)) { New-Item -Path $TrimmedArtifactFolder -ItemType Directory -Force | Out-Null }
+    Copy-Item $FullOutputFile $TrimmedArtifactFolder
 }

--- a/src/plugins/trace/dll/QuicTraceLib.csproj
+++ b/src/plugins/trace/dll/QuicTraceLib.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
-    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.9-rc1" />
+    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.14-rc1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)..\..\LICENSE">

--- a/src/plugins/trace/exe/Program.cs
+++ b/src/plugins/trace/exe/Program.cs
@@ -61,7 +61,20 @@ namespace QuicTrace
             //
             // Create our runtime environment, add file, enable cookers, and process.
             //
-            using var dataSources = DataSourceSet.Create();
+
+            PluginSet pluginSet;
+
+            if (string.IsNullOrWhiteSpace(typeof(QuicEtwSource).Assembly.Location))
+            {
+                // Single File EXE
+                pluginSet = PluginSet.Load(new[] { Environment.CurrentDirectory }, new SingleFileAssemblyLoader());
+            }
+            else
+            {
+                pluginSet = PluginSet.Load();
+            }
+
+            using var dataSources = DataSourceSet.Create(pluginSet);
             dataSources.AddFile(filePath);
             var info = new EngineCreateInfo(dataSources.AsReadOnly());
             using var runtime = Engine.Create(info);

--- a/src/plugins/trace/exe/QuicTrace.csproj
+++ b/src/plugins/trace/exe/QuicTrace.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.9-rc1" />
-    <PackageReference Include="Microsoft.Performance.Toolkit.Engine" Version="1.0.9-rc1" />
+    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.14-rc1" />
+    <PackageReference Include="Microsoft.Performance.Toolkit.Engine" Version="1.0.14-rc1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dll\QuicTraceLib.csproj" />

--- a/src/plugins/trace/exe/SingleFileAssemblyLoader.cs
+++ b/src/plugins/trace/exe/SingleFileAssemblyLoader.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Runtime;
+
+namespace QuicTrace
+{
+    internal class SingleFileAssemblyLoader : IAssemblyLoader
+    {
+        private readonly string CurrentExePath = Environment.ProcessPath!;
+
+
+        public bool SupportsIsolation => false;
+
+        public bool IsAssembly(string path)
+        {
+            return path == CurrentExePath;
+        }
+
+        public Assembly? LoadAssembly(string assemblyPath, out ErrorInfo error)
+        {
+            if (assemblyPath != CurrentExePath)
+            {
+                error = new ErrorInfo(ErrorCodes.AssemblyLoadFailed, $"AssemblyPath must be {CurrentExePath}, was {assemblyPath}");
+                return null;
+            }
+
+            error = ErrorInfo.None;
+            return typeof(QuicEtwSource).Assembly;
+        }
+    }
+}

--- a/src/plugins/trace/exe/SingleFileAssemblyLoader.cs
+++ b/src/plugins/trace/exe/SingleFileAssemblyLoader.cs
@@ -9,7 +9,6 @@ namespace QuicTrace
     {
         private readonly string CurrentExePath = Environment.ProcessPath!;
 
-
         public bool SupportsIsolation => false;
 
         public bool IsAssembly(string path)


### PR DESCRIPTION
Closes #1491 

A workaround was made to allow single file exes to work in our case.