### PR TITLE
Add Stream AppCloseInProgress flag to shutdown

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -459,6 +459,8 @@ QuicStreamIndicateShutdownComplete(
         Event.SHUTDOWN_COMPLETE.ConnectionShutdown =
             Stream->Connection->State.ClosedLocally ||
             Stream->Connection->State.ClosedRemotely;
+        Event.SHUTDOWN_COMPLETE.AppCloseInProgress =
+            Stream->Flags.HandleClosed;
         QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -2008,6 +2008,36 @@ namespace Microsoft.Quic
             {
                 [NativeTypeName("BOOLEAN")]
                 public byte Graceful;
+
+                public byte _bitfield;
+
+                [NativeTypeName("BOOLEAN : 1")]
+                public byte AppCloseInProgress
+                {
+                    get
+                    {
+                        return (byte)(_bitfield & 0x1u);
+                    }
+
+                    set
+                    {
+                        _bitfield = (byte)((_bitfield & ~0x1u) | (value & 0x1u));
+                    }
+                }
+
+                [NativeTypeName("BOOLEAN : 7")]
+                public byte RESERVED
+                {
+                    get
+                    {
+                        return (byte)((_bitfield >> 1) & 0x7Fu);
+                    }
+
+                    set
+                    {
+                        _bitfield = (byte)((_bitfield & ~(0x7Fu << 1)) | ((value & 0x7Fu) << 1));
+                    }
+                }
             }
 
             public partial struct _SHUTDOWN_COMPLETE_e__Struct

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1116,6 +1116,8 @@ typedef struct QUIC_STREAM_EVENT {
         } SEND_SHUTDOWN_COMPLETE;
         struct {
             BOOLEAN ConnectionShutdown;
+            BOOLEAN AppCloseInProgress  : 1;
+            BOOLEAN RESERVED            : 7;
         } SHUTDOWN_COMPLETE;
         struct {
             uint64_t ByteCount;

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -593,7 +593,9 @@ ClientStreamCallback(
         // with the stream. It can now be safely cleaned up.
         //
         printf("[strm][%p] All done\n", Stream);
-        MsQuic->StreamClose(Stream);
+        if (!Event->SHUTDOWN_COMPLETE.AppCloseInProgress) {
+            MsQuic->StreamClose(Stream);
+        }
         break;
     default:
         break;


### PR DESCRIPTION
Closes #2220 

If a stream is closed from an app thread, the shutdown complete event is called, which causes a double free if StreamClose is called again in that event. For the app to handle this, they'd have to add external state tracking. Instead add a small amount of internal state tracking. We had this same issue with connections, and solved this the same way.