### PR TITLE
Ensure TLS secrets code path doesn't read null pointer

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -463,6 +463,7 @@ CxPlatTlsSetEncryptionSecretsCallback(
         TlsContext->TlsSecrets->SecretLength = (uint8_t)SecretLen;
         switch (KeyType) {
         case QUIC_PACKET_KEY_HANDSHAKE:
+            CXPLAT_FRE_ASSERT(ReadSecret != NULL && WriteSecret != NULL);
             if (TlsContext->IsServer) {
                 memcpy(TlsContext->TlsSecrets->ClientHandshakeTrafficSecret, ReadSecret, SecretLen);
                 memcpy(TlsContext->TlsSecrets->ServerHandshakeTrafficSecret, WriteSecret, SecretLen);
@@ -474,6 +475,7 @@ CxPlatTlsSetEncryptionSecretsCallback(
             TlsContext->TlsSecrets->IsSet.ServerHandshakeTrafficSecret = TRUE;
             break;
         case QUIC_PACKET_KEY_1_RTT:
+            CXPLAT_FRE_ASSERT(ReadSecret != NULL && WriteSecret != NULL);
             if (TlsContext->IsServer) {
                 memcpy(TlsContext->TlsSecrets->ClientTrafficSecret0, ReadSecret, SecretLen);
                 memcpy(TlsContext->TlsSecrets->ServerTrafficSecret0, WriteSecret, SecretLen);
@@ -490,6 +492,7 @@ CxPlatTlsSetEncryptionSecretsCallback(
             break;
         case QUIC_PACKET_KEY_0_RTT:
             if (!TlsContext->IsServer) {
+                CXPLAT_FRE_ASSERT(WriteSecret != NULL);
                 memcpy(TlsContext->TlsSecrets->ClientEarlyTrafficSecret, WriteSecret, SecretLen);
                 TlsContext->TlsSecrets->IsSet.ClientEarlyTrafficSecret = TRUE;
             }


### PR DESCRIPTION
Codecheck saw this in a PR run, where its possible for these to be null. Assert, because its really not, and if that ever happens things are very blown up.