### PR TITLE
Allow 0-RTT packets not in a retry scenario to start a connection

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1513,7 +1513,7 @@ QuicBindingDeliverDatagrams(
                     QuicBindingQueueStatelessOperation(
                         Binding, QUIC_OPER_TYPE_RETRY, DatagramChain);
             }
-            QuicPacketLogDrop(Binding, Packet, "Reject non-initial packet during retry.");
+            QuicPacketLogDrop(Binding, Packet, "Non-initial packet during retry.");
             return FALSE;
         }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3552,7 +3552,10 @@ QuicConnRecvHeader(
 
             CXPLAT_DBG_ASSERT(Token.Encrypted.OrigConnIdLength <= sizeof(Token.Encrypted.OrigConnId));
             CXPLAT_DBG_ASSERT(QuicAddrCompare(&Path->Route.RemoteAddress, &Token.Encrypted.RemoteAddress));
-            CXPLAT_DBG_ASSERT(Connection->OrigDestCID == NULL);
+
+            if (Connection->OrigDestCID != NULL) {
+                CXPLAT_FREE(Connection->OrigDestCID, QUIC_POOL_CID);
+            }
 
             Connection->OrigDestCID =
                 CXPLAT_ALLOC_NONPAGED(


### PR DESCRIPTION
0-RTT packets received out of order from initial packets should be considered valid packets and read. This is a behavior change from currently, where only initial packets can create a connection, and 0-RTT packets received out of order would be dropped. 

In a retry scenario, its possible for an initial to create the connection, but a 0-RTT packet to actually be the first one queued. If this occurs, its possible for the original dest cid to be overwritten. In dbg this would have asserted, but we now handle this case correctly.