### PR TITLE
Revert "Update to OpenSSL_1_1_1m+quic (#2229)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/quictls/openssl.git
-	branch = OpenSSL_1_1_1m+quic
+	branch = OpenSSL_1_1_1l+quic


### PR DESCRIPTION
This reverts commit 8894bc6f32927cbefe0b94fd96ccba673b3b1109.

This change seems to be causing a spike in test failures. PRing to verify it is this change. The failure results in no dumps.