### PR TITLE
Kill drivers on test machines before checkout

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -27,6 +27,12 @@ jobs:
   variables:
     runCodesignValidationInjection: false
   steps:
+  - script: |
+      sc.exe stop msquictestpriv
+      sc.exe stop msquicpriv
+    displayName: Stop Services
+    condition: eq('${{ parameters.platform }}', 'windows')
+
   - checkout: self
 
   - template: ./download-artifacts.yml

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -30,6 +30,7 @@ jobs:
   - script: |
       sc.exe stop msquictestpriv
       sc.exe stop msquicpriv
+      exit 0
     displayName: Stop Services
     condition: eq('${{ parameters.platform }}', 'windows')
 

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -39,6 +39,7 @@ jobs:
   - script: |
       sc.exe stop secnetperfdrvpriv
       sc.exe stop msquicpriv
+      exit 0
     displayName: Stop Services
     condition: eq('${{ parameters.platform }}', 'windows')
 

--- a/.azure/templates/run-performance.yml
+++ b/.azure/templates/run-performance.yml
@@ -36,6 +36,12 @@ jobs:
     value: true
   - group: DeploymentKeys
   steps:
+  - script: |
+      sc.exe stop secnetperfdrvpriv
+      sc.exe stop msquicpriv
+    displayName: Stop Services
+    condition: eq('${{ parameters.platform }}', 'windows')
+
   - checkout: self
 
   - template: ./download-artifacts.yml

--- a/.azure/templates/run-quicinterop.yml
+++ b/.azure/templates/run-quicinterop.yml
@@ -24,6 +24,7 @@ jobs:
   - script: |
       sc.exe stop msquictestpriv
       sc.exe stop msquicpriv
+      exit 0
     displayName: Stop Services
     condition: eq('${{ parameters.platform }}', 'windows')
 

--- a/.azure/templates/run-quicinterop.yml
+++ b/.azure/templates/run-quicinterop.yml
@@ -21,6 +21,12 @@ jobs:
   variables:
     runCodesignValidationInjection: false
   steps:
+  - script: |
+      sc.exe stop msquictestpriv
+      sc.exe stop msquicpriv
+    displayName: Stop Services
+    condition: eq('${{ parameters.platform }}', 'windows')
+
   - checkout: self
 
   - template: ./download-artifacts.yml

--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -27,6 +27,12 @@ jobs:
   variables:
     runCodesignValidationInjection: false
   steps:
+  - script: |
+      sc.exe stop msquictestpriv
+      sc.exe stop msquicpriv
+    displayName: Stop Services
+    condition: eq('${{ parameters.platform }}', 'windows')
+
   - checkout: self
 
   - template: ./download-artifacts.yml

--- a/.azure/templates/run-spinquic.yml
+++ b/.azure/templates/run-spinquic.yml
@@ -30,6 +30,7 @@ jobs:
   - script: |
       sc.exe stop msquictestpriv
       sc.exe stop msquicpriv
+      exit 0
     displayName: Stop Services
     condition: eq('${{ parameters.platform }}', 'windows')
 


### PR DESCRIPTION
Assuming the drivers are not hung, this should allow the checkout step to complete