### PR TITLE
Publish macos logs from bvt runs

### DIFF
--- a/.azure/templates/upload-test-artifacts.yml
+++ b/.azure/templates/upload-test-artifacts.yml
@@ -54,7 +54,7 @@ steps:
   - ${{ if eq(parameters.codeCoverage, false) }}:
     - task: PublishBuildArtifacts@1
       displayName: Publish Test Output
-      ${{ if eq(parameters.publishTest, true) }}:
+      ${{ if and(eq(parameters.publishTest, true), not(eq(parameters.platform, 'macos'))) }}:
         condition: failed()
       inputs:
         artifactName: ${{ parameters.artifactName }}


### PR DESCRIPTION
Currently, logs are only published if a failure occurs. On mac, we suppress failures, so logs and dumps never get uploaded. This isn't what we want, as we want to be able to hopefully fix these issues.