### PR TITLE
Fix InvalidAddress test on macOS

### DIFF
--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -836,7 +836,8 @@ CxPlatSocketContextInitialize(
             MappedAddress.Ipv6.sin6_family = AF_INET6;
         }
 
-        if (ForceIpv4) {
+        // If we're going to be connecting, we need to bind to the correct local address family.
+        if ((RemoteAddress && LocalAddress->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET) || ForceIpv4) {
             MappedAddress.Ipv4.sin_family = AF_INET;
             MappedAddress.Ipv4.sin_port = Binding->LocalAddress.Ipv4.sin_port;
             // For Wildcard address we only need to copy port.


### PR DESCRIPTION
Because of how we were doing connected sockets on macOS, the invalid address test would always fail, as we would always get the incorrect error code. The logic was only forcing a bind to an IPv4 socket if the remote was ipv4. But if a local ipv4 addr and remote ipv6 addr was passed, this would result in the failure not occurring until packets started to flow, and would be an unreachable error. Ideally macOS should fail to bind when an ipv4 mapped ipv6 address is passed to an ipv4 socket, but thats not the case.