### PR TITLE
Zero out perproc structures on library initialization

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -342,10 +342,11 @@ MsQuicLibraryInitialize(
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)", "connection pools",
-            MsQuicLib.PartitionCount * sizeof(QUIC_LIBRARY_PP));
+            MsQuicLib.ProcessorCount * sizeof(QUIC_LIBRARY_PP));
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
+    CxPlatZeroMemory(MsQuicLib.PerProc, MsQuicLib.ProcessorCount * sizeof(QUIC_LIBRARY_PP));
 
     uint8_t ResetHashKey[20];
     CxPlatRandom(sizeof(ResetHashKey), ResetHashKey);

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -346,12 +346,12 @@ MsQuicLibraryInitialize(
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
-    CxPlatZeroMemory(MsQuicLib.PerProc, MsQuicLib.ProcessorCount * sizeof(QUIC_LIBRARY_PP));
 
     uint8_t ResetHashKey[20];
     CxPlatRandom(sizeof(ResetHashKey), ResetHashKey);
 
     for (uint16_t i = 0; i < MsQuicLib.ProcessorCount; ++i) {
+        CxPlatZeroMemory(&MsQuicLib.PerProc[i], sizeof(QUIC_LIBRARY_PP));
         CxPlatPoolInitialize(
             FALSE,
             sizeof(QUIC_CONNECTION),

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -223,7 +223,7 @@ typedef struct QUIC_LIBRARY {
     //
     // Per-processor storage. Count of `ProcessorCount`.
     //
-    _Field_size_full_(ProcessorCount)
+    _Field_size_(ProcessorCount)
     QUIC_LIBRARY_PP* PerProc;
 
     //

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -221,9 +221,9 @@ typedef struct QUIC_LIBRARY {
     QUIC_REGISTRATION* StatelessRegistration;
 
     //
-    // Per-processor storage. Count of `PartitionCount`.
+    // Per-processor storage. Count of `ProcessorCount`.
     //
-    _Field_size_(PartitionCount)
+    _Field_size_full_(ProcessorCount)
     QUIC_LIBRARY_PP* PerProc;
 
     //

--- a/src/generated/linux/library.c.clog.h
+++ b/src/generated/linux/library.c.clog.h
@@ -383,9 +383,9 @@ tracepoint(CLOG_LIBRARY_C, AllocFailure , arg2, arg3);\
 // QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)", "connection pools",
-            MsQuicLib.PartitionCount * sizeof(QUIC_LIBRARY_PP));
+            MsQuicLib.ProcessorCount * sizeof(QUIC_LIBRARY_PP));
 // arg2 = arg2 = "connection pools"
-// arg3 = arg3 = MsQuicLib.PartitionCount * sizeof(QUIC_LIBRARY_PP)
+// arg3 = arg3 = MsQuicLib.ProcessorCount * sizeof(QUIC_LIBRARY_PP)
 ----------------------------------------------------------*/
 #define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\
 


### PR DESCRIPTION
The PerProc library structures are not zeroed on initialization. This didn't used to be a problem until #2045 was merged. It uses a new ReceivePacketId field, and has an assertion that the value or'd with the proc is non zero. On all but core 0 this would always be fine, but on core 0 if this field starts high and then rolls over, the assertion hits. We likely should make it so that assertion can't be hit even in a rollover situation, but we also should always just 0 this memory out, as it will be a source of future buts, and it only happens during library initialization.

macOS tests have been hitting this since merge, since theyre always core 0, but since we don't report failures there it was never noticed.