### PR TITLE
Artificially increase ProcShifted by 1 for PacketId

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1563,7 +1563,7 @@ QuicBindingReceive(
     //
 
     uint32_t Proc = CxPlatProcCurrentNumber();
-    uint64_t ProcShifted = ((uint64_t)Proc) << 40;
+    uint64_t ProcShifted = ((uint64_t)Proc + 1) << 40;
 
     CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = DatagramChain) != NULL) {

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -209,7 +209,7 @@ QuicPacketBuilderPrepare(
     //
 
     uint32_t Proc = CxPlatProcCurrentNumber();
-    uint64_t ProcShifted = ((uint64_t)Proc) << 40;
+    uint64_t ProcShifted = ((uint64_t)Proc + 1) << 40;
 
     BOOLEAN NewQuicPacket = FALSE;
     if (Builder->PacketType != NewPacketType || IsPathMtuDiscovery ||


### PR DESCRIPTION
The existing code has a lot of checks for Id not equal to 0. However, on core 0 with rollover this is a valid case. We can make this an always invalid case by artificially increasing the proc by 1 before shifting it. 