### PR TITLE
Improve Pacing Send Logic

### DIFF
--- a/scripts/wpa.ps1
+++ b/scripts/wpa.ps1
@@ -22,11 +22,11 @@ This script provides helpers for running Windows Performance Analyzer.
 
 param (
     [Parameter(Mandatory = $false)]
-    [ValidateSet("Debug", "Release")]
-    [string]$Config = "Release",
+    [string]$FilePath = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$FilePath = ""
+    [ValidateSet("Debug", "Release")]
+    [string]$Config = "Release"
 )
 
 Set-StrictMode -Version 'Latest'

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -147,7 +147,8 @@ CubicCongestionControlGetSendAllowance(
     } else if (
         !TimeSinceLastSendValid ||
         !Connection->Settings.PacingEnabled ||
-        !Connection->Paths[0].GotFirstRttSample) {
+        !Connection->Paths[0].GotFirstRttSample ||
+        Connection->Paths[0].SmoothedRtt < MS_TO_US(QUIC_SEND_PACING_INTERVAL)) {
         //
         // We're not in the necessary state to pace.
         //

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -182,7 +182,8 @@ CubicCongestionControlGetSendAllowance(
         SendAllowance =
             Cubic->LastSendAllowance +
             (uint32_t)((EstimatedWnd * TimeSinceLastSend) / Connection->Paths[0].SmoothedRtt);
-        if (SendAllowance > (Cubic->CongestionWindow - Cubic->BytesInFlight)) {
+        if (SendAllowance < Cubic->LastSendAllowance || // Overflow case
+            SendAllowance > (Cubic->CongestionWindow - Cubic->BytesInFlight)) {
             SendAllowance = Cubic->CongestionWindow - Cubic->BytesInFlight;
         }
 

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -147,8 +147,7 @@ CubicCongestionControlGetSendAllowance(
     } else if (
         !TimeSinceLastSendValid ||
         !Connection->Settings.PacingEnabled ||
-        !Connection->Paths[0].GotFirstRttSample ||
-        Connection->Paths[0].SmoothedRtt < MS_TO_US(QUIC_SEND_PACING_INTERVAL)) {
+        !Connection->Paths[0].GotFirstRttSample) {
         //
         // We're not in the necessary state to pace.
         //

--- a/src/core/cubic.h
+++ b/src/core/cubic.h
@@ -59,6 +59,11 @@ typedef struct QUIC_CONGESTION_CONTROL_CUBIC {
     uint32_t BytesInFlightMax;
 
     //
+    // The leftover send allowance from a previous send. Olny used when pacing.
+    //
+    uint32_t LastSendAllowance; // bytes
+
+    //
     // A count of packets which can be sent ignoring CongestionWindow.
     // The count is decremented as the packets are sent. BytesInFlight is still
     // incremented for these packets. This is used to send probe packets for

--- a/src/core/cubic.h
+++ b/src/core/cubic.h
@@ -59,7 +59,7 @@ typedef struct QUIC_CONGESTION_CONTROL_CUBIC {
     uint32_t BytesInFlightMax;
 
     //
-    // The leftover send allowance from a previous send. Olny used when pacing.
+    // The leftover send allowance from a previous send. Only used when pacing.
     //
     uint32_t LastSendAllowance; // bytes
 


### PR DESCRIPTION
Fixes an issue with large pacing send allowances, where `QUIC_MAX_DATAGRAMS_PER_SEND` actually ends up limiting the send, instead of the allowance, resulting in a complete loss of all that allowance.

The fix is to save the previous allowance, subtract what was actually sent, and then in the next send use (add) that old allowance too.