### PR TITLE
WPA Plugin Tx Delay Graph

### DIFF
--- a/src/plugins/trace/dll/DataModel/QuicData.cs
+++ b/src/plugins/trace/dll/DataModel/QuicData.cs
@@ -155,10 +155,10 @@ namespace QuicTrace.DataModel
 
     public enum QuicTputDataType
     {
-        Tx,
-        TxAck,
-        TxUdp,
-        Rx,
+        Tx,         // Sent to UDP
+        PktCreate,  // Packet created to be sent
+        TxAck,      // Packet(s) bytes acknowledged
+        Rx,         // Packet received
         Rtt,
         InFlight,
         CWnd,

--- a/src/plugins/trace/dll/DataModel/QuicData.cs
+++ b/src/plugins/trace/dll/DataModel/QuicData.cs
@@ -164,7 +164,8 @@ namespace QuicTrace.DataModel
         CWnd,
         Bufferred,
         ConnFC,
-        StreamFC
+        StreamFC,
+        TxDelay
     }
 
     public struct QuicRawTputData

--- a/src/plugins/trace/dll/DataModel/QuicObjectSet.cs
+++ b/src/plugins/trace/dll/DataModel/QuicObjectSet.cs
@@ -147,6 +147,9 @@ namespace QuicTrace.DataModel
             return value;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
+        public T FindOrCreateActive(QuicEvent evt) => FindOrCreateActive((ushort)evt.EventId, new QuicObjectKey(evt));
+
         public void FinalizeObjects()
         {
             inactiveList.AddRange(activeTable.Select(it => it.Value));

--- a/src/plugins/trace/dll/DataModel/QuicObjectSet.cs
+++ b/src/plugins/trace/dll/DataModel/QuicObjectSet.cs
@@ -114,13 +114,15 @@ namespace QuicTrace.DataModel
             T? value;
             if (eventId == CreateEventId)
             {
-                RemoveActiveObject(key);
+                var old = RemoveActiveObject(key);
+                if (old != null) inactiveList.Add(old);
                 value = ObjectConstructor(key.Pointer, key.ProcessId);
                 activeTable.Add(key, value);
             }
             else if (eventId == DestroyedEventId)
             {
                 value = RemoveActiveObject(key);
+                if (value != null) inactiveList.Add(value);
             }
             else
             {

--- a/src/plugins/trace/dll/DataModel/QuicState.cs
+++ b/src/plugins/trace/dll/DataModel/QuicState.cs
@@ -64,15 +64,10 @@ namespace QuicTrace.DataModel
                     break;
                 case QuicObjectType.Datapath:
                     DatapathSet.FindOrCreateActive(new QuicObjectKey(evt)).AddEvent(evt, this);
-                    if (evt.EventId == QuicEventId.DatapathSend)
+                    if (evt.EventId == QuicEventId.DatapathSend &&
+                        LastConnections.TryGetValue(evt.ThreadId, out var LastConn))
                     {
-                        try {
-                            var LastConn = LastConnections[evt.ThreadId];
-                            if (LastConn != null)
-                            {
-                                LastConn.AddEvent(evt, this);
-                            }
-                        } catch { }
+                        LastConn.AddEvent(evt, this);
                     }
                     break;
                 default:

--- a/src/plugins/trace/dll/DataModel/QuicState.cs
+++ b/src/plugins/trace/dll/DataModel/QuicState.cs
@@ -36,7 +36,6 @@ namespace QuicTrace.DataModel
 
         public List<QuicEvent> Events { get; } = new List<QuicEvent>();
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
         internal void AddEvent(QuicEvent evt)
         {
             switch (evt.ObjectType)

--- a/src/plugins/trace/dll/DataModel/QuicState.cs
+++ b/src/plugins/trace/dll/DataModel/QuicState.cs
@@ -49,20 +49,20 @@ namespace QuicTrace.DataModel
                     break;
                 case QuicObjectType.Worker:
                     DataAvailableFlags |= QuicDataAvailableFlags.Worker;
-                    WorkerSet.FindOrCreateActive(new QuicObjectKey(evt)).AddEvent(evt, this);
+                    WorkerSet.FindOrCreateActive(evt).AddEvent(evt, this);
                     break;
                 case QuicObjectType.Connection:
                     DataAvailableFlags |= QuicDataAvailableFlags.Connection;
-                    var Conn = ConnectionSet.FindOrCreateActive(new QuicObjectKey(evt));
+                    var Conn = ConnectionSet.FindOrCreateActive(evt);
                     Conn.AddEvent(evt, this);
                     LastConnections[evt.ThreadId] = Conn;
                     break;
                 case QuicObjectType.Stream:
                     DataAvailableFlags |= QuicDataAvailableFlags.Stream;
-                    StreamSet.FindOrCreateActive(new QuicObjectKey(evt)).AddEvent(evt, this);
+                    StreamSet.FindOrCreateActive(evt).AddEvent(evt, this);
                     break;
                 case QuicObjectType.Datapath:
-                    DatapathSet.FindOrCreateActive(new QuicObjectKey(evt)).AddEvent(evt, this);
+                    DatapathSet.FindOrCreateActive(evt).AddEvent(evt, this);
                     if (evt.EventId == QuicEventId.DatapathSend &&
                         LastConnections.TryGetValue(evt.ThreadId, out var LastConn))
                     {

--- a/src/plugins/trace/dll/DataModel/QuicState.cs
+++ b/src/plugins/trace/dll/DataModel/QuicState.cs
@@ -36,6 +36,7 @@ namespace QuicTrace.DataModel
 
         public List<QuicEvent> Events { get; } = new List<QuicEvent>();
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
         internal void AddEvent(QuicEvent evt)
         {
             switch (evt.ObjectType)
@@ -65,11 +66,13 @@ namespace QuicTrace.DataModel
                     DatapathSet.FindOrCreateActive(new QuicObjectKey(evt)).AddEvent(evt, this);
                     if (evt.EventId == QuicEventId.DatapathSend)
                     {
-                        var LastConn = LastConnections[evt.ThreadId];
-                        if (LastConn != null)
-                        {
-                            LastConn.AddEvent(evt, this);
-                        }
+                        try {
+                            var LastConn = LastConnections[evt.ThreadId];
+                            if (LastConn != null)
+                            {
+                                LastConn.AddEvent(evt, this);
+                            }
+                        } catch { }
                     }
                     break;
                 default:

--- a/src/plugins/trace/dll/QuicEventParser.cs
+++ b/src/plugins/trace/dll/QuicEventParser.cs
@@ -101,8 +101,9 @@ namespace QuicTrace
                             dataProcessor.ProcessDataElement(quicEvent, this, cancellationToken);
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        Console.WriteLine(ex.ToString());
                     }
                 }
 

--- a/src/plugins/trace/dll/Tables/QuicDataBatchingTable.cs
+++ b/src/plugins/trace/dll/Tables/QuicDataBatchingTable.cs
@@ -59,11 +59,6 @@ namespace QuicTrace.Tables
                 new ColumnMetadata(new Guid("{1ad097ad-11a0-40c3-9425-d9255512be82}"), "Bits"),
                 new UIHints { AggregationMode = AggregationMode.Sum });
 
-        private static readonly ColumnConfiguration txDelayColumnConfig =
-            new ColumnConfiguration(
-                new ColumnMetadata(new Guid("{53ab73a2-db04-4bd2-a196-1032227e9ca2}"), "TX Delay (us)"),
-                new UIHints { AggregationMode = AggregationMode.Average });
-
         private static readonly TableConfiguration tableConfig1 =
             new TableConfiguration("Data Rates by Datapath")
             {
@@ -101,24 +96,6 @@ namespace QuicTrace.Tables
                 }
             };
 
-        private static readonly TableConfiguration tableConfig3 =
-            new TableConfiguration("TX Delay by Datapath")
-            {
-                Columns = new[]
-                {
-                     typeColumnConfig,
-                     TableConfiguration.PivotColumn,
-                     TableConfiguration.LeftFreezeColumn,
-                     cpuColumnConfig,
-                     processIdColumnConfig,
-                     threadIdColumnConfig,
-                     timeColumnConfig,
-                     TableConfiguration.RightFreezeColumn,
-                     TableConfiguration.GraphColumn,
-                     txDelayColumnConfig,
-                }
-            };
-
         public static bool IsDataAvailable(IDataExtensionRetrieval tableData)
         {
             Debug.Assert(!(tableData is null));
@@ -153,16 +130,12 @@ namespace QuicTrace.Tables
             table.AddColumn(timeColumnConfig, dataProjection.Compose(ProjectTime));
             table.AddColumn(bytesColumnConfig, dataProjection.Compose(ProjectBytes));
             table.AddColumn(bitsColumnConfig, dataProjection.Compose(ProjectBits));
-            table.AddColumn(txDelayColumnConfig, dataProjection.Compose(ProjectTxDelay));
 
             tableConfig1.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
             tableBuilder.AddTableConfiguration(tableConfig1);
 
             tableConfig2.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
             tableBuilder.AddTableConfiguration(tableConfig2);
-
-            tableConfig3.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
-            tableBuilder.AddTableConfiguration(tableConfig3);
 
             tableBuilder.SetDefaultTableConfiguration(tableConfig1);
         }
@@ -207,18 +180,6 @@ namespace QuicTrace.Tables
         }
 
         private static uint ProjectBits(QuicEvent evt)
-        {
-            if (evt.EventId == QuicEventId.DatapathSend)
-            {
-                return (evt as QuicDatapathSendEvent)!.TotalSize * 8;
-            }
-            else
-            {
-                return (evt as QuicDatapathRecvEvent)!.TotalSize * 8;
-            }
-        }
-
-        private static uint ProjectTxDelay(QuicEvent evt)
         {
             if (evt.EventId == QuicEventId.DatapathSend)
             {

--- a/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
+++ b/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
@@ -195,7 +195,7 @@ namespace QuicTrace.Tables
             tableConfig2.AddColumnRole(ColumnRole.Duration, durationColumnConfig);
             tableConfig2.InitialSelectionQuery = "[Type]:=\"InFlight\"";
             tableConfig2.InitialFilterQuery =
-                "[Type]:=\"Tx\" OR [Type]:=\"TxAck\" OR [Type]:=\"TxUdp\" OR [Type]:=\"Rx\" OR [Type]:=\"Rtt\"";
+                "[Type]:=\"Tx\" OR [Type]:=\"TxAck\" OR [Type]:=\"TxUdp\" OR [Type]:=\"Rx\" OR [Type]:=\"Rtt\" OR [Type]:=\"TxDelay\"";
             tableBuilder.AddTableConfiguration(tableConfig2);
 
             tableConfig3.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);

--- a/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
+++ b/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
@@ -187,15 +187,15 @@ namespace QuicTrace.Tables
             table.AddColumn(txDelayColumnConfig, dataProjection.Compose(ProjectTxDelay));
 
             tableConfig1.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
-            tableConfig1.InitialSelectionQuery = "[Series Name]:=\"Type\"";
-            tableConfig1.InitialFilterQuery = "[Type]:<>\"Tx\" AND [Type]:<>\"Rx\"";
+            tableConfig1.InitialSelectionQuery = "[Type]:=\"Tx\" OR [Type]:=\"Rx\"";
+            tableConfig1.InitialFilterQuery = "[Type]:<>\"Tx\" AND [Type]:<>\"PktCreate\" AND [Type]:<>\"TxAck\" AND [Type]:<>\"Rx\"";
             tableBuilder.AddTableConfiguration(tableConfig1);
 
             tableConfig2.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
             tableConfig2.AddColumnRole(ColumnRole.Duration, durationColumnConfig);
             tableConfig2.InitialSelectionQuery = "[Type]:=\"InFlight\"";
             tableConfig2.InitialFilterQuery =
-                "[Type]:=\"Tx\" OR [Type]:=\"TxAck\" OR [Type]:=\"TxUdp\" OR [Type]:=\"Rx\" OR [Type]:=\"Rtt\" OR [Type]:=\"TxDelay\"";
+                "[Type]:=\"Tx\" OR [Type]:=\"TxAck\" OR [Type]:=\"PktCreate\" OR [Type]:=\"Rx\" OR [Type]:=\"Rtt\" OR [Type]:=\"TxDelay\"";
             tableBuilder.AddTableConfiguration(tableConfig2);
 
             tableConfig3.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
@@ -204,9 +204,9 @@ namespace QuicTrace.Tables
             tableBuilder.AddTableConfiguration(tableConfig3);
 
             tableConfig4.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
-            tableConfig4.InitialSelectionQuery = "[Type]:=\"TxUdp\" OR [Type]:=\"Rx\"";
+            tableConfig4.InitialSelectionQuery = "[Type]:=\"Tx\" OR [Type]:=\"Rx\"";
             tableConfig4.InitialFilterQuery =
-                "[Type]:<>\"Tx\" AND [Type]:<>\"TxAck\" AND [Type]:<>\"TxUdp\" AND [Type]:<>\"Rx\"";
+                "[Type]:<>\"Tx\" AND [Type]:<>\"TxAck\" AND [Type]:<>\"PktCreate\" AND [Type]:<>\"Rx\"";
             tableBuilder.AddTableConfiguration(tableConfig4);
 
             tableConfig5.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);

--- a/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
+++ b/src/plugins/trace/dll/Tables/QuicNetworkTable.cs
@@ -64,6 +64,11 @@ namespace QuicTrace.Tables
                 new ColumnMetadata(new Guid("{0487D420-EE35-4E6F-A9B4-D535D9AED1AB}"), "Rtt (ms)"),
                 new UIHints { AggregationMode = AggregationMode.Average });
 
+        private static readonly ColumnConfiguration txDelayColumnConfig =
+            new ColumnConfiguration(
+                new ColumnMetadata(new Guid("{8c364574-f245-450c-8b95-651822704af9}"), "TX Delay (us)"),
+                new UIHints { AggregationMode = AggregationMode.Average });
+
         private static readonly TableConfiguration tableConfig1 =
             new TableConfiguration("Data Rates by Connection")
             {
@@ -123,15 +128,32 @@ namespace QuicTrace.Tables
                 Columns = new[]
                 {
                      connectionColumnConfig,
-                     typeColumnConfig,
                      TableConfiguration.PivotColumn,
                      TableConfiguration.LeftFreezeColumn,
+                     typeColumnConfig,
                      processIdColumnConfig,
                      timeColumnConfig,
                      durationColumnConfig,
                      TableConfiguration.RightFreezeColumn,
                      TableConfiguration.GraphColumn,
                      rttColumnConfig,
+                }
+            };
+
+        private static readonly TableConfiguration tableConfig5 =
+            new TableConfiguration("TX Delay by Connection")
+            {
+                Columns = new[]
+                {
+                     connectionColumnConfig,
+                     TableConfiguration.PivotColumn,
+                     TableConfiguration.LeftFreezeColumn,
+                     typeColumnConfig,
+                     processIdColumnConfig,
+                     timeColumnConfig,
+                     TableConfiguration.RightFreezeColumn,
+                     TableConfiguration.GraphColumn,
+                     txDelayColumnConfig,
                 }
             };
 
@@ -162,6 +184,7 @@ namespace QuicTrace.Tables
             table.AddColumn(bitsColumnConfig, dataProjection.Compose(ProjectBits));
             table.AddColumn(bytesColumnConfig, dataProjection.Compose(ProjectBytes));
             table.AddColumn(rttColumnConfig, dataProjection.Compose(ProjectRtt));
+            table.AddColumn(txDelayColumnConfig, dataProjection.Compose(ProjectTxDelay));
 
             tableConfig1.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
             tableConfig1.InitialSelectionQuery = "[Series Name]:=\"Type\"";
@@ -185,6 +208,10 @@ namespace QuicTrace.Tables
             tableConfig4.InitialFilterQuery =
                 "[Type]:<>\"Tx\" AND [Type]:<>\"TxAck\" AND [Type]:<>\"TxUdp\" AND [Type]:<>\"Rx\"";
             tableBuilder.AddTableConfiguration(tableConfig4);
+
+            tableConfig5.AddColumnRole(ColumnRole.StartTime, timeColumnConfig);
+            tableConfig5.InitialFilterQuery = "[Type]:<>\"TxDelay\"";
+            tableBuilder.AddTableConfiguration(tableConfig5);
 
             tableBuilder.SetDefaultTableConfiguration(tableConfig1);
         }
@@ -229,6 +256,11 @@ namespace QuicTrace.Tables
         private static double ProjectRtt(ValueTuple<QuicConnection, QuicRawTputData> data)
         {
             return data.Item2.Value / 1000.0;
+        }
+
+        private static ulong ProjectTxDelay(ValueTuple<QuicConnection, QuicRawTputData> data)
+        {
+            return Math.Min(data.Item2.Value, 1000);
         }
 
         #endregion


### PR DESCRIPTION
<img width="629" alt="image" src="https://user-images.githubusercontent.com/20663557/149148523-ee844476-8d26-4690-95a3-c07ca45a1864.png">

Adds a new graph type that plots the delay (in microseconds, capped to 1 ms) between sends, over time. This can help to see how spaced out transmits are for pacing related issues.

Also just added a few bug fixes I found while using this.