### PR TITLE
Allow client and server to share bindings

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1441,7 +1441,7 @@ QuicBindingDeliverDatagrams(
                 Packet->DestCidLen);
     }
 
-    if (Connection == NULL) {
+    if (Connection == NULL && Binding->ServerOwned) {
 
         //
         // Because the packet chain is ordered by control packets first, we

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -178,12 +178,15 @@ typedef struct QUIC_BINDING {
     BOOLEAN Exclusive : 1;
 
     //
-    // Indicates whether the binding is owned by the server side (i.e. listener
-    // and server connections) or by the client side. Different receive side
-    // logic is used for each, so the binding cannot be shared between clients
-    // and servers.
+    // Indicates whether the binding has server side (i.e. listener
+    // and server connections) owners.
     //
     BOOLEAN ServerOwned : 1;
+
+    //
+    // Indicates whether this binding has client side owners or not.
+    //
+    BOOLEAN ClientOwned : 1;
 
     //
     // Indicates that the binding is also explicitly connected to a remote

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1526,8 +1526,7 @@ SharedEphemeralRetry:
             UdpConfig->LocalAddress,
             UdpConfig->RemoteAddress);
     if (Binding != NULL) {
-        if (!ShareBinding || Binding->Exclusive ||
-            (ServerOwned != Binding->ServerOwned)) {
+        if (!ShareBinding || Binding->Exclusive) {
             //
             // The binding does already exist, but cannot be shared with the
             // requested configuration.


### PR DESCRIPTION
Allow bindings to be shared between clients and servers. This will allow a client to create outbound connections on the same address and port as a listener on the same node.