### PR TITLE
Support High Resolution Timer (WinUser)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option(QUIC_CI "CI Specific build" OFF)
 option(QUIC_SKIP_CI_CHECKS "Disable CI specific build checks" OFF)
 option(QUIC_TELEMETRY_ASSERTS "Enable telemetry asserts in release builds" OFF)
 option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
+option(QUIC_HIGH_RES_TIMERS "Configure the system to use high resolution timers" OFF)
 option(QUIC_DISABLE_POSIX_GSO "Disable GSO for systems that say they support it but don't" OFF)
 set(QUIC_FOLDER_PREFIX "" CACHE STRING "Optional prefix for source group folders when using an IDE generator")
 set(QUIC_LIBRARY_NAME "msquic" CACHE STRING "Override the output library name")
@@ -273,6 +274,10 @@ list(APPEND QUIC_COMMON_DEFINES VER_SUFFIX=${QUIC_VER_SUFFIX})
 
 if(QUIC_TELEMETRY_ASSERTS)
     list(APPEND QUIC_COMMON_DEFINES QUIC_TELEMETRY_ASSERTS=1)
+endif()
+
+if(QUIC_HIGH_RES_TIMERS)
+    list(APPEND QUIC_COMMON_DEFINES QUIC_HIGH_RES_TIMERS=1)
 endif()
 
 if(QUIC_TLS STREQUAL "schannel")

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -81,6 +81,9 @@ This script provides helpers for building msquic.
 .PARAMETER UseSystemOpenSSLCrypto
     Use system provided OpenSSL libcrypto rather then statically linked. Only affects OpenSSL Linux builds
 
+.PARAMETER EnableHighResolutionTimers
+    Configures the system to use high resolution timers.
+
 .PARAMETER ExtraArtifactDir
     Add an extra classifier to the artifact directory to allow publishing alternate builds of same base library
 
@@ -174,6 +177,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [switch]$UseSystemOpenSSLCrypto = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$EnableHighResolutionTimers = $false,
 
     [Parameter(Mandatory = $false)]
     [string]$ExtraArtifactDir = "",
@@ -392,6 +398,9 @@ function CMake-Generate {
     }
     if ($UseSystemOpenSSLCrypto) {
         $Arguments += " -DQUIC_USE_SYSTEM_LIBCRYPTO=on"
+    }
+    if ($EnableHighResolutionTimers) {
+        $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
         $env:PATH = "$env:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"

--- a/src/generated/linux/platform_winuser.c.clog.h
+++ b/src/generated/linux/platform_winuser.c.clog.h
@@ -124,6 +124,24 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized2 , arg2, arg3, arg4);
 
 
 /*----------------------------------------------------------
+// Decoder Ring for WindowsUserInitialized
+// [ dll] Initialized (AvailMem = %llu bytes)
+// QuicTraceLogInfo(
+        WindowsUserInitialized,
+        "[ dll] Initialized (AvailMem = %llu bytes)",
+        CxPlatTotalMemory);
+// arg2 = arg2 = CxPlatTotalMemory = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_WindowsUserInitialized
+#define _clog_3_ARGS_TRACE_WindowsUserInitialized(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized , arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for WindowsUserUninitialized
 // [ dll] Uninitialized
 // QuicTraceLogInfo(

--- a/src/generated/linux/platform_winuser.c.clog.h
+++ b/src/generated/linux/platform_winuser.c.clog.h
@@ -102,17 +102,21 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, ProcessorInfo , arg2, arg3, arg4, arg5);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for WindowsUserInitialized
-// [ dll] Initialized (AvailMem = %llu bytes)
+// Decoder Ring for WindowsUserInitialized2
+// [ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])
 // QuicTraceLogInfo(
-        WindowsUserInitialized,
-        "[ dll] Initialized (AvailMem = %llu bytes)",
-        CxPlatTotalMemory);
+        WindowsUserInitialized2,
+        "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])",
+        CxPlatTotalMemory,
+        CxPlatTimerCapabilities.wPeriodMin,
+        CxPlatTimerCapabilities.wPeriodMax);
 // arg2 = arg2 = CxPlatTotalMemory = arg2
+// arg3 = arg3 = CxPlatTimerCapabilities.wPeriodMin = arg3
+// arg4 = arg4 = CxPlatTimerCapabilities.wPeriodMax = arg4
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_WindowsUserInitialized
-#define _clog_3_ARGS_TRACE_WindowsUserInitialized(uniqueId, encoded_arg_string, arg2)\
-tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized , arg2);\
+#ifndef _clog_5_ARGS_TRACE_WindowsUserInitialized2
+#define _clog_5_ARGS_TRACE_WindowsUserInitialized2(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
+tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized2 , arg2, arg3, arg4);\
 
 #endif
 

--- a/src/generated/linux/platform_winuser.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_winuser.c.clog.h.lttng.h
@@ -117,6 +117,25 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized2,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for WindowsUserInitialized
+// [ dll] Initialized (AvailMem = %llu bytes)
+// QuicTraceLogInfo(
+        WindowsUserInitialized,
+        "[ dll] Initialized (AvailMem = %llu bytes)",
+        CxPlatTotalMemory);
+// arg2 = arg2 = CxPlatTotalMemory = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized,
+    TP_ARGS(
+        unsigned long long, arg2), 
+    TP_FIELDS(
+        ctf_integer(uint64_t, arg2, arg2)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for WindowsUserUninitialized
 // [ dll] Uninitialized
 // QuicTraceLogInfo(

--- a/src/generated/linux/platform_winuser.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_winuser.c.clog.h.lttng.h
@@ -90,19 +90,27 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, ProcessorInfo,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for WindowsUserInitialized
-// [ dll] Initialized (AvailMem = %llu bytes)
+// Decoder Ring for WindowsUserInitialized2
+// [ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])
 // QuicTraceLogInfo(
-        WindowsUserInitialized,
-        "[ dll] Initialized (AvailMem = %llu bytes)",
-        CxPlatTotalMemory);
+        WindowsUserInitialized2,
+        "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])",
+        CxPlatTotalMemory,
+        CxPlatTimerCapabilities.wPeriodMin,
+        CxPlatTimerCapabilities.wPeriodMax);
 // arg2 = arg2 = CxPlatTotalMemory = arg2
+// arg3 = arg3 = CxPlatTimerCapabilities.wPeriodMin = arg3
+// arg4 = arg4 = CxPlatTimerCapabilities.wPeriodMax = arg4
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized,
+TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserInitialized2,
     TP_ARGS(
-        unsigned long long, arg2), 
+        unsigned long long, arg2,
+        unsigned int, arg3,
+        unsigned int, arg4), 
     TP_FIELDS(
         ctf_integer(uint64_t, arg2, arg2)
+        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(unsigned int, arg4, arg4)
     )
 )
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -10521,6 +10521,26 @@
       "UniqueId": "PerfControlInitialized",
       "splitArgs": [],
       "macroName": "QuicTraceLogVerbose"
+    },
+    "WindowsUserInitialized2": {
+      "ModuleProperites": {},
+      "TraceString": "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])",
+      "UniqueId": "WindowsUserInitialized2",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
     }
   },
   "ConfigFile": {
@@ -14336,6 +14356,11 @@
         "UniquenessHash": "e7d3b50d-c315-3189-9752-de68bf66c705",
         "TraceID": "LogPacketVersionNegotiation",
         "EncodingString": "[%c][%cX][-] VerNeg DestCid:%s SrcCid:%s (Payload %hu bytes)"
+      },
+      {
+        "UniquenessHash": "4f262ea3-4eb1-45f3-019c-54d89cf92893",
+        "TraceID": "WindowsUserInitialized2",
+        "EncodingString": "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])"
       }
     ]
   }

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -43,10 +43,8 @@ add_library(platform STATIC ${SOURCES})
 
 target_link_libraries(platform PUBLIC inc)
 
-if(QUIC_HIGH_RES_TIMERS)
-    if("${CX_PLATFORM}" STREQUAL "windows")
-        target_link_libraries(platform PUBLIC winmm)
-    endif()
+if("${CX_PLATFORM}" STREQUAL "windows")
+    target_link_libraries(platform PUBLIC winmm)
 endif()
 
 target_link_libraries(platform PRIVATE warnings main_binary_link_args)

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -43,6 +43,12 @@ add_library(platform STATIC ${SOURCES})
 
 target_link_libraries(platform PUBLIC inc)
 
+if(QUIC_HIGH_RES_TIMERS)
+    if("${CX_PLATFORM}" STREQUAL "windows")
+        target_link_libraries(platform PUBLIC winmm)
+    endif()
+endif()
+
 target_link_libraries(platform PRIVATE warnings main_binary_link_args)
 
 set_property(TARGET platform PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -25,7 +25,9 @@ CX_PLATFORM CxPlatform = { NULL };
 CXPLAT_PROCESSOR_INFO* CxPlatProcessorInfo;
 uint64_t* CxPlatNumaMasks;
 uint32_t* CxPlatProcessorGroupOffsets;
+#ifdef TIMERR_NOERROR
 TIMECAPS CxPlatTimerCapabilities;
+#endif // TIMERR_NOERROR
 QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -284,7 +286,6 @@ CxPlatInitialize(
     QUIC_STATUS Status;
     MEMORYSTATUSEX memInfo;
     memInfo.dwLength = sizeof(MEMORYSTATUSEX);
-    MMRESULT mmResult;
 
     CxPlatform.Heap = HeapCreate(0, 0, 0);
     if (CxPlatform.Heap == NULL) {
@@ -312,6 +313,7 @@ CxPlatInitialize(
         goto Error;
     }
 
+    MMRESULT mmResult;
     if ((mmResult = timeGetDevCaps(&CxPlatTimerCapabilities, sizeof(TIMECAPS))) != TIMERR_NOERROR) {
         QuicTraceEvent(
             LibraryErrorStatus,
@@ -332,7 +334,8 @@ CxPlatInitialize(
         Status = HRESULT_FROM_WIN32(mmResult);
         goto Error;
     }
-#endif
+#endif // QUIC_HIGH_RES_TIMERS
+#endif // TIMERR_NOERROR
 
     Status = CxPlatCryptInitialize();
     if (QUIC_FAILED(Status)) {
@@ -341,12 +344,19 @@ CxPlatInitialize(
 
     CxPlatTotalMemory = memInfo.ullTotalPageFile;
 
+#ifdef TIMERR_NOERROR
     QuicTraceLogInfo(
         WindowsUserInitialized2,
         "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])",
         CxPlatTotalMemory,
         CxPlatTimerCapabilities.wPeriodMin,
         CxPlatTimerCapabilities.wPeriodMax);
+#else // TIMERR_NOERROR
+    QuicTraceLogInfo(
+        WindowsUserInitialized,
+        "[ dll] Initialized (AvailMem = %llu bytes)",
+        CxPlatTotalMemory);
+#endif // TIMERR_NOERROR
 
 Error:
 
@@ -368,9 +378,11 @@ CxPlatUninitialize(
 {
     CxPlatCryptUninitialize();
     CXPLAT_DBG_ASSERT(CxPlatform.Heap);
+#ifdef TIMERR_NOERROR
 #ifdef QUIC_HIGH_RES_TIMERS
     timeEndPeriod(CxPlatTimerCapabilities.wPeriodMin);
 #endif
+#endif // TIMERR_NOERROR
     CXPLAT_FREE(CxPlatNumaMasks, QUIC_POOL_PLATFORM_PROC);
     CxPlatNumaMasks = NULL;
     CXPLAT_FREE(CxPlatProcessorGroupOffsets, QUIC_POOL_PLATFORM_PROC);

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -313,6 +313,7 @@ CxPlatInitialize(
         goto Error;
     }
 
+#ifdef TIMERR_NOERROR
     MMRESULT mmResult;
     if ((mmResult = timeGetDevCaps(&CxPlatTimerCapabilities, sizeof(TIMECAPS))) != TIMERR_NOERROR) {
         QuicTraceEvent(


### PR DESCRIPTION
Adds a compile-time flag to enable configuring the highest possible timer resolution for the system. Only implemented for Windows usermode right now.