### PR TITLE
Make `CXPLAT_POOL_ENTRY::SpecialFlag` to `uint64_t` to avoid unexpected assertion error

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -433,9 +433,9 @@ typedef struct CXPLAT_POOL {
 #if DEBUG
 typedef struct CXPLAT_POOL_ENTRY {
     CXPLAT_SLIST_ENTRY ListHead;
-    uint32_t SpecialFlag;
+    uint64_t SpecialFlag;
 } CXPLAT_POOL_ENTRY;
-#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAA
+#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAAAAAAAAAAui64
 
 int32_t
 CxPlatGetAllocFailDenominator(

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -435,7 +435,7 @@ typedef struct CXPLAT_POOL_ENTRY {
     CXPLAT_SLIST_ENTRY ListHead;
     uint64_t SpecialFlag;
 } CXPLAT_POOL_ENTRY;
-#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAAAAAAAAAAui64
+#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAAAAAAAAAAull
 
 int32_t
 CxPlatGetAllocFailDenominator(

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -255,9 +255,9 @@ typedef struct CXPLAT_POOL {
 #if DEBUG
 typedef struct CXPLAT_POOL_ENTRY {
     SLIST_ENTRY ListHead;
-    uint32_t SpecialFlag;
+    uint64_t SpecialFlag;
 } CXPLAT_POOL_ENTRY;
-#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAA
+#define CXPLAT_POOL_SPECIAL_FLAG    0xAAAAAAAAAAAAAAAAui64
 
 int32_t
 CxPlatGetAllocFailDenominator(


### PR DESCRIPTION
As described in #2298 , the `uint32_t SpecialFlag` field in `CXPLAT_POOL_ENTRY` could lead to some unexpected assertion error in debug mode.

In this PR, we make the `SpecialFlag` as `uint64_t` to reduce the possibility of the false alert.