### PR TITLE
Don't Double CWND Reduction in Persistent Congestion

### DIFF
--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -263,10 +263,10 @@ CubicCongestionControlOnCongestionEvent(
 
         Cubic->IsInPersistentCongestion = TRUE;
         Cubic->WindowMax =
-            Cubic->WindowLastMax =
-            Cubic->SlowStartThreshold =
-            Cubic->AimdWindow =
-                Cubic->CongestionWindow * TEN_TIMES_BETA_CUBIC / 10;
+        Cubic->WindowLastMax =
+        Cubic->SlowStartThreshold =
+        Cubic->AimdWindow =
+            Cubic->CongestionWindow * TEN_TIMES_BETA_CUBIC / 10;
         Cubic->CongestionWindow =
             DatagramPayloadLength * QUIC_PERSISTENT_CONGESTION_WINDOW_PACKETS;
         Cubic->KCubic = 0;

--- a/src/generated/linux/cubic.c.clog.h
+++ b/src/generated/linux/cubic.c.clog.h
@@ -69,9 +69,9 @@ tracepoint(CLOG_CUBIC_C, ConnCongestion , arg2);\
 // Decoder Ring for ConnPersistentCongestion
 // [conn][%p] Persistent congestion event
 // QuicTraceEvent(
-        ConnPersistentCongestion,
-        "[conn][%p] Persistent congestion event",
-        Connection);
+            ConnPersistentCongestion,
+            "[conn][%p] Persistent congestion event",
+            Connection);
 // arg2 = arg2 = Connection = arg2
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_ConnPersistentCongestion

--- a/src/generated/linux/cubic.c.clog.h.lttng.h
+++ b/src/generated/linux/cubic.c.clog.h.lttng.h
@@ -59,9 +59,9 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnCongestion,
 // Decoder Ring for ConnPersistentCongestion
 // [conn][%p] Persistent congestion event
 // QuicTraceEvent(
-        ConnPersistentCongestion,
-        "[conn][%p] Persistent congestion event",
-        Connection);
+            ConnPersistentCongestion,
+            "[conn][%p] Persistent congestion event",
+            Connection);
 // arg2 = arg2 = Connection = arg2
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnPersistentCongestion,


### PR DESCRIPTION
Fixes #2231. Don't apply both normal and persistent congestion logic on the same "data lost" event.