### PR TITLE
Some Cubic Clean Up

### DIFF
--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -403,12 +403,13 @@ CubicCongestionControlOnDataAcknowledged(
         //
 
         //
-        // TODO: CongestionWindow should only be allowed to grow up to SlowStartThreshold
-        // here, and then any spare bytes should be handled in the Congestion Avoidance path.
+        // TODO: CongestionWindow should only be allowed to grow up to
+        // SlowStartThreshold here, and then any spare bytes should be handled
+        // in the Congestion Avoidance path.
         //
         Cubic->CongestionWindow += AckEvent->NumRetransmittableBytes;
         if (Cubic->CongestionWindow >= Cubic->SlowStartThreshold) {
-            Cubic->TimeOfCongAvoidStart = CxPlatTimeUs64();
+            Cubic->TimeOfCongAvoidStart = TimeNowUs;
         }
 
     } else {
@@ -427,7 +428,7 @@ CubicCongestionControlOnDataAcknowledged(
         // growth during the gap.
         //
         if (Cubic->TimeOfLastAckValid) {
-            uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNowUs);
+            const uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNowUs);
             if (TimeSinceLastAck > MS_TO_US((uint64_t)Cubic->SendIdleTimeoutMs) &&
                 TimeSinceLastAck > (Connection->Paths[0].SmoothedRtt + 4 * Connection->Paths[0].RttVariance)) {
                 Cubic->TimeOfCongAvoidStart += TimeSinceLastAck;

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -369,7 +369,7 @@ CubicCongestionControlOnDataAcknowledged(
 {
     QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
 
-    uint64_t TimeNow = US_TO_MS(AckEvent->TimeNow);
+    const uint64_t TimeNowUs = AckEvent->TimeNow;
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     BOOLEAN PreviousCanSendState = CubicCongestionControlCanSend(Cc);
 
@@ -389,7 +389,7 @@ CubicCongestionControlOnDataAcknowledged(
                 Connection);
             Cubic->IsInRecovery = FALSE;
             Cubic->IsInPersistentCongestion = FALSE;
-            Cubic->TimeOfCongAvoidStart = CxPlatTimeMs64();
+            Cubic->TimeOfCongAvoidStart = CxPlatTimeUs64();
         }
         goto Exit;
     } else if (AckEvent->NumRetransmittableBytes == 0) {
@@ -408,7 +408,7 @@ CubicCongestionControlOnDataAcknowledged(
         //
         Cubic->CongestionWindow += AckEvent->NumRetransmittableBytes;
         if (Cubic->CongestionWindow >= Cubic->SlowStartThreshold) {
-            Cubic->TimeOfCongAvoidStart = CxPlatTimeMs64();
+            Cubic->TimeOfCongAvoidStart = CxPlatTimeUs64();
         }
 
     } else {
@@ -427,21 +427,18 @@ CubicCongestionControlOnDataAcknowledged(
         // growth during the gap.
         //
         if (Cubic->TimeOfLastAckValid) {
-            uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNow);
-            if (TimeSinceLastAck > Cubic->SendIdleTimeoutMs &&
-                TimeSinceLastAck > US_TO_MS(Connection->Paths[0].SmoothedRtt + 4 * Connection->Paths[0].RttVariance)) {
+            uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNowUs);
+            if (TimeSinceLastAck > MS_TO_US((uint64_t)Cubic->SendIdleTimeoutMs) &&
+                TimeSinceLastAck > (Connection->Paths[0].SmoothedRtt + 4 * Connection->Paths[0].RttVariance)) {
                 Cubic->TimeOfCongAvoidStart += TimeSinceLastAck;
-                if (CxPlatTimeAtOrBefore64(TimeNow, Cubic->TimeOfCongAvoidStart)) {
-                    Cubic->TimeOfCongAvoidStart = TimeNow;
+                if (CxPlatTimeAtOrBefore64(TimeNowUs, Cubic->TimeOfCongAvoidStart)) {
+                    Cubic->TimeOfCongAvoidStart = TimeNowUs;
                 }
             }
         }
 
-        uint64_t TimeInCongAvoid =
-            CxPlatTimeDiff64(Cubic->TimeOfCongAvoidStart, CxPlatTimeMs64());
-        if (TimeInCongAvoid > UINT32_MAX) {
-            TimeInCongAvoid = UINT32_MAX;
-        }
+        const uint64_t TimeInCongAvoidUs =
+            CxPlatTimeDiff64(Cubic->TimeOfCongAvoidStart, TimeNowUs);
 
         //
         // Compute the cubic window:
@@ -460,9 +457,14 @@ CubicCongestionControlOnDataAcknowledged(
         //
 
         int64_t DeltaT =
-            (int64_t)TimeInCongAvoid -
-            (int64_t)Cubic->KCubic +
-            (int64_t)US_TO_MS(AckEvent->SmoothedRtt);
+            US_TO_MS(
+                (int64_t)TimeInCongAvoidUs -
+                (int64_t)MS_TO_US(Cubic->KCubic) +
+                (int64_t)AckEvent->SmoothedRtt
+            );
+        if (DeltaT > 2500000) {
+            DeltaT = 2500000;
+        }
 
         int64_t CubicWindow =
             ((((DeltaT * DeltaT) >> 10) * DeltaT *
@@ -533,7 +535,7 @@ CubicCongestionControlOnDataAcknowledged(
 
 Exit:
 
-    Cubic->TimeOfLastAck = TimeNow;
+    Cubic->TimeOfLastAck = TimeNowUs;
     Cubic->TimeOfLastAckValid = TRUE;
     return CubicCongestionControlUpdateBlockedState(Cc, PreviousCanSendState);
 }

--- a/src/core/cubic.h
+++ b/src/core/cubic.h
@@ -74,8 +74,8 @@ typedef struct QUIC_CONGESTION_CONTROL_CUBIC {
     //
     uint8_t Exemptions;
 
-    uint64_t TimeOfLastAck; // millisec
-    uint64_t TimeOfCongAvoidStart; // millisec
+    uint64_t TimeOfLastAck; // microseconds
+    uint64_t TimeOfCongAvoidStart; // microseconds
     uint32_t KCubic; // millisec
     uint32_t PrevKCubic; // millisec
     uint32_t WindowMax; // bytes


### PR DESCRIPTION
Changes time values (except `kCubic`) to microseconds instead of milliseconds, since they're already 64-bit (which can represent something like half a million years worth of microseconds). Also tries to update some of the calculations a bit to better handle limits/overflows at different stages, but still not exactly happy with it. I want to talk with @maolson-msft some on this.