### PR TITLE
Cap CWND Growth to Prevent Large Send Bursts

### DIFF
--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -402,7 +402,7 @@ CubicCongestionControlOnDataAcknowledged(
         //
 
         const uint32_t MaxCwndGrowth =
-            (uint32_t)DatagramPayloadLength * QUIC_MAX_CWND_GROWTH_PACKETS;
+            (uint32_t)DatagramPayloadLength * QUIC_MAX_CONGESTION_WINDOW_INCREASE;
 
         if (BytesAcked > MaxCwndGrowth) {
             //

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -374,8 +374,8 @@ CubicCongestionControlOnDataAcknowledged(
 
     if (BytesAcked > QUIC_MAX_CONGESTION_WINDOW_INCREASE) {
         //
-        // Cap the increase CWND growth to prevent it from resulting in large
-        // bursts into the network.
+        // Cap the CWND growth to prevent it from resulting in large bursts into
+        // the network.
         //
         BytesAcked = QUIC_MAX_CONGESTION_WINDOW_INCREASE;
     }

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -372,6 +372,14 @@ CubicCongestionControlOnDataAcknowledged(
     CXPLAT_DBG_ASSERT(Cubic->BytesInFlight >= BytesAcked);
     Cubic->BytesInFlight -= BytesAcked;
 
+    if (BytesAcked > QUIC_MAX_CONGESTION_WINDOW_INCREASE) {
+        //
+        // Cap the increase CWND growth to prevent it from resulting in large
+        // bursts into the network.
+        //
+        BytesAcked = QUIC_MAX_CONGESTION_WINDOW_INCREASE;
+    }
+
     if (Cubic->IsInRecovery) {
         if (AckEvent->LargestPacketNumberAcked > Cubic->RecoverySentPacketNumber) {
             //

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -409,11 +409,14 @@ CubicCongestionControlOnDataAcknowledged(
             // Cap the CWND growth in slow start to prevent it from resulting in
             // large bursts into the network.
             //
-            BytesAcked = MaxCwndGrowth;
+            Cubic->CongestionWindow += MaxCwndGrowth;
+            BytesAcked -= MaxCwndGrowth;
+
+        } else {
+            Cubic->CongestionWindow += BytesAcked;
+            BytesAcked = 0;
         }
 
-        Cubic->CongestionWindow += BytesAcked;
-        BytesAcked = 0;
         if (Cubic->CongestionWindow >= Cubic->SlowStartThreshold) {
             Cubic->TimeOfCongAvoidStart = TimeNowUs;
 
@@ -423,8 +426,11 @@ CubicCongestionControlOnDataAcknowledged(
             // to SlowStartThreshold and treat the spare BytesAcked as if the bytes
             // were acknowledged during Congestion Avoidance below.
             //
-            BytesAcked = Cubic->CongestionWindow - Cubic->SlowStartThreshold;
+            BytesAcked += Cubic->CongestionWindow - Cubic->SlowStartThreshold;
             Cubic->CongestionWindow = Cubic->SlowStartThreshold;
+
+        } else {
+            BytesAcked = 0;
         }
     }
 

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -377,6 +377,12 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_SEND_PACING_INTERVAL               1000
 
 //
+// The maximum number of bytes we will allow the congestion window to grow from
+// a single acknowledgement.
+//
+#define QUIC_MAX_CONGESTION_WINDOW_INCREASE     (8 * 1472)
+
+//
 // The maximum number of bytes to send in a given key phase
 // before performing a key phase update. Roughly, 274GB.
 //

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -377,10 +377,10 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_SEND_PACING_INTERVAL               1000
 
 //
-// The maximum number of bytes we will allow the congestion window to grow from
-// a single acknowledgement.
+// The maximum number of MTUs (datagram payload length) we will allow the
+// congestion window to grow from a single acknowledgement.
 //
-#define QUIC_MAX_CONGESTION_WINDOW_INCREASE     (8 * 1472)
+#define QUIC_MAX_CONGESTION_WINDOW_INCREASE     8
 
 //
 // The maximum number of bytes to send in a given key phase

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -377,8 +377,8 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_SEND_PACING_INTERVAL               1000
 
 //
-// The maximum number of MTUs (datagram payload length) we will allow the
-// congestion window to grow from a single acknowledgement.
+// Slow start congestion window increase limit L from RFC 3465, to reduce
+// burstiness.
 //
 #define QUIC_MAX_CONGESTION_WINDOW_INCREASE     8
 


### PR DESCRIPTION
Updated the QUIC code to match TCP's logic of caping the CWND growth in slow start to no more than 8 MTUs for a single ACK.