### PR TITLE
Set Large FC Window for Perf

### DIFF
--- a/src/perf/lib/PerfCommon.h
+++ b/src/perf/lib/PerfCommon.h
@@ -16,6 +16,7 @@ Abstract:
 #define PERF_DEFAULT_PORT                   4433
 #define PERF_DEFAULT_DISCONNECT_TIMEOUT     (10 * 1000)
 #define PERF_DEFAULT_IDLE_TIMEOUT           (30 * 1000)
+#define PERF_DEFAULT_CONN_FLOW_CONTROL      0x8000000
 #define PERF_DEFAULT_STREAM_COUNT           100
 #define PERF_MAX_THREAD_COUNT               128
 

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -133,6 +133,7 @@ private:
         Registration,
         Alpn,
         MsQuicSettings()
+            .SetConnFlowControlWindow(PERF_DEFAULT_CONN_FLOW_CONTROL)
             .SetPeerBidiStreamCount(PERF_DEFAULT_STREAM_COUNT)
             .SetPeerUnidiStreamCount(PERF_DEFAULT_STREAM_COUNT)
             .SetDisconnectTimeoutMs(PERF_DEFAULT_DISCONNECT_TIMEOUT)

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -114,6 +114,7 @@ private:
         Registration,
         MsQuicAlpn(PERF_ALPN),
         MsQuicSettings()
+            .SetConnFlowControlWindow(PERF_DEFAULT_CONN_FLOW_CONTROL)
             .SetIdleTimeoutMs(TPUT_DEFAULT_IDLE_TIMEOUT),
         MsQuicCredentialConfig(
             QUIC_CREDENTIAL_FLAG_CLIENT |


### PR DESCRIPTION
Set a really large FC window to make sure it's not limiting throughput in really large BDP WAN perf scenarios.