### PR TITLE
Switch API table to v2

### DIFF
--- a/docs/api/MsQuicOpen.md
+++ b/docs/api/MsQuicOpen.md
@@ -1,4 +1,0 @@
-MsQuicOpen function
-======
-
-A simple helper inline function (or macro in C on Linux) that wraps [MsQuicOpenVersion](MsQuicOpenVersion.md) to open a version 1 API table.

--- a/docs/api/MsQuicOpen2.md
+++ b/docs/api/MsQuicOpen2.md
@@ -1,0 +1,4 @@
+MsQuicOpen2 function
+======
+
+A simple helper inline function (or macro in C on Linux) that wraps [MsQuicOpenVersion](MsQuicOpenVersion.md) to open a version 2 API table.

--- a/docs/api/MsQuicOpenVersion.md
+++ b/docs/api/MsQuicOpenVersion.md
@@ -40,7 +40,7 @@ Calls to **MsQuicOpenVersion** and [MsQuicClose](MsQuicClose.md) increment and d
 
 **MsQuicOpenVersion** may dynamically load other dependencies, so it **must not** be called from [DllMain](https://docs.microsoft.com/en-us/windows/win32/dlls/dllmain) on Windows.
 
-**MsQuicOpenVersion** Takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. For backwards compatiblity with old clients, the previous **MsQuicOpen** exists as an export in the binary. The **MsQuicOpen** definition in msquic.h now forwards to **MsQuicOpenVersion**
+**MsQuicOpenVersion** Takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. For backwards compatiblity with old clients, the previous **MsQuicOpen2** exists as an export in the binary. The **MsQuicOpen2** definition in msquic.h now forwards to **MsQuicOpenVersion**
 
 # See Also
 

--- a/docs/api/MsQuicOpenVersion.md
+++ b/docs/api/MsQuicOpenVersion.md
@@ -40,7 +40,7 @@ Calls to **MsQuicOpenVersion** and [MsQuicClose](MsQuicClose.md) increment and d
 
 **MsQuicOpenVersion** may dynamically load other dependencies, so it **must not** be called from [DllMain](https://docs.microsoft.com/en-us/windows/win32/dlls/dllmain) on Windows.
 
-**MsQuicOpenVersion** Takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. For backwards compatiblity with old clients, the previous **MsQuicOpen2** exists as an export in the binary. The **MsQuicOpen2** definition in msquic.h now forwards to **MsQuicOpenVersion**
+**MsQuicOpenVersion** Takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. The **MsQuicOpen2** definition in msquic.h now forwards to **MsQuicOpenVersion**
 
 # See Also
 

--- a/docs/api/QUIC_API_TABLE.md
+++ b/docs/api/QUIC_API_TABLE.md
@@ -170,4 +170,4 @@ See [DatagramSend](DatagramSend.md)
 
 # See Also
 
-[MsQuicOpen](MsQuicOpen.md)<br>
+[MsQuicOpen2](MsQuicOpen2.md)<br>

--- a/src/bin/darwin/exports.txt
+++ b/src/bin/darwin/exports.txt
@@ -1,3 +1,2 @@
-_MsQuicOpen
 _MsQuicOpenVersion
 _MsQuicClose

--- a/src/bin/linux/exports.txt
+++ b/src/bin/linux/exports.txt
@@ -1,5 +1,5 @@
 msquic
 {
-  global: MsQuicOpen; MsQuicOpenVersion; MsQuicClose;
+  global: MsQuicOpenVersion; MsQuicClose;
   local: *;
 };

--- a/src/bin/winkernel/driver.c
+++ b/src/bin/winkernel/driver.c
@@ -85,7 +85,7 @@ Return Value:
     //
     // We explicitly load the MsQuic library upfront (instead of letting it
     // delay load) because we need to be able to query performance counters at
-    // any time, even if there hasn't been a call to MsQuicOpen yet.
+    // any time, even if there hasn't been a call to MsQuicOpenVersion yet.
     //
     MsQuicLibraryLoad();
 

--- a/src/bin/winkernel/msquic.src
+++ b/src/bin/winkernel/msquic.src
@@ -1,6 +1,5 @@
 NAME msquic.sys
 
 EXPORTS
-    MsQuicOpen
     MsQuicOpenVersion
     MsQuicClose

--- a/src/bin/winkernel/msquicpriv.src
+++ b/src/bin/winkernel/msquicpriv.src
@@ -1,6 +1,5 @@
 NAME msquicpriv.sys
 
 EXPORTS
-    MsQuicOpen
     MsQuicOpenVersion
     MsQuicClose

--- a/src/bin/winuser/msquic.def.in
+++ b/src/bin/winuser/msquic.def.in
@@ -1,6 +1,5 @@
 LIBRARY @QUIC_LIBRARY_NAME@
 
 EXPORTS
-    MsQuicOpen
     MsQuicOpenVersion
     MsQuicClose

--- a/src/bin/winuser_fuzz/msquic_fuzz.def
+++ b/src/bin/winuser_fuzz/msquic_fuzz.def
@@ -1,7 +1,6 @@
 LIBRARY msquic_fuzz
 
 EXPORTS
-    MsQuicOpen
     MsQuicOpenVersion
     MsQuicClose
     MsQuicFuzzInit

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1309,9 +1309,10 @@ MsQuicOpenVersion(
     BOOLEAN ReleaseRefOnFailure = FALSE;
 
     if (Version != 2) {
-        QuicTraceLogVerbose(
-            LibraryMsQuicOpenVersionUnsupported,
-            "[ api] MsQuicOpenVersion, Only version 2 supported");
+        QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "Only v2 is supported in MsQuicOpenVersion");
         return QUIC_STATUS_NOT_SUPPORTED;
     }
 

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1309,6 +1309,9 @@ MsQuicOpenVersion(
     BOOLEAN ReleaseRefOnFailure = FALSE;
 
     if (Version != 2) {
+        QuicTraceLogVerbose(
+            LibraryMsQuicOpenVersionUnsupported,
+            "[ api] MsQuicOpenVersion, Only version 2 supported");
         return QUIC_STATUS_NOT_SUPPORTED;
     }
 
@@ -1316,15 +1319,15 @@ MsQuicOpenVersion(
 
     if (QuicApi == NULL) {
         QuicTraceLogVerbose(
-            LibraryMsQuicOpenNull,
-            "[ api] MsQuicOpen, NULL");
+            LibraryMsQuicOpenVersionNull,
+            "[ api] MsQuicOpenVersion, NULL");
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Exit;
     }
 
     QuicTraceLogVerbose(
-        LibraryMsQuicOpenEntry,
-        "[ api] MsQuicOpen");
+        LibraryMsQuicOpenVersionEntry,
+        "[ api] MsQuicOpenVersion");
 
     Status = MsQuicAddRef();
     if (QUIC_FAILED(Status)) {
@@ -1380,8 +1383,8 @@ MsQuicOpenVersion(
 Exit:
 
     QuicTraceLogVerbose(
-        LibraryMsQuicOpenExit,
-        "[ api] MsQuicOpen, status=0x%x",
+        LibraryMsQuicOpenVersionExit,
+        "[ api] MsQuicOpenVersion, status=0x%x",
         Status);
 
     if (QUIC_FAILED(Status)) {

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1297,6 +1297,7 @@ Error:
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+_Check_return_
 QUIC_STATUS
 QUIC_API
 MsQuicOpenVersion(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1296,18 +1296,20 @@ Error:
     return Status;
 }
 
-//
-// N.B Maintained and exported for backwards compatiblity with old V1 clients.
-//
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QUIC_API
-MsQuicOpen(
-    _Out_ _Pre_defensive_ const QUIC_API_TABLE** QuicApi
+MsQuicOpenVersion(
+    _In_ uint32_t Version,
+    _Out_ _Pre_defensive_ const void** QuicApi
     )
 {
     QUIC_STATUS Status;
     BOOLEAN ReleaseRefOnFailure = FALSE;
+
+    if (Version != 2) {
+        return QUIC_STATUS_NOT_SUPPORTED;
+    }
 
     MsQuicLibraryLoad();
 
@@ -1390,20 +1392,6 @@ Exit:
     }
 
     return Status;
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-QUIC_STATUS
-QUIC_API
-MsQuicOpenVersion(
-    _In_ uint32_t Version,
-    _Out_ _Pre_defensive_ const void** QuicApi
-    )
-{
-    if (Version != 1) {
-        return QUIC_STATUS_NOT_SUPPORTED;
-    }
-    return MsQuicOpen((const QUIC_API_TABLE**)QuicApi);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -137,7 +137,7 @@ typedef struct QUIC_LIBRARY {
     volatile short LoadRefCount;
 
     //
-    // Total outstanding references from calls to MsQuicOpen.
+    // Total outstanding references from calls to MsQuicOpenVersion.
     //
     uint16_t OpenRefCount;
 

--- a/src/core/precomp.h
+++ b/src/core/precomp.h
@@ -17,7 +17,6 @@
 #pragma warning(disable:28931) // Unused Assignment
 
 #define QUIC_API_ENABLE_INSECURE_FEATURES 1
-#define QUIC_CORE_INTERNAL 1
 
 //
 // Platform or Public Headers.

--- a/src/cs/lib/msquic.cs
+++ b/src/cs/lib/msquic.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quic
         public static unsafe QUIC_API_TABLE* Open()
         {
             QUIC_API_TABLE* ApiTable;
-            int Status = MsQuicOpenVersion(1, (void**)&ApiTable);
+            int Status = MsQuicOpenVersion(2, (void**)&ApiTable);
             ThrowIfFailure(Status);
             return ApiTable;
         }

--- a/src/generated/linux/library.c.clog.h
+++ b/src/generated/linux/library.c.clog.h
@@ -224,22 +224,6 @@ tracepoint(CLOG_LIBRARY_C, LibraryNotInUse );\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenVersionUnsupported
-// [ api] MsQuicOpenVersion, Only version 2 supported
-// QuicTraceLogVerbose(
-            LibraryMsQuicOpenVersionUnsupported,
-            "[ api] MsQuicOpenVersion, Only version 2 supported");
-----------------------------------------------------------*/
-#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionUnsupported
-#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionUnsupported(uniqueId, encoded_arg_string)\
-tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionUnsupported );\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for LibraryMsQuicOpenVersionNull
 // [ api] MsQuicOpenVersion, NULL
 // QuicTraceLogVerbose(
@@ -446,6 +430,24 @@ tracepoint(CLOG_LIBRARY_C, LibraryAddRef );\
 #ifndef _clog_2_ARGS_TRACE_LibraryRelease
 #define _clog_2_ARGS_TRACE_LibraryRelease(uniqueId, encoded_arg_string)\
 tracepoint(CLOG_LIBRARY_C, LibraryRelease );\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "Only v2 is supported in MsQuicOpenVersion");
+// arg2 = arg2 = "Only v2 is supported in MsQuicOpenVersion" = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_LibraryError
+#define _clog_3_ARGS_TRACE_LibraryError(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_LIBRARY_C, LibraryError , arg2);\
 
 #endif
 

--- a/src/generated/linux/library.c.clog.h
+++ b/src/generated/linux/library.c.clog.h
@@ -224,15 +224,15 @@ tracepoint(CLOG_LIBRARY_C, LibraryNotInUse );\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenNull
-// [ api] MsQuicOpen, NULL
+// Decoder Ring for LibraryMsQuicOpenVersionUnsupported
+// [ api] MsQuicOpenVersion, Only version 2 supported
 // QuicTraceLogVerbose(
-            LibraryMsQuicOpenNull,
-            "[ api] MsQuicOpen, NULL");
+            LibraryMsQuicOpenVersionUnsupported,
+            "[ api] MsQuicOpenVersion, Only version 2 supported");
 ----------------------------------------------------------*/
-#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenNull
-#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenNull(uniqueId, encoded_arg_string)\
-tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenNull );\
+#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionUnsupported
+#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionUnsupported(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionUnsupported );\
 
 #endif
 
@@ -240,15 +240,15 @@ tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenNull );\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenEntry
-// [ api] MsQuicOpen
+// Decoder Ring for LibraryMsQuicOpenVersionNull
+// [ api] MsQuicOpenVersion, NULL
 // QuicTraceLogVerbose(
-        LibraryMsQuicOpenEntry,
-        "[ api] MsQuicOpen");
+            LibraryMsQuicOpenVersionNull,
+            "[ api] MsQuicOpenVersion, NULL");
 ----------------------------------------------------------*/
-#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenEntry
-#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenEntry(uniqueId, encoded_arg_string)\
-tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenEntry );\
+#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionNull
+#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionNull(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionNull );\
 
 #endif
 
@@ -256,17 +256,33 @@ tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenEntry );\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenExit
-// [ api] MsQuicOpen, status=0x%x
+// Decoder Ring for LibraryMsQuicOpenVersionEntry
+// [ api] MsQuicOpenVersion
 // QuicTraceLogVerbose(
-        LibraryMsQuicOpenExit,
-        "[ api] MsQuicOpen, status=0x%x",
+        LibraryMsQuicOpenVersionEntry,
+        "[ api] MsQuicOpenVersion");
+----------------------------------------------------------*/
+#ifndef _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionEntry
+#define _clog_2_ARGS_TRACE_LibraryMsQuicOpenVersionEntry(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionEntry );\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryMsQuicOpenVersionExit
+// [ api] MsQuicOpenVersion, status=0x%x
+// QuicTraceLogVerbose(
+        LibraryMsQuicOpenVersionExit,
+        "[ api] MsQuicOpenVersion, status=0x%x",
         Status);
 // arg2 = arg2 = Status = arg2
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_LibraryMsQuicOpenExit
-#define _clog_3_ARGS_TRACE_LibraryMsQuicOpenExit(uniqueId, encoded_arg_string, arg2)\
-tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenExit , arg2);\
+#ifndef _clog_3_ARGS_TRACE_LibraryMsQuicOpenVersionExit
+#define _clog_3_ARGS_TRACE_LibraryMsQuicOpenVersionExit(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionExit , arg2);\
 
 #endif
 

--- a/src/generated/linux/library.c.clog.h.lttng.h
+++ b/src/generated/linux/library.c.clog.h.lttng.h
@@ -193,13 +193,13 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryNotInUse,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenNull
-// [ api] MsQuicOpen, NULL
+// Decoder Ring for LibraryMsQuicOpenVersionUnsupported
+// [ api] MsQuicOpenVersion, Only version 2 supported
 // QuicTraceLogVerbose(
-            LibraryMsQuicOpenNull,
-            "[ api] MsQuicOpen, NULL");
+            LibraryMsQuicOpenVersionUnsupported,
+            "[ api] MsQuicOpenVersion, Only version 2 supported");
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenNull,
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionUnsupported,
     TP_ARGS(
 ), 
     TP_FIELDS(
@@ -209,13 +209,13 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenNull,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenEntry
-// [ api] MsQuicOpen
+// Decoder Ring for LibraryMsQuicOpenVersionNull
+// [ api] MsQuicOpenVersion, NULL
 // QuicTraceLogVerbose(
-        LibraryMsQuicOpenEntry,
-        "[ api] MsQuicOpen");
+            LibraryMsQuicOpenVersionNull,
+            "[ api] MsQuicOpenVersion, NULL");
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenEntry,
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionNull,
     TP_ARGS(
 ), 
     TP_FIELDS(
@@ -225,15 +225,31 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenEntry,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenExit
-// [ api] MsQuicOpen, status=0x%x
+// Decoder Ring for LibraryMsQuicOpenVersionEntry
+// [ api] MsQuicOpenVersion
 // QuicTraceLogVerbose(
-        LibraryMsQuicOpenExit,
-        "[ api] MsQuicOpen, status=0x%x",
+        LibraryMsQuicOpenVersionEntry,
+        "[ api] MsQuicOpenVersion");
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionEntry,
+    TP_ARGS(
+), 
+    TP_FIELDS(
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryMsQuicOpenVersionExit
+// [ api] MsQuicOpenVersion, status=0x%x
+// QuicTraceLogVerbose(
+        LibraryMsQuicOpenVersionExit,
+        "[ api] MsQuicOpenVersion, status=0x%x",
         Status);
 // arg2 = arg2 = Status = arg2
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenExit,
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionExit,
     TP_ARGS(
         unsigned int, arg2), 
     TP_FIELDS(

--- a/src/generated/linux/library.c.clog.h.lttng.h
+++ b/src/generated/linux/library.c.clog.h.lttng.h
@@ -193,22 +193,6 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryNotInUse,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for LibraryMsQuicOpenVersionUnsupported
-// [ api] MsQuicOpenVersion, Only version 2 supported
-// QuicTraceLogVerbose(
-            LibraryMsQuicOpenVersionUnsupported,
-            "[ api] MsQuicOpenVersion, Only version 2 supported");
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryMsQuicOpenVersionUnsupported,
-    TP_ARGS(
-), 
-    TP_FIELDS(
-    )
-)
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for LibraryMsQuicOpenVersionNull
 // [ api] MsQuicOpenVersion, NULL
 // QuicTraceLogVerbose(
@@ -433,6 +417,25 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryRelease,
     TP_ARGS(
 ), 
     TP_FIELDS(
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "Only v2 is supported in MsQuicOpenVersion");
+// arg2 = arg2 = "Only v2 is supported in MsQuicOpenVersion" = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryError,
+    TP_ARGS(
+        const char *, arg2), 
+    TP_FIELDS(
+        ctf_string(arg2, arg2)
     )
 )
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1323,6 +1323,10 @@ typedef struct QUIC_API_TABLE {
 // MsQuicClose must be called when the app is done with the function table.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
+_Check_return_
+#if (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
+[[nodiscard]]
+#endif
 QUIC_STATUS
 QUIC_API
 MsQuicOpenVersion(
@@ -1334,11 +1338,13 @@ MsQuicOpenVersion(
 // Version specific helpers that wrap MsQuicOpenVersion.
 //
 
-#ifndef QUIC_CORE_INTERNAL
-
-/*#if defined(__cplusplus) || defined(WIN32)
+#if defined(__cplusplus)
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+_Check_return_
+#if (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
+[[nodiscard]]
+#endif
 #ifdef WIN32
 __forceinline
 #else
@@ -1349,16 +1355,14 @@ MsQuicOpen(
     _Out_ _Pre_defensive_ const QUIC_API_TABLE** QuicApi
     )
 {
-    return MsQuicOpenVersion(1, (const void**)QuicApi);
+    return MsQuicOpenVersion(2, (const void**)QuicApi);
 }
 
-#else*/
+#else
 
-#define MsQuicOpen(QuicApi) MsQuicOpenVersion(1, (const void**)QuicApi)
+#define MsQuicOpen(QuicApi) MsQuicOpenVersion(2, (const void**)QuicApi)
 
-/*#endif // defined(__cplusplus) || defined(WIN32)*/
-
-#endif // QUIC_CORE_INTERNAL
+#endif // defined(__cplusplus)
 
 //
 // Cleans up the function table returned from MsQuicOpen and releases the

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1351,7 +1351,7 @@ __forceinline
 __attribute__((always_inline)) inline
 #endif
 QUIC_STATUS
-MsQuicOpen(
+MsQuicOpen2(
     _Out_ _Pre_defensive_ const QUIC_API_TABLE** QuicApi
     )
 {
@@ -1360,7 +1360,7 @@ MsQuicOpen(
 
 #else
 
-#define MsQuicOpen(QuicApi) MsQuicOpenVersion(2, (const void**)QuicApi)
+#define MsQuicOpen2(QuicApi) MsQuicOpenVersion(2, (const void**)QuicApi)
 
 #endif // defined(__cplusplus)
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1271,8 +1271,8 @@ QUIC_STATUS
     );
 
 //
-// Version 1 API Function Table. Returned from MsQuicOpenVersion when Version
-// is 1. Also returned from MsQuicOpen.
+// Version 2 API Function Table. Returned from MsQuicOpenVersion when Version
+// is 2. Also returned from MsQuicOpen2.
 //
 typedef struct QUIC_API_TABLE {
 
@@ -1365,7 +1365,7 @@ MsQuicOpen2(
 #endif // defined(__cplusplus)
 
 //
-// Cleans up the function table returned from MsQuicOpen and releases the
+// Cleans up the function table returned from MsQuicOpenVersion and releases the
 // reference on the API.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -294,7 +294,7 @@ class MsQuicApi : public QUIC_API_TABLE {
     QUIC_STATUS InitStatus;
 public:
     MsQuicApi() noexcept {
-        if (QUIC_SUCCEEDED(InitStatus = MsQuicOpen(&ApiTable))) {
+        if (QUIC_SUCCEEDED(InitStatus = MsQuicOpen2(&ApiTable))) {
             QUIC_API_TABLE* thisTable = this;
             memcpy(thisTable, ApiTable, sizeof(*ApiTable));
         }

--- a/src/inc/quic_sal_stub.h
+++ b/src/inc/quic_sal_stub.h
@@ -271,4 +271,8 @@
 #define _At_(...)
 #endif
 
+#ifndef _Check_return_
+#define _Check_return_
+#endif
+
 #endif // _SAL_STUB_H

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,7 +1036,7 @@ impl CredentialConfig {
 impl Api {
     pub fn new() -> Api {
         let new_table: *const ApiTable = ptr::null();
-        let status = unsafe { MsQuicOpenVersion(1, &new_table) };
+        let status = unsafe { MsQuicOpenVersion(2, &new_table) };
         if Status::failed(status) {
             panic!("MsQuicOpenVersion failure 0x{:x}", status);
         }

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -10541,6 +10541,39 @@
         }
       ],
       "macroName": "QuicTraceLogInfo"
+    },
+    "LibraryMsQuicOpenVersionUnsupported": {
+      "ModuleProperites": {},
+      "TraceString": "[ api] MsQuicOpenVersion, Only version 2 supported",
+      "UniqueId": "LibraryMsQuicOpenVersionUnsupported",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LibraryMsQuicOpenVersionNull": {
+      "ModuleProperites": {},
+      "TraceString": "[ api] MsQuicOpenVersion, NULL",
+      "UniqueId": "LibraryMsQuicOpenVersionNull",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LibraryMsQuicOpenVersionEntry": {
+      "ModuleProperites": {},
+      "TraceString": "[ api] MsQuicOpenVersion",
+      "UniqueId": "LibraryMsQuicOpenVersionEntry",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "LibraryMsQuicOpenVersionExit": {
+      "ModuleProperites": {},
+      "TraceString": "[ api] MsQuicOpenVersion, status=0x%x",
+      "UniqueId": "LibraryMsQuicOpenVersionExit",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
     }
   },
   "ConfigFile": {
@@ -14361,6 +14394,26 @@
         "UniquenessHash": "4f262ea3-4eb1-45f3-019c-54d89cf92893",
         "TraceID": "WindowsUserInitialized2",
         "EncodingString": "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])"
+      },
+      {
+        "UniquenessHash": "a9f59856-9834-de26-4bb6-bb8a05fc47ab",
+        "TraceID": "LibraryMsQuicOpenVersionUnsupported",
+        "EncodingString": "[ api] MsQuicOpenVersion, Only version 2 supported"
+      },
+      {
+        "UniquenessHash": "9dbf9e05-d5cd-4ec3-ea93-fb33942ff968",
+        "TraceID": "LibraryMsQuicOpenVersionNull",
+        "EncodingString": "[ api] MsQuicOpenVersion, NULL"
+      },
+      {
+        "UniquenessHash": "108ce8c8-296c-0dfd-9efc-9ed86bcb1c7d",
+        "TraceID": "LibraryMsQuicOpenVersionEntry",
+        "EncodingString": "[ api] MsQuicOpenVersion"
+      },
+      {
+        "UniquenessHash": "fc39ba20-c315-583e-6b62-656fbbd3d077",
+        "TraceID": "LibraryMsQuicOpenVersionExit",
+        "EncodingString": "[ api] MsQuicOpenVersion, status=0x%x"
       }
     ]
   }

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -89,7 +89,7 @@ QuicTestCtlInitialize(
             LibraryErrorStatus,
             "[ lib] ERROR, %u, %s.",
             MsQuic->GetInitStatus(),
-            "MsQuicOpen");
+            "MsQuicApi Constructor");
         goto Error;
     }
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -20,7 +20,7 @@ void QuicTestValidateApi()
 {
     TEST_QUIC_STATUS(
         QUIC_STATUS_INVALID_PARAMETER,
-        MsQuicOpen(nullptr));
+        MsQuicOpen2(nullptr));
 
     MsQuicClose(nullptr);
 }

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -1214,7 +1214,7 @@ main(
     CxPlatLockInitialize(&TestResultsLock);
 
     if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
-        printf("MsQuicOpen failed, 0x%x!\n", Status);
+        printf("MsQuicOpen2 failed, 0x%x!\n", Status);
         goto Error;
     }
 

--- a/src/tools/interop/interop.cpp
+++ b/src/tools/interop/interop.cpp
@@ -1213,7 +1213,7 @@ main(
 
     CxPlatLockInitialize(&TestResultsLock);
 
-    if (QUIC_FAILED(Status = MsQuicOpen(&MsQuic))) {
+    if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
         printf("MsQuicOpen failed, 0x%x!\n", Status);
         goto Error;
     }

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -57,7 +57,7 @@ main(
     }
 
     HQUIC Registration = nullptr;
-    EXIT_ON_FAILURE(MsQuicOpen(&MsQuic));
+    EXIT_ON_FAILURE(MsQuicOpen2(&MsQuic));
     const QUIC_REGISTRATION_CONFIG RegConfig = { "interopserver", QUIC_EXECUTION_PROFILE_LOW_LATENCY };
     EXIT_ON_FAILURE(MsQuic->RegistrationOpen(&RegConfig, &Registration));
 

--- a/src/tools/ip/quicip.h
+++ b/src/tools/ip/quicip.h
@@ -222,7 +222,7 @@ MsQuicGetPublicIP(
     HQUIC Registration = NULL;
     const QUIC_REGISTRATION_CONFIG RegConfig = { "ip", QUIC_EXECUTION_PROFILE_LOW_LATENCY };
 
-    if (QUIC_FAILED(Status = MsQuicOpen(&MsQuic))) {
+    if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
         QUIC_PRINTF("MsQuicOpen failed, 0x%x!\n", Status);
         goto Error;
     }

--- a/src/tools/ip/quicip.h
+++ b/src/tools/ip/quicip.h
@@ -223,7 +223,7 @@ MsQuicGetPublicIP(
     const QUIC_REGISTRATION_CONFIG RegConfig = { "ip", QUIC_EXECUTION_PROFILE_LOW_LATENCY };
 
     if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
-        QUIC_PRINTF("MsQuicOpen failed, 0x%x!\n", Status);
+        QUIC_PRINTF("MsQuicOpen2 failed, 0x%x!\n", Status);
         goto Error;
     }
 

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -211,7 +211,7 @@ main(
     }
 
     if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
-        printf("MsQuicOpen failed, 0x%x!\n", Status);
+        printf("MsQuicOpen2 failed, 0x%x!\n", Status);
         goto Error;
     }
 

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -210,7 +210,7 @@ main(
         return Status;
     }
 
-    if (QUIC_FAILED(Status = MsQuicOpen(&MsQuic))) {
+    if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
         printf("MsQuicOpen failed, 0x%x!\n", Status);
         goto Error;
     }

--- a/src/tools/post/post.cpp
+++ b/src/tools/post/post.cpp
@@ -146,7 +146,7 @@ main(
     CredConfig.Type = QUIC_CREDENTIAL_TYPE_NONE;
     CredConfig.Flags = QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION | QUIC_CREDENTIAL_FLAG_CLIENT;
 
-    EXIT_ON_FAILURE(MsQuicOpen(&MsQuic));
+    EXIT_ON_FAILURE(MsQuicOpen2(&MsQuic));
     const QUIC_REGISTRATION_CONFIG RegConfig = { "post", QUIC_EXECUTION_PROFILE_LOW_LATENCY };
     EXIT_ON_FAILURE(MsQuic->RegistrationOpen(&RegConfig, &Registration));
     EXIT_ON_FAILURE(MsQuic->ConfigurationOpen(Registration, ALPNs, ARRAYSIZE(ALPNs), nullptr, 0, nullptr, &Configuration));

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -180,7 +180,7 @@ main(int argc, char **argv)
         }
     }
 
-    if (QUIC_FAILED(MsQuicOpen(&MsQuic))) {
+    if (QUIC_FAILED(MsQuicOpen2(&MsQuic))) {
         printf("MsQuicOpen failed.\n");
         exit(1);
     }

--- a/src/tools/reach/reach.cpp
+++ b/src/tools/reach/reach.cpp
@@ -181,7 +181,7 @@ main(int argc, char **argv)
     }
 
     if (QUIC_FAILED(MsQuicOpen2(&MsQuic))) {
-        printf("MsQuicOpen failed.\n");
+        printf("MsQuicOpen2 failed.\n");
         exit(1);
     }
 

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -80,7 +80,7 @@ const uint64_t IdleTimeoutMs = 1000;
 const uint32_t SendBufferLength = 100;
 
 //
-// The QUIC API/function table returned from MsQuicOpen. It contains all the
+// The QUIC API/function table returned from MsQuicOpen2. It contains all the
 // functions called by the app to interact with MsQuic.
 //
 const QUIC_API_TABLE* MsQuic;
@@ -864,7 +864,7 @@ main(
     // Open a handle to the library and get the API function table.
     //
     if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
-        printf("MsQuicOpen failed, 0x%x!\n", Status);
+        printf("MsQuicOpen2 failed, 0x%x!\n", Status);
         goto Error;
     }
 

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -863,7 +863,7 @@ main(
     //
     // Open a handle to the library and get the API function table.
     //
-    if (QUIC_FAILED(Status = MsQuicOpen(&MsQuic))) {
+    if (QUIC_FAILED(Status = MsQuicOpen2(&MsQuic))) {
         printf("MsQuicOpen failed, 0x%x!\n", Status);
         goto Error;
     }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -915,7 +915,7 @@ CXPLAT_THREAD_CALLBACK(RunThread, Context)
             ASSERT_ON_NOT(Gb.Buffers[j].Buffer);
         }
 
-        QUIC_STATUS Status = MsQuicOpen(&Gb.MsQuic);
+        QUIC_STATUS Status = MsQuicOpen2(&Gb.MsQuic);
         if (QUIC_FAILED(Status)) {
             break;
         }
@@ -1098,7 +1098,7 @@ main(int argc, char **argv)
     // Initial MsQuicOpen and initialization.
     //
     const QUIC_API_TABLE* TempMsQuic = nullptr;
-    ASSERT_ON_FAILURE(MsQuicOpen(&TempMsQuic));
+    ASSERT_ON_FAILURE(MsQuicOpen2(&TempMsQuic));
     CxPlatCopyMemory(&MsQuic, TempMsQuic, sizeof(MsQuic));
 
     if (Settings.AllocFailDenominator > 0) {

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -1095,7 +1095,7 @@ main(int argc, char **argv)
     srand(RngSeed);
 
     //
-    // Initial MsQuicOpen and initialization.
+    // Initial MsQuicOpen2 and initialization.
     //
     const QUIC_API_TABLE* TempMsQuic = nullptr;
     ASSERT_ON_FAILURE(MsQuicOpen2(&TempMsQuic));


### PR DESCRIPTION
This makes the API change more breaking to users. This also allows us to remove the existing MsQuicOpen backcompat function. Doing this lets us add the inline helper back in. Additionally, added [[nodiscard]] to ensure the result here is not discarded