### PR TITLE
Readd macos spinquic running

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -677,6 +677,7 @@ stages:
   dependsOn:
   - build_windows_debug
   - build_linux_debug
+  - build_macos_debug
   jobs:
   - template: ./templates/run-spinquic.yml
     parameters:
@@ -714,6 +715,12 @@ stages:
     parameters:
       image: ubuntu-latest
       platform: linux
+      tls: openssl
+      allocFail: 100
+  - template: ./templates/run-spinquic.yml
+    parameters:
+      image: macOS-10.15
+      platform: macos
       tls: openssl
       allocFail: 100
 


### PR DESCRIPTION
Because we now have macOS dumps enabled, we can investigate failures here better. We should get to the bottom of why this was failing in the past.