### PR TITLE
QuicStreamSendFlush: Don't double start the stream

### DIFF
--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -561,7 +561,7 @@ QuicStreamSendFlush(
             SendRequest->StreamOffset,
             SendRequest->Flags);
 
-        if (SendRequest->Flags & QUIC_SEND_FLAG_START) {
+        if (SendRequest->Flags & QUIC_SEND_FLAG_START && !Stream->Flags.Started) {
             //
             // Start the stream if the flag is set.
             //

--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -658,7 +658,7 @@ struct ValidateStreamEventArgs {
     uint32_t Test;
     static ::std::vector<ValidateStreamEventArgs> Generate() {
         ::std::vector<ValidateStreamEventArgs> list;
-        for (uint32_t Test = 0; Test < 7; ++Test)
+        for (uint32_t Test = 0; Test < 8; ++Test)
             list.push_back({ Test });
         return list;
     }

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -1313,6 +1313,131 @@ QuicTestValidateStreamEvents7(
     } // Connections scope
 }
 
+
+void
+QuicTestValidateStreamEvents8(
+    _In_ MsQuicRegistration& Registration,
+    _In_ HQUIC Listener,
+    _In_ QuicAddr& ServerLocalAddr
+    )
+{
+    TestScopeLogger ScopeLogger(__FUNCTION__);
+
+    MsQuicSettings Settings;
+    Settings.SetPeerBidiStreamCount(1).SetMinimumMtu(1280).SetMaximumMtu(1280);
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", Settings, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", MsQuicSettings().SetMinimumMtu(1280).SetMaximumMtu(1280), MsQuicCredentialConfig());
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    { // Connections scope
+    ConnValidator Client, Server(ServerConfiguration);
+
+    MsQuic->SetContext(Listener, &Server);
+
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionOpen(
+            Registration,
+            ConnValidatorCallback,
+            &Client,
+            &Client.Handle));
+
+    { // Stream scope
+
+    StreamValidator ClientStream(
+        new(std::nothrow) StreamEventValidator* [7] {
+            new(std::nothrow) StreamStartCompleteEventValidator(),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_RECEIVE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, 0, true),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
+            nullptr
+        });
+    StreamValidator ServerStream(
+        new(std::nothrow) StreamEventValidator* [7] {
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_RECEIVE), // First send buffer
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_RECEIVE), // Second send buffer
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_RECEIVE), // FIN
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN, QUIC_EVENT_ACTION_SHUTDOWN_STREAM),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE),
+            new(std::nothrow) StreamEventValidator(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE),
+            nullptr
+        });
+
+    Client.SetExpectedEvents(
+        new(std::nothrow) ConnEventValidator* [7] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+            nullptr
+        });
+    Server.SetExpectedEvents(
+        new(std::nothrow) ConnEventValidator* [6] {
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
+            new(std::nothrow) NewStreamEventValidator(&ServerStream),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
+            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
+            nullptr
+        });
+
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamOpen(
+            Client.Handle,
+            QUIC_STREAM_OPEN_FLAG_NONE,
+            StreamValidatorCallback,
+            &ClientStream,
+            &ClientStream.Handle));
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamStart(
+            ClientStream.Handle,
+            QUIC_STREAM_START_FLAG_IMMEDIATE));
+
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionStart(
+            Client.Handle,
+            ClientConfiguration,
+            QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+            QUIC_LOCALHOST_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+            ServerLocalAddr.GetPort()));
+    TEST_TRUE(Client.HandshakeComplete.WaitTimeout(1000));
+
+    CxPlatSleep(100);
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamSend(
+            ClientStream.Handle,
+            &StreamBuffer,
+            1,
+            QUIC_SEND_FLAG_START,
+            nullptr));
+    CxPlatSleep(20);
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamSend(
+            ClientStream.Handle,
+            &StreamBuffer,
+            1,
+            QUIC_SEND_FLAG_START,
+            nullptr));
+
+    CxPlatSleep(100);
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamShutdown(
+            ClientStream.Handle,
+            QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL,
+            0));
+
+    TEST_TRUE(Client.Complete.WaitTimeout(2000));
+    TEST_TRUE(Server.Complete.WaitTimeout(1000));
+
+    } // Stream scope
+    } // Connections scope
+}
+
 void QuicTestValidateStreamEvents(uint32_t Test)
 {
     MsQuicRegistration Registration(true);
@@ -1337,7 +1462,8 @@ void QuicTestValidateStreamEvents(uint32_t Test)
         QuicTestValidateStreamEvents4,
         QuicTestValidateStreamEvents5,
         QuicTestValidateStreamEvents6,
-        QuicTestValidateStreamEvents7
+        QuicTestValidateStreamEvents7,
+        QuicTestValidateStreamEvents8
     };
 
     Tests[Test](Registration, Listener, ServerLocalAddr);

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -1169,6 +1169,13 @@ QuicTestValidateStreamEvents6(
             0,
             QUIC_SEND_FLAG_START,
             nullptr));
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->StreamSend(
+            ClientStream.Handle,
+            nullptr,
+            0,
+            QUIC_SEND_FLAG_START,
+            nullptr));
 
     TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(


### PR DESCRIPTION
This changes the behavior of `StreamSend` when supplied with the `QUIC_SEND_FLAG_START` flag.

With this change, the stream will only be started once and not subsequently if it has already been started.

This avoids an unwanted scenario that follows when multiple stream `QUIC_STREAM_EVENT_START_COMPLETE` events are raised that risk undefined application or implementation specific behavior.

This does not change the behavior of multiple calls to `StreamStart`.