### PR TITLE
Revert QUIC_ADDRESS_FAMILY back to platform specific values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,5 @@ cmake = "0.1"
 
 [dependencies]
 libc = "0.2.0"
+c-types = "1.2.0"
 serde = { version = "1.0.117", features = ["derive"] }

--- a/src/cs/lib/msquic.cs
+++ b/src/cs/lib/msquic.cs
@@ -95,10 +95,9 @@ namespace Microsoft.Quic
         public static readonly int QUIC_STATUS_CERT_EXPIRED = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MsQuic_Windows.QUIC_STATUS_CERT_EXPIRED : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MsQuic_MacOS.QUIC_STATUS_CERT_EXPIRED : MsQuic_Linux.QUIC_STATUS_CERT_EXPIRED;
         public static readonly int QUIC_STATUS_CERT_UNTRUSTED_ROOT = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MsQuic_Windows.QUIC_STATUS_CERT_UNTRUSTED_ROOT : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MsQuic_MacOS.QUIC_STATUS_CERT_UNTRUSTED_ROOT : MsQuic_Linux.QUIC_STATUS_CERT_UNTRUSTED_ROOT;
 
-
-        public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
-        public const int QUIC_ADDRESS_FAMILY_INET = 2;
-        public const int QUIC_ADDRESS_FAMILY_INET6 = 23;
+        public static readonly int QUIC_ADDRESS_FAMILY_UNSPEC = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_UNSPEC : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MsQuic_MacOS.QUIC_ADDRESS_FAMILY_UNSPEC : MsQuic_Linux.QUIC_ADDRESS_FAMILY_UNSPEC;
+        public static readonly int QUIC_ADDRESS_FAMILY_INET = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_INET : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MsQuic_MacOS.QUIC_ADDRESS_FAMILY_INET : MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET;
+        public static readonly int QUIC_ADDRESS_FAMILY_INET6 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_INET6 : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MsQuic_MacOS.QUIC_ADDRESS_FAMILY_INET6 : MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET6;
     }
 
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>

--- a/src/cs/lib/msquic_generated_linux.cs
+++ b/src/cs/lib/msquic_generated_linux.cs
@@ -102,5 +102,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_STATUS_CERT_UNTRUSTED_ROOT QUIC_STATUS_CERT_ERROR(2)")]
         public const int QUIC_STATUS_CERT_UNTRUSTED_ROOT = ((int)(2) + 512 + 200000000);
+
+        public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
+        public const int QUIC_ADDRESS_FAMILY_INET = 2;
+        public const int QUIC_ADDRESS_FAMILY_INET6 = 10;
     }
 }

--- a/src/cs/lib/msquic_generated_macos.cs
+++ b/src/cs/lib/msquic_generated_macos.cs
@@ -102,5 +102,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_STATUS_CERT_UNTRUSTED_ROOT QUIC_STATUS_CERT_ERROR(2)")]
         public const int QUIC_STATUS_CERT_UNTRUSTED_ROOT = ((int)(2) + 512 + 200000000);
+
+        public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
+        public const int QUIC_ADDRESS_FAMILY_INET = 2;
+        public const int QUIC_ADDRESS_FAMILY_INET6 = 30;
     }
 }

--- a/src/cs/lib/msquic_generated_windows.cs
+++ b/src/cs/lib/msquic_generated_windows.cs
@@ -99,5 +99,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_STATUS_CERT_UNTRUSTED_ROOT CERT_E_UNTRUSTEDROOT")]
         public const int QUIC_STATUS_CERT_UNTRUSTED_ROOT = unchecked((int)(0x800B0109));
+
+        public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
+        public const int QUIC_ADDRESS_FAMILY_INET = 2;
+        public const int QUIC_ADDRESS_FAMILY_INET6 = 23;
     }
 }

--- a/src/cs/tool/Program.cs
+++ b/src/cs/tool/Program.cs
@@ -83,6 +83,16 @@ namespace MsQuicTool
         private static unsafe int NativeCallback(QUIC_HANDLE* handle, void* context, QUIC_CONNECTION_EVENT* evnt)
         {
             Console.WriteLine(evnt->Type);
+            if (evnt->Type == QUIC_CONNECTION_EVENT_TYPE.QUIC_CONNECTION_EVENT_CONNECTED)
+            {
+                QUIC_API_TABLE* ApiTable = (QUIC_API_TABLE*)context;
+                void* buf = stackalloc byte[128];
+                uint len = 128;
+                if (MsQuic.StatusSucceeded(ApiTable->GetParam(handle, MsQuic.QUIC_PARAM_CONN_REMOTE_ADDRESS, &len, buf))) {
+                    QuicAddr* addr = (QuicAddr*)(buf);
+                    Console.WriteLine($"Connected Family: {addr->Family}");
+                }
+            }
             if (evnt->Type == QUIC_CONNECTION_EVENT_TYPE.QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED)
             {
                 Console.WriteLine("Aborting Stream");

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -147,12 +147,9 @@ typedef struct in6_addr IN6_ADDR;
 typedef struct addrinfo ADDRINFO;
 typedef sa_family_t QUIC_ADDRESS_FAMILY;
 
-//
-// Defines match windows values.
-//
-#define QUIC_ADDRESS_FAMILY_UNSPEC 0
-#define QUIC_ADDRESS_FAMILY_INET 2
-#define QUIC_ADDRESS_FAMILY_INET6 23
+#define QUIC_ADDRESS_FAMILY_UNSPEC AF_UNSPEC
+#define QUIC_ADDRESS_FAMILY_INET AF_INET
+#define QUIC_ADDRESS_FAMILY_INET6 AF_INET6
 
 typedef union QUIC_ADDR {
     struct sockaddr Ip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ pub type BOOLEAN = ::std::os::raw::c_uchar;
 
 /// Family of an IP address.
 pub type AddressFamily = u16;
-pub const ADDRESS_FAMILY_UNSPEC: AddressFamily = c_types::AF_UNSPEC;
-pub const ADDRESS_FAMILY_INET: AddressFamily = c_types::AF_INET;
-pub const ADDRESS_FAMILY_INET6: AddressFamily = c_types::AF_INET6;
+pub const ADDRESS_FAMILY_UNSPEC: AddressFamily = c_types::AF_UNSPEC as u16;
+pub const ADDRESS_FAMILY_INET: AddressFamily = c_types::AF_INET as u16;
+pub const ADDRESS_FAMILY_INET6: AddressFamily = c_types::AF_INET6 as u16;
 
 /// IPv4 address payload.
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 use libc::c_void;
-use ctypes::AF_UNSPEC;
-use ctypes::AF_INET;
-use ctypes::AF_INET6;
+use c_types::AF_UNSPEC;
+use c_types::AF_INET;
+use c_types::AF_INET6;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::option::Option;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 use libc::c_void;
+use ctypes::AF_UNSPEC;
+use ctypes::AF_INET;
+use ctypes::AF_INET6;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::option::Option;
@@ -23,9 +26,9 @@ pub type BOOLEAN = ::std::os::raw::c_uchar;
 
 /// Family of an IP address.
 pub type AddressFamily = u16;
-pub const ADDRESS_FAMILY_UNSPEC: AddressFamily = 0;
-pub const ADDRESS_FAMILY_INET: AddressFamily = 2;
-pub const ADDRESS_FAMILY_INET6: AddressFamily = 23;
+pub const ADDRESS_FAMILY_UNSPEC: AddressFamily = c_types::AF_UNSPEC;
+pub const ADDRESS_FAMILY_INET: AddressFamily = c_types::AF_INET;
+pub const ADDRESS_FAMILY_INET6: AddressFamily = c_types::AF_INET6;
 
 /// IPv4 address payload.
 #[repr(C)]


### PR DESCRIPTION
After some discussion with a lot more groups doing interop, this was potentially the wrong way to go. Doing an initial PR to test that my simplified revert idea works. If it does, we can investigate and discuss this more.

See #1709 for more specifics.