### PR TITLE
Revert "Remove optional reviewers from git checkin (#2427)"

### DIFF
--- a/scripts/generate-git-checkin.ps1
+++ b/scripts/generate-git-checkin.ps1
@@ -54,7 +54,7 @@ class CheckinBranch {
     [string]$completePR = "False";
     [string]$pullRequestTitle;
     [string]$workitem = "37338822"
-    [string]$optionalReviewers = "quicdev@microsoft.com"
+    [string]$optionalReviewers = "thhous@microsoft.com;nibanks@microsoft.com"
     [CheckinFile[]]$CheckinFiles;
 
     CheckinBranch($ManifestFile, $BranchToPushTo, $PRTitle) {

--- a/scripts/generate-git-checkin.ps1
+++ b/scripts/generate-git-checkin.ps1
@@ -54,6 +54,7 @@ class CheckinBranch {
     [string]$completePR = "False";
     [string]$pullRequestTitle;
     [string]$workitem = "37338822"
+    [string]$optionalReviewers = "quicdev@microsoft.com"
     [CheckinFile[]]$CheckinFiles;
 
     CheckinBranch($ManifestFile, $BranchToPushTo, $PRTitle) {


### PR DESCRIPTION
This reverts commit f54c2355b133f254dfa6068da2624fd0f205e73b.

Its groups that don't work. Use users instead.