### PR TITLE
Remove VN gtest suite

### DIFF
--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1702,10 +1702,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 #endif // QUIC_TEST_DATAPATH_HOOKS_ENABLED
 
-INSTANTIATE_TEST_SUITE_P(
-    Basic,
-    WithVersionNegotiationExtArgs,
-    testing::ValuesIn(VersionNegotiationExtArgs::Generate()));
+// INSTANTIATE_TEST_SUITE_P(
+//     Basic,
+//     WithVersionNegotiationExtArgs,
+//     testing::ValuesIn(VersionNegotiationExtArgs::Generate()));
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,

--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -219,9 +219,9 @@ std::ostream& operator << (std::ostream& o, const VersionNegotiationExtArgs& arg
         (args.DisableVNEServer ? "DisableServer" : "EnableServer");
 }
 
-class WithVersionNegotiationExtArgs : public testing::Test,
-    public testing::WithParamInterface<VersionNegotiationExtArgs> {
-};
+// class WithVersionNegotiationExtArgs : public testing::Test,
+//     public testing::WithParamInterface<VersionNegotiationExtArgs> {
+// };
 
 struct HandshakeArgs6 {
     int Family;


### PR DESCRIPTION
Otherwise we get a warning, that will potentially fail windows builds