### PR TITLE
Use New XDP Sharing Flag

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -755,7 +755,7 @@ CxPlatDpRawInterfaceUpdateRules(
         .SubLayer = XDP_HOOK_INSPECT,
     };
 
-    const UINT32 Flags = 0; // TODO: support native/generic forced flags.
+    const UINT32 Flags = XDP_CREATE_PROGRAM_FLAG_SHARE; // TODO: support native/generic forced flags.
 
     for (uint32_t i = 0; i < Interface->QueueCount; i++) {
 


### PR DESCRIPTION
## Description

Updates the calls to `XdpCreateProgram` to pass the `XDP_CREATE_PROGRAM_FLAG_SHARE` flag. This seems to be necessary with the latest XDP.

## Testing

In progress.