### PR TITLE
Static assert that malloc alignment is correct

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -975,8 +975,10 @@ QuicSendGetNextStream(
                 //
                 CXPLAT_LIST_ENTRY* LastEntry = Stream->SendLink.Flink;
                 while (Stream->SendLink.Flink != &Send->SendStreams) {
-                    if (Stream->SendPriority >
-                        CXPLAT_CONTAINING_RECORD(LastEntry, QUIC_STREAM, SendLink)->SendPriority) {
+                    QUIC_STREAM* EntryStream = CXPLAT_CONTAINING_RECORD(LastEntry, QUIC_STREAM, SendLink);
+                    CXPLAT_DBG_ASSERT(((intptr_t)EntryStream % _Alignof(struct QUIC_STREAM)) == 0);
+                    CXPLAT_DBG_ASSERT(((intptr_t)Stream % _Alignof(struct QUIC_STREAM)) == 0);
+                    if (Stream->SendPriority > EntryStream->SendPriority) {
                         break;
                     }
                     LastEntry = LastEntry->Flink;

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -38,6 +38,8 @@ QuicStreamInitialize(
         goto Exit;
     }
 
+    CXPLAT_DBG_ASSERT(((intptr_t)Stream % _Alignof(struct QUIC_STREAM)) == 0);
+
     QuicTraceEvent(
         StreamAlloc,
         "[strm][%p] Allocated, Conn=%p",

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -311,7 +311,11 @@ CxPlatFree(
 
 typedef struct CXPLAT_LOCK {
 
-    alignas(16) pthread_mutex_t Mutex;
+    //
+    // Mutex and condition. The alignas is important, as the perf tanks
+    // if the event is not aligned to the size of 2 pointers.
+    //
+    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
 
 } CXPLAT_LOCK;
 
@@ -688,9 +692,9 @@ typedef struct CXPLAT_EVENT {
 
     //
     // Mutex and condition. The alignas is important, as the perf tanks
-    // if the event is not aligned.
+    // if the event is not aligned to the size of 2 pointers.
     //
-    alignas(16) pthread_mutex_t Mutex;
+    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
     pthread_cond_t Cond;
 
     //

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -315,7 +315,7 @@ typedef struct CXPLAT_LOCK {
     // Mutex and condition. The alignas is important, as the perf tanks
     // if the event is not aligned to the size of 2 pointers.
     //
-    _Alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
+    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
 
 } CXPLAT_LOCK;
 
@@ -694,7 +694,7 @@ typedef struct CXPLAT_EVENT {
     // Mutex and condition. The alignas is important, as the perf tanks
     // if the event is not aligned to the size of 2 pointers.
     //
-    _Alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
+    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
     pthread_cond_t Cond;
 
     //

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -315,7 +315,7 @@ typedef struct CXPLAT_LOCK {
     // Mutex and condition. The alignas is important, as the perf tanks
     // if the event is not aligned to the size of 2 pointers.
     //
-    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
+    _Alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
 
 } CXPLAT_LOCK;
 
@@ -694,7 +694,7 @@ typedef struct CXPLAT_EVENT {
     // Mutex and condition. The alignas is important, as the perf tanks
     // if the event is not aligned to the size of 2 pointers.
     //
-    alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
+    _Alignas(sizeof(void*) * 2) pthread_mutex_t Mutex;
     pthread_cond_t Cond;
 
     //

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -242,7 +242,7 @@ CxPlatUninitialize(
         "[ dso] Uninitialized");
 }
 
-CXPLAT_STATIC_ASSERT(alignof(max_align_t) >= sizeof(void*) * 2);
+CXPLAT_STATIC_ASSERT(alignof(max_align_t) >= sizeof(void*) * 2, "Must have an alignment that works for locks");
 
 void*
 CxPlatAlloc(

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -242,8 +242,6 @@ CxPlatUninitialize(
         "[ dso] Uninitialized");
 }
 
-CXPLAT_STATIC_ASSERT(alignof(max_align_t) >= sizeof(void*) * 2, "Must have an alignment that works for locks");
-
 void*
 CxPlatAlloc(
     _In_ size_t ByteCount,

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -242,6 +242,8 @@ CxPlatUninitialize(
         "[ dso] Uninitialized");
 }
 
+CXPLAT_STATIC_ASSERT(alignof(max_align_t) >= sizeof(void*) * 2);
+
 void*
 CxPlatAlloc(
     _In_ size_t ByteCount,


### PR DESCRIPTION
We had a test run with an alignment error. Testing to see if any of our test platforms actually would have the error.