### PR TITLE
Fix possible infinite loop in priority stream scheduling

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -974,7 +974,7 @@ QuicSendGetNextStream(
                 // that entry.
                 //
                 CXPLAT_LIST_ENTRY* LastEntry = Stream->SendLink.Flink;
-                while (Stream->SendLink.Flink != &Send->SendStreams) {
+                while (LastEntry != &Send->SendStreams) {
                     if (Stream->SendPriority >
                         CXPLAT_CONTAINING_RECORD(LastEntry, QUIC_STREAM, SendLink)->SendPriority) {
                         break;

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -434,6 +434,10 @@ QuicTestStreamPriority(
     );
 
 void
+QuicTestStreamPriorityInfiniteLoop(
+    );
+
+void
 QuicTestStreamDifferentAbortErrors(
     );
 
@@ -991,4 +995,7 @@ typedef struct {
     QUIC_CTL_CODE(85, METHOD_BUFFERED, FILE_WRITE_DATA)
     // QUIC_RUN_CIBIR_EXTENSION
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 85
+#define IOCTL_QUIC_RUN_STREAM_PRIORITY_INFINITE_LOOP \
+    QUIC_CTL_CODE(86, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 86

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1588,6 +1588,15 @@ TEST(Misc, StreamPriority) {
     }
 }
 
+TEST(Misc, StreamPriorityInfiniteLoop) {
+    TestLogger Logger("StreamPriorityInfiniteLoop");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STREAM_PRIORITY_INFINITE_LOOP));
+    } else {
+        QuicTestStreamPriorityInfiniteLoop();
+    }
+}
+
 TEST(Misc, StreamDifferentAbortErrors) {
     TestLogger Logger("StreamDifferentAbortErrors");
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -456,6 +456,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     sizeof(QUIC_RUN_CRED_VALIDATION),
     sizeof(QUIC_RUN_CIBIR_EXTENSION),
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1178,6 +1179,11 @@ QuicTestCtlEvtIoDeviceControl(
             QuicTestCibirExtension(
                 Params->CibirParams.Family,
                 Params->CibirParams.Mode));
+        break;
+
+
+    case IOCTL_QUIC_RUN_STREAM_PRIORITY_INFINITE_LOOP:
+        QuicTestCtlRun(QuicTestStreamPriorityInfiniteLoop());
         break;
 
     default:


### PR DESCRIPTION
If the app enabled round robin stream scheduling, and stream priority is set to anything less than 0xFFFF, a possible infinite loop occurs.

The loop is checking the wrong variable, which means it turns infinite. There is an exit case, but it depends on a comparison to either another stream priority, or a random variable from the QUIC_SEND struct. If the stream priority is set to 0, the check will always fail, and the loop will go infinite. If only a single stream is used, and its priority is less then the random variable, this will also result in an infinite loop.

The fix is to use the correct loop condition. As this code was from last summer, can only be triggered by app behavior, and requires a non default setting to be explicitly set by the app, this can be fixed without an MSRC.