### PR TITLE
Improve crash dump debugging in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,7 +539,7 @@ else() #!WIN32
 
     if(QUIC_ENABLE_SANITIZERS)
         message(STATUS "Configuring sanitizers")
-        list(APPEND QUIC_COMMON_FLAGS -fsanitize=address,leak,undefined -fsanitize-address-use-after-scope -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        list(APPEND QUIC_COMMON_FLAGS -fsanitize=address,leak,undefined,alignment -fsanitize-address-use-after-scope -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls)
         if (CX_PLATFORM STREQUAL "darwin")
             list(APPEND QUIC_COMMON_FLAGS -gdwarf)
         else()

--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -196,11 +196,15 @@ function Log-Stop {
             Write-Debug "Decoding LTTng into BabelTrace format ($BableTraceFile)"
             babeltrace --names all $TempDir/* > $BableTraceFile
 
-            Write-Host "Decoding into human-readable text: $ClogOutputDecodeFile"
-            $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile --showTimestamp --showCpuInfo"
-            Write-Host $Command
-            Invoke-Expression $Command | Write-Debug
-            Remove-Item -Path $BableTraceFile -Force | Out-Null
+            Write-Host "Babeltrace ran. Compile clog2text and run the following command"
+            $Command = "clog2text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile --showTimestamp --showCpuInfo"
+            $Command
+
+            # Write-Host "Decoding into human-readable text: $ClogOutputDecodeFile"
+            # $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile --showTimestamp --showCpuInfo"
+            # Write-Host $Command
+            # Invoke-Expression $Command | Write-Debug
+            # Remove-Item -Path $BableTraceFile -Force | Out-Null
         }
 
         Invoke-Expression "lttng destroy $InstanceName" | Write-Debug
@@ -234,10 +238,14 @@ function Log-Decode {
         Write-Host "Decoding LTTng into BabelTrace format ($BableTraceFile)"
         babeltrace --names all $DecompressedLogs/* > $BableTraceFile
 
-        Write-Host "Decoding Babeltrace into human text using CLOG"
-        $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile"
-        Write-Host $Command
-        Invoke-Expression $Command
+        Write-Host "Babeltrace ran. Compile clog2text and run the following command"
+        $Command = "clog2text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile"
+        $Command
+
+        #Write-Host "Decoding Babeltrace into human text using CLOG"
+        #$Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile"
+        #Write-Host $Command
+        #Invoke-Expression $Command
     }
 }
 

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -401,7 +401,7 @@ if ($IsWindows) {
 } elseif ($IsMacOS) {
     if ($Configuration -eq "Test") {
         Write-Host "[$(Get-Date)] Setting core dump pattern..."
-        sudo sysctl -w kern.corefile=%N.%P.%H.core
+        sudo sysctl -w kern.corefile=%N.%P.core
     }
 }
 

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -358,6 +358,7 @@ if ($IsWindows) {
             sudo apt-add-repository ppa:lttng/stable-2.12
             sudo apt-get update
             sudo apt-get install -y lttng-tools
+            sudo apt-get install -y gdb
 
             # Enable core dumps for the system.
             Write-Host "[$(Get-Date)] Setting core dump size limit..."

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -229,7 +229,7 @@ function Start-Executable {
             }
         } else {
             $pinfo.FileName = "bash"
-            $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 $($Path) $($Arguments) && echo Done`""
+            $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $($Path) $($Arguments) && echo Done`""
             $pinfo.WorkingDirectory = $LogDir
         }
     }

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -373,7 +373,7 @@ function Wait-Executable($Exe) {
             }
             $KeepOutput = $true
         }
-        $CoreFiles = (Get-ChildItem $TestCase.LogDir) | Where-Object { $_.Extension -eq ".core" }
+        $CoreFiles = (Get-ChildItem $LogDir) | Where-Object { $_.Extension -eq ".core" }
         if ($CoreFiles) {
             LogWrn "Core file(s) generated"
             foreach ($File in $CoreFiles) {

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -77,7 +77,10 @@ param (
     [switch]$CodeCoverage = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$AZP = $false
+    [switch]$AZP = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ExtraArtifactDir = ""
 )
 
 Set-StrictMode -Version 'Latest'

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -414,6 +414,8 @@ function Start-AllTestCases {
 function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
     try {
+        Write-Host $env:BUILD_BUILDNUMBER
+        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
         if ($env:BUILD_BUILDNUMBER -ne $null) {
             $env:PATH += ";c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
         }
@@ -426,11 +428,13 @@ function PrintDumpCallStack($DumpFile) {
         $Output | Out-File "$DumpFile.txt"
     } catch {
         # Silently fail
+        $_
     }
 }
 
 function PrintLldbCoreCallStack($CoreFile) {
     try {
+        Write-Host "Running  lldb $Path -c $CoreFile -b -o `"bt all`""
         $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
@@ -461,11 +465,13 @@ function PrintLldbCoreCallStack($CoreFile) {
         $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
     } catch {
         # Silently Fail
+        $_
     }
 }
 
 function PrintGdbCoreCallStack($CoreFile) {
     try {
+        Write-Host "Running gdb $Path $CoreFile -batch -ex `"bt`" -ex `"quit`""
         $Output = gdb $Path $CoreFile -batch -ex "`"bt`"" -ex "`"quit`""
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
@@ -486,6 +492,7 @@ function PrintGdbCoreCallStack($CoreFile) {
         $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
     } catch {
         # Silently Fail
+        $_
     }
 }
 

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -323,7 +323,7 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
             }
         } else {
             $pinfo.FileName = "bash"
-            $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 $($Path) $($Arguments) && echo Done`""
+            $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $($Path) $($Arguments) && echo Done`""
             $pinfo.WorkingDirectory = $OutputDir
         }
     }
@@ -415,7 +415,15 @@ function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
     try {
         Write-Host $env:BUILD_BUILDNUMBER
+        try {
+        Get-ChildItem -Path "c:\Program Files (x86)"
+        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits"
+        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10"
+        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10\Debuggers"
         Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
+        } catch {
+
+        }
         if ($env:BUILD_BUILDNUMBER -ne $null) {
             $env:PATH += ";c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
         }
@@ -434,7 +442,7 @@ function PrintDumpCallStack($DumpFile) {
 
 function PrintLldbCoreCallStack($CoreFile) {
     try {
-        Write-Host "Running  lldb $Path -c $CoreFile -b -o `"bt all`""
+        Write-Host "Running lldb $Path -c $CoreFile -b -o `"bt all`""
         $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -414,16 +414,6 @@ function Start-AllTestCases {
 function PrintDumpCallStack($DumpFile) {
     $env:_NT_SYMBOL_PATH = Split-Path $Path
     try {
-        Write-Host $env:BUILD_BUILDNUMBER
-        try {
-        Get-ChildItem -Path "c:\Program Files (x86)"
-        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits"
-        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10"
-        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10\Debuggers"
-        Get-ChildItem -Path "c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
-        } catch {
-
-        }
         if ($env:BUILD_BUILDNUMBER -ne $null) {
             $env:PATH += ";c:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
         }
@@ -436,13 +426,11 @@ function PrintDumpCallStack($DumpFile) {
         $Output | Out-File "$DumpFile.txt"
     } catch {
         # Silently fail
-        $_
     }
 }
 
 function PrintLldbCoreCallStack($CoreFile) {
     try {
-        Write-Host "Running lldb $Path -c $CoreFile -b -o `"bt all`""
         $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
@@ -473,13 +461,11 @@ function PrintLldbCoreCallStack($CoreFile) {
         $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
     } catch {
         # Silently Fail
-        $_
     }
 }
 
 function PrintGdbCoreCallStack($CoreFile) {
     try {
-        Write-Host "Running gdb $Path $CoreFile -batch -ex `"bt`" -ex `"quit`""
         $Output = gdb $Path $CoreFile -batch -ex "`"bt`"" -ex "`"quit`""
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
@@ -500,7 +486,6 @@ function PrintGdbCoreCallStack($CoreFile) {
         $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
     } catch {
         # Silently Fail
-        $_
     }
 }
 

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -119,7 +119,10 @@ param (
     [switch]$AZP = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$ErrorsAsWarnings = $false
+    [switch]$ErrorsAsWarnings = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ExtraArtifactDir = ""
 )
 
 Set-StrictMode -Version 'Latest'
@@ -187,8 +190,13 @@ $LogScript = Join-Path $RootDir "scripts" "log.ps1"
 $TestExeName = Split-Path $Path -Leaf
 $CoverageName = "$(Split-Path $Path -LeafBase).cov"
 
+$ExeLogFolder = $TestExeName
+if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
+    $ExeLogFolder += "_$ExtraArtifactDir"
+}
+
 # Folder for log files.
-$LogDir = Join-Path $RootDir "artifacts" "logs" $TestExeName (Get-Date -UFormat "%m.%d.%Y.%T").Replace(':','.')
+$LogDir = Join-Path $RootDir "artifacts" "logs" $ExeLogFolder (Get-Date -UFormat "%m.%d.%Y.%T").Replace(':','.')
 New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
 
 # Folder for coverage files
@@ -415,8 +423,69 @@ function PrintDumpCallStack($DumpFile) {
         Write-Host " $(Split-Path $DumpFile -Leaf)"
         Write-Host "=================================================================================="
         $Output -replace "quit:", "=================================================================================="
+        $Output | Out-File "$DumpFile.txt"
     } catch {
         # Silently fail
+    }
+}
+
+function PrintLldbCoreCallStack($CoreFile) {
+    try {
+        $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
+        Write-Host "=================================================================================="
+        Write-Host " $(Split-Path $CoreFile -Leaf)"
+        Write-Host "=================================================================================="
+        # Find line containing Current thread
+        $Found = $false
+        $LastThreadStart = 0
+        for ($i = 0; $i -lt $Output.Length; $i++) {
+            if ($Output[$i] -like "*stop reason =*") {
+                if ($Found) {
+                    break
+                }
+                $LastThreadStart = $i
+            }
+            if ($Output[$i] -like "*quic_bugcheck*") {
+                $Found = $true
+                for ($j = $LastThreadStart; $j -lt $i; $j++) {
+                    $Output[$j]
+                }
+            }
+            if ($Found) {
+                $Output[$i]
+            }
+        }
+        if (!$Found) {
+            $Output | Join-String -Separator "`n"
+        }
+        $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
+    } catch {
+        # Silently Fail
+    }
+}
+
+function PrintGdbCoreCallStack($CoreFile) {
+    try {
+        $Output = gdb $Path $CoreFile -batch -ex "`"bt`"" -ex "`"quit`""
+        Write-Host "=================================================================================="
+        Write-Host " $(Split-Path $CoreFile -Leaf)"
+        Write-Host "=================================================================================="
+        # Find line containing Current thread
+        $Found = $false
+        for ($i = 0; $i -lt $Output.Length; $i++) {
+            if ($Output[$i] -like "*Current thread*") {
+                $Found = $true
+            }
+            if ($Found) {
+                $Output[$i]
+            }
+        }
+        if (!$Found) {
+            $Output | Join-String -Separator "`n"
+        }
+        $Output | Join-String -Separator "`n" | Out-File "$CoreFile.txt"
+    } catch {
+        # Silently Fail
     }
 }
 
@@ -460,6 +529,18 @@ function Wait-TestCase($TestCase) {
             LogWrn "Dump file(s) generated"
             foreach ($File in $DumpFiles) {
                 PrintDumpCallStack($File)
+            }
+            $ProcessCrashed = $true
+        }
+        $CoreFiles = (Get-ChildItem $TestCase.LogDir) | Where-Object { $_.Extension -eq ".core" }
+        if ($CoreFiles) {
+            LogWrn "Core file(s) generated"
+            foreach ($File in $CoreFiles) {
+                if ($IsMacOS) {
+                    PrintLldbCoreCallStack $File
+                } else {
+                    PrintGdbCoreCallStack $File
+                }
             }
             $ProcessCrashed = $true
         }

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -169,7 +169,7 @@ if ($AZP) {
 }
 
 if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
-    $TestArguments += " -ExtraArtifactDir $ExtraArtifactDir"
+    $Arguments += " -ExtraArtifactDir $ExtraArtifactDir"
 }
 
 # Run the script.

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -168,5 +168,9 @@ if ($AZP) {
     $Arguments += " -AZP"
 }
 
+if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
+    $TestArguments += " -ExtraArtifactDir $ExtraArtifactDir"
+}
+
 # Run the script.
 Invoke-Expression ($RunExecutable + " " + $Arguments)

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -259,10 +259,9 @@ $TestArguments =  "-IsolationMode $IsolationMode -PfxPath $PfxFile"
 if ($Kernel) {
     $TestArguments += " -Kernel $KernelPath"
 }
-$TestArguments += " -Filter *StreamPriority*"
-# if ("" -ne $Filter) {
-#     $TestArguments += " -Filter $Filter"
-# }
+if ("" -ne $Filter) {
+    $TestArguments += " -Filter $Filter"
+}
 if ($ListTestCases) {
     $TestArguments += " -ListTestCases"
 }
@@ -310,15 +309,11 @@ if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
     $TestArguments += " -ExtraArtifactDir $ExtraArtifactDir"
 }
 
-if ($Kernel) {
-    exit 0
+# Run the script.
+if (!$Kernel -and !$SkipUnitTests) {
+    Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
+    Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
 }
-
-# # Run the script.
-# if (!$Kernel -and !$SkipUnitTests) {
-#     Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
-#     Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
-# }
 Invoke-Expression ($RunTest + " -Path $MsQuicTest " + $TestArguments)
 
 if ($CodeCoverage) {

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -259,9 +259,10 @@ $TestArguments =  "-IsolationMode $IsolationMode -PfxPath $PfxFile"
 if ($Kernel) {
     $TestArguments += " -Kernel $KernelPath"
 }
-if ("" -ne $Filter) {
-    $TestArguments += " -Filter $Filter"
-}
+$TestArguments += " -Filter *StreamPriority*"
+# if ("" -ne $Filter) {
+#     $TestArguments += " -Filter $Filter"
+# }
 if ($ListTestCases) {
     $TestArguments += " -ListTestCases"
 }
@@ -305,11 +306,19 @@ if ($ErrorsAsWarnings) {
     $TestArguments += " -ErrorsAsWarnings"
 }
 
-# Run the script.
-if (!$Kernel -and !$SkipUnitTests) {
-    Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
-    Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
+if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
+    $TestArguments += " -ExtraArtifactDir $ExtraArtifactDir"
 }
+
+if ($Kernel) {
+    exit 0
+}
+
+# # Run the script.
+# if (!$Kernel -and !$SkipUnitTests) {
+#     Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
+#     Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
+# }
 Invoke-Expression ($RunTest + " -Path $MsQuicTest " + $TestArguments)
 
 if ($CodeCoverage) {

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -21,7 +21,7 @@ if (HAS_GUARDCF)
 endif()
 
 if (NOT MSVC AND QUIC_ENABLE_SANITIZERS)
-    target_link_libraries(base_link INTERFACE -fsanitize=address,leak,undefined)
+    target_link_libraries(base_link INTERFACE -fsanitize=address,leak,undefined,alignment)
 endif()
 
 if (NOT MSVC AND NOT APPLE AND NOT ANDROID)

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2404,14 +2404,6 @@ QuicTestStreamPriority(
     TEST_TRUE(Context.ReceiveEvents[0] == Stream2.ID());
     TEST_TRUE(Context.ReceiveEvents[1] == Stream3.ID());
     TEST_TRUE(Context.ReceiveEvents[2] == Stream1.ID());
-
-
-    const QUIC_API_TABLE* ApiTable;
-#if DEBUG
-    ApiTable = NULL;
-#endif
-    (void)MsQuicOpenVersion(42, (const void**)&ApiTable);
-    ApiTable->RegistrationOpen(nullptr, nullptr);
 }
 
 void
@@ -2465,8 +2457,6 @@ QuicTestStreamPriorityInfiniteLoop(
     Connection.GetStatistics(&Stats);
 
     TEST_TRUE(Context.AllReceivesComplete.WaitTimeout(TestWaitTimeout));
-
-    CXPLAT_DBG_ASSERT(FALSE);
 }
 
 struct StreamDifferentAbortErrors {

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2404,6 +2404,10 @@ QuicTestStreamPriority(
     TEST_TRUE(Context.ReceiveEvents[0] == Stream2.ID());
     TEST_TRUE(Context.ReceiveEvents[1] == Stream3.ID());
     TEST_TRUE(Context.ReceiveEvents[2] == Stream1.ID());
+
+    const QUIC_API_TABLE* ApiTable;
+    (void)MsQuicOpenVersion(42, (const void**)&ApiTable);
+    ApiTable->RegistrationOpen(nullptr, nullptr);
 }
 
 void
@@ -2457,6 +2461,8 @@ QuicTestStreamPriorityInfiniteLoop(
     Connection.GetStatistics(&Stats);
 
     TEST_TRUE(Context.AllReceivesComplete.WaitTimeout(TestWaitTimeout));
+
+    CXPLAT_DBG_ASSERT(FALSE);
 }
 
 struct StreamDifferentAbortErrors {

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -2405,7 +2405,11 @@ QuicTestStreamPriority(
     TEST_TRUE(Context.ReceiveEvents[1] == Stream3.ID());
     TEST_TRUE(Context.ReceiveEvents[2] == Stream1.ID());
 
+
     const QUIC_API_TABLE* ApiTable;
+#if DEBUG
+    ApiTable = NULL;
+#endif
     (void)MsQuicOpenVersion(42, (const void**)&ApiTable);
     ApiTable->RegistrationOpen(nullptr, nullptr);
 }


### PR DESCRIPTION
Debugging a dump on linux or mac at all requires downloading the dump, and corresponding symbols. Add code to print the stacks of the failures, which often can be used in many cases to avoid needing to do this.

Additionally, from the logs folder, deducing if the log is from a sanitize run or not is difficult. Solve this by adding the extra artifacts dir to the log folder

Do not merge this in its current state, as 2 tests are purposely failing (1 with a bugcheck, 1 with a segfault) to verify everything is working correctly.