### PR TITLE
Add CIBIR Support to SecNetPerf

### DIFF
--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -72,7 +72,8 @@ HpsClient::Init(
     }
 
     const char* target;
-    if (!TryGetValue(argc, argv, "target", &target)) {
+    if (!TryGetValue(argc, argv, "target", &target) &&
+        !TryGetValue(argc, argv, "server", &target)) {
         WriteOutput("Must specify '-target' argument!\n");
         PrintHelp();
         return QUIC_STATUS_INVALID_PARAMETER;

--- a/src/perf/lib/PerfHelpers.h
+++ b/src/perf/lib/PerfHelpers.h
@@ -20,6 +20,7 @@ Abstract:
 #endif
 
 #define QUIC_API_ENABLE_INSECURE_FEATURES 1 // For disabling encryption
+#define QUIC_API_ENABLE_PREVIEW_FEATURES  1 // For CIBIR extension
 
 #include "quic_platform.h"
 #include "quic_trace.h"

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -34,6 +34,15 @@ PerfServer::Init(
         }
     }
 
+    const char* CibirBytes = nullptr;
+    if (TryGetValue(argc, argv, "cibir", &CibirBytes)) {
+        CibirId[0] = 0; // offset
+        if ((CibirIdLength = DecodeHexBuffer(CibirBytes, 6, CibirId+1)) == 0) {
+            WriteOutput("Cibir ID must be a hex string <= 6 bytes.\n");
+            return QUIC_STATUS_INVALID_PARAMETER;
+        }
+    }
+
     DataBuffer = (QUIC_BUFFER*)CXPLAT_ALLOC_NONPAGED(sizeof(QUIC_BUFFER) + PERF_DEFAULT_IO_SIZE, QUIC_POOL_PERF);
     if (!DataBuffer) {
         return QUIC_STATUS_OUT_OF_MEMORY;
@@ -56,6 +65,13 @@ PerfServer::Start(
     }
 
     StopEvent = _StopEvent;
+
+    QUIC_STATUS Status;
+    if (CibirIdLength &&
+        QUIC_FAILED(Status = Listener.SetCibirId(CibirId, (uint8_t)CibirIdLength+1))) {
+        WriteOutput("Failed to set CibirId!\n");
+        return Status;
+    }
 
     return Listener.Start(Alpn, &LocalAddr);
 }

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -151,6 +151,9 @@ private:
     TcpServer Server;
     HashTable StreamTable;
 
+    uint32_t CibirIdLength {0};
+    uint8_t CibirId[7]; // {offset, values}
+
     void
     SendTcpResponse(
         _In_ StreamContext* Context,

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -28,12 +28,14 @@ PrintHelp(
         "  -encrypt:<0/1>              Enables/disables encryption. (def:1)\n"
         "  -port:<####>                The UDP port of the server. (def:%u)\n"
         "  -ip:<0/4/6>                 A hint for the resolving the hostname to an IP address. (def:0)\n"
+        "  -cibir:<hex_bytes>          A CIBIR well-known idenfitier.\n"
         "  -conns:<####>               The number of connections to use. (def:%u)\n"
         "  -requests:<####>            The number of requests to send at a time. (def:2*conns)\n"
         "  -request:<####>             The length of request payloads. (def:%u)\n"
         "  -response:<####>            The length of request payloads. (def:%u)\n"
         "  -threads:<####>             The number of threads to use. Defaults and capped to number of cores\n"
         "  -affinitize:<0/1>           Affinitizes threads to a core. (def:0)\n"
+        "  -cibir:<hex_bytes>          A CIBIR well-known idenfitier.\n"
         "\n",
         RPS_DEFAULT_RUN_TIME,
         PERF_DEFAULT_PORT,
@@ -58,7 +60,8 @@ RpsClient::Init(
     }
 
     const char* target;
-    if (!TryGetValue(argc, argv, "target", &target)) {
+    if (!TryGetValue(argc, argv, "target", &target) &&
+        !TryGetValue(argc, argv, "server", &target)) {
         WriteOutput("Must specify '-target' argument!\n");
         PrintHelp();
         return QUIC_STATUS_INVALID_PARAMETER;
@@ -80,6 +83,15 @@ RpsClient::Init(
     TryGetValue(argc, argv, "requests", &RequestCount);
     TryGetValue(argc, argv, "request", &RequestLength);
     TryGetValue(argc, argv, "response", &ResponseLength);
+
+    const char* CibirBytes = nullptr;
+    if (TryGetValue(argc, argv, "cibir", &CibirBytes)) {
+        CibirId[0] = 0; // offset
+        if ((CibirIdLength = DecodeHexBuffer(CibirBytes, 6, CibirId+1)) == 0) {
+            WriteOutput("Cibir ID must be a hex string <= 6 bytes.\n");
+            return QUIC_STATUS_INVALID_PARAMETER;
+        }
+    }
 
     uint16_t Ip;
     if (TryGetValue(argc, argv, "ip", &Ip)) {
@@ -243,6 +255,19 @@ RpsClient::Start(
         if (QUIC_FAILED(Status)) {
             WriteOutput("SetParam(CONN_SHARE_UDP_BINDING) failed, 0x%x\n", Status);
             return Status;
+        }
+
+        if (CibirIdLength) {
+            Status =
+                MsQuic->SetParam(
+                    Connections[i],
+                    QUIC_PARAM_CONN_CIBIR_ID,
+                    CibirIdLength+1,
+                    CibirId);
+            if (QUIC_FAILED(Status)) {
+                WriteOutput("SetParam(CONN_CIBIR_ID) failed, 0x%x\n", Status);
+                return Status;
+            }
         }
 
         if (i >= RPS_MAX_CLIENT_PORT_COUNT) {

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -35,7 +35,6 @@ PrintHelp(
         "  -response:<####>            The length of request payloads. (def:%u)\n"
         "  -threads:<####>             The number of threads to use. Defaults and capped to number of cores\n"
         "  -affinitize:<0/1>           Affinitizes threads to a core. (def:0)\n"
-        "  -cibir:<hex_bytes>          A CIBIR well-known idenfitier.\n"
         "\n",
         RPS_DEFAULT_RUN_TIME,
         PERF_DEFAULT_PORT,

--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -180,6 +180,8 @@ public:
     uint32_t RequestCount {RPS_DEFAULT_CONNECTION_COUNT * 2};
     uint32_t RequestLength {RPS_DEFAULT_REQUEST_LENGTH};
     uint32_t ResponseLength {RPS_DEFAULT_RESPONSE_LENGTH};
+    uint32_t CibirIdLength {0};
+    uint8_t CibirId[7]; // {offset, values}
 
     struct QuicBufferScopeQuicAlloc {
         QUIC_BUFFER* Buffer;

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -84,6 +84,7 @@ PrintHelp(
         "Server: secnetperf [options]\n"
         "\n"
         "  -bind:<addr>                A local IP address to bind to.\n"
+        "  -cibir:<hex_bytes>          A CIBIR well-known idenfitier.\n"
         "\n"
         "Client: secnetperf -TestName:<Throughput|RPS|HPS> [options]\n"
         "\n"

--- a/src/perf/lib/ThroughputClient.h
+++ b/src/perf/lib/ThroughputClient.h
@@ -135,6 +135,8 @@ private:
     uint64_t UploadLength {0};
     uint64_t DownloadLength {0};
     uint32_t IoSize {0};
+    uint32_t CibirIdLength {0};
+    uint8_t CibirId[7]; // {offset, values}
 
     TcpEngine Engine;
     CXPLAT_LOCK TcpLock;


### PR DESCRIPTION
## Description

Adds a new option `-cibir:<bytes>` to secnetperf for specifying the CIBIR extension's well-known identifier.

## Testing

Tested by manually running over localhost.