### PR TITLE
Extra Protection Around Stream Send Queue

### DIFF
--- a/src/core/send.h
+++ b/src/core/send.h
@@ -309,7 +309,6 @@ void
 QuicSendQueueFlushForStream(
     _In_ QUIC_SEND* Send,
     _In_ QUIC_STREAM* Stream,
-    _In_ BOOLEAN WasPreviouslyQueued,
     _In_ BOOLEAN DelaySend
     );
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -277,8 +277,7 @@ QuicStreamStart(
         // Send flags were queued up before starting so we need to queue the
         // stream data to be sent out now.
         //
-        QuicSendQueueFlushForStream(
-            &Stream->Connection->Send, Stream, FALSE, FALSE);
+        QuicSendQueueFlushForStream(&Stream->Connection->Send, Stream, FALSE);
     }
 
     Stream->Flags.SendOpen = !!(Flags & QUIC_STREAM_START_FLAG_IMMEDIATE);


### PR DESCRIPTION
## Description

We've seen some crashes internally in the latest builds where somehow a stream seems to be dequeued twice. I haven't yet pinned down the extact repro steps of the scenario that triggers this, but it's simple enough to check and protect from this happening.

## Testing

Verified existing tests pass. Ideally, I'd like to write a new test case to repro the original issue, but I haven't figured out the steps to do so yet.