### PR TITLE
Expose shutdown in RUST's connection object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1212,6 +1212,12 @@ impl Connection {
         }
     }
 
+    pub fn shutdown(&self, flags: ConnectionShutdownFlags, error_code: u62) {
+        unsafe {
+            ((*self.table).connection_shutdown)(self.handle, flags, error_code);
+        }
+    }
+
     pub fn stream_close(&self, stream: Handle) {
         unsafe {
             ((*self.table).stream_close)(stream);


### PR DESCRIPTION
## Description

Would be nice to be able to shutdown connection & send status code in RUST

## Testing

Manual test