### PR TITLE
Build on windows-2019 (release/1.0)

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -104,63 +104,63 @@ stages:
   # Officially supported configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x86
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm64
       tls: schannel
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: stub
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: mitls
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: uwp
       arch: x64
       tls: schannel
       extraBuildArgs: -DisableTools -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: openssl
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm64
       tls: openssl
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x86
       tls: openssl

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -8,7 +8,7 @@ jobs:
 - job: build_winkernel_${{ parameters.arch }}
   displayName: ${{ parameters.arch }}
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
   steps:
   - checkout: self
     submodules: recursive


### PR DESCRIPTION
Recent AZP default changes moved to 2022, which breaks Windows builds.