### PR TITLE
Build on windows-2019 (release/1.1)

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -88,7 +88,7 @@ stages:
   # Officially supported configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: schannel
@@ -96,14 +96,14 @@ stages:
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: openssl
       config: Release
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: mitls
@@ -116,7 +116,7 @@ stages:
   # Officially supported configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: schannel
@@ -124,21 +124,21 @@ stages:
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: stub
       config: Debug
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: mitls
       config: Debug
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: openssl
@@ -150,45 +150,45 @@ stages:
   jobs:
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x64
       tls: stub
       config: Release
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x86
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm64
       tls: schannel
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: uwp
       arch: x64
       tls: schannel
       extraBuildArgs: -DisableTools -DisableTest
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: arm64
       tls: openssl
   - template: ./templates/build-config-user.yml
     parameters:
-      image: windows-latest
+      image: windows-2019
       platform: windows
       arch: x86
       tls: openssl

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -8,7 +8,7 @@ jobs:
 - job: build_winkernel_${{ parameters.arch }}
   displayName: ${{ parameters.arch }}
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
   steps:
   - checkout: self
     path: msquic


### PR DESCRIPTION
Recent AZP default changes moved to 2022, which breaks Windows builds.