### PR TITLE
fix packaging on macOS

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -82,10 +82,6 @@ else
 fi
 
 ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
-if [ ! -e "$ARTIFACTS/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ] && [ ! -e "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.${LIBEXT}" ]; then
-    echo "$ARTIFACTS/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" does not exist. Run build first.
-    exit 1
-fi
 
 if [ -z ${OUTPUT} ]; then
     OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_openssl"
@@ -131,5 +127,5 @@ if [ "$OS" == "macos" ]; then
     --package "$OUTPUT" --log error \
     --description "${DESCRIPTION}" \
     --provides libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib \
-    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
+    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib2"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
 fi

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -127,5 +127,5 @@ if [ "$OS" == "macos" ]; then
     --package "$OUTPUT" --log error \
     --description "${DESCRIPTION}" \
     --provides libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib \
-    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib2"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
+    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
 fi

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -82,7 +82,7 @@ else
 fi
 
 ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
-if [ ! -e "$ARTIFACTS/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ]; then
+if [ ! -e "$ARTIFACTS/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ] && [ ! -e "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.${LIBEXT}" ]; then
     echo "$ARTIFACTS/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" does not exist. Run build first.
     exit 1
 fi


### PR DESCRIPTION
It seems like this got broken by the versioning changes.
```
Shining:msquic furt$ ls -al artifacts/bin/macos/x64_Release_openssl/
total 1768
drwxr-xr-x  8 furt  staff     256 Mar  8 18:35 .
drwxr-xr-x  4 furt  staff     128 Mar  8 18:35 ..
-rwxr-xr-x  1 furt  staff  901816 Mar  8 18:35 libmsquic.2.1.0.dylib
drwxr-xr-x  3 furt  staff      96 Mar  8 18:35 libmsquic.2.1.0.dylib.dSYM
lrwxr-xr-x  1 furt  staff      21 Mar  8 18:35 libmsquic.2.dylib -> libmsquic.2.1.0.dylib
drwxr-xr-x  3 furt  staff      96 Mar  8 18:35 libmsquic.2.dylib.dSYM
lrwxr-xr-x  1 furt  staff      17 Mar  8 18:35 libmsquic.dylib -> libmsquic.2.dylib
drwxr-xr-x  3 furt  staff      96 Mar  8 18:35 libmsquic.dylib.dSYM
```

Unlike Linux, the version precedes the extension. Bottom of the script was properly updated,
```bash
if [ "$OS" == "macos" ]; then
  fpm -f -s dir -t osxpkg -n ${NAME} -v ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} --license MIT --url https://github.com/microsoft/msquic \
    --package "$OUTPUT" --log error \
    --description "${DESCRIPTION}" \
    --provides libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib \
    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
fi
``` 

but we will not get there because of the check if file exist. 
It seems like `fpm` fails if the file is missing so I removed the extra check in the script.
(my original fix was to change the check but I decided it is not worth it) 