### PR TITLE
release/2.0 CP - Fix Rust Issues #2485

### DIFF
--- a/.azure/azure-pipelines.qns.yml
+++ b/.azure/azure-pipelines.qns.yml
@@ -60,7 +60,7 @@ jobs:
         ${{ if eq(variables['Build.Reason'], 'BatchedCI') }}:
           tags: |
             latest
-            v2.0.0.$(Build.BuildId)
+            v2.0.1.$(Build.BuildId)
         ${{ if ne(variables['Build.Reason'], 'BatchedCI') }}:
           tags: custom-$(Build.BuildId)
 - template: .\templates\run-qns.yml

--- a/.azure/obtemplates/push-vpack.yml
+++ b/.azure/obtemplates/push-vpack.yml
@@ -29,7 +29,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 2
       minorVer: 0
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - publish: $(XES_VPACKMANIFESTDIRECTORY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ message(STATUS "Platform version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(QUIC_MAJOR_VERSION 2)
-set(QUIC_FULL_VERSION 2.0.0)
+set(QUIC_FULL_VERSION 2.0.1)
 
 if (WIN32)
     set(CX_PLATFORM "windows")

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -19,7 +19,7 @@ $ArtifactsBinDir = Join-Path $BaseArtifactsDir "bin"
 # All direct subfolders are OS's
 $Platforms = Get-ChildItem -Path $ArtifactsBinDir
 
-$Version = "2.0.0"
+$Version = "2.0.1"
 
 $WindowsBuilds = @()
 $AllBuilds = @()

--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -141,7 +141,7 @@ $DistDir = Join-Path $BaseArtifactsDir "dist"
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
 $RepoRemote = Get-GitRemote -RepoDir $RootDir
 
-$Version = "2.0.0"
+$Version = "2.0.1"
 
 $BuildId = $env:BUILD_BUILDID
 if ($null -ne $BuildId) {

--- a/scripts/write-versions.ps1
+++ b/scripts/write-versions.ps1
@@ -26,7 +26,7 @@ $ArtifactsDir = $BuildConfig.ArtifactsDir
 $SourceVersion = $env:BUILD_SOURCEVERSION;
 $SourceBranch = $env:BUILD_SOURCEBRANCH;
 $BuildId = $env:BUILD_BUILDID;
-$VersionNumber = "2.0.0";
+$VersionNumber = "2.0.1";
 
 class BuildData {
     [string]$SourceVersion;

--- a/src/distribution/Info.plist
+++ b/src/distribution/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleVersion</key>
-    <string>2.0.0</string>
+    <string>2.0.1</string>
     <key>NSHumanReadableCopyright</key>
     <string>MIT</string>
     <key>CFBundleGetInfoString</key>

--- a/src/inc/msquic.ver
+++ b/src/inc/msquic.ver
@@ -12,7 +12,7 @@
 #endif
 
 #ifndef VER_PATCH
-#define VER_PATCH 0
+#define VER_PATCH 1
 #endif
 
 #ifndef VER_BUILD_ID

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,6 +523,7 @@ pub struct Settings {
     pub max_bytes_per_key: u64,
     pub handshake_idle_timeout_ms: u64,
     pub idle_timeout_ms: u64,
+    pub mtu_discovery_search_complete_timeout_us: u64,
     pub tls_client_max_send_buffer: u32,
     pub tls_server_max_send_buffer: u32,
     pub stream_recv_window_default: u32,
@@ -536,19 +537,16 @@ pub struct Settings {
     pub max_ack_delay_ms: u32,
     pub disconnect_timeout_ms: u32,
     pub keep_alive_interval_ms: u32,
+    pub congestion_control_algorithm: u16,
     pub peer_bidi_stream_count: u16,
     pub peer_unidi_stream_count: u16,
-    pub retry_memory_limit: u16,
-    pub load_balancing_mode: u16,
-    pub other_flags: u8,
-    pub desired_version_list: *const u32,
-    pub desired_version_list_length: u32,
-    pub minimum_mtu: u16,
-    pub maximum_mtu: u16,
-    pub mtu_discovery_search_complete_timeout_us: u64,
-    pub mtu_discovery_missing_probe_count: u8,
     pub max_binding_stateless_operations: u16,
     pub stateless_operation_expiration_ms: u16,
+    pub minimum_mtu: u16,
+    pub maximum_mtu: u16,
+    pub other_flags: u8,
+    pub mtu_operations_per_drain: u8,
+    pub mtu_discovery_missing_probe_count: u8,
 }
 
 pub const PARAM_GLOBAL_RETRY_MEMORY_PERCENT: u32 = 0x01000000;
@@ -971,6 +969,7 @@ impl Settings {
             max_bytes_per_key: 0,
             handshake_idle_timeout_ms: 0,
             idle_timeout_ms: 0,
+            mtu_discovery_search_complete_timeout_us: 0,
             tls_client_max_send_buffer: 0,
             tls_server_max_send_buffer: 0,
             stream_recv_window_default: 0,
@@ -984,33 +983,30 @@ impl Settings {
             max_ack_delay_ms: 0,
             disconnect_timeout_ms: 0,
             keep_alive_interval_ms: 0,
+            congestion_control_algorithm: 0,
             peer_bidi_stream_count: 0,
             peer_unidi_stream_count: 0,
-            retry_memory_limit: 0,
-            load_balancing_mode: 0,
-            other_flags: 0,
-            desired_version_list: ptr::null(),
-            desired_version_list_length: 0,
-            minimum_mtu: 0,
-            maximum_mtu: 0,
-            mtu_discovery_search_complete_timeout_us: 0,
-            mtu_discovery_missing_probe_count: 0,
             max_binding_stateless_operations: 0,
             stateless_operation_expiration_ms: 0,
+            minimum_mtu: 0,
+            maximum_mtu: 0,
+            other_flags: 0,
+            mtu_operations_per_drain: 0,
+            mtu_discovery_missing_probe_count: 0,
         }
     }
     pub fn set_peer_bidi_stream_count(&mut self, value: u16) -> &mut Settings {
-        self.is_set_flags |= 0x10000;
+        self.is_set_flags |= 0x40000;
         self.peer_bidi_stream_count = value;
         self
     }
     pub fn set_peer_unidi_stream_count(&mut self, value: u16) -> &mut Settings {
-        self.is_set_flags |= 0x20000;
+        self.is_set_flags |= 0x80000;
         self.peer_unidi_stream_count = value;
         self
     }
     pub fn set_idle_timeout_ms(&mut self, value: u64) -> &mut Settings {
-        self.is_set_flags |= 0x8;
+        self.is_set_flags |= 0x4;
         self.idle_timeout_ms = value;
         self
     }
@@ -1198,7 +1194,7 @@ impl Connection {
                 configuration.handle,
                 0,
                 server_name_safe.as_ptr(),
-                server_port.to_be(),
+                server_port,
             )
         };
         if Status::failed(status) {
@@ -1428,7 +1424,7 @@ extern "C" fn test_stream_callback(
 ) -> u32 {
     let connection = unsafe { &*(context as *const Connection) };
     match event.event_type {
-        STREAM_EVENT_START_COMPLETE => println!("Start complete 0x{:x}", unsafe {
+        STREAM_EVENT_START_COMPLETE => println!("Stream start complete 0x{:x}", unsafe {
             event.payload.start_complete.status
         }),
         STREAM_EVENT_RECEIVE => println!("Receive {} bytes", unsafe {
@@ -1440,7 +1436,7 @@ extern "C" fn test_stream_callback(
         STREAM_EVENT_PEER_RECEIVE_ABORTED => println!("Peer receive aborted"),
         STREAM_EVENT_SEND_SHUTDOWN_COMPLETE => println!("Peer receive aborted"),
         STREAM_EVENT_SHUTDOWN_COMPLETE => {
-            println!("Shutdown complete");
+            println!("Stream shutdown complete");
             connection.stream_close(stream);
         }
         STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE => println!("Ideal send buffer size"),
@@ -1472,7 +1468,7 @@ fn test_module() {
         test_conn_callback,
         &connection as *const Connection as *const c_void,
     );
-    connection.start(&configuration, "google.com", 443);
+    connection.start(&configuration, "www.cloudflare.com", 443);
 
     let duration = std::time::Duration::from_millis(1000);
     std::thread::sleep(duration);


### PR DESCRIPTION
- CP #2485 to release/2.0.
- Looks like I accidentally updated the clog submodule to latest as well, but it doesn't hurt.