### PR TITLE
Fix onebranch builds after removing 32 bit

### DIFF
--- a/scripts/onebranch-build-kernel.cmd
+++ b/scripts/onebranch-build-kernel.cmd
@@ -1,3 +1,3 @@
 call C:\ewdk\BuildEnv\SetupBuildEnv.cmd
-msbuild msquic.kernel.sln -t:restore -p:RestorePackagesConfig=true
+msbuild msquic.kernel.sln -t:restore -p:RestorePackagesConfig=true /p:Configuration=%1 /p:Platform=%2
 msbuild msquic.kernel.sln -p:ONEBRANCH_BUILD=true /p:Configuration=%1 /p:Platform=%2 /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_BUILD_ID=%BUILD_BUILDID%


### PR DESCRIPTION
msbuild defaults to 32 bit, so the restore step was not correctly working.