### PR TITLE
Create XDP BVT test job

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -201,7 +201,7 @@ stages:
       config: Debug
       extraName: 'xdp'
       extraPrepareArgs: -Xdp
-      extraBuildArgs: -EnableTelemetryAsserts -UseXdp -ExtraArtifactDir xdp
+      extraBuildArgs: -EnableTelemetryAsserts -UseXdp -ExtraArtifactDir Xdp
 
 - stage: build_windows_nontest
   displayName: Build Windows - Non Tested

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -653,6 +653,7 @@ stages:
       tls: schannel
       logProfile: Full.Light
       testCerts: true
+      extraArtifactDir: '_Xdp'
       extraArgs: -DuoNic -ExtraArtifactDir Xdp
   - template: ./templates/run-bvt.yml
     parameters:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -648,6 +648,14 @@ stages:
       testCerts: true
   - template: ./templates/run-bvt.yml
     parameters:
+      pool: MsQuic-Win-Latest
+      platform: windows
+      tls: schannel
+      logProfile: Full.Light
+      testCerts: true
+      extraArgs: -DuoNic -ExtraArtifactDir Xdp
+  - template: ./templates/run-bvt.yml
+    parameters:
       image: windows-2019
       platform: windows
       tls: openssl

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -44,9 +44,9 @@ jobs:
       filePath: scripts/prepare-machine.ps1
       ${{ if and(eq(parameters.kernel, true), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates -SignCode
-      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactsDir, '_Xdp')) }}:
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates -DuoNic
-      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactsDir, '_Xdp')) }}:
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:
         arguments: -Configuration Test

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -46,7 +46,7 @@ jobs:
         arguments: -Configuration Test -TestCertificates -SignCode
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactsDir, 'Xdp')) }}:
         arguments: -Configuration Test -TestCertificates -DuoNic
-      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true)) }}:
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactsDir, 'Xdp')) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:
         arguments: -Configuration Test

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -44,6 +44,8 @@ jobs:
       filePath: scripts/prepare-machine.ps1
       ${{ if and(eq(parameters.kernel, true), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates -SignCode
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactsDir, 'Xdp')) }}:
+        arguments: -Configuration Test -TestCertificates -DuoNic
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -44,9 +44,9 @@ jobs:
       filePath: scripts/prepare-machine.ps1
       ${{ if and(eq(parameters.kernel, true), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates -SignCode
-      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactsDir, 'Xdp')) }}:
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactsDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates -DuoNic
-      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactsDir, 'Xdp')) }}:
+      ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactsDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:
         arguments: -Configuration Test

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -59,6 +59,9 @@ as necessary.
 .Parameter ErrorsAsWarnings
     Treats all errors as warnings.
 
+.PARAMETER DuoNic
+    Uses DuoNic instead of loopback.
+
 #>
 
 param (
@@ -123,6 +126,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [string]$ExtraArtifactDir = ""
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DuoNic = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -689,6 +695,11 @@ function Get-WindowsKitTool {
 ##############################################################
 #                     Main Execution                         #
 ##############################################################
+
+if ($DuoNic) {
+    Log "Short-circuiting unimplemented DuoNic tests."
+    exit
+}
 
 # Query all the test cases.
 $TestCases = GetTestCases

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -125,7 +125,7 @@ param (
     [switch]$ErrorsAsWarnings = $false,
 
     [Parameter(Mandatory = $false)]
-    [string]$ExtraArtifactDir = ""
+    [string]$ExtraArtifactDir = "",
 
     [Parameter(Mandatory = $false)]
     [switch]$DuoNic = $false

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -64,6 +64,9 @@ This script runs the MsQuic tests.
 .Parameter ErrorsAsWarnings
     Treats all errors as warnings.
 
+.Parameter DuoNic
+    Uses DuoNic instead of loopback (DuoNic must already be installed by prepare-machine.ps1).
+
 .EXAMPLE
     test.ps1
 
@@ -155,6 +158,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [switch]$ErrorsAsWarnings = $false
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DuoNic = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -256,6 +262,9 @@ if (!(Test-Path $PfxFile)) {
 # Build up all the arguments to pass to the Powershell script.
 $TestArguments =  "-IsolationMode $IsolationMode -PfxPath $PfxFile"
 
+if ($DuoNic) {
+    $TestArguments += " -DuoNic"
+}
 if ($Kernel) {
     $TestArguments += " -Kernel $KernelPath"
 }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -157,7 +157,7 @@ param (
     [switch]$SkipUnitTests = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$ErrorsAsWarnings = $false
+    [switch]$ErrorsAsWarnings = $false,
 
     [Parameter(Mandatory = $false)]
     [switch]$DuoNic = $false


### PR DESCRIPTION
Creates a test job for XDP which downloads the XDP build, installs duonic,
and invokes test.ps1/run-gtest.ps1 with a new "DuoNic" parameter. The tests
have not been modified to use duonic yet, so for the time being the test
is short-circuited in the beginning of run-gtest.ps1.