### PR TITLE
Refactor Performance Pipeline

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -491,54 +491,6 @@ stages:
       image: macOS-10.15
 
 #
-# Performance Tests
-#
-
-- stage: performance
-  displayName: Performance Testing
-  dependsOn:
-  - build_windows_release
-  - build_linux_release
-  - build_winkernel_release
-  jobs:
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: schannel
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: schannel
-      testTypes: 'Remote'
-      extraName: 'Kernel'
-      kernelMode: -Kernel
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: openssl
-      remoteTls: openssl
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Linux-Perf
-      platform: linux
-      localTls: openssl
-      remoteTls: openssl
-
-- ${{ if not(eq(variables['Build.Reason'], 'Schedule')) }}:
-  - stage: perf_post_process
-    displayName: Perf Post Processing
-    condition: succeededOrFailed()
-    dependsOn:
-    - performance
-    jobs:
-    - template: ./templates/post-process-performance.yml
-
-#
 # Release BVTs
 #
 

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -3,8 +3,31 @@
 # This pipeline builds and runs MsQuic performance tests.
 #
 
-trigger: none
-pr: none
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    include:
+    - .azure/azure-pipelines.perf.yml
+    - .azure/templates/run-performance.yml
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    include:
+    - .azure/azure-pipelines.perf.yml
+    - .azure/templates/run-performance.yml
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
@@ -156,4 +179,100 @@ stages:
 # Tests
 #
 
+- ${{ if eq(parameters.winkernel, true) }}:
+  - stage: perf_winkernel
+    displayName: Performance Testing Windows Kernel
+    dependsOn:
+    - build_winkernel
+    jobs:
+    - template: ./templates/run-performance.yml
+      parameters:
+        pool: MsQuic-Win-Perf
+        platform: windows
+        localTls: schannel
+        remoteTls: schannel
+        arch: ${{ parameters.arch }}
+        protocol: ${{ parameters.protocol }}
+        logProfile: ${{ parameters.logging }}
+        ${{ if ne(parameters.testToRun, 'all') }}:
+          testToRun: ${{ parameters.testToRun }}
+        kernelMode: -Kernel
+        extraName: 'Kernel'
+        testTypes: 'Remote'
+        ${{ if eq(parameters.mode, 'PGO') }}:
+          extraArgs: -PGO
 
+- ${{ if eq(parameters.winuser_schannel, true) }}:
+  - stage: perf_winuser_schannel
+    displayName: Performance Testing Windows (Schannel)
+    dependsOn:
+    - build_winuser_schannel
+    jobs:
+    - template: ./templates/run-performance.yml
+      parameters:
+        pool: MsQuic-Win-Perf
+        platform: windows
+        localTls: schannel
+        remoteTls: schannel
+        arch: ${{ parameters.arch }}
+        protocol: ${{ parameters.protocol }}
+        logProfile: ${{ parameters.logging }}
+        ${{ if ne(parameters.testToRun, 'all') }}:
+          testToRun: ${{ parameters.testToRun }}
+        testTypes: ${{ parameters.testTypes }}
+        ${{ if eq(parameters.mode, 'PGO') }}:
+          extraArgs: -PGO
+
+- ${{ if eq(parameters.winuser_openssl, true) }}:
+  - stage: perf_winuser_openssl
+    displayName: Performance Testing Windows (OpenSSL)
+    dependsOn:
+    - build_winuser_openssl
+    jobs:
+    - template: ./templates/run-performance.yml
+      parameters:
+        pool: MsQuic-Win-Perf
+        platform: windows
+        localTls: openssl
+        remoteTls: openssl
+        arch: ${{ parameters.arch }}
+        protocol: ${{ parameters.protocol }}
+        logProfile: ${{ parameters.logging }}
+        ${{ if ne(parameters.testToRun, 'all') }}:
+          testToRun: ${{ parameters.testToRun }}
+        testTypes: ${{ parameters.testTypes }}
+        ${{ if eq(parameters.mode, 'PGO') }}:
+          extraArgs: -PGO
+
+- ${{ if eq(parameters.linux_openssl, true) }}:
+  - stage: perf_linux_openssl
+    displayName: Performance Testing Linux (OpenSSL)
+    dependsOn:
+    - build_linux_openssl
+    jobs:
+    - template: ./templates/run-performance.yml
+      parameters:
+        pool: MsQuic-Linux-Perf
+        platform: linux
+        localTls: openssl
+        remoteTls: openssl
+        arch: ${{ parameters.arch }}
+        protocol: ${{ parameters.protocol }}
+        logProfile: ${{ parameters.logging }}
+        ${{ if ne(parameters.testToRun, 'all') }}:
+          testToRun: ${{ parameters.testToRun }}
+        testTypes: ${{ parameters.testTypes }}
+        ${{ if eq(parameters.mode, 'PGO') }}:
+          extraArgs: -PGO
+
+- ${{ if eq(variables['Build.Reason'], 'BatchedCI') }}:
+  - stage: perf_post_process
+    displayName: Perf Post Processing
+    condition: succeededOrFailed()
+    dependsOn:
+    - perf_winkernel
+    - perf_winuser_schannel
+    - perf_winuser_openssl
+    - perf_linux_openssl
+    jobs:
+    - template: ./templates/post-process-performance.yml

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -9,13 +9,33 @@ pr: none
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
 parameters:
-- name: mode
+- name: winkernel
+  type: boolean
+  displayName: Windows Kernel
+  default: true
+- name: winuser_schannel
+  type: boolean
+  displayName: Windows (Schannel)
+  default: true
+- name: winuser_openssl
+  type: boolean
+  displayName: Windows (openssl)
+  default: true
+- name: linux_openssl
+  type: boolean
+  displayName: Linux (openssl)
+  default: true
+- name: arch
   type: string
-  displayName: Mode
-  default: Normal
+  displayName: Architecture
+  default: x64
   values:
-  - Normal
-  - PGO
+  - x64
+  - x86
+- name: pgo_mode
+  type: boolean
+  displayName: PGO Mode
+  default: false
 - name: logging
   type: string
   displayName: Logging Type
@@ -34,24 +54,6 @@ parameters:
   - Full.Light
   - Full.Verbose
   - SpinQuic.Light
-- name: arch
-  type: string
-  displayName: Architecture
-  default: x64
-  values:
-  - x64
-  - x86
-- name: kernelmode
-  type: boolean
-  displayName: Server Kernel Mode
-  default: false
-- name: tls
-  type: string
-  displayName: Server TLS
-  default: schannel
-  values:
-  - schannel
-  - openssl
 - name: testToRun
   type: string
   displayName: Run Specific Test
@@ -84,67 +86,55 @@ stages:
 # Builds
 #
 
-- stage: build_windows
-  displayName: Build Windows
+- stage: build_winkernel
+  displayName: Build Windows Kernel
   dependsOn: []
   variables:
     runCodesignValidationInjection: false
-  jobs:
-  - ${{ if and(eq(parameters.kernelmode, false), ne(parameters.tls, 'schannel')) }}:
-    - template: ./templates/build-config-user.yml
-      parameters:
-        image: windows-2019
-        platform: windows
-        arch: ${{ parameters.arch }}
-        tls: ${{ parameters.tls }}
-        config: Release
-        ${{ if eq(parameters.mode, 'PGO') }}:
-          extraBuildArgs: -DisableTest -DisableTools -PGO
-        ${{ if ne(parameters.mode, 'PGO') }}:
-          extraBuildArgs: -DisableTest -DisableTools
-  - ${{ if eq(parameters.kernelmode, true) }}:
+  - ${{ if eq(parameters.winkernel, true) }}:
+    jobs:
     - template: ./templates/build-config-winkernel.yml
       parameters:
         arch: ${{ parameters.arch }}
         config: Release
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-2019
-      platform: windows
-      arch: ${{ parameters.arch }}
-      tls: schannel
-      config: Release
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraBuildArgs: -DisableTest -DisableTools -PGO
-      ${{ if ne(parameters.mode, 'PGO') }}:
+
+- stage: build_winuser_schannel
+  displayName: Build Windows (Schannel)
+  dependsOn: []
+  variables:
+    runCodesignValidationInjection: false
+  - ${{ if eq(parameters.winuser_schannel, true) }}:
+    jobs:
+    - template: ./templates/build-config-user.yml
+      parameters:
+        image: windows-latest
+        platform: windows
+        arch: ${{ parameters.arch }}
+        tls: schannel
+        config: Release
+        ${{ if eq(parameters.pgo_mode, false) }}:
+          extraBuildArgs: -DisableTest -DisableTools
+        ${{ if eq(parameters.pgo_mode, true) }}:
+          extraBuildArgs: -DisableTest -DisableTools -PGO
+
+- stage: build_linux_openssl
+  displayName: Build Linux (OpenSSL)
+  dependsOn: []
+  variables:
+    runCodesignValidationInjection: false
+  - ${{ if eq(parameters.winuser_openssl, true) }}:
+    jobs:
+    - template: ./templates/build-config-user.yml
+      parameters:
+        image: ubuntu-latest
+        platform: linux
+        arch: ${{ parameters.arch }}
+        tls: openssl
+        config: Release
         extraBuildArgs: -DisableTest -DisableTools
 
 #
-# Performance Tests
+# Tests
 #
 
-- stage: performance
-  displayName: Performance Testing (${{ parameters.mode }})
-  dependsOn:
-  - build_windows
-  jobs:
-  - template: ./templates/run-performance.yml
-    parameters:
-      pool: MsQuic-Win-Perf
-      platform: windows
-      localTls: schannel
-      remoteTls: ${{ parameters.tls }}
-      arch: ${{ parameters.arch }}
-      protocol: ${{ parameters.protocol }}
-      logProfile: ${{ parameters.logging }}
-      failOnRegression: 0
-      ${{ if ne(parameters.testToRun, 'all') }}:
-        testToRun: ${{ parameters.testToRun }}
-      ${{ if eq(parameters.kernelmode, true) }}:
-        kernelMode: -Kernel
-        extraName: 'Kernel'
-        testTypes: 'Remote'
-      ${{ if eq(parameters.kernelmode, false) }}:
-        testTypes: ${{ parameters.testTypes }}
-      ${{ if eq(parameters.mode, 'PGO') }}:
-        extraArgs: -PGO
+

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -42,11 +42,11 @@ parameters:
   default: true
 - name: winuser_openssl
   type: boolean
-  displayName: Windows (openssl)
+  displayName: Windows (OpenSSL)
   default: true
 - name: linux_openssl
   type: boolean
-  displayName: Linux (openssl)
+  displayName: Linux (OpenSSL)
   default: true
 - name: arch
   type: string
@@ -199,7 +199,7 @@ stages:
         kernelMode: -Kernel
         extraName: 'Kernel'
         testTypes: 'Remote'
-        ${{ if eq(parameters.mode, 'PGO') }}:
+        ${{ if eq(parameters.pgo_mode, true) }}:
           extraArgs: -PGO
 
 - ${{ if eq(parameters.winuser_schannel, true) }}:
@@ -220,7 +220,7 @@ stages:
         ${{ if ne(parameters.testToRun, 'all') }}:
           testToRun: ${{ parameters.testToRun }}
         testTypes: ${{ parameters.testTypes }}
-        ${{ if eq(parameters.mode, 'PGO') }}:
+        ${{ if eq(parameters.pgo_mode, true) }}:
           extraArgs: -PGO
 
 - ${{ if eq(parameters.winuser_openssl, true) }}:
@@ -241,7 +241,7 @@ stages:
         ${{ if ne(parameters.testToRun, 'all') }}:
           testToRun: ${{ parameters.testToRun }}
         testTypes: ${{ parameters.testTypes }}
-        ${{ if eq(parameters.mode, 'PGO') }}:
+        ${{ if eq(parameters.pgo_mode, true) }}:
           extraArgs: -PGO
 
 - ${{ if eq(parameters.linux_openssl, true) }}:
@@ -262,7 +262,7 @@ stages:
         ${{ if ne(parameters.testToRun, 'all') }}:
           testToRun: ${{ parameters.testToRun }}
         testTypes: ${{ parameters.testTypes }}
-        ${{ if eq(parameters.mode, 'PGO') }}:
+        ${{ if eq(parameters.pgo_mode, true) }}:
           extraArgs: -PGO
 
 - ${{ if eq(variables['Build.Reason'], 'BatchedCI') }}:

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -86,24 +86,24 @@ stages:
 # Builds
 #
 
-- stage: build_winkernel
-  displayName: Build Windows Kernel
-  dependsOn: []
-  variables:
-    runCodesignValidationInjection: false
-  - ${{ if eq(parameters.winkernel, true) }}:
+- ${{ if eq(parameters.winkernel, true) }}:
+  - stage: build_winkernel
+    displayName: Build Windows Kernel
+    dependsOn: []
+    variables:
+      runCodesignValidationInjection: false
     jobs:
     - template: ./templates/build-config-winkernel.yml
       parameters:
         arch: ${{ parameters.arch }}
         config: Release
 
-- stage: build_winuser_schannel
-  displayName: Build Windows (Schannel)
-  dependsOn: []
-  variables:
-    runCodesignValidationInjection: false
-  - ${{ if eq(parameters.winuser_schannel, true) }}:
+- ${{ if eq(parameters.winuser_schannel, true) }}:
+  - stage: build_winuser_schannel
+    displayName: Build Windows (Schannel)
+    dependsOn: []
+    variables:
+      runCodesignValidationInjection: false
     jobs:
     - template: ./templates/build-config-user.yml
       parameters:
@@ -117,12 +117,31 @@ stages:
         ${{ if eq(parameters.pgo_mode, true) }}:
           extraBuildArgs: -DisableTest -DisableTools -PGO
 
-- stage: build_linux_openssl
-  displayName: Build Linux (OpenSSL)
-  dependsOn: []
-  variables:
-    runCodesignValidationInjection: false
-  - ${{ if eq(parameters.winuser_openssl, true) }}:
+- ${{ if eq(parameters.winuser_openssl, true) }}:
+  - stage: build_winuser_openssl
+    displayName: Build Windows (OpenSSL)
+    dependsOn: []
+    variables:
+      runCodesignValidationInjection: false
+    jobs:
+    - template: ./templates/build-config-user.yml
+      parameters:
+        image: windows-latest
+        platform: windows
+        arch: ${{ parameters.arch }}
+        tls: openssl
+        config: Release
+        ${{ if eq(parameters.pgo_mode, false) }}:
+          extraBuildArgs: -DisableTest -DisableTools
+        ${{ if eq(parameters.pgo_mode, true) }}:
+          extraBuildArgs: -DisableTest -DisableTools -PGO
+
+- ${{ if eq(parameters.winuser_openssl, true) }}:
+  - stage: build_linux_openssl
+    displayName: Build Linux (OpenSSL)
+    dependsOn: []
+    variables:
+      runCodesignValidationInjection: false
     jobs:
     - template: ./templates/build-config-user.yml
       parameters:

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -159,7 +159,7 @@ stages:
         ${{ if eq(parameters.pgo_mode, true) }}:
           extraBuildArgs: -DisableTest -DisableTools -PGO
 
-- ${{ if eq(parameters.winuser_openssl, true) }}:
+- ${{ if eq(parameters.linux_openssl, true) }}:
   - stage: build_linux_openssl
     displayName: Build Linux (OpenSSL)
     dependsOn: []


### PR DESCRIPTION
## Description

This change completely refactors the performance automation so that it is only run from the "perf" pipeline. We constantly have (windows) perf machines issues which cause perf jobs to stall, which causes the main AZP CI pipeline to stall. Putting all perf in its own pipeline means it will only stall other perf pipeline runs.

The refactor also cleans up the options for running custom jobs as well.

This might be a candidate for backport to release/2.0