### PR TITLE
Fix kqueue timeout with shared ec mode

### DIFF
--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2293,7 +2293,8 @@ CxPlatDataPathRunEC(
 
     struct timespec Timeout = {0, 0};
     if (WaitTime != UINT32_MAX) {
-        CxPlatGetAbsoluteTime(WaitTime, &Timeout);
+        Timeout.tv_sec += (WaitTime / CXPLAT_MS_PER_SECOND);
+        Timeout.tv_nsec += ((WaitTime % CXPLAT_MS_PER_SECOND) * CXPLAT_NANOSEC_PER_MS);
     }
 
     int ReadyEventCount =


### PR DESCRIPTION
kqueue was receiving an absolute timeout, when it needed a relative timeout. 

Closes #2500 