### PR TITLE
Switch XDP BVT job to run on Server 2022

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -608,7 +608,7 @@ stages:
       testCerts: true
   - template: ./templates/run-bvt.yml
     parameters:
-      pool: MsQuic-Win-Latest
+      image: windows-2022
       platform: windows
       tls: schannel
       logProfile: Full.Light

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -45,7 +45,7 @@ jobs:
       ${{ if and(eq(parameters.kernel, true), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates -SignCode
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactDir, '_Xdp')) }}:
-        arguments: -Configuration Test -TestCertificates -DuoNic
+        arguments: -Configuration Test -DuoNic
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -45,7 +45,7 @@ jobs:
       ${{ if and(eq(parameters.kernel, true), eq(parameters.testCerts, true)) }}:
         arguments: -Configuration Test -TestCertificates -SignCode
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), eq(parameters.extraArtifactDir, '_Xdp')) }}:
-        arguments: -Configuration Test -DuoNic
+        arguments: -Configuration Test -TestCertificates -DuoNic
       ${{ if and(eq(parameters.kernel, false), eq(parameters.testCerts, true), ne(parameters.extraArtifactDir, '_Xdp')) }}:
         arguments: -Configuration Test -TestCertificates
       ${{ if eq(parameters.testCerts, false) }}:


### PR DESCRIPTION
The XDP build's BVT currently runs on the MsQuic-Win-Latest pool, which reuses VMs.
This is problematic because the duonic installation is not cleaned up at the end of the
test. There's no reason not to run on Server 2022, for which we have one-time-use VMs.