### PR TITLE
CP Latest OpenSSL to prerelease/1.9

### DIFF
--- a/.azure/azure-pipelines.qns.yml
+++ b/.azure/azure-pipelines.qns.yml
@@ -60,7 +60,7 @@ jobs:
         ${{ if eq(variables['Build.Reason'], 'BatchedCI') }}:
           tags: |
             latest
-            v1.9.0.$(Build.BuildId)
+            v1.9.1.$(Build.BuildId)
         ${{ if ne(variables['Build.Reason'], 'BatchedCI') }}:
           tags: custom-$(Build.BuildId)
 - template: .\templates\run-qns.yml

--- a/.azure/obtemplates/create-vpack.yml
+++ b/.azure/obtemplates/create-vpack.yml
@@ -62,7 +62,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -76,7 +76,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -90,7 +90,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -104,7 +104,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -118,7 +118,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -132,7 +132,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -146,7 +146,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -160,7 +160,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -174,7 +174,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -188,5 +188,5 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)

--- a/.azure/templates/create-package.yml
+++ b/.azure/templates/create-package.yml
@@ -47,7 +47,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -62,7 +62,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -77,7 +77,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -92,7 +92,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -107,7 +107,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -122,7 +122,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -137,7 +137,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -152,7 +152,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -167,7 +167,7 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)
 
   - task: PkgESVPack@12
@@ -182,5 +182,5 @@ jobs:
       vpackToken: $(VPACK_PAT)
       majorVer: 1
       minorVer: 9
-      patchVer: 0
+      patchVer: 1
       prereleaseVer: $(Build.BuildId)

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/quictls/openssl.git
-	branch = OpenSSL_1_1_1l+quic
+	branch = OpenSSL_1_1_1n+quic

--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -141,7 +141,7 @@ $DistDir = Join-Path $BaseArtifactsDir "dist"
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
 $RepoRemote = Get-GitRemote -RepoDir $RootDir
 
-$Version = "1.9.0"
+$Version = "1.9.1"
 
 $BuildId = $env:BUILD_BUILDID
 if ($null -ne $BuildId) {

--- a/src/distribution/Info.plist
+++ b/src/distribution/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleVersion</key>
-    <string>1.9.0</string>
+    <string>1.9.1</string>
     <key>NSHumanReadableCopyright</key>
     <string>MIT</string>
     <key>CFBundleGetInfoString</key>

--- a/src/inc/msquic.ver
+++ b/src/inc/msquic.ver
@@ -12,7 +12,7 @@
 #endif
 
 #ifndef VER_PATCH
-#define VER_PATCH 0
+#define VER_PATCH 1
 #endif
 
 #ifndef VER_BUILD_ID


### PR DESCRIPTION
.NET 6 uses prerelease/1.9, so this cherry-picks the latest OpenSSL security fixes for .NET to consume. cc @wfurt 