### PR TITLE
Send MAX_DATA on Stream FIN

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -1000,6 +1000,13 @@ QuicStreamReceiveComplete(
         QuicStreamTryCompleteShutdown(Stream);
 
         //
+        // Flush the connection-wide MAX_DATA.
+        //
+        QuicSendSetSendFlag(
+            &Stream->Connection->Send,
+            QUIC_CONN_SEND_FLAG_MAX_DATA);
+
+        //
         // Remove any flags we shouldn't be sending now that the receive
         // direction is closed.
         //


### PR DESCRIPTION
## Description

Update the connection-wide flow control logic to also send updates when a stream shuts down (drains a FIN).

## Testing

TBD