### PR TITLE
Accumulator logic for MAX_DATA updates

### DIFF
--- a/src/core/send.h
+++ b/src/core/send.h
@@ -217,6 +217,13 @@ typedef struct QUIC_SEND {
     uint64_t OrderedStreamBytesSent;
 
     //
+    // An accumulator for in-order delivered bytes across all streams. When this
+    // reaches ConnFlowControlWindow / QUIC_RECV_BUFFER_DRAIN_RATIO, the accumulator
+    // is reset and a MAX_DATA frame is sent.
+    //
+    uint64_t OrderedStreamBytesDeliveredAccumulator;
+
+    //
     // Set of flags indicating what data is ready to be sent out.
     //
     uint32_t SendFlags;

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -629,13 +629,15 @@ QuicStreamRecv(
 }
 
 //
-// Generally, every time bytes are delivered to the application we update our max
-// data (stream and connection) values and queue an update to be sent to the
-// peer. It is done every time, because nearly always an ACK frame is also
-// ready to be sent out, so we might as well take advantage of that packet to
-// send this data as well. If we don't have an ACK ready to be sent out
-// immediately then we only update the values if we have reached the drain
-// limit.
+// Criteria for sending MAX_DATA/MAX_STREAM_DATA frames:
+//
+// Whenever bytes are delivered on a stream, a MAX_STREAM_DATA frame is sent if an ACK
+// is already queued, or if the buffer tuning algorithm below increases the buffer size.
+//
+// The connection-wide MAX_DATA frame is sent independently from MAX_STREAM_DATA (see use
+// of OrderedStreamBytesDeliveredAccumulator). This prevents issues in corner cases, like
+// when many short streams are used, in which case we might never actually send a
+// MAX_STREAM_DATA update since each stream's entire payload fits in the initial window.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
@@ -649,6 +651,15 @@ QuicStreamOnBytesDelivered(
 
     Stream->RecvWindowBytesDelivered += BytesDelivered;
     Stream->Connection->Send.MaxData += BytesDelivered;
+
+    Stream->Connection->Send.OrderedStreamBytesDeliveredAccumulator += BytesDelivered;
+    if (Stream->Connection->Send.OrderedStreamBytesDeliveredAccumulator >=
+        Stream->Connection->Settings.ConnFlowControlWindow / QUIC_RECV_BUFFER_DRAIN_RATIO) {
+        Stream->Connection->Send.OrderedStreamBytesDeliveredAccumulator = 0;
+        QuicSendSetSendFlag(
+            &Stream->Connection->Send,
+            QUIC_CONN_SEND_FLAG_MAX_DATA);
+    }
 
     if (Stream->RecvWindowBytesDelivered >= RecvBufferDrainThreshold) {
 
@@ -704,7 +715,7 @@ QuicStreamOnBytesDelivered(
     } else if (!(Stream->Connection->Send.SendFlags & QUIC_CONN_SEND_FLAG_ACK)) {
         //
         // We haven't hit the drain limit AND we don't have any ACKs to send
-        // immediately, so we don't need to immediately update the max data
+        // immediately, so we don't need to immediately update the max stream data
         // values.
         //
         return;
@@ -726,9 +737,6 @@ QuicStreamOnBytesDelivered(
     Stream->MaxAllowedRecvOffset =
         Stream->RecvBuffer.BaseOffset + Stream->RecvBuffer.VirtualBufferLength;
 
-    QuicSendSetSendFlag(
-        &Stream->Connection->Send,
-        QUIC_CONN_SEND_FLAG_MAX_DATA);
     QuicSendSetStreamSendFlag(
         &Stream->Connection->Send,
         Stream,

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -737,6 +737,9 @@ QuicStreamOnBytesDelivered(
     Stream->MaxAllowedRecvOffset =
         Stream->RecvBuffer.BaseOffset + Stream->RecvBuffer.VirtualBufferLength;
 
+    QuicSendSetSendFlag(
+        &Stream->Connection->Send,
+        QUIC_CONN_SEND_FLAG_MAX_DATA);
     QuicSendSetStreamSendFlag(
         &Stream->Connection->Send,
         Stream,


### PR DESCRIPTION
When many small streams are used, it's possible that we never actually send MAX_STREAM_DATA updates. The current logic ties MAX_STREAM_DATA and (connection-wide) MAX_DATA updates together, which causes the peer to be eventually connection FC blocked in this case.

This PR adds an accumulator variable for connectionwide delivered bytes. When the accumulator hits a fraction (I propose 1/4 but haven't carefully thought about it) of the conn FC window, we send a MAX_DATA frame to open the window.