### PR TITLE
Misc Updates

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Cargo
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
+      with:
+        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
     - name: Prepare Machine

--- a/.github/workflows/check-clog.yml
+++ b/.github/workflows/check-clog.yml
@@ -19,10 +19,6 @@ jobs:
     name: Validate
     runs-on: windows-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Setup .NET
       uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829
       with:

--- a/.github/workflows/check-dotnet.yml
+++ b/.github/workflows/check-dotnet.yml
@@ -19,10 +19,6 @@ jobs:
     name: Validate
     runs-on: windows-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Setup .NET
       uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829
       with:

--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -18,10 +18,6 @@ jobs:
     name: Mirror
     runs-on: windows-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
       with:

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['2.0.0']
+        release: ['2.0.1']
         os: [ubuntu-latest, windows-latest]
         arch: [x64]
         tls: [schannel, openssl]

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -30,10 +30,6 @@ jobs:
     name: Build Perf
     runs-on: windows-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
     - name: Prepare Machine
@@ -81,10 +77,6 @@ jobs:
           rtt: 500
           queueRatio: 5 # Exceeds QueueLimitPackets limit of 100000
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
     - name: Prepare Machine
@@ -118,10 +110,6 @@ jobs:
     runs-on: windows-2022
     needs: wan-perf
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
       with:

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -259,7 +259,7 @@ Official (v1) RFC and draft-29 are supported by this release.
 
 ## MsQuic v2.0 (SAC)
 
-[MsQuic v2.0](https://github.com/microsoft/msquic/releases/tag/v2.0.0) is an official release. Signed Windows binaries and [NuGet packages](https://www.nuget.org/profiles/msquic) are available. Signed Linux package are also available.
+[MsQuic v2.0](https://github.com/microsoft/msquic/releases/tag/v2.0.1) is an official release. Signed Windows binaries and [NuGet packages](https://www.nuget.org/profiles/msquic) are available. Signed Linux package are also available.
 
 Official (v1) RFC and draft-29 are supported by this release.
 


### PR DESCRIPTION
- Remove security hardener from all Windows jobs since it's not supported.
- Try add back security hardener to cargo (since the issue might be fixed)
- Update 2.0.0 references to latest patch 2.0.1