### PR TITLE
Add note to StreamReceiveSetEnabled that disable does not disable enqueued receives

### DIFF
--- a/docs/api/StreamReceiveSetEnabled.md
+++ b/docs/api/StreamReceiveSetEnabled.md
@@ -25,7 +25,7 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 # Remarks
 
-**TODO**
+This function always delegates to the worker queue, even if called from a quic worker thread. This matters if disabling receives, as there could be a receive in the queue before this call is processed, and that receive would still indicated to the app. To disable receives safely, reject a receive by draining 0 bytes in the `QUIC_STREAM_EVENT_RECEIVE` callback.
 
 # See Also
 


### PR DESCRIPTION
Currently, StreamReceiveSetEnabled with IsEnabled set to false won't stop all receives from coming in. It always goes into the worker queue, and there could be receives pending either in the queue or in the current processing packet, which would still be received by the app. Add a note to the docs that this is the case, and the only way to guarantee disable is to drain no bytes from a receive callback.

Noticed in #2541 