### PR TITLE
Only compute TailBuffer in FreeBuffer on debug builds

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2380,16 +2380,22 @@ CxPlatSendDataFreeBuffer(
     // This must be the final send buffer; intermediate buffers cannot be freed.
     //
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc = SendData->Owner;
+#ifdef DEBUG
     uint8_t* TailBuffer = SendData->Buffers[SendData->BufferCount - 1].Buffer;
+#endif
 
     if (SendData->SegmentSize == 0) {
+#ifdef DEBUG
         CXPLAT_DBG_ASSERT(Buffer->Buffer == (uint8_t*)TailBuffer);
+#endif
 
         CxPlatPoolFree(&DatapathProc->SendBufferPool, Buffer->Buffer);
         --SendData->BufferCount;
     } else {
+#ifdef DEBUG
         TailBuffer += SendData->Buffers[SendData->BufferCount - 1].Length;
         CXPLAT_DBG_ASSERT(Buffer->Buffer == (uint8_t*)TailBuffer);
+#endif
 
         if (SendData->Buffers[SendData->BufferCount - 1].Length == 0) {
             CxPlatPoolFree(&DatapathProc->LargeSendBufferPool, Buffer->Buffer);

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1972,16 +1972,22 @@ CxPlatSendDataFreeBuffer(
     // This must be the final send buffer; intermediate buffers cannot be freed.
     //
     CXPLAT_DATAPATH_PROC_CONTEXT* DatapathProc = SendData->Owner;
+#ifdef DEBUG
     uint8_t* TailBuffer = SendData->Buffers[SendData->BufferCount - 1].Buffer;
+#endif
 
     if (SendData->SegmentSize == 0) {
+#ifdef DEBUG
         CXPLAT_DBG_ASSERT(Buffer->Buffer == (uint8_t*)TailBuffer);
+#endif
 
         CxPlatPoolFree(&DatapathProc->SendBufferPool, Buffer->Buffer);
         --SendData->BufferCount;
     } else {
+#ifdef DEBUG
         TailBuffer += SendData->Buffers[SendData->BufferCount - 1].Length;
         CXPLAT_DBG_ASSERT(Buffer->Buffer == (uint8_t*)TailBuffer);
+#endif
 
         if (SendData->Buffers[SendData->BufferCount - 1].Length == 0) {
             CxPlatPoolFree(&DatapathProc->LargeSendBufferPool, Buffer->Buffer);


### PR DESCRIPTION
Newer versions of clang are detecting TailBuffer as unused in release mode, as its only ever set to, and not read from. Make it so the entire variable is gone in release mode. Will need to be backported.