### PR TITLE
[RUST] Implements stats v2 struct and missing stream events 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.0.1-beta"
+version = "2.1.0-beta"
 edition = "2018"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.1.0-beta"
+version = "2.0.1-beta"
 edition = "2018"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"
@@ -47,6 +47,7 @@ include = [
 cmake = "0.1"
 
 [dependencies]
+bitfield = "0.13.2"
 libc = "0.2.0"
 c-types = "1.2.0"
 serde = { version = "1.0.117", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use libc::c_void;
-#[allow(unused_imports)]
-use c_types::AF_UNSPEC;
 #[allow(unused_imports)]
 use c_types::AF_INET;
 #[allow(unused_imports)]
 use c_types::AF_INET6;
+#[allow(unused_imports)]
+use c_types::AF_UNSPEC;
+use libc::c_void;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
+use std::fmt;
 use std::option::Option;
 use std::ptr;
+#[macro_use]
+extern crate bitfield;
 
 //
 // The following starts the C interop layer of MsQuic API.
@@ -399,42 +402,61 @@ pub struct HandshakeInfo {
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct QuicStatisticsTiming {
     pub start: u64,
-    pub initial_flight_end: u64,
-    pub handshake_flight_end: u64,
+    /// Processed all peer's Initial packets
+    pub start_flight_end: u64,
+    /// Processed all peer's Handshake packets
+    pub handshake_fligh_end: u64,
 }
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct QuicStatisticsHandshake {
-    pub client_flight1_bytes: u32,
-    pub server_flight1_bytes: u32,
-    pub client_flight2_bytes: u32,
+    /// Sum of TLS payloads
+    pub client_flight_1_bytes: u32,
+    /// Sum of TLS payloads
+    pub server_flight_1_bytes: u32,
+    /// Sum of TLS payloads
+    pub client_flight_2_bytes: u32,
 }
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct QuicStatisticsSend {
+    /// Current path MTU.
     pub path_mtu: u16,
+    /// QUIC packets; could be coalesced into fewer UDP datagrams.
     pub total_packets: u64,
     pub retransmittable_packets: u64,
     pub suspected_lost_packets: u64,
+    /// Actual lost is (suspected_lost_packets - spurious_lost_packets)
     pub spurious_lost_packets: u64,
+    /// Sum of UDP payloads
     pub total_bytes: u64,
+    /// Sum of stream payloads
     pub total_stream_bytes: u64,
+    /// Number of congestion events
     pub congestion_count: u32,
+    /// Number of persistent congestion events
     pub persistent_congestion_count: u32,
 }
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct QuicStatisticsRecv {
+    /// QUIC packets; could be coalesced into fewer UDP datagrams.
     pub total_packets: u64,
+    /// Packets where packet number is less than highest seen.
     pub reordered_packets: u64,
+    /// Includes DuplicatePackets.
     pub dropped_packets: u64,
     pub duplicate_packets: u64,
+    /// Sum of UDP payloads
     pub total_bytes: u64,
+    /// Sum of stream payloads
     pub total_stream_bytes: u64,
+    /// Count of packet decryption failures.
     pub decryption_failures: u64,
+    /// Count of receive ACK frames.
     pub valid_ack_frames: u64,
 }
 
@@ -444,15 +466,37 @@ pub struct QuicStatisticsMisc {
     pub key_update_count: u32,
 }
 
+bitfield! {
+    #[repr(C)]
+    #[derive(Serialize, Deserialize, Clone, Copy)]
+    pub struct QuicStatisticsBitfields(u32);
+    // The fields default to u32
+    version_negotiation, _: 1, 0;
+    stateless_retry, _: 1, 1;
+    resumption_attempted, _: 1, 2;
+    resumption_succeeded, _: 1, 3;
+}
+
+/// Implementation of Debug for formatting the QuicStatisticsBitfields struct.
+/// This is implemented manually because the derived implementation by the bitfield macro
+/// has been observed to cause panic.
+impl fmt::Debug for QuicStatisticsBitfields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{:#06x}", &self.0))
+    }
+}
+
+/// A helper struct for accessing connection statistics
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, Copy, Clone)]
 pub struct QuicStatistics {
-    pub correlation_id: u64,
-    pub _bitfield_align_1: [u8; 0],
-    //pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub _bitfield_1: u8,
+    correlation_id: u64,
+    pub flags: QuicStatisticsBitfields,
+    /// In microseconds
     pub rtt: u32,
+    /// In microseconds
     pub min_rtt: u32,
+    /// In microseconds
     pub max_rtt: u32,
     pub timing: QuicStatisticsTiming,
     pub handshake: QuicStatisticsHandshake,
@@ -461,25 +505,76 @@ pub struct QuicStatistics {
     pub misc: QuicStatisticsMisc,
 }
 
-/*#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct QUIC_LISTENER_STATISTICS__bindgen_ty_1__bindgen_ty_1 {
-    pub DroppedPackets: u64,
+/// A helper struct for accessing connection statistics
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+pub struct QuicStatisticsV2 {
+    correlation_id: u64,
+    pub flags: QuicStatisticsBitfields,
+    /// In microseconds
+    pub rtt: u32,
+    /// In microseconds
+    pub min_rtt: u32,
+    /// In microseconds
+    pub max_rtt: u32,
+
+    pub timing_start: u64,
+    /// Processed all peer's Initial packets
+    pub timing_start_flight_end: u64,
+    /// Processed all peer's Handshake packets
+    pub timing_handshake_fligh_end: u64,
+
+    /// Sum of TLS payloads
+    pub handshake_client_flight_1_bytes: u32,
+    /// Sum of TLS payloads
+    pub handshake_server_flight_1_bytes: u32,
+    /// Sum of TLS payloads
+    pub handshake_client_flight_2_bytes: u32,
+
+    /// Current path MTU.
+    pub send_path_mtu: u16,
+    /// QUIC packets; could be coalesced into fewer UDP datagrams.
+    pub send_total_packets: u64,
+    pub send_retransmittable_packets: u64,
+    pub send_suspected_lost_packets: u64,
+    /// Actual lost is (suspected_lost_packets - spurious_lost_packets)
+    pub send_spurious_lost_packets: u64,
+    /// Sum of UDP payloads
+    pub send_total_bytes: u64,
+    /// Sum of stream payloads
+    pub send_total_stream_bytes: u64,
+    /// Number of congestion events
+    pub send_congestion_count: u32,
+    /// Number of persistent congestion events
+    pub send_persistent_congestion_count: u32,
+
+    /// QUIC packets; could be coalesced into fewer UDP datagrams.
+    pub recv_total_packets: u64,
+    /// Packets where packet number is less than highest seen.
+    pub recv_reordered_packets: u64,
+    /// Includes DuplicatePackets.
+    pub recv_dropped_packets: u64,
+    pub recv_duplicate_packets: u64,
+    /// Sum of UDP payloads
+    pub recv_total_bytes: u64,
+    /// Sum of stream payloads
+    pub recv_total_stream_bytes: u64,
+    /// Count of packet decryption failures.
+    pub recv_decryption_failures: u64,
+    /// Count of receive ACK frames.
+    pub recv_valid_ack_frames: u64,
+
+    pub key_update_count: u32,
 }
 
+/// A helper struct for accessing listener statistics.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct QUIC_LISTENER_STATISTICS__bindgen_ty_1 {
-    pub Recv: QUIC_LISTENER_STATISTICS__bindgen_ty_1__bindgen_ty_1,
+pub struct QuicListenerStatistics {
+    pub total_accepted_connections: u64,
+    pub total_rejected_connections: u64,
+    pub binding: u64,
 }
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct QUIC_LISTENER_STATISTICS {
-    pub TotalAcceptedConnections: u64,
-    pub TotalRejectedConnections: u64,
-    pub Binding: QUIC_LISTENER_STATISTICS__bindgen_ty_1,
-}*/
 
 /// A helper struct for accessing performance counters.
 pub struct QuicPerformance {
@@ -603,7 +698,7 @@ pub const PARAM_CONN_PEER_CERTIFICATE_VALID: u32 = 0x05000011;
 pub const PARAM_CONN_LOCAL_INTERFACE: u32 = 0x05000012;
 pub const PARAM_CONN_TLS_SECRETS: u32 = 0x05000013;
 pub const PARAM_CONN_VERSION_SETTINGS: u32 = 0x05000014;
-pub const PARAM_CONN_CIBIR_ID: u32 = 0x05000015;
+pub const PARAM_CONN_INITIAL_DCID_PREFIX: u32 = 0x05000015;
 pub const PARAM_CONN_STATISTICS_V2: u32 = 0x05000016;
 pub const PARAM_CONN_STATISTICS_V2_PLAT: u32 = 0x05000017;
 
@@ -768,16 +863,64 @@ pub struct StreamEventReceive {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StreamEventSendComplete {
+    pub canceled: bool,
+    pub client_context: *const c_void,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StreamEventPeerSendAborted {
+    pub error_code: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StreamEventPeerReceiveAborted {
+    pub error_code: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StreamEventSendShutdownComplete {
+    pub graceful: bool,
+}
+
+
+bitfield! {
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct StreamEventShutdownCompleteBitfields(u8);
+    // The fields default to u8
+    app_close_in_progress, _: 1, 0;
+    _reserved, _: 7, 1;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct StreamEventShutdownComplete {
+    connection_shutdown: bool,
+    flags: StreamEventShutdownCompleteBitfields
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StreamEventIdealSendBufferSize {
+    pub byte_count: u64,
+}
+
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub union StreamEventPayload {
     pub start_complete: StreamEventStartComplete,
     pub receive: StreamEventReceive,
-    //pub send_complete: StreamEventSendComplete,
-    //pub peer_send_aborted: StreamEventPeerSendAborted,
-    //pub peer_receive_aborted: StreamEventPeerReceiveAborted,
-    //pub send_shutdown_complete: StreamEventSendShutdownComplete,
-    //pub shutdown_complete: StreamEventShutdownComplete,
-    //pub ideal_send_buffer_size: StreamEventIdealSendBufferSize,
+    pub send_complete: StreamEventSendComplete,
+    pub peer_send_aborted: StreamEventPeerSendAborted,
+    pub peer_receive_aborted: StreamEventPeerReceiveAborted,
+    pub send_shutdown_complete: StreamEventSendShutdownComplete,
+    pub shutdown_complete: StreamEventShutdownComplete,
+    pub ideal_send_buffer_size: StreamEventIdealSendBufferSize,
 }
 
 #[repr(C)]
@@ -795,12 +938,8 @@ struct ApiTable {
     get_context: extern "C" fn(handle: Handle) -> *mut c_void,
     set_callback_handler:
         extern "C" fn(handle: Handle, handler: *const c_void, context: *const c_void),
-    set_param: extern "C" fn(
-        handle: Handle,
-        param: u32,
-        buffer_length: u32,
-        buffer: *const c_void,
-    ) -> u32,
+    set_param:
+        extern "C" fn(handle: Handle, param: u32, buffer_length: u32, buffer: *const c_void) -> u32,
     get_param: extern "C" fn(
         handle: Handle,
         param: u32,
@@ -1233,11 +1372,9 @@ impl Connection {
             ((*self.table).connection_shutdown)(self.handle, flags, error_code);
         }
     }
-    
+
     pub fn set_param(&self, param: u32, buffer_length: u32, buffer: *const c_void) -> u32 {
-        unsafe {
-            ((*self.table).set_param)(self.handle, param, buffer_length, buffer)
-        }        
+        unsafe { ((*self.table).set_param)(self.handle, param, buffer_length, buffer) }
     }
 
     pub fn stream_close(&self, stream: Handle) {
@@ -1260,6 +1397,22 @@ impl Connection {
         };
 
         unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatistics) }
+    }
+
+    pub fn get_stats_v2(&self) -> QuicStatisticsV2 {
+        let mut stat_buffer: [u8; std::mem::size_of::<QuicStatisticsV2>()] =
+            [0; std::mem::size_of::<QuicStatisticsV2>()];
+        let stat_size_mut = std::mem::size_of::<QuicStatisticsV2>();
+        unsafe {
+            ((*self.table).get_param)(
+                self.handle,
+                PARAM_CONN_STATISTICS_V2,
+                (&stat_size_mut) as *const usize as *const u32 as *mut u32,
+                stat_buffer.as_mut_ptr() as *const c_void,
+            )
+        };
+
+        unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatisticsV2) }
     }
 
     pub fn set_configuration(&self, configuration: &Configuration) {


### PR DESCRIPTION
## Description
This is a minor change to the lib.rs file to support the connection stats v2 function and struct. In addition, the PR also implements some StreamEvents types that were missing. 

## Testing
No tests implemented, porting of the C structs were manually converted to Rust.