### PR TITLE
Always treat unit test warnings as errors

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -310,9 +310,6 @@ if ($CodeCoverage) {
 if ($AZP) {
     $TestArguments += " -AZP"
 }
-if ($ErrorsAsWarnings) {
-    $TestArguments += " -ErrorsAsWarnings"
-}
 
 if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {
     $TestArguments += " -ExtraArtifactDir $ExtraArtifactDir"
@@ -323,6 +320,12 @@ if (!$Kernel -and !$SkipUnitTests) {
     Invoke-Expression ($RunTest + " -Path $MsQuicCoreTest " + $TestArguments)
     Invoke-Expression ($RunTest + " -Path $MsQuicPlatTest " + $TestArguments)
 }
+
+# Still consider units test failures to be errors on all platforms.
+if ($ErrorsAsWarnings) {
+    $TestArguments += " -ErrorsAsWarnings"
+}
+
 # TODO: fix main tests to run with XDP.
 if (!$DuoNic) {
     Invoke-Expression ($RunTest + " -Path $MsQuicTest " + $TestArguments)


### PR DESCRIPTION

## Description

macOS unit tests are stable, and we've taken some changes recently that have broken them. Make sure this does not happen again


## Testing

It enables more testing

## Documentation

No
