### PR TITLE
Stream Shutdown on Failure in Operation Cleanup

### DIFF
--- a/src/core/operation.c
+++ b/src/core/operation.c
@@ -228,6 +228,12 @@ QuicOperationQueueClear(
                     CXPLAT_DBG_ASSERT(ApiCtx->Completed == NULL);
                     QuicStreamIndicateStartComplete(
                         ApiCtx->STRM_START.Stream, QUIC_STATUS_ABORTED);
+                    if (ApiCtx->STRM_START.Flags & QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL) {
+                        QuicStreamShutdown(
+                            ApiCtx->STRM_START.Stream,
+                            QUIC_STREAM_SHUTDOWN_FLAG_ABORT | QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE,
+                            0);
+                    }
                 }
             }
             QuicOperationFree(Worker, Oper);


### PR DESCRIPTION
## Description

While inspecting the code I noticed that we only were apply the logic for `QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL` in the failure path of `QuicStreamStart`, and not in the operation clean up path of `QuicOperationQueueClear` which happens when a connection is cleaned up.

## Testing

As this is a nearly impossible timing window to hit with a test, I will rely on spinquic and existing tests to hopefully exercise.

## Documentation

None. This is just fixing a bug.
