### PR TITLE
Remove library git hash and datapath processors from preview features

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -704,9 +704,9 @@ void
 #define QUIC_PARAM_GLOBAL_GLOBAL_SETTINGS               0x01000006  // QUIC_GLOBAL_SETTINGS
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 #define QUIC_PARAM_GLOBAL_VERSION_SETTINGS              0x01000007  // QUIC_VERSION_SETTINGS
+#endif
 #define QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH              0x01000008  // char[64]
 #define QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS           0x01000009  // uint16_t[]
-#endif
 
 //
 // Parameters for Registration.


### PR DESCRIPTION
They should not have been considered preview features anyway.