### PR TITLE
One Connection/Stream Perf Test for Latency Data

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -128,7 +128,7 @@ stages:
         arch: ${{ parameters.arch }}
         config: Release
 
-- ${{ if eq(parameters.winuser_schannel, true) }}:
+- ${{ if or(eq(parameters.winkernel, true), eq(parameters.winuser_schannel, true)) }}:
   - stage: build_winuser_schannel
     displayName: Build Windows (Schannel)
     dependsOn: []
@@ -215,6 +215,7 @@ stages:
     displayName: Performance Testing Windows Kernel
     dependsOn:
     - build_winkernel
+    - build_winuser_schannel
     jobs:
     - template: ./templates/run-performance.yml
       parameters:

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -8,11 +8,11 @@ trigger:
   branches:
     include:
     - main
-    - release/*
   paths:
     include:
     - .azure/azure-pipelines.perf.yml
     - .azure/templates/run-performance.yml
+    - scripts/RemoteTests.json
     - src/bin/*
     - src/core/*
     - src/platform/*
@@ -22,11 +22,11 @@ pr:
   branches:
     include:
     - main
-    - release/*
   paths:
     include:
     - .azure/azure-pipelines.perf.yml
     - .azure/templates/run-performance.yml
+    - scripts/RemoteTests.json
     - src/bin/*
     - src/core/*
     - src/platform/*
@@ -148,14 +148,14 @@ stages:
           extraBuildArgs: -DisableTest -DisableTools
         ${{ if eq(parameters.pgo_mode, true) }}:
           extraBuildArgs: -DisableTest -DisableTools -PGO
-         
+
 - ${{ if eq(parameters.winuser_xdp, true) }}:
   - stage: build_winuser_xdp
     displayName: Build Windows (XDP)
     dependsOn: []
     variables:
       runCodesignValidationInjection: false
-    jobs: 
+    jobs:
     - template: ./templates/build-config-user.yml
       parameters:
         image: windows-latest

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -4,7 +4,6 @@
 #
 
 trigger:
-  batch: true
   branches:
     include:
     - main

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -60,13 +60,13 @@ jobs:
       pacing: 1
       reorder: "(0,1000,10000)"
       delay: "(0,5,10)"
+      loss: "("0,1000,10000)"
     strategy:
       fail-fast: false
       matrix:
         rate: [5, 10, 20, 50, 100, 200, 1000]
         rtt: [5, 50, 200, 500]
         queueRatio: [0.2, 1, 5]
-        loss: [0,1000,10000]
         exclude:
         - rate: 5
           rtt: 5
@@ -87,11 +87,11 @@ jobs:
     - name: Run WAN Perf (QUIC only)
       if: ${{ github.event_name == 'pull_request' }}
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Debug -Protocol QUIC -LogProfile Performance.Light -NoDateLogDir -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
+      run: scripts/emulated-performance.ps1 -Debug -Protocol QUIC -LogProfile Performance.Light -NoDateLogDir -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ env.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
     - name: Run WAN Perf (QUIC + TCP)
       if: ${{ github.event_name != 'pull_request' }}
       shell: pwsh
-      run: scripts/emulated-performance.ps1 -Debug -Protocol ('QUIC','TCPTLS') -LogProfile Performance.Light -NoDateLogDir -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ matrix.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
+      run: scripts/emulated-performance.ps1 -Debug -Protocol ('QUIC','TCPTLS') -LogProfile Performance.Light -NoDateLogDir -NumIterations ${{ env.iterations }} -DurationMs ${{ env.duration }} -Pacing ${{ env.pacing }} -BottleneckMbps ${{ matrix.rate }} -RttMs ${{ matrix.rtt }} -BottleneckQueueRatio ${{ matrix.queueRatio }} -RandomLossDenominator ${{ env.loss }} -RandomReorderDenominator ${{ env.reorder }} -ReorderDelayDeltaMs ${{ env.delay }} -BaseRandomSeed ${{ env.seed }}
     - name: Upload Results
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
       with:

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -60,7 +60,7 @@ jobs:
       pacing: 1
       reorder: "(0,1000,10000)"
       delay: "(0,5,10)"
-      loss: "("0,1000,10000)"
+      loss: "(0,1000,10000)"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - release/*
     paths:
     - .github/workflows/wan-perf.yml
     - src/core/*
@@ -13,7 +12,6 @@ on:
   pull_request:
     branches:
     - main
-    - release/*
     paths:
     - .github/workflows/wan-perf.yml
     - src/core/*

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -176,6 +176,7 @@
                 {
                     "Name": "ConnectionCount",
                     "Local": {
+                        "1": "-conns:1 -requests:1",
                         "40": "-conns:40 -requests:20",
                         "250": "-conns:250 -requests:7500"
                     },
@@ -219,6 +220,7 @@
                 {
                     "Name": "ConnectionCount",
                     "Local": {
+                        "1": "-conns:1 -requests:1",
                         "40": "-conns:40 -requests:20",
                         "250": "-conns:250 -requests:7500"
                     },


### PR DESCRIPTION
## Description

- Onboards a single connection, single stream RPS test so we can get the minimal latency numbers from it.
- Decided to officially only run perf on main branch, so we don't have to maintain perf on previous releases.
- Some WAN perf cleanup too.

## Testing

Perf automation runs in CI.

## Documentation

N/A
