### PR TITLE
Run Latency RPS for Longer

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -176,7 +176,7 @@
                 {
                     "Name": "ConnectionCount",
                     "Local": {
-                        "1": "-conns:1 -requests:1",
+                        "1": "-conns:1 -requests:1 -runtime:30000",
                         "40": "-conns:40 -requests:20",
                         "250": "-conns:250 -requests:7500"
                     },


### PR DESCRIPTION
## Description

In order to get a larger data set, let's run the RPS used for latency measurements longer (30 seconds).