### PR TITLE
Fix openssl tls initialize not verifying server vs client state checks

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -1594,6 +1594,16 @@ CxPlatTlsInitialize(
 
     CXPLAT_DBG_ASSERT(Config->HkdfLabels);
 
+    if (Config->IsServer != !(Config->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_CLIENT)) {
+        QuicTraceEvent(
+            TlsError,
+            "[ tls][%p] ERROR, %s.",
+            Config->Connection,
+            "Mismatched SEC_CONFIG IsServer state");
+        Status = QUIC_STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
     TlsContext = CXPLAT_ALLOC_NONPAGED(sizeof(CXPLAT_TLS), QUIC_POOL_TLS_CTX);
     if (TlsContext == NULL) {
         QuicTraceEvent(


### PR DESCRIPTION
## Description

These states should be matched, and this is checked in schannel

## Testing

Existing tests will likely cover this, although they are going to fail. And likely fail downlevel as well.

## Documentation

No
