### PR TITLE
Update Down Level Tests to Official 2.0 Release Binaries

### DIFF
--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['2.0.1']
+        release: ['2.0.2']
         os: [ubuntu-latest, windows-latest]
         arch: [x64]
         tls: [schannel, openssl]


### PR DESCRIPTION
## Description

Now that we have an official v2.0 release (v2.0.2) update the down-level tests to use those release binaries for testing.

## Testing

Validated via Test Down Level test in CI.

## Documentation

N/A
