### PR TITLE
Discard Initial Packet Keys on Handshake Send

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -941,6 +941,17 @@ QuicCryptoWriteFrames(
         return TRUE;
     }
 
+    if (QuicConnIsClient(Connection) &&
+        Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_HANDSHAKE &&
+        Crypto->TlsState.WriteKeys[QUIC_PACKET_KEY_INITIAL] &&
+        Builder->Key != Crypto->TlsState.WriteKeys[QUIC_PACKET_KEY_INITIAL]) {
+        //
+        // Per spec, client MUST discard Initial keys when it starts
+        // encrypting packets with handshake keys.
+        //
+        QuicCryptoDiscardKeys(Crypto, QUIC_PACKET_KEY_INITIAL);
+    }
+
     uint8_t PrevFrameCount = Builder->Metadata->FrameCount;
 
     uint16_t AvailableBufferLength =
@@ -1405,14 +1416,6 @@ QuicCryptoProcessTlsCompletion(
         CXPLAT_DBG_ASSERT(Crypto->TlsState.WriteKey <= QUIC_PACKET_KEY_1_RTT);
         _Analysis_assume_(Crypto->TlsState.WriteKey >= 0);
         CXPLAT_TEL_ASSERT(Crypto->TlsState.WriteKeys[Crypto->TlsState.WriteKey] != NULL);
-        if (Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_HANDSHAKE &&
-            QuicConnIsClient(Connection)) {
-            //
-            // Per spec, client MUST discard Initial keys when it starts
-            // encrypting packets with handshake keys.
-            //
-            QuicCryptoDiscardKeys(Crypto, QUIC_PACKET_KEY_INITIAL);
-        }
         if (Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_1_RTT) {
             if (QuicConnIsClient(Connection)) {
                 //


### PR DESCRIPTION
## Description

In order to fix #2604 move the key / packet space discard logic to the send path instead of the receive path.

## Testing

Existing tests should cover.

## Documentation

N/A
