### PR TITLE
Fix route resolution error handling

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1088,6 +1088,7 @@ QuicSendFlush(
             //
             // Route resolution failed or pended. We need to pause sending.
             //
+            CXPLAT_DBG_ASSERT(Status == QUIC_STATUS_PENDING || QUIC_FAILED(Status));
             return TRUE;
         }
     } else if (Path->Route.State == RouteResolving) {

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -332,6 +332,8 @@ CxPlatResolveRoute(
 
     CXPLAT_DBG_ASSERT(!QuicAddrIsWildCard(&Route->RemoteAddress));
 
+    Route->State = RouteResolving;
+
     //
     // Find the best next hop IP address.
     //
@@ -442,7 +444,6 @@ CxPlatResolveRoute(
     // We queue an operation on the route worker for NS because it involves network IO and
     // we don't want our connection worker queue blocked.
     //
-    Route->State = RouteResolving;
     if ((Status != ERROR_SUCCESS || IpnetRow.State <= NlnsIncomplete) ||
         (State == RouteSuspected &&
          memcmp(

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -479,8 +479,8 @@ Done:
         Callback(Context, NULL, PathId, FALSE);
     }
 
-    if (Status == ERROR_IO_PENDING || Status == ERROR_SUCCESS) {
-        return SUCCESS_HRESULT_FROM_WIN32(Status);
+    if (Status == ERROR_IO_PENDING) {
+        return QUIC_STATUS_PENDING;
     } else {
         return HRESULT_FROM_WIN32(Status);
     }

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -464,7 +464,6 @@ CxPlatResolveRoute(
         Operation->Context = Context;
         Operation->Callback = Callback;
         Operation->PathId = PathId;
-        Route->State = RouteResolving;
         CxPlatDispatchLockAcquire(&Worker->Lock);
         CxPlatListInsertTail(&Worker->Operations, &Operation->WorkerLink);
         CxPlatDispatchLockRelease(&Worker->Lock);

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -442,6 +442,7 @@ CxPlatResolveRoute(
     // We queue an operation on the route worker for NS because it involves network IO and
     // we don't want our connection worker queue blocked.
     //
+    Route->State = RouteResolving;
     if ((Status != ERROR_SUCCESS || IpnetRow.State <= NlnsIncomplete) ||
         (State == RouteSuspected &&
          memcmp(
@@ -475,13 +476,6 @@ CxPlatResolveRoute(
 
 Done:
     if (Status != ERROR_IO_PENDING && Status != ERROR_SUCCESS) {
-        //
-        // Failed to resolve route. Queue route resolution completion with failure and
-        // set route state to resolving in case multiple route resolution jobs get queued
-        // up before the failure gets drained. Conceptually, before the completion gets
-        // drained, we are still "resolving" it.
-        //
-        Route->State = RouteResolving;
         Callback(Context, NULL, PathId, FALSE);
     }
 

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -546,7 +546,7 @@ struct CxPlatSocket {
                 // complete synchronously. If this changes, we will need to add code to
                 // wait for an event set by ResolveRouteComplete.
                 //
-                ASSERT_TRUE(InitStatus == QUIC_STATUS_SUCCESS);
+                EXPECT_EQ(InitStatus, QUIC_STATUS_SUCCESS);
             }
 #endif
         }


### PR DESCRIPTION
## Description

The status code handling logic CxPlatResolveRoute is problematic because the status code conversion at the end of the function assumes `NETIO_STATUS Status` is `NT_STATUS`. However, in usermode, `NETIO_STATUS` = WIN32 errors.

Also, set route state to resolving before we queue a non-successful route resolution completion to prevent multiple route resolution jobs get queued up before the completion gets drained.

## Testing

Covered by existing tests.
