### PR TITLE
Fix QuicTestCibirExtension for LoLa and enable *CibirExtension* tests

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -612,8 +612,8 @@ stages:
       logProfile: Full.Light
       extraArtifactDir: '_Xdp'
       extraPrepareArgs: -InstallDuoNic -InstallXdpDriver
-      # TODO: reenable these testcases: *Unreachable*:*DrillInitialPacket*:*CibirExtension*
-      extraTestArgs: -DuoNic -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*:*Tcp*:*Unreachable*:*DrillInitialPacket*:*CibirExtension* -ExtraArtifactDir Xdp
+      # TODO: reenable these testcases: *Unreachable*:*DrillInitialPacket*
+      extraTestArgs: -DuoNic -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*:*Tcp*:*Unreachable*:*DrillInitialPacket* -ExtraArtifactDir Xdp
   - template: ./templates/run-bvt.yml
     parameters:
       image: windows-2019

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -2966,7 +2966,7 @@ QuicTestCibirExtension(
         // TODO - Set expected transport error
     }
     TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
-    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout);
     TEST_EQUAL(Connection.HandshakeComplete, ShouldConnnect);
 }
 


### PR DESCRIPTION
When the server uses CIBIR but the client doesn't, the connection should be rejected.
In regular sockets, the client's invalid handshake makes it up to QUIC and a transport
error is sent. But for LoLa, there is a filter based on the CIBIR ID for packet delivery to
the server, so the client's connect attempt times out instead. We already have a check
at the end for the connection not being successfully set up, so this can be addressed
by simply not asserting that we don't time out waiting for the handshake to complete.