### PR TITLE
Fix errant warning on some versions of VS2022 build tools.

### DIFF
--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -23,7 +23,10 @@ Environment:
 #define WIN32_LEAN_AND_MEAN
 #endif
 
+#pragma warning(push)
+#pragma warning(disable:6553) // Annotation does not apply to value type.
 #include <windows.h>
+#pragma warning(pop)
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #pragma warning(push)

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -34,6 +34,7 @@ Environment:
 #pragma warning(disable:28252)
 #pragma warning(disable:28253)
 #pragma warning(disable:28301)
+#pragma warning(disable:6553) // Bad SAL annotation in public header
 #pragma warning(disable:5105) // The conformant preprocessor along with the newest SDK throws this warning for a macro.
 #include <windows.h>
 #include <winsock2.h>

--- a/src/platform/cert_capi.c
+++ b/src/platform/cert_capi.c
@@ -19,7 +19,10 @@ Environment:
 #include "cert_capi.c.clog.h"
 #endif
 
+#pragma warning(push)
+#pragma warning(disable:6553) // Annotation does not apply to value type.
 #include <wincrypt.h>
+#pragma warning(pop)
 #include "msquic.h"
 
 #ifdef QUIC_RESTRICTED_BUILD

--- a/src/platform/certificates_capi.c
+++ b/src/platform/certificates_capi.c
@@ -21,7 +21,10 @@ Environment:
 #include "certificates_capi.c.clog.h"
 #endif
 
+#pragma warning(push)
+#pragma warning(disable:6553) // Annotation does not apply to value type.
 #include <wincrypt.h>
+#pragma warning(pop)
 #include "msquic.h"
 
 #define CXPLAT_CERT_CREATION_EVENT_NAME                 L"MsQuicCertEvent"

--- a/src/platform/selfsign_capi.c
+++ b/src/platform/selfsign_capi.c
@@ -16,7 +16,10 @@ Abstract:
 #include "selfsign_capi.c.clog.h"
 #endif
 
+#pragma warning(push)
+#pragma warning(disable:6553) // Annotation does not apply to value type.
 #include <wincrypt.h>
+#pragma warning(pop)
 #include "msquic.h"
 
 #define CXPLAT_CERT_CREATION_EVENT_NAME                 L"MsQuicCertEvent"

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -10,7 +10,10 @@
 #include "msquic.h"
 #include "quic_tls.h"
 #ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable:6553) // Annotation does not apply to value type.
 #include <wincrypt.h>
+#pragma warning(pop)
 #endif
 #include <fcntl.h>
 


### PR DESCRIPTION
## Description

Fix a build break from spurious warnings in public headers on certain versions of the VS2022 build tools.

## Testing

Existing CI will cover this.

## Documentation

No Documentation changes needed.
