### PR TITLE
Cancel Long Running Workflows on New PR Commits

### DIFF
--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -10,6 +10,12 @@ on:
     - main
     - release/*
 
+concurrency:
+  # Cancel any workflow currently in progress for the same PR.
+  # Allow running concurrently with any other commits.
+  group: testdownlevel-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -19,6 +19,12 @@ on:
     - src/perf/*
     - submodules/openssl/*
 
+concurrency:
+  # Cancel any workflow currently in progress for the same PR.
+  # Allow running concurrently with any other commits.
+  group: wanperf-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Description

Cancels the down-level test and wan perf test workflows if a new commit is pushed to a PR.

## Testing

N/A

## Documentation

N/A
