### PR TITLE
Control socket for closing secnetperf in XDP path

### DIFF
--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -331,6 +331,7 @@ QuicMainFree(
 #ifdef QUIC_USE_RAW_DATAPATH
     if (BackdoorThreadHandle) {
         CxPlatThreadWait(&BackdoorThreadHandle);
+        CxPlatThreadDelete(&BackdoorThreadHandle);
     }
 #else
     if (Datapath) {

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -32,7 +32,6 @@ const uint8_t SecNetPerfShutdownGuid[16] = { // {ff15e657-4f26-570e-88ab-0796b25
     0x57, 0xe6, 0x15, 0xff, 0x26, 0x4f, 0x0e, 0x57,
     0x88, 0xab, 0x07, 0x96, 0xb2, 0x58, 0xd1, 0x1c};
 CXPLAT_THREAD BackdoorThreadHandle;
-BOOLEAN BackdoorRunning = false;
 CXPLAT_DATAPATH_RECEIVE_CALLBACK DatapathReceive;
 CXPLAT_DATAPATH_UNREACHABLE_CALLBACK DatapathUnreachable;
 CXPLAT_DATAPATH* Datapath;
@@ -119,7 +118,7 @@ CXPLAT_THREAD_CALLBACK(BackdoorThread, Context)
         goto Done;
     }
 
-    while (BackdoorRunning) {
+    while (true) {
         int BytesRcvd =
             recvfrom(
                 Listener, (char*)RecvBuf, sizeof(RecvBuf), 0, NULL, NULL);
@@ -134,7 +133,6 @@ CXPLAT_THREAD_CALLBACK(BackdoorThread, Context)
 
         if (BytesRcvd == sizeof(RecvBuf) &&
             memcmp(RecvBuf, SecNetPerfShutdownGuid, sizeof(SecNetPerfShutdownGuid)) == 0) {
-            printf("matched\n");
             break;
         }
     }
@@ -190,7 +188,6 @@ QuicMainStart(
         return Status;
     }
 
-    BackdoorRunning = TRUE;
 #else
     const CXPLAT_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
         DatapathReceive,

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -28,6 +28,11 @@ PerfBase* TestToRun;
 
 #include "quic_datapath.h"
 
+const uint8_t SecNetPerfShutdownGuid[16] = { // {ff15e657-4f26-570e-88ab-0796b258d11c}
+    0x57, 0xe6, 0x15, 0xff, 0x26, 0x4f, 0x0e, 0x57,
+    0x88, 0xab, 0x07, 0x96, 0xb2, 0x58, 0xd1, 0x1c};
+CXPLAT_THREAD BackdoorThreadHandle;
+BOOLEAN BackdoorRunning = false;
 CXPLAT_DATAPATH_RECEIVE_CALLBACK DatapathReceive;
 CXPLAT_DATAPATH_UNREACHABLE_CALLBACK DatapathUnreachable;
 CXPLAT_DATAPATH* Datapath;
@@ -96,6 +101,50 @@ PrintHelp(
         );
 }
 
+#ifdef QUIC_USE_RAW_DATAPATH
+CXPLAT_THREAD_CALLBACK(BackdoorThread, Context)
+{
+    WSADATA WsaData;
+    WSAStartup(MAKEWORD(2, 2), &WsaData);
+
+    CXPLAT_EVENT* Event = static_cast<CXPLAT_EVENT*>(Context);
+    SOCKADDR_STORAGE Addr = {0};
+    uint8_t RecvBuf[sizeof(SecNetPerfShutdownGuid)] = {0};
+
+    IN4ADDR_SETANY((SOCKADDR_IN*)&Addr);
+    SS_PORT(&Addr) = htons(9999);
+    SOCKET Listener = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (bind(Listener, (SOCKADDR*)&Addr, sizeof(Addr)) == SOCKET_ERROR) {
+        printf("backdoor listener failed to bind with error %d\n", WSAGetLastError());
+        goto Done;
+    }
+
+    while (BackdoorRunning) {
+        int BytesRcvd =
+            recvfrom(
+                Listener, (char*)RecvBuf, sizeof(RecvBuf), 0, NULL, NULL);
+        if (BytesRcvd == SOCKET_ERROR) {
+            int Error = WSAGetLastError();
+            if (Error == WSAEMSGSIZE) {
+                continue;
+            }
+            printf("recvfrom failed with error %d\n", Error);
+            goto Done;
+        }
+
+        if (BytesRcvd == sizeof(RecvBuf) &&
+            memcmp(RecvBuf, SecNetPerfShutdownGuid, sizeof(SecNetPerfShutdownGuid)) == 0) {
+            printf("matched\n");
+            break;
+        }
+    }
+Done:
+    CxPlatEventSet(*Event);
+    closesocket(Listener);
+    CXPLAT_THREAD_RETURN(QUIC_STATUS_SUCCESS);
+}
+#endif
+
 QUIC_STATUS
 QuicMainStart(
     _In_ int argc,
@@ -127,7 +176,22 @@ QuicMainStart(
 
     QUIC_STATUS Status;
 
-#ifndef QUIC_USE_RAW_DATAPATH
+#ifdef QUIC_USE_RAW_DATAPATH
+    CXPLAT_THREAD_CONFIG ThreadConfig = {
+        CXPLAT_THREAD_FLAG_NONE,
+        0,
+        "BackdoorThread",
+        BackdoorThread,
+        StopEvent
+    };
+
+    Status = CxPlatThreadCreate(&ThreadConfig, &BackdoorThreadHandle);
+    if (QUIC_FAILED(Status)) {
+        return Status;
+    }
+
+    BackdoorRunning = TRUE;
+#else
     const CXPLAT_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {
         DatapathReceive,
         DatapathUnreachable
@@ -266,10 +330,17 @@ QuicMainFree(
         CxPlatSocketDelete(Binding);
         Binding = nullptr;
     }
+
+#ifdef QUIC_USE_RAW_DATAPATH
+    if (BackdoorThreadHandle) {
+        CxPlatThreadWait(&BackdoorThreadHandle);
+    }
+#else
     if (Datapath) {
         CxPlatDataPathUninitialize(Datapath);
         Datapath = nullptr;
     }
+#endif
 
     delete Watchdog;
     Watchdog = nullptr;
@@ -301,10 +372,6 @@ QuicMainGetExtraData(
 
     return TestToRun->GetExtraData(Data, Length);
 }
-
-const uint8_t SecNetPerfShutdownGuid[16] = { // {ff15e657-4f26-570e-88ab-0796b258d11c}
-    0x57, 0xe6, 0x15, 0xff, 0x26, 0x4f, 0x0e, 0x57,
-    0x88, 0xab, 0x07, 0x96, 0xb2, 0x58, 0xd1, 0x1c};
 
 void
 DatapathReceive(


### PR DESCRIPTION
For XDP path, create a thread to do blocking UDP receive to control secnetperf instead of a whole new datapath.