### PR TITLE
Fix unique RSS procs counting

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -63,7 +63,7 @@ typedef struct XDP_QUEUE {
 
 typedef struct XDP_INTERFACE {
     CXPLAT_INTERFACE;
-    uint32_t QueueCount;
+    uint16_t QueueCount;
     uint8_t RuleCount;
     CXPLAT_LOCK RuleLock;
     XDP_RULE* Rules;
@@ -139,7 +139,7 @@ CxPlatDataPathRecvDataToRecvPacket(
 QUIC_STATUS
 CxPlatGetInterfaceRssQueueCount(
     _In_ uint32_t InterfaceIndex,
-    _Out_ uint32_t* Count
+    _Out_ uint16_t* Count
     )
 {
     HRESULT hRes;
@@ -147,7 +147,7 @@ CxPlatGetInterfaceRssQueueCount(
     IEnumWbemClassObject *pEnum = NULL;
     IWbemServices *pSvc = NULL;
     DWORD ret = 0;
-    uint32_t cnt = 0;
+    uint16_t cnt = 0;
     NET_LUID if_luid = { 0 };
     WCHAR if_alias[256 + 1] = { 0 };
 
@@ -524,6 +524,11 @@ CxPlatDpRawInterfaceInitialize(
 
     if (Interface->QueueCount == 0) {
         Status = QUIC_STATUS_INVALID_STATE;
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "CxPlatGetInterfaceRssQueueCount");
         goto Error;
     }
 

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -63,7 +63,7 @@ typedef struct XDP_QUEUE {
 
 typedef struct XDP_INTERFACE {
     CXPLAT_INTERFACE;
-    uint8_t QueueCount;
+    uint32_t QueueCount;
     uint8_t RuleCount;
     CXPLAT_LOCK RuleLock;
     XDP_RULE* Rules;
@@ -139,7 +139,7 @@ CxPlatDataPathRecvDataToRecvPacket(
 QUIC_STATUS
 CxPlatGetInterfaceRssQueueCount(
     _In_ uint32_t InterfaceIndex,
-    _Out_ uint8_t* Count
+    _Out_ uint32_t* Count
     )
 {
     HRESULT hRes;
@@ -147,7 +147,7 @@ CxPlatGetInterfaceRssQueueCount(
     IEnumWbemClassObject *pEnum = NULL;
     IWbemServices *pSvc = NULL;
     DWORD ret = 0;
-    uint8_t cnt = 0;
+    uint32_t cnt = 0;
     NET_LUID if_luid = { 0 };
     WCHAR if_alias[256 + 1] = { 0 };
 

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -323,6 +323,11 @@ CxPlatGetInterfaceRssQueueCount(
                 IWbemClassObject *obj = NULL;
                 pIUnk->lpVtbl->QueryInterface(pIUnk, &IID_IWbemClassObject, (void **)&obj);
                 if (obj == NULL) {
+                    QuicTraceEvent(
+                        LibraryErrorStatus,
+                        "[ lib] ERROR, %u, %s.",
+                        hRes,
+                        "QueryInterface");
                     free(rssTable);
                     hRes = QUIC_STATUS_OUT_OF_MEMORY;
                     goto Cleanup;

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -310,10 +310,10 @@ CxPlatGetInterfaceRssQueueCount(
             IUnknown** rawArray;
             SafeArrayAccessData(pSafeArray, (void**)&rawArray);
 
-            // Set up the RSS table according to number of processors
+            // Set up the RSS table according to number of procs and proc groups.
             numberOfProcs = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
             numberOfProcGroups = GetActiveProcessorGroupCount();
-            rssTableSize = numberOfProcs * numberOfProcGroups; // large enough to fit the entire indirection table
+            rssTableSize = numberOfProcs * numberOfProcGroups;
             rssTable = malloc(rssTableSize);
             memset(rssTable, 0, rssTableSize);
 


### PR DESCRIPTION
When we count unique RSS procs from the interface's indirection table, we forget to take CPU group into account and thus undercount the number of unique RSS procs. When plumbing XDP rules, only a portion of the queues get rules applied.

Also, fail interface initialization if queue count == 0.