### PR TITLE
Document API Thread-Safety Issues

### DIFF
--- a/docs/api/MsQuicClose.md
+++ b/docs/api/MsQuicClose.md
@@ -25,6 +25,8 @@ The function table from a previous call to [MsQuicOpenVersion](MsQuicOpenVersion
 
 This function **must** be called when the app is done with the MsQuic library.
 
+**MsQuicClose** and [MsQuicOpenVersion](MsQuicOpenVersion.md) are not thread-safe if the caller is statically linking MsQuic, and therefore must not be called in parallel.
+
 # See Also
 
 [MsQuicOpenVersion](MsQuicOpenVersion.md)<br>

--- a/docs/api/MsQuicOpenVersion.md
+++ b/docs/api/MsQuicOpenVersion.md
@@ -32,7 +32,7 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 # Remarks
 
-This function is the entry point for the MsQuic API. This function may be called multiple times to get multiple new function tables, but this is generally unnecessary. An app should only need call this once.
+This function is the entry point for the MsQuic API. This function may be called multiple times to get multiple new function tables, but this is generally unnecessary. An app should only need call this once. A single `QuicApi` may be shared and safely used by multiple callers on parallel threads.
 
 For every successful call to **MsQuicOpenVersion** the app must call [MsQuicClose](MsQuicClose.md), passing in the function table from *QuicApi* when the app is done with it.
 
@@ -40,7 +40,9 @@ Calls to **MsQuicOpenVersion** and [MsQuicClose](MsQuicClose.md) increment and d
 
 **MsQuicOpenVersion** may dynamically load other dependencies, so it **must not** be called from [DllMain](https://docs.microsoft.com/en-us/windows/win32/dlls/dllmain) on Windows.
 
-**MsQuicOpenVersion** Takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. The **MsQuicOpen2** definition in msquic.h now forwards to **MsQuicOpenVersion**
+**MsQuicOpenVersion** takes a version number to indicate which version of the API to use. Newer versions of the library will support older versions of the API for binary compatibility. The **MsQuicOpen2** definition in msquic.h now forwards to **MsQuicOpenVersion**
+
+**MsQuicOpenVersion** and [MsQuicClose](MsQuicClose.md) are not thread-safe if the caller is statically linking MsQuic, and therefore must not be called in parallel.
 
 # See Also
 


### PR DESCRIPTION
## Description

Fixes #2641 by adding more documentation on the calling restrictions around `MsQuicOpenVersion` and `MsQuicClose`.

cc @wizmann

