### PR TITLE
Fix only setting minimum mtu during config open failing

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -229,12 +229,20 @@ QuicSettingsCopy(
                 QuicSettingsCopyVersionSettings(Source->VersionSettings, FALSE);
         }
     }
-    if (!Destination->IsSet.MinimumMtu) {
+
+    if (!Destination->IsSet.MinimumMtu && !Destination->IsSet.MaximumMtu) {
         Destination->MinimumMtu = Source->MinimumMtu;
-    }
-    if (!Destination->IsSet.MaximumMtu) {
         Destination->MaximumMtu = Source->MaximumMtu;
+    } else if (Destination->IsSet.MinimumMtu && !Destination->IsSet.MaximumMtu) {
+        if (Source->MaximumMtu > Destination->MinimumMtu) {
+            Destination->MaximumMtu = Source->MaximumMtu;
+        }
+    } else if (Destination->IsSet.MaximumMtu && !Destination->IsSet.MinimumMtu) {
+        if (Source->MinimumMtu < Destination->MaximumMtu) {
+            Destination->MinimumMtu = Source->MinimumMtu;
+        }
     }
+
     if (!Destination->IsSet.MtuDiscoveryMissingProbeCount) {
         Destination->MtuDiscoveryMissingProbeCount = Source->MtuDiscoveryMissingProbeCount;
     }
@@ -503,8 +511,10 @@ QuicSettingApply(
         if (MinimumMtu > MaximumMtu) {
             return FALSE;
         }
-        if (Source->IsSet.MinimumMtu || Source->IsSet.MaximumMtu) {
+        if (Source->IsSet.MinimumMtu) {
             Destination->IsSet.MinimumMtu = TRUE;
+        }
+        if (Source->IsSet.MaximumMtu) {
             Destination->IsSet.MaximumMtu = TRUE;
         }
         Destination->MinimumMtu = MinimumMtu;

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -480,8 +480,10 @@ QuicSettingApply(
     }
 
     if (AllowMtuChanges) {
-        uint16_t MinimumMtu = Destination->MinimumMtu;
-        uint16_t MaximumMtu = Destination->MaximumMtu;
+        uint16_t MinimumMtu =
+            Destination->IsSet.MinimumMtu ? Destination->MinimumMtu : QUIC_DPLPMUTD_MIN_MTU;
+        uint16_t MaximumMtu =
+            Destination->IsSet.MaximumMtu ? Destination->MaximumMtu : CXPLAT_MAX_MTU;
         if (Source->IsSet.MinimumMtu && (!Destination->IsSet.MinimumMtu || OverWrite)) {
             MinimumMtu = Source->MinimumMtu;
             if (MinimumMtu < QUIC_DPLPMUTD_MIN_MTU) {
@@ -501,10 +503,8 @@ QuicSettingApply(
         if (MinimumMtu > MaximumMtu) {
             return FALSE;
         }
-        if (Destination->MinimumMtu != MinimumMtu) {
+        if (Source->IsSet.MinimumMtu || Source->IsSet.MaximumMtu) {
             Destination->IsSet.MinimumMtu = TRUE;
-        }
-        if (Destination->MaximumMtu != MaximumMtu) {
             Destination->IsSet.MaximumMtu = TRUE;
         }
         Destination->MinimumMtu = MinimumMtu;

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -42,7 +42,7 @@ static QUIC_STATUS MtuSettingsCallback(_In_ MsQuicConnection*, _In_opt_ void*, _
 
 struct ResetSettings {
     MsQuicSettings CurrentSettings;
-    HRESULT GetResult = QUIC_STATUS_OUT_OF_MEMORY;
+    QUIC_STATUS GetResult = QUIC_STATUS_OUT_OF_MEMORY;
     ResetSettings() {
         GetResult = CurrentSettings.GetGlobal();
     }

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -77,6 +77,18 @@ QuicTestMtuSettings()
     MsQuicAlpn Alpn("MsQuicTest");
     {
         {
+            MsQuicSettings Settings;
+
+            //
+            // Test just setting lower bound
+            //
+            Settings.SetMinimumMtu(1);
+
+            MsQuicCredentialConfig ClientCredConfig;
+            MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
+            TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+        }
+        {
             MsQuicCredentialConfig ClientCredConfig;
             MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCredConfig);
             TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -40,6 +40,23 @@ static QUIC_STATUS MtuSettingsCallback(_In_ MsQuicConnection*, _In_opt_ void*, _
     return QUIC_STATUS_SUCCESS;
 }
 
+struct ResetSettings {
+    MsQuicSettings CurrentSettings;
+    HRESULT GetResult = QUIC_STATUS_OUT_OF_MEMORY;
+    ResetSettings() {
+        GetResult = CurrentSettings.GetGlobal();
+    }
+
+    ~ResetSettings() {
+        if (QUIC_SUCCEEDED(GetResult)) {
+            CurrentSettings.IsSetFlags = 0;
+            CurrentSettings.IsSet.MaximumMtu = 1;
+            CurrentSettings.IsSet.MinimumMtu = 1;
+            CurrentSettings.SetGlobal();
+        }
+    }
+};
+
 void
 QuicTestMtuSettings()
 {
@@ -47,8 +64,7 @@ QuicTestMtuSettings()
         //
         // Test setting on library works
         //
-        MsQuicSettings CurrentSettings;
-        TEST_QUIC_SUCCEEDED(CurrentSettings.GetGlobal());
+        ResetSettings Resetter;
 
         MsQuicSettings NewSettings;
         QUIC_STATUS SetSuccess =
@@ -59,11 +75,6 @@ QuicTestMtuSettings()
 
         MsQuicSettings UpdatedSettings;
         QUIC_STATUS GetSuccess = UpdatedSettings.GetGlobal();
-
-        CurrentSettings.IsSetFlags = 0;
-        CurrentSettings.IsSet.MaximumMtu = TRUE;
-        CurrentSettings.IsSet.MinimumMtu = TRUE;
-        TEST_QUIC_SUCCEEDED(CurrentSettings.SetGlobal());
 
         TEST_QUIC_SUCCEEDED(SetSuccess);
         TEST_QUIC_SUCCEEDED(GetSuccess);
@@ -88,6 +99,64 @@ QuicTestMtuSettings()
             MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
             TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
         }
+
+        {
+            ResetSettings Resetter;
+
+            MsQuicSettings NewGlobalSettings;
+            TEST_QUIC_SUCCEEDED(
+                NewGlobalSettings.
+                    SetMinimumMtu(1400).
+                    SetMaximumMtu(1400).
+                    SetGlobal());
+
+
+            MsQuicSettings Settings;
+
+            //
+            // Test setting minimum higher then global maximum
+            //
+            Settings.SetMinimumMtu(1450);
+
+            MsQuicCredentialConfig ClientCredConfig;
+            MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
+            TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+            Settings.IsSetFlags = 0;
+            TEST_QUIC_SUCCEEDED(ClientConfiguration.GetSettings(Settings));
+            TEST_EQUAL(1450, Settings.MinimumMtu);
+            TEST_NOT_EQUAL(Settings.MaximumMtu, NewGlobalSettings.MaximumMtu);
+            TEST_TRUE(Settings.MinimumMtu <= Settings.MaximumMtu);
+        }
+
+        {
+            ResetSettings Resetter;
+
+            MsQuicSettings NewGlobalSettings;
+            TEST_QUIC_SUCCEEDED(
+                NewGlobalSettings.
+                    SetMinimumMtu(1400).
+                    SetMaximumMtu(1460).
+                    SetGlobal());
+
+
+            MsQuicSettings Settings;
+
+            //
+            // Test setting minimum higher then global, and setting global max
+            //
+            Settings.SetMinimumMtu(1450);
+
+            MsQuicCredentialConfig ClientCredConfig;
+            MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
+            TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+            Settings.IsSetFlags = 0;
+            TEST_QUIC_SUCCEEDED(ClientConfiguration.GetSettings(Settings));
+            TEST_EQUAL(1450, Settings.MinimumMtu);
+            TEST_EQUAL(Settings.MaximumMtu, NewGlobalSettings.MaximumMtu);
+        }
+
         {
             MsQuicCredentialConfig ClientCredConfig;
             MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCredConfig);


### PR DESCRIPTION
## Description

Closes #2647. Setting a minimum mtu only during ConfigurationOpen results in a failure, because the default values are 0. Set the default values to things more sane.

Also fixes a bug where minimum can be higher then maximum, if only 1 value is set on the configuration, and the global value is not within the bounds.

## Testing

New test added to cover case

## Documentation
N/A
