### PR TITLE
Fix UWP builds missing storage APIs

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -242,7 +242,7 @@ stages:
       arch: x64
       tls: schannel
       extraPrepareArgs: -DisableTest
-      extraBuildArgs: -DisableTools -DisableTest -EnableTelemetryAsserts
+      extraBuildArgs: -EnableTelemetryAsserts
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-2019
@@ -250,7 +250,7 @@ stages:
       arch: x64
       tls: openssl
       extraPrepareArgs: -DisableTest
-      extraBuildArgs: -DisableTools -DisableTest -EnableTelemetryAsserts
+      extraBuildArgs: -EnableTelemetryAsserts
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-2019
@@ -258,7 +258,7 @@ stages:
       arch: x86
       tls: openssl
       extraPrepareArgs: -DisableTest
-      extraBuildArgs: -DisableTools -DisableTest -EnableTelemetryAsserts
+      extraBuildArgs: -EnableTelemetryAsserts
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-2019
@@ -266,7 +266,7 @@ stages:
       arch: arm64
       tls: openssl
       extraPrepareArgs: -DisableTest
-      extraBuildArgs: -DisableTools -DisableTest -EnableTelemetryAsserts
+      extraBuildArgs: -EnableTelemetryAsserts
   - template: ./templates/build-config-user.yml
     parameters:
       image: windows-2019

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1882,6 +1882,24 @@ INSTANTIATE_TEST_SUITE_P(
     WithDrillInitialPacketTokenArgs,
     testing::ValuesIn(DrillInitialPacketTokenArgs::Generate()));
 
+#ifdef QUIC_UWP_BUILD
+WINADVAPI
+LSTATUS
+APIENTRY
+RegCreateKeyA (
+    _In_ HKEY hKey,
+    _In_opt_ LPCSTR lpSubKey,
+    _Out_ PHKEY phkResult
+    );
+
+WINADVAPI
+LSTATUS
+APIENTRY
+RegCloseKey(
+    _In_ HKEY hKey
+    );
+#endif
+
 int main(int argc, char** argv) {
 #ifdef _WIN32
     //

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2127,6 +2127,53 @@ QuicTestCredentialLoad(const QUIC_CREDENTIAL_CONFIG* Config)
     TEST_QUIC_SUCCEEDED(Configuration.LoadCredential(Config));
 }
 
+#ifdef QUIC_UWP_BUILD
+WINADVAPI
+LSTATUS
+APIENTRY
+RegDeleteKeyValueA(
+    _In_ HKEY hKey,
+    _In_opt_ LPCSTR lpSubKey,
+    _In_opt_ LPCSTR lpValueName
+    );
+
+WINADVAPI
+LSTATUS
+APIENTRY
+RegDeleteKeyA (
+    _In_ HKEY hKey,
+    _In_ LPCSTR lpSubKey
+    );
+
+WINADVAPI
+LSTATUS
+APIENTRY
+RegCreateKeyA (
+    _In_ HKEY hKey,
+    _In_opt_ LPCSTR lpSubKey,
+    _Out_ PHKEY phkResult
+    );
+
+WINADVAPI
+LSTATUS
+APIENTRY
+RegSetKeyValueA(
+    _In_ HKEY hKey,
+    _In_opt_ LPCSTR lpSubKey,
+    _In_opt_ LPCSTR lpValueName,
+    _In_ DWORD dwType,
+    _In_reads_bytes_opt_(cbData) LPCVOID lpData,
+    _In_ DWORD cbData
+    );
+
+WINADVAPI
+LSTATUS
+APIENTRY
+RegCloseKey(
+    _In_ HKEY hKey
+    );
+#endif
+
 void
 QuicTestStorage()
 {


### PR DESCRIPTION
## Description

Fix internal build break caused by #2182

## Testing

Build tests in external pipeline

## Documentation

N/A
