### PR TITLE
Allow Too Big IP in Raw Parsing

### DIFF
--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -623,7 +623,7 @@ CxPlatDpRawParseIPv4(
         uint16_t IPTotalLength;
         IPTotalLength = CxPlatByteSwapUint16(IP->TotalLength);
 
-        if (Length != IPTotalLength) {
+        if (Length < IPTotalLength) {
             QuicTraceEvent(
                 DatapathErrorStatus,
                 "[data][%p] ERROR, %u, %s.",
@@ -674,7 +674,7 @@ CxPlatDpRawParseIPv6(
     if (IP->NextHeader == IPPROTO_UDP) {
         uint16_t IPPayloadLength;
         IPPayloadLength = CxPlatByteSwapUint16(IP->PayloadLength);
-        if (IPPayloadLength != Length - sizeof(IPV6_HEADER)) {
+        if (IPPayloadLength + sizeof(IPV6_HEADER) > Length) {
             QuicTraceEvent(
                 DatapathErrorStatus,
                 "[data][%p] ERROR, %u, %s.",


### PR DESCRIPTION
## Description

Support cases in the raw datapath where the ethernet frame is larger than the IP frame.

## Testing

Existing test coverage.

## Documentation

N/A
