### PR TITLE
Switch epoll and kqueue to level triggers

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1772,9 +1772,9 @@ CxPlatSocketContextProcessEvents(
 
     if (EPOLLIN & Events) {
         //
-        // Read up to 1 receives before moving to another event.
+        // Read up to 4 receives before moving to another event.
         //
-        for (int i = 0; i < 1; i++) {
+        for (int i = 0; i < 4; i++) {
 
             for (ssize_t i = 0; i < CXPLAT_MAX_BATCH_RECEIVE; i++) {
                 CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlocks[i] != NULL);

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1431,7 +1431,7 @@ CxPlatSocketContextStartReceive(
     }
 
     struct epoll_event SockFdEpEvt = {
-        .events = EPOLLIN | EPOLLLT,
+        .events = EPOLLIN,
         .data = {
             .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
         }
@@ -1644,7 +1644,7 @@ CxPlatSocketContextSendComplete(
     CXPLAT_SEND_DATA* SendData = NULL;
 
     struct epoll_event SockFdEpEvt = {
-        .events = EPOLLIN | EPOLLLT,
+        .events = EPOLLIN,
         .data = {
             .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
         }
@@ -2611,7 +2611,7 @@ CxPlatSocketSendInternal(
                 }
                 SendPending = TRUE;
                 struct epoll_event SockFdEpEvt = {
-                    .events = EPOLLIN | EPOLLOUT | EPOLLLT,
+                    .events = EPOLLIN | EPOLLOUT,
                     .data = {
                         .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
                     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1431,7 +1431,7 @@ CxPlatSocketContextStartReceive(
     }
 
     struct epoll_event SockFdEpEvt = {
-        .events = EPOLLIN | EPOLLET,
+        .events = EPOLLIN | EPOLLLT,
         .data = {
             .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
         }
@@ -1644,7 +1644,7 @@ CxPlatSocketContextSendComplete(
     CXPLAT_SEND_DATA* SendData = NULL;
 
     struct epoll_event SockFdEpEvt = {
-        .events = EPOLLIN | EPOLLET,
+        .events = EPOLLIN | EPOLLLT,
         .data = {
             .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
         }
@@ -2611,7 +2611,7 @@ CxPlatSocketSendInternal(
                 }
                 SendPending = TRUE;
                 struct epoll_event SockFdEpEvt = {
-                    .events = EPOLLIN | EPOLLOUT | EPOLLET,
+                    .events = EPOLLIN | EPOLLOUT | EPOLLLT,
                     .data = {
                         .ptr = &SocketContext->EventContexts[QUIC_SOCK_EVENT_SOCKET]
                     }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1771,7 +1771,10 @@ CxPlatSocketContextProcessEvents(
     }
 
     if (EPOLLIN & Events) {
-        while (TRUE) {
+        //
+        // Read up to 4 receives before moving to another event.
+        //
+        for (int i = 0; i < 4; i++) {
 
             for (ssize_t i = 0; i < CXPLAT_MAX_BATCH_RECEIVE; i++) {
                 CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlocks[i] != NULL);

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1772,9 +1772,9 @@ CxPlatSocketContextProcessEvents(
 
     if (EPOLLIN & Events) {
         //
-        // Read up to 4 receives before moving to another event.
+        // Read up to 1 receives before moving to another event.
         //
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 1; i++) {
 
             for (ssize_t i = 0; i < CXPLAT_MAX_BATCH_RECEIVE; i++) {
                 CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlocks[i] != NULL);

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1129,7 +1129,7 @@ CxPlatSocketContextStartReceive(
     struct kevent Event = {0};
     EV_SET(
         &Event, SocketContext->SocketFd,
-        EVFILT_READ, EV_ADD | EV_ENABLE | EV_CLEAR,
+        EVFILT_READ, EV_ADD | EV_ENABLE,
         0,
         0,
         (void*)SocketContext);

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1369,7 +1369,10 @@ CxPlatSocketContextProcessEvents(
     }
 
     if (Event->filter == EVFILT_READ) {
-        while (TRUE) {
+        //
+        // Read up to 4 receives before moving to another event.
+        //
+        for (int i = 0; i < 4; i++) {
             CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlock != NULL);
 
             ssize_t Ret =

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1370,9 +1370,9 @@ CxPlatSocketContextProcessEvents(
 
     if (Event->filter == EVFILT_READ) {
         //
-        // Read up to 1 receives before moving to another event.
+        // Read up to 4 receives before moving to another event.
         //
-        for (int i = 0; i < 1; i++) {
+        for (int i = 0; i < 4; i++) {
             CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlock != NULL);
 
             ssize_t Ret =

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1370,9 +1370,9 @@ CxPlatSocketContextProcessEvents(
 
     if (Event->filter == EVFILT_READ) {
         //
-        // Read up to 4 receives before moving to another event.
+        // Read up to 1 receives before moving to another event.
         //
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 1; i++) {
             CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlock != NULL);
 
             ssize_t Ret =


### PR DESCRIPTION
## Description

kqueue and epoll datapaths have a race condition upon pended sends whereas they might not get trigger notifications. By switching to level triggers, we solve this issue.

Closes #2654

## Testing

Existing tests cover the change.

## Documentation

N/A
