### PR TITLE
Use all processors for XDP perf test

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -411,6 +411,11 @@ function Invoke-Test {
         $RemoteArguments += " -stats:1"
     }
 
+    if ($XDP) {
+        $RemoteArguments += " -cpu:-1"
+        $LocalArguments += " -cpu:-1"
+    }
+
     if ($Kernel) {
         $Arch = Split-Path (Split-Path $LocalExe -Parent) -Leaf
         $RootBinPath = Split-Path (Split-Path (Split-Path $LocalExe -Parent) -Parent) -Parent

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5453,7 +5453,7 @@ QuicConnRecvDatagrams(
 
 #ifdef QUIC_USE_RAW_DATAPATH
         if (DatagramPath->Route.State == RouteResolved && !DatagramPath->Route.QueueUpdated) {
-            Datagram->Route->Queue;
+            DatagramPath->Route.Queue = Datagram->Route->Queue;
             DatagramPath->Route.QueueUpdated = TRUE;
         }
 #endif

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5452,10 +5452,10 @@ QuicConnRecvDatagrams(
         }
 
 #ifdef QUIC_USE_RAW_DATAPATH
-    if (!DatagramPath->Route.QueueUpdated) {
-        Datagram->Route->Queue;
-        DatagramPath->Route.QueueUpdated = TRUE;
-    }
+        if (DatagramPath->Route.State == RouteResolved && !DatagramPath->Route.QueueUpdated) {
+            Datagram->Route->Queue;
+            DatagramPath->Route.QueueUpdated = TRUE;
+        }
 #endif
 
         if (DatagramPath != CurrentPath) {

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5451,6 +5451,13 @@ QuicConnRecvDatagrams(
             goto Drop;
         }
 
+#ifdef QUIC_USE_RAW_DATAPATH
+    if (!DatagramPath->Route.QueueUpdated) {
+        Datagram->Route->Queue;
+        DatagramPath->Route.QueueUpdated = TRUE;
+    }
+#endif
+
         if (DatagramPath != CurrentPath) {
             if (BatchCount != 0) {
                 //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5452,9 +5452,9 @@ QuicConnRecvDatagrams(
         }
 
 #ifdef QUIC_USE_RAW_DATAPATH
-        if (DatagramPath->Route.State == RouteResolved && !DatagramPath->Route.QueueUpdated) {
+        if (DatagramPath->Route.State == RouteResolved &&
+            DatagramPath->Route.Queue != Datagram->Route->Queue) {
             DatagramPath->Route.Queue = Datagram->Route->Queue;
-            DatagramPath->Route.QueueUpdated = TRUE;
         }
 #endif
 

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -263,7 +263,6 @@ CubicCongestionControlOnCongestionEvent(
         Connection->Stats.Send.PersistentCongestionCount++;
 #ifdef QUIC_USE_RAW_DATAPATH
         Connection->Paths[0].Route.State = RouteSuspected;
-        Connection->Paths[0].Route.QueueUpdated = FALSE;
 #endif
         Cubic->IsInPersistentCongestion = TRUE;
         Cubic->WindowMax =

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -263,6 +263,7 @@ CubicCongestionControlOnCongestionEvent(
         Connection->Stats.Send.PersistentCongestionCount++;
 #ifdef QUIC_USE_RAW_DATAPATH
         Connection->Paths[0].Route.State = RouteSuspected;
+        Connection->Paths[0].Route.QueueUpdated = FALSE;
 #endif
         Cubic->IsInPersistentCongestion = TRUE;
         Cubic->WindowMax =

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -161,7 +161,15 @@ typedef struct CXPLAT_ROUTE {
     uint8_t NextHopLinkLayerAddress[6];
     void* Queue;
 
-    CXPLAT_ROUTE_STATE State; // Keep this as the last property in the struct.
+    //
+    // QuicCopyRouteInfo copies memory up to this point (not including State).
+    //
+
+    CXPLAT_ROUTE_STATE State;
+    //
+    // Indicates the queue has been updated for this route.
+    //
+    uint8_t QueueUpdated : 1;
 #endif // QUIC_USE_RAW_DATAPATH
 
 } CXPLAT_ROUTE;
@@ -703,6 +711,7 @@ CxPlatResolveRoute(
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     );
+
 #endif // QUIC_USE_RAW_DATAPATH
 
 #if defined(__cplusplus)

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -166,10 +166,6 @@ typedef struct CXPLAT_ROUTE {
     //
 
     CXPLAT_ROUTE_STATE State;
-    //
-    // Indicates the queue has been updated for this route.
-    //
-    uint8_t QueueUpdated : 1;
 #endif // QUIC_USE_RAW_DATAPATH
 
 } CXPLAT_ROUTE;

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -16,7 +16,9 @@ Abstract:
 #include "HpsClient.h"
 #include "Tcp.h"
 
+#ifndef _KERNEL_MODE
 #include <vector>
+#endif
 
 #ifdef QUIC_CLOG
 #include "SecNetPerfMain.cpp.clog.h"

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -250,7 +250,7 @@ QuicMainStart(
     const char* CpuStr;
     if ((CpuStr = GetValue(argc, argv, "cpu")) != nullptr) {
         std::vector<uint16_t> ProcList;
-        if (strtoul(CpuStr, nullptr, 10) == -1) {
+        if (strtol(CpuStr, nullptr, 10) == -1) {
             // Use all procs for raw datapath.
             for (uint16_t i = 0; i < CxPlatProcActiveCount(); ++i) {
                 ProcList.push_back(i);

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -251,7 +251,7 @@ QuicMainStart(
     if ((CpuStr = GetValue(argc, argv, "cpu")) != nullptr) {
         std::vector<uint16_t> ProcList;
         if (strtol(CpuStr, nullptr, 10) == -1) {
-            // Use all procs for raw datapath except proc 0 so that the machine will be in usable state.
+            // Use all procs for raw datapath except proc 0 so that the machine will be in a usable state.
             for (uint16_t i = 1; i < CxPlatProcActiveCount(); ++i) {
                 ProcList.push_back(i);
             }

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -251,8 +251,8 @@ QuicMainStart(
     if ((CpuStr = GetValue(argc, argv, "cpu")) != nullptr) {
         std::vector<uint16_t> ProcList;
         if (strtol(CpuStr, nullptr, 10) == -1) {
-            // Use all procs for raw datapath.
-            for (uint16_t i = 0; i < CxPlatProcActiveCount(); ++i) {
+            // Use all procs for raw datapath except proc 0 so that the machine will be in usable state.
+            for (uint16_t i = 1; i < CxPlatProcActiveCount(); ++i) {
                 ProcList.push_back(i);
             }
         } else {

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -248,7 +248,7 @@ QuicMainStart(
     const char* CpuStr;
     if ((CpuStr = GetValue(argc, argv, "cpu")) != nullptr) {
         std::vector<uint16_t> ProcList;
-        if (strtoul(CpuStr, (char**)&CpuStr, 10) == -1) {
+        if (strtoul(CpuStr, nullptr, 10) == -1) {
             // Use all procs for raw datapath.
             for (uint16_t i = 0; i < CxPlatProcActiveCount(); ++i) {
                 ProcList.push_back(i);
@@ -259,12 +259,13 @@ QuicMainStart(
                 ProcList.push_back((uint16_t)strtoul(CpuStr, (char**)&CpuStr, 10));
             } while (*CpuStr);
         }
+
         if (QUIC_FAILED(
             Status =
             MsQuic->SetParam(
                 nullptr,
                 QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS,
-                ProcList.size() * sizeof(uint16_t),
+                (uint32_t)ProcList.size() * sizeof(uint16_t),
                 ProcList.data()))) {
             WriteOutput("MsQuic Failed To Set DataPath Procs %d\n", Status);
             return Status;

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -16,6 +16,8 @@ Abstract:
 #include "HpsClient.h"
 #include "Tcp.h"
 
+#include <vector>
+
 #ifdef QUIC_CLOG
 #include "SecNetPerfMain.cpp.clog.h"
 #endif
@@ -245,19 +247,25 @@ QuicMainStart(
 #ifndef _KERNEL_MODE
     const char* CpuStr;
     if ((CpuStr = GetValue(argc, argv, "cpu")) != nullptr) {
-        uint16_t ProcList[64];
-        uint32_t ProcCount = 0;
-        do {
-            if (*CpuStr == ',') CpuStr++;
-            ProcList[ProcCount++] = (uint16_t)strtoul(CpuStr, (char**)&CpuStr, 10);
-        } while (*CpuStr && ProcCount < ARRAYSIZE(ProcList));
+        std::vector<uint16_t> ProcList;
+        if (strtoul(CpuStr, (char**)&CpuStr, 10) == -1) {
+            // Use all procs for raw datapath.
+            for (uint16_t i = 0; i < CxPlatProcActiveCount(); ++i) {
+                ProcList.push_back(i);
+            }
+        } else {
+            do {
+                if (*CpuStr == ',') CpuStr++;
+                ProcList.push_back((uint16_t)strtoul(CpuStr, (char**)&CpuStr, 10));
+            } while (*CpuStr);
+        }
         if (QUIC_FAILED(
             Status =
             MsQuic->SetParam(
                 nullptr,
                 QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS,
-                ProcCount * sizeof(uint16_t),
-                ProcList))) {
+                ProcList.size() * sizeof(uint16_t),
+                ProcList.data()))) {
             WriteOutput("MsQuic Failed To Set DataPath Procs %d\n", Status);
             return Status;
         }


### PR DESCRIPTION
## Description

Change secnetperf to take `-cpu:-1` as all procs used by raw datapath. Also, change perf test script to pass in `-cpu:-1` for XDP.

## Testing

Covered by existing tests.