### PR TITLE
Increase RPS latency storage

### DIFF
--- a/src/perf/lib/PerfCommon.h
+++ b/src/perf/lib/PerfCommon.h
@@ -26,7 +26,7 @@ Abstract:
 #define TPUT_DEFAULT_IDLE_TIMEOUT           (1 * 1000)
 
 #define RPS_MAX_CLIENT_PORT_COUNT           256
-#define RPS_MAX_REQUESTS_PER_SECOND         1500000 // 1.5 million RPS max as a guess
+#define RPS_MAX_REQUESTS_PER_SECOND         2000000 // 1.5 million RPS max as a guess
 #define RPS_DEFAULT_RUN_TIME                (10 * 1000)
 #define RPS_DEFAULT_CONNECTION_COUNT        1000
 #define RPS_DEFAULT_REQUEST_LENGTH          0


### PR DESCRIPTION
XDP is getting dangerously close to the hardcoded RPS limit for latency data, and some times has gone over, causing a crash

## Description

_Describe the purpose of and changes within this Pull Request._

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
