### PR TITLE
Fix PMTU packets logging as a 0 length send in kernel mode

### DIFF
--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2658,6 +2658,7 @@ CxPlatSendDataFinalizeSendBuffer(
 
     if (SendData->SegmentSize == 0) {
         SendData->TailBuf->Link.Buffer.Length = SendData->ClientBuffer.Length;
+        SendData->TotalSize += SendData->ClientBuffer.Length;
         SendData->ClientBuffer.Length = 0;
         return;
     }


### PR DESCRIPTION
Packets without segmentation enabled were always resulting in SendData->TotalSize being 0. This didn't affect the sends, but make log debugging harder
