### PR TITLE
Fix Builder->TotalDatagramsLength being incorrectly calculated

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -947,9 +947,9 @@ Exit:
         if (Builder->Datagram != NULL) {
             Builder->Datagram->Length = Builder->DatagramLength;
             Builder->Datagram = NULL;
-            Builder->DatagramLength = 0;
             ++Builder->TotalCountDatagrams;
             Builder->TotalDatagramsLength += Builder->DatagramLength;
+            Builder->DatagramLength = 0;
         }
 
         if (FlushBatchedDatagrams || CxPlatSendDataIsFull(Builder->SendData)) {


### PR DESCRIPTION
It was being incremented by a variable that had just been set to 0, which means it always stayed 0 itself
