### PR TITLE
Drop Unmatched Client Packets on Shared Binding

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1496,6 +1496,11 @@ QuicBindingDeliverDatagrams(
         // be created.
         //
 
+        if (!Binding->ServerOwned) {
+            QuicPacketLogDrop(Binding, Packet, "No matching client connection");
+            return FALSE;
+        }
+
         if (Binding->Exclusive) {
             QuicPacketLogDrop(Binding, Packet, "No connection on exclusive binding");
             return FALSE;


### PR DESCRIPTION
## Description

While looking at the Binding code I noticed that we weren't dropping mismatched packets for shared client bindings, and instead would send stateless resets. This is incorrect behavior. This change updates the code to drop packets on non-server bindings in this case.

## Testing

Use existing tests for regression testing.

## Documentation

None
