### PR TITLE
Add Callback Helpers to .NET Interop Layer

### DIFF
--- a/src/cs/lib/msquic_extensions.cs
+++ b/src/cs/lib/msquic_extensions.cs
@@ -1,0 +1,29 @@
+#pragma warning disable IDE0073
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+#pragma warning restore IDE0073
+
+using System;
+
+namespace Microsoft.Quic
+{
+    internal unsafe static class MsQuicExtensions
+    {
+        public static void SetConnectionCallback(this ref QUIC_API_TABLE Table, QUIC_HANDLE* Handle, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_CONNECTION_EVENT*, int> Callback, void* Context)
+        {
+            Table.SetCallbackHandler(Handle, Callback, Context);
+        }
+
+        public static void SetStreamCallback(this ref QUIC_API_TABLE Table, QUIC_HANDLE* Handle, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_STREAM_EVENT*, int> Callback, void* Context)
+        {
+            Table.SetCallbackHandler(Handle, Callback, Context);
+        }
+
+        public static void SetListenerCallback(this ref QUIC_API_TABLE Table, QUIC_HANDLE* Handle, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_LISTENER_EVENT*, int> Callback, void* Context)
+        {
+            Table.SetCallbackHandler(Handle, Callback, Context);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Because of how function pointers in .NET work, calling SetCallbackHandler is a bit more difficult then it should be, and requires a weird and uncommon pattern. A solution to this problem is to write a few extension methods that abstract out the function pointers. These are just called like normal on the api table, but can take a .NET function directly rather then requiring a local of the function pointer to be created first.

This is in a separate file so it doesn't always have to be imported if callers don't want extension methods.