### PR TITLE
Move Arm Builds to GitHub Actions

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -40,11 +40,6 @@ schedules:
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
-resources:
-  containers:
-  - container: raspbian
-    image:  wpilib/raspbian-cross-ubuntu:10-18.04
-
 stages:
 
 #
@@ -361,15 +356,6 @@ stages:
       tls: openssl
       extraBuildArgs: -Clang -ExtraArtifactDir Clang
       extraName: 'clang'
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: ubuntu-latest
-      container: raspbian
-      platform: linux
-      arch: arm
-      tls: openssl
-      ubuntuVersion: 18.04
-      extraBuildArgs: -DisableLogs -ToolchainFile cmake/toolchains/arm-pi-gnueabihf.toolchain.cmake
 
   - template: ./templates/build-config-user.yml
     parameters:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,0 +1,42 @@
+name: Container Builds
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/build-containers.yml
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .github/workflows/build-containers.yml
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
+    - submodules/openssl/*
+
+concurrency:
+  # Cancel any workflow currently in progress for the same PR.
+  # Allow running concurrently with any other commits.
+  group: containers-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-arm:
+    runs-on: ubuntu-latest
+    container:
+      image: wpilib/raspbian-cross-ubuntu:10-18.04
+    name: Build Arm
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
+    - name: Prepare Machine
+      shell: pwsh
+      run: scripts/prepare-machine.ps1 -ForBuild
+    - name: Build Debug
+      shell: pwsh
+      run: scripts/build.ps1 -Config Debug -DisableLogs -ToolchainFile cmake/toolchains/arm-pi-gnueabihf.toolchain.cmake


### PR DESCRIPTION
These will not be able to be ran on AZP soon in the future, so moving them off of the pipeline.
