### PR TITLE
Add variable to skip docker detector in onebranch

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -29,6 +29,7 @@ variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   system.debug: ${{ parameters.debug }}
   ENABLE_PRS_DELAYSIGN: 1
+  DisableDockerDetector: true
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out

--- a/.azure/OneBranch.Package.yml
+++ b/.azure/OneBranch.Package.yml
@@ -22,6 +22,9 @@ parameters:
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
+variables:
+  DisableDockerDetector: true
+
 stages:
 - stage: prepare
   displayName: Prepare VPack

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -26,6 +26,7 @@ parameters:
 variables:
   system.debug: ${{ parameters.debug }}
   ENABLE_PRS_DELAYSIGN: 0
+  DisableDockerDetector: true
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out

--- a/.azure/OneBranch.Tests.Official.yml
+++ b/.azure/OneBranch.Tests.Official.yml
@@ -8,6 +8,9 @@ resources:
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
+variables:
+  DisableDockerDetector: true
+
 stages:
 - stage: package_distribution
   displayName: Package Distribution

--- a/.azure/OneBranch.Tests.PullRequest.yml
+++ b/.azure/OneBranch.Tests.PullRequest.yml
@@ -8,6 +8,9 @@ resources:
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
+variables:
+  DisableDockerDetector: true
+
 stages:
 - stage: package
   displayName: Package


### PR DESCRIPTION
The docker image we build is not used internally, and is built for public consumption in an external setup. Disable the detector that warns for this case in internal builds.
