### PR TITLE
Add helper service for performance testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,9 @@ endif()
 if(QUIC_BUILD_PERF)
     add_subdirectory(src/perf/lib)
     add_subdirectory(src/perf/bin)
+    if (WIN32)
+        add_subdirectory(src/perf/svc)
+    endif()
 endif()
 
 # Test code

--- a/src/perf/svc/CMakeLists.txt
+++ b/src/perf/svc/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set(SOURCES
+    main.c
+)
+
+add_executable(secnetperfservice ${SOURCES})
+
+set_property(TARGET secnetperfservice PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}perf")
+
+target_link_libraries(secnetperfservice inc warnings perflib)
+
+if (BUILD_SHARED_LIBS)
+    target_link_libraries(secnetperfservice platform)
+endif()
+
+target_link_libraries(secnetperfservice logging base_link)

--- a/src/perf/svc/main.c
+++ b/src/perf/svc/main.c
@@ -1,0 +1,358 @@
+//
+//    Copyright (c) Microsoft Corporation.
+//    Licensed under the MIT License.
+//
+
+#define QUIC_TEST_APIS
+#include "quic_platform.h"
+
+#include <windows.h>
+#include <tchar.h>
+#include <strsafe.h>
+
+#define SVCNAME TEXT("SecNetPerf Helper Service")
+
+SERVICE_STATUS          gSvcStatus;
+SERVICE_STATUS_HANDLE   gSvcStatusHandle;
+HANDLE                  ghSvcStopEvent = NULL;
+
+VOID SvcInstall(void);
+VOID WINAPI SvcCtrlHandler( DWORD );
+VOID WINAPI SvcMain( DWORD, LPTSTR * );
+
+VOID ReportSvcStatus( DWORD, DWORD, DWORD );
+VOID SvcInit( DWORD, LPTSTR * );
+VOID SvcReportEvent( LPTSTR );
+
+//
+// Purpose:
+//   Entry point for the process
+//
+// Parameters:
+//   None
+//
+// Return value:
+//   None, defaults to 0 (zero)
+//
+int __cdecl _tmain(int argc, TCHAR *argv[])
+{
+    // If command-line parameter is "install", install the service.
+    // Otherwise, the service is probably being started by the SCM.
+
+    if (argc >= 2) {
+        if( lstrcmpi( argv[1], TEXT("install")) == 0 )
+        {
+            SvcInstall();
+            return 0;
+        }
+    }
+
+    // TO_DO: Add any additional services for the process to this table.
+    SERVICE_TABLE_ENTRY DispatchTable[] =
+    {
+        { SVCNAME, (LPSERVICE_MAIN_FUNCTION) SvcMain },
+        { NULL, NULL }
+    };
+
+    // This call returns when the service has stopped.
+    // The process should simply terminate when the call returns.
+
+    if (!StartServiceCtrlDispatcher( DispatchTable ))
+    {
+        SvcReportEvent(TEXT("StartServiceCtrlDispatcher"));
+    }
+}
+
+//
+// Purpose:
+//   Installs a service in the SCM database
+//
+// Parameters:
+//   None
+//
+// Return value:
+//   None
+//
+VOID SvcInstall()
+{
+    SC_HANDLE schSCManager;
+    SC_HANDLE schService;
+    TCHAR szUnquotedPath[MAX_PATH];
+
+    if( !GetModuleFileName( NULL, szUnquotedPath, MAX_PATH ) )
+    {
+        printf("Cannot install service (%d)\n", GetLastError());
+        return;
+    }
+
+    // In case the path contains a space, it must be quoted so that
+    // it is correctly interpreted. For example,
+    // "d:\my share\myservice.exe" should be specified as
+    // ""d:\my share\myservice.exe"".
+    TCHAR szPath[MAX_PATH];
+    StringCbPrintf(szPath, MAX_PATH, TEXT("\"%s\""), szUnquotedPath);
+
+    // Get a handle to the SCM database.
+
+    schSCManager = OpenSCManager(
+        NULL,                    // local computer
+        NULL,                    // ServicesActive database
+        SC_MANAGER_ALL_ACCESS);  // full access rights
+
+    if (NULL == schSCManager)
+    {
+        printf("OpenSCManager failed (%d)\n", GetLastError());
+        return;
+    }
+
+    // Create the service
+
+    schService = CreateService(
+        schSCManager,              // SCM database
+        SVCNAME,                   // name of service
+        SVCNAME,                   // service name to display
+        SERVICE_ALL_ACCESS,        // desired access
+        SERVICE_WIN32_OWN_PROCESS, // service type
+        SERVICE_DEMAND_START,      // start type
+        SERVICE_ERROR_NORMAL,      // error control type
+        szPath,                    // path to service's binary
+        NULL,                      // no load ordering group
+        NULL,                      // no tag identifier
+        NULL,                      // no dependencies
+        NULL,                      // LocalSystem account
+        NULL);                     // no password
+
+    if (schService == NULL)
+    {
+        printf("CreateService failed (%d)\n", GetLastError());
+        CloseServiceHandle(schSCManager);
+        return;
+    }
+    else printf("Service installed successfully\n");
+
+    CloseServiceHandle(schService);
+    CloseServiceHandle(schSCManager);
+}
+
+//
+// Purpose:
+//   Entry point for the service
+//
+// Parameters:
+//   dwArgc - Number of arguments in the lpszArgv array
+//   lpszArgv - Array of strings. The first string is the name of
+//     the service and subsequent strings are passed by the process
+//     that called the StartService function to start the service.
+//
+// Return value:
+//   None.
+//
+VOID WINAPI SvcMain( DWORD dwArgc, LPTSTR *lpszArgv )
+{
+    // Register the handler function for the service
+
+    gSvcStatusHandle = RegisterServiceCtrlHandler(
+        SVCNAME,
+        SvcCtrlHandler);
+
+    if( !gSvcStatusHandle )
+    {
+        SvcReportEvent(TEXT("RegisterServiceCtrlHandler"));
+        return;
+    }
+
+    // These SERVICE_STATUS members remain as set here
+
+    gSvcStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
+    gSvcStatus.dwServiceSpecificExitCode = 0;
+
+    // Report initial status to the SCM
+
+    ReportSvcStatus( SERVICE_START_PENDING, NO_ERROR, 3000 );
+
+    // Perform service-specific initialization and work.
+
+    SvcInit( dwArgc, lpszArgv );
+}
+
+//
+// Purpose:
+//   The service code
+//
+// Parameters:
+//   dwArgc - Number of arguments in the lpszArgv array
+//   lpszArgv - Array of strings. The first string is the name of
+//     the service and subsequent strings are passed by the process
+//     that called the StartService function to start the service.
+//
+// Return value:
+//   None
+//
+VOID SvcInit( DWORD dwArgc, LPTSTR *lpszArgv)
+{
+    // TO_DO: Declare and set any required variables.
+    //   Be sure to periodically call ReportSvcStatus() with
+    //   SERVICE_START_PENDING. If initialization fails, call
+    //   ReportSvcStatus with SERVICE_STOPPED.
+
+    UNREFERENCED_PARAMETER(lpszArgv);
+    UNREFERENCED_PARAMETER(dwArgc);
+
+    QUIC_STATUS QuicStatus;
+    DWORD ServiceStatus = NO_ERROR;
+    QUIC_CREDENTIAL_CONFIG* DriverCert = NULL;
+    QUIC_CREDENTIAL_CONFIG* UserCert = NULL;
+    BOOLEAN QuicInitialized = FALSE;
+
+    CxPlatSystemLoad();
+    if (QUIC_FAILED(QuicStatus = CxPlatInitialize())) {
+        CxPlatSystemUnload();
+        ServiceStatus = ERROR_OUTOFMEMORY;
+        goto Exit;
+    }
+
+    QuicInitialized = TRUE;
+
+    // Create an event. The control handler function, SvcCtrlHandler,
+    // signals this event when it receives the stop control code.
+
+    ghSvcStopEvent = CreateEvent(
+                         NULL,    // default security attributes
+                         TRUE,    // manual reset event
+                         FALSE,   // not signaled
+                         NULL);   // no name
+
+    if ( ghSvcStopEvent == NULL)
+    {
+        ServiceStatus = GetLastError();
+        goto Exit;
+    }
+
+    // Report running status when initialization is complete.
+
+    ReportSvcStatus( SERVICE_RUNNING, NO_ERROR, 0 );
+
+    DriverCert = CxPlatGetSelfSignedCert(CXPLAT_SELF_SIGN_CERT_MACHINE, FALSE);
+    UserCert = CxPlatGetSelfSignedCert(CXPLAT_SELF_SIGN_CERT_USER, FALSE);
+
+    if (DriverCert == NULL || UserCert == NULL) {
+        ServiceStatus = ERROR_INTERNAL_ERROR;
+        goto Exit;
+    }
+
+
+
+    WaitForSingleObject(ghSvcStopEvent, INFINITE);
+
+    ServiceStatus = NO_ERROR;
+
+Exit:
+
+    if (DriverCert) {
+        CxPlatFreeSelfSignedCert(DriverCert);
+    }
+
+    if (UserCert) {
+        CxPlatFreeSelfSignedCert(UserCert);
+    }
+
+    if (QuicInitialized) {
+        CxPlatUninitialize();
+        CxPlatSystemUnload();
+    }
+
+    ReportSvcStatus( SERVICE_STOPPED, ServiceStatus, 0 );
+    return;
+}
+
+//
+// Purpose:
+//   Sets the current service status and reports it to the SCM.
+//
+// Parameters:
+//   dwCurrentState - The current state (see SERVICE_STATUS)
+//   dwWin32ExitCode - The system error code
+//   dwWaitHint - Estimated time for pending operation,
+//     in milliseconds
+//
+// Return value:
+//   None
+//
+VOID ReportSvcStatus( DWORD dwCurrentState,
+                      DWORD dwWin32ExitCode,
+                      DWORD dwWaitHint)
+{
+    static DWORD dwCheckPoint = 1;
+
+    // Fill in the SERVICE_STATUS structure.
+
+    gSvcStatus.dwCurrentState = dwCurrentState;
+    gSvcStatus.dwWin32ExitCode = dwWin32ExitCode;
+    gSvcStatus.dwWaitHint = dwWaitHint;
+
+    if (dwCurrentState == SERVICE_START_PENDING)
+        gSvcStatus.dwControlsAccepted = 0;
+    else gSvcStatus.dwControlsAccepted = SERVICE_ACCEPT_STOP;
+
+    if ( (dwCurrentState == SERVICE_RUNNING) ||
+           (dwCurrentState == SERVICE_STOPPED) )
+        gSvcStatus.dwCheckPoint = 0;
+    else gSvcStatus.dwCheckPoint = dwCheckPoint++;
+
+    // Report the status of the service to the SCM.
+    SetServiceStatus( gSvcStatusHandle, &gSvcStatus );
+}
+
+//
+// Purpose:
+//   Called by SCM whenever a control code is sent to the service
+//   using the ControlService function.
+//
+// Parameters:
+//   dwCtrl - control code
+//
+// Return value:
+//   None
+//
+VOID WINAPI SvcCtrlHandler( DWORD dwCtrl )
+{
+   // Handle the requested control code.
+
+   switch(dwCtrl)
+   {
+      case SERVICE_CONTROL_STOP:
+         ReportSvcStatus(SERVICE_STOP_PENDING, NO_ERROR, 0);
+
+         // Signal the service to stop.
+
+         SetEvent(ghSvcStopEvent);
+         ReportSvcStatus(gSvcStatus.dwCurrentState, NO_ERROR, 0);
+
+         return;
+
+      case SERVICE_CONTROL_INTERROGATE:
+         break;
+
+      default:
+         break;
+   }
+
+}
+
+//
+// Purpose:
+//   Logs messages to the event log
+//
+// Parameters:
+//   szFunction - name of function that failed
+//
+// Return value:
+//   None
+//
+// Remarks:
+//   The service must have an entry in the Application event log.
+//
+VOID SvcReportEvent(LPTSTR szFunction)
+{
+    UNREFERENCED_PARAMETER(szFunction);
+}


### PR DESCRIPTION
This service opens a handle to the certificates, which makes it so the server perf system only has to be logged into to bypass the certificate issue, rather then running a special command. This also likely makes it so another user logging in does not break performance

