### PR TITLE
Publish Symbols for Perf Pipeline

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -145,6 +145,7 @@ stages:
       parameters:
         arch: ${{ parameters.arch }}
         config: Release
+        publishSymbols: true
 
 - ${{ if or(eq(parameters.winkernel, true), eq(parameters.winuser_schannel, true)) }}:
   - stage: build_winuser_schannel
@@ -160,6 +161,7 @@ stages:
         arch: ${{ parameters.arch }}
         tls: schannel
         config: Release
+        publishSymbols: true
         extraPrepareArgs: -DisableTest
         ${{ if eq(parameters.pgo_mode, false) }}:
           extraBuildArgs: -DisableTest -DisableTools
@@ -180,6 +182,7 @@ stages:
         arch: ${{ parameters.arch }}
         tls: schannel
         config: Release
+        publishSymbols: true
         extraName: 'sharedec'
         extraPrepareArgs: -DisableTest
         ${{ if eq(parameters.pgo_mode, false) }}:
@@ -201,6 +204,7 @@ stages:
         arch: ${{ parameters.arch }}
         tls: schannel
         config: Release
+        publishSymbols: true
         extraName: 'xdp'
         extraPrepareArgs: -DisableTest -InstallXdpSdk
         ${{ if eq(parameters.pgo_mode, false) }}:
@@ -222,6 +226,7 @@ stages:
         arch: ${{ parameters.arch }}
         tls: openssl
         config: Release
+        publishSymbols: true
         extraPrepareArgs: -DisableTest
         ${{ if eq(parameters.pgo_mode, false) }}:
           extraBuildArgs: -DisableTest -DisableTools

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -64,11 +64,5 @@ jobs:
 
   - ${{ if eq(parameters.skipArtifacts, false) }}:
     - template: ./upload-artifacts.yml
-
-  - ${{ if eq(parameters.publishSymbols, true) }}:
-    - task: PublishSymbols@2
-      inputs:
-        sourceFolder: '$(Build.SourcesDirectory)'
-        searchPattern: '**/bin/windows/**/*.pdb'
-        symbolServerType: teamServices
-        indexSources: false
+      parameters:
+        publishSymbols: ${{ parameters.publishSymbols }}

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -68,6 +68,7 @@ jobs:
   - ${{ if eq(parameters.publishSymbols, true) }}:
     - task: PublishSymbols@2
       inputs:
-        searchPattern: 'artifacts/bin/windows/**/*.pdb'
+        sourceFolder: '$(Build.SourcesDirectory)'
+        searchPattern: '**/bin/windows/**/*.pdb'
         symbolServerType: teamServices
         indexSources: false

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -10,6 +10,7 @@ parameters:
   extraPrepareArgs: ''
   extraBuildArgs: ''
   skipArtifacts: false
+  publishSymbols: false
   extraName: ''
   ubuntuVersion: 20.04
 
@@ -63,3 +64,11 @@ jobs:
 
   - ${{ if eq(parameters.skipArtifacts, false) }}:
     - template: ./upload-artifacts.yml
+
+  - ${{ if eq(parameters.publishSymbols, true) }}:
+    - task: PublishSymbols@2
+      inputs:
+          sourceFolder: artifacts/bin/windows
+          searchPattern: '**/*.pdb'
+          symbolServerType: teamServices
+          indexSources: false

--- a/.azure/templates/build-config-user.yml
+++ b/.azure/templates/build-config-user.yml
@@ -68,7 +68,6 @@ jobs:
   - ${{ if eq(parameters.publishSymbols, true) }}:
     - task: PublishSymbols@2
       inputs:
-          sourceFolder: artifacts/bin/windows
-          searchPattern: '**/*.pdb'
-          symbolServerType: teamServices
-          indexSources: false
+        searchPattern: 'artifacts/bin/windows/**/*.pdb'
+        symbolServerType: teamServices
+        indexSources: false

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -45,11 +45,5 @@ jobs:
       msbuildArgs: /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_BUILD_ID=$(Build.BuildId) /p:QUIC_VER_GIT_HASH=$(Build.SourceVersion)
 
   - template: ./upload-artifacts.yml
-
-  - ${{ if eq(parameters.publishSymbols, true) }}:
-    - task: PublishSymbols@2
-      inputs:
-        sourceFolder: '$(Build.SourcesDirectory)'
-        searchPattern: '**/bin/winkernel/**/*.pdb'
-        symbolServerType: teamServices
-        indexSources: false
+    parameters:
+      publishSymbols: ${{ parameters.publishSymbols }}

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -3,6 +3,7 @@
 parameters:
   arch: ''
   config: 'Debug,Release'
+  publishSymbols: false
 
 jobs:
 - job: build_winkernel_${{ parameters.arch }}
@@ -44,3 +45,11 @@ jobs:
       msbuildArgs: /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_BUILD_ID=$(Build.BuildId) /p:QUIC_VER_GIT_HASH=$(Build.SourceVersion)
 
   - template: ./upload-artifacts.yml
+
+  - ${{ if eq(parameters.publishSymbols, true) }}:
+    - task: PublishSymbols@2
+      inputs:
+          sourceFolder: artifacts/bin/winkernel
+          searchPattern: '**/*.pdb'
+          symbolServerType: teamServices
+          indexSources: false

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -49,6 +49,7 @@ jobs:
   - ${{ if eq(parameters.publishSymbols, true) }}:
     - task: PublishSymbols@2
       inputs:
-        searchPattern: 'artifacts/bin/winkernel/**/*.pdb'
+        sourceFolder: '$(Build.SourcesDirectory)'
+        searchPattern: '**/bin/winkernel/**/*.pdb'
         symbolServerType: teamServices
         indexSources: false

--- a/.azure/templates/build-config-winkernel.yml
+++ b/.azure/templates/build-config-winkernel.yml
@@ -49,7 +49,6 @@ jobs:
   - ${{ if eq(parameters.publishSymbols, true) }}:
     - task: PublishSymbols@2
       inputs:
-          sourceFolder: artifacts/bin/winkernel
-          searchPattern: '**/*.pdb'
-          symbolServerType: teamServices
-          indexSources: false
+        searchPattern: 'artifacts/bin/winkernel/**/*.pdb'
+        symbolServerType: teamServices
+        indexSources: false

--- a/.azure/templates/upload-artifacts.yml
+++ b/.azure/templates/upload-artifacts.yml
@@ -1,5 +1,10 @@
 # Uploads the build artifacts for a single build configuration.
 
+parameters:
+  arch: ''
+  config: 'Debug,Release'
+  publishSymbols: false
+
 steps:
 - task: CopyFiles@2
   displayName: Move Build Artifacts
@@ -20,6 +25,14 @@ steps:
     artifactName: artifacts
     pathToPublish: $(Build.ArtifactStagingDirectory)
     parallel: true
+
+- ${{ if eq(parameters.publishSymbols, true) }}:
+  - task: PublishSymbols@2
+    inputs:
+      symbolsFolder: $(Build.ArtifactStagingDirectory)/bin
+      searchPattern: '**/*.pdb'
+      symbolServerType: teamServices
+      indexSources: false
 
 - task: DeleteFiles@1
   displayName: Clear Staging


### PR DESCRIPTION
## Description

To make it easier to look at stack traces, publish the symbols from binaries built in the perf pipeline.
