### PR TITLE
Add sendbuf param to RPS client

### DIFF
--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -22,16 +22,14 @@ struct RpsWorkerContext;
 class RpsClient;
 
 struct StreamContext {
-    HQUIC Handle {nullptr};
     StreamContext(
         _In_ RpsConnectionContext* Connection,
         _In_ uint64_t StartTime)
         : Connection{Connection}, StartTime{StartTime} { }
-    ~StreamContext() noexcept { if (Handle) { MsQuic->StreamClose(Handle); } }
     RpsConnectionContext* Connection;
     uint64_t StartTime;
 #if DEBUG
-    uint8_t Padding[12]; // TODO: Should this change?
+    uint8_t Padding[12];
 #endif
 };
 


### PR DESCRIPTION
~~Add scenarios to RPS client that align with how System.Net.Quic uses MsQuic, to be able to compare performance fairly:~~
~~- Turn on/off send buffering~~
~~- Sending data after receiving stream started event~~

Add param to RPS client to turn on/off send buffering