### PR TITLE
Ignore XDP workers that do not have an XDP queue assigned

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -1090,6 +1090,14 @@ CxPlatDpRawInitialize(
 
     Xdp->Running = TRUE;
     for (uint32_t i = 0; i < Xdp->WorkerCount; i++) {
+        if (Xdp->Workers->Queues == NULL) {
+            //
+            // Becasue queues are assigned in a round-robin manner, subsequent workers will not
+            // have a queue assigned. Stop the loop and update worker count.
+            //
+            Xdp->WorkerCount = i - 1;
+            break;
+        }
         Xdp->Workers[i].Xdp = Xdp;
         Xdp->Workers[i].ProcIndex = ProcList[i];
         CxPlatEventInitialize(&Xdp->Workers[i].CompletionEvent, TRUE, FALSE);

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -1095,7 +1095,7 @@ CxPlatDpRawInitialize(
             // Becasue queues are assigned in a round-robin manner, subsequent workers will not
             // have a queue assigned. Stop the loop and update worker count.
             //
-            Xdp->WorkerCount = i - 1;
+            Xdp->WorkerCount = i;
             break;
         }
         Xdp->Workers[i].Xdp = Xdp;


### PR DESCRIPTION
## Description

Since XDP queues are assigned to XDP workers in a round-robin pattern, some workers might not get assigned any queues. Simply skip registering those workers to datapath for now.

## Testing

CI