### PR TITLE
make sure PEER_CERTIFICATE_RECEIVED has certificate chain even if Quic does not do validation

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -279,6 +279,16 @@ CxPlatTlsCertificateVerifyCallback(
                     (int)CxPlatTlsMapOpenSSLErrorToQuicStatus(X509_STORE_CTX_get_error(x509_ctx));
             }
         }
+    } else if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) {
+        //
+        // We need to get certificates provided by peer if we going to pass them via Callbacks.CertificateReceived.
+        // We don't really care about validation status but without calling X509_verify_cert() x509_ctx has 
+        // no certificates attached to it and that impacts validation of custom certificate chains.
+        //
+        // OpenSSL 3 has X509_build_chain() to build just the chain.
+        // We may do something similar here for OpenSsl 1.1
+        //
+        X509_verify_cert(x509_ctx);
     }
 
     if (!(TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION) &&

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -279,7 +279,8 @@ CxPlatTlsCertificateVerifyCallback(
                     (int)CxPlatTlsMapOpenSSLErrorToQuicStatus(X509_STORE_CTX_get_error(x509_ctx));
             }
         }
-    } else if (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) {
+    } else if ((TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED) &&
+               (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_USE_PORTABLE_CERTIFICATES)) {
         //
         // We need to get certificates provided by peer if we going to pass them via Callbacks.CertificateReceived.
         // We don't really care about validation status but without calling X509_verify_cert() x509_ctx has 


### PR DESCRIPTION
This is fix for regression caused by #2419, reported by @manickap.
The problem is that without calling X509_verify_cert() there are no chain certificates in x509_ctx.
The logic kicks in in but `sk_X509_num` on `X509_STORE_CTX_get0_chain(x509_ctx)`  return -1 so we pass empty buffer instead of peer's certificates.  

There may be other ways how to fix it but for now I put the call back for cases when certificate and chain is going to be presented to caller. For non-portable, it is ok since the raw x509_ctx is passed in so callers can fix it anyway they need to. 

contributes to #2732

cc: @rzikm 
