### PR TITLE
Add polyfill for .NET Standard support

### DIFF
--- a/src/cs/LicenseHeader.txt
+++ b/src/cs/LicenseHeader.txt
@@ -6,3 +6,10 @@
 #pragma warning restore IDE0073
 
 #pragma warning disable CS0649
+
+// Polyfill for MemoryMarshall on .NET Standard
+#if NETSTANDARD && !NETSTANDARD2_1_OR_GREATER
+using MemoryMarshal = Microsoft.Quic.Polyfill.MemoryMarshal;
+#else
+using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
+#endif

--- a/src/cs/lib/msquic.cs
+++ b/src/cs/lib/msquic.cs
@@ -10,6 +10,12 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+#if NETSTANDARD
+using OperatingSystem = Microsoft.Quic.Polyfill.OperatingSystem;
+#else
+using OperatingSystem = System.OperatingSystem;
+#endif
+
 namespace Microsoft.Quic
 {
     internal unsafe partial struct QUIC_BUFFER

--- a/src/cs/lib/msquic.csproj
+++ b/src/cs/lib/msquic.csproj
@@ -1,13 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Quic</RootNamespace>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -7,6 +7,12 @@
 
 #pragma warning disable CS0649
 
+#if NETSTANDARD && !NETSTANDARD2_1_OR_GREATER
+using MemoryMarshal = Microsoft.Quic.Polyfill.MemoryMarshal;
+#else
+using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
+#endif
+
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Quic

--- a/src/cs/lib/msquic_polyfill.cs
+++ b/src/cs/lib/msquic_polyfill.cs
@@ -1,0 +1,76 @@
+#pragma warning disable IDE0073
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+#pragma warning restore IDE0073
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Quic.Polyfill
+{
+#if NETSTANDARD
+    internal static class OperatingSystem
+    {
+        public static bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        public static bool IsLinux()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        public static bool IsAndroid()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        public static bool IsMacOS()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        public static bool IsIOS()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        public static bool IsMacCatalyst()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        public static bool IsTvOS()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        public static bool IsWatchOS()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        public static bool IsFreeBSD()
+        {
+            return false;
+        }
+    }
+#endif
+
+#if NETSTANDARD && !NETSTANDARD2_1_OR_GREATER
+    internal static class MemoryMarshal
+    {
+        public static ref T GetReference<T>(Span<T> span) {
+            return ref span.GetPinnableReference();
+        }
+
+        public static unsafe Span<T> CreateSpan<T>(ref T reference, int length) {
+            return new(Unsafe.AsPointer(ref reference), length);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
.NET does not need to include this, but external users that want to support .NET Standard will find it useful.

.NET Standard is a .NET Target that supports old .NET Framework, UWP, and many alternate platforms as well. Fully supporting .NET Standard for all builds would result in performance compromises in mainline .NET itself, which we don't want. Instead, we use a few tricks to polyfill the necessary functions. So running on .NET standard things will use some older functionality, but everything works fine.

## Testing

Build will ensure things will still work

## Documentation

N/A
