### PR TITLE
Copy xdp-devkit.json to perf test setup

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -286,6 +286,7 @@ $RemoteDirectorySMB = $null
 
 # Copy manifest and log script to local directory
 Copy-Item -Path (Join-Path $RootDir scripts log.ps1) -Destination $LocalDirectory
+Copy-Item -Path (Join-Path $RootDir scripts xdp-devkit.json) -Destination $LocalDirectory
 Copy-Item -Path (Join-Path $RootDir scripts prepare-machine.ps1) -Destination $LocalDirectory
 Copy-Item -Path (Join-Path $RootDir src manifest MsQuic.wprp) -Destination $LocalDirectory
 


### PR DESCRIPTION
## Description

prepare-machine.ps1 is copied to the perf test machines but xdp-devkit.json is not.

## Testing

CI
