### PR TITLE
Fix build on Ubuntu 22.04

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -416,6 +416,16 @@ stages:
       extraName: 'static'
       extraBuildArgs: -Static -ExtraArtifactDir Static
 
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: ubuntu-22.04
+      platform: linux
+      arch: x64
+      tls: openssl
+      extraName: 'ubuntu2204'
+      extraBuildArgs: -ExtraArtifactDir ubuntu2204
+      ubuntuVersion: 22.04
+
 - stage: build_macos_release
   displayName: Build macOS - Release
   dependsOn: []

--- a/src/core/unittest/SettingsTest.cpp
+++ b/src/core/unittest/SettingsTest.cpp
@@ -229,7 +229,9 @@ TEST(SettingsTest, TestAllGlobalSettingsFieldsGet)
 TEST(SettingsTest, SettingsSizesGet)
 {
     uint8_t Buffer[sizeof(QUIC_SETTINGS) * 2];
+    CxPlatZeroMemory(Buffer, ARRAYSIZE(Buffer));
     QUIC_SETTINGS_INTERNAL InternalSettings;
+    CxPlatZeroMemory(&InternalSettings, sizeof(InternalSettings));
 
     uint32_t MinimumSettingsSize = (uint32_t)SETTINGS_SIZE_THRU_FIELD(QUIC_SETTINGS, MtuDiscoveryMissingProbeCount);
 
@@ -279,7 +281,9 @@ TEST(SettingsTest, SettingsSizesGet)
 TEST(SettingsTest, SettingsSizesSet)
 {
     uint8_t Buffer[sizeof(QUIC_SETTINGS) * 2];
+    CxPlatZeroMemory(Buffer, ARRAYSIZE(Buffer));
     QUIC_SETTINGS_INTERNAL InternalSettings;
+    CxPlatZeroMemory(&InternalSettings, sizeof(InternalSettings));
 
     uint32_t MinimumSettingsSize = (uint32_t)SETTINGS_SIZE_THRU_FIELD(QUIC_SETTINGS, MtuDiscoveryMissingProbeCount);
 
@@ -325,7 +329,9 @@ TEST(SettingsTest, SettingsSizesSet)
 TEST(SettingsTest, GlobalSettingsSizesGet)
 {
     uint8_t Buffer[sizeof(QUIC_GLOBAL_SETTINGS) * 2];
+    CxPlatZeroMemory(Buffer, ARRAYSIZE(Buffer));
     QUIC_SETTINGS_INTERNAL InternalSettings;
+    CxPlatZeroMemory(&InternalSettings, sizeof(InternalSettings));
 
     uint32_t MinimumSettingsSize = (uint32_t)SETTINGS_SIZE_THRU_FIELD(QUIC_GLOBAL_SETTINGS, LoadBalancingMode);
 
@@ -375,7 +381,9 @@ TEST(SettingsTest, GlobalSettingsSizesGet)
 TEST(SettingsTest, GlobalSettingsSizesSet)
 {
     uint8_t Buffer[sizeof(QUIC_GLOBAL_SETTINGS) * 2];
+    CxPlatZeroMemory(Buffer, ARRAYSIZE(Buffer));
     QUIC_SETTINGS_INTERNAL InternalSettings;
+    CxPlatZeroMemory(&InternalSettings, sizeof(InternalSettings));
 
     uint32_t MinimumSettingsSize = (uint32_t)SETTINGS_SIZE_THRU_FIELD(QUIC_GLOBAL_SETTINGS, LoadBalancingMode);
 


### PR DESCRIPTION
Newer GCC has a new warning that triggers on the SettingsTest. Explcitly zero buffers to avoid the warning.

Also adds a 22.04 build configuration on azure pipelines


