### PR TITLE
Allow TCP perf to fail to complete without failing pipeline

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -130,7 +130,6 @@
             },
             "Variables": [
             ],
-
             "SkipKernel": true,
             "AllowLoopback": true,
             "Iterations": 5,

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -50,6 +50,7 @@
             },
             "Variables": [
             ],
+            "AllowFailure": true,
             "SkipKernel": true,
             "AllowLoopback": true,
             "Iterations": 5,
@@ -129,6 +130,7 @@
             },
             "Variables": [
             ],
+            "AllowFailure": true,
             "SkipKernel": true,
             "AllowLoopback": true,
             "Iterations": 5,

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -50,12 +50,12 @@
             },
             "Variables": [
             ],
-            "AllowFailure": true,
             "SkipKernel": true,
             "AllowLoopback": true,
             "Iterations": 5,
             "RemoteReadyMatcher": "Started!",
             "ResultsMatcher": ".*@ (.*) kbps.*",
+            "FailureDefault": "Result: 0 bytes @ 0 kbps (0.0 ms).",
             "Formats": ["{0} kbps"],
             "RegressionThreshold": "-50.0"
         },
@@ -130,12 +130,13 @@
             },
             "Variables": [
             ],
-            "AllowFailure": true,
+
             "SkipKernel": true,
             "AllowLoopback": true,
             "Iterations": 5,
             "RemoteReadyMatcher": "Started!",
             "ResultsMatcher": ".*@ (.*) kbps.*",
+            "FailureDefault": "Result: 0 bytes @ 0 kbps (0.0 ms).",
             "Formats": ["{0} kbps"],
             "RegressionThreshold": "-50.0"
         },

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -605,15 +605,16 @@ function Get-MedianTestResults($FullResults) {
     }
 }
 
-function Get-TestResult($Results, $Matcher, $AllowFailure = $false) {
+function Get-TestResult($Results, $Matcher, $FailureDefault) {
     $Found = $Results -match $Matcher
     if ($Found) {
         return $Matches
     } else {
-        if($AllowFailure) {
-            return "0.0";
-        } else {
+        if([string]::IsNullOrWhiteSpace($FailureDefault)) {
             Write-Error "Error Processing Results:`n`n$Results"
+        } else {
+            $Found = $FailureDefault -match $Matcher
+            return $Matches
         }
     }
 }
@@ -1181,7 +1182,7 @@ class TestRunDefinition {
     [hashtable]$VariableValues;
     [boolean]$Loopback;
     [boolean]$AllowLoopback;
-    [boolean]$AllowFailure;
+    [string]$FailureDefault;
     [boolean]$SharedEC;
     [boolean]$XDP;
     [string[]]$Formats;
@@ -1208,7 +1209,7 @@ class TestRunDefinition {
         $this.RegressionThreshold = $existingDef.RegressionThreshold
         $this.SharedEC = $script:SharedEC
         $this.XDP = $script:XDP
-        $this.AllowFailure = $existingDef.AllowFailure
+        $this.FailureDefault = $existingDef.FailureDefault
     }
 
     TestRunDefinition (
@@ -1223,8 +1224,7 @@ class TestRunDefinition {
         $this.AllowLoopback = $existingDef.AllowLoopback
         $this.Formats = $existingDef.Formats
         $this.RegressionThreshold = $existingDef.RegressionThreshold
-        $this.AllowFailure =
-        $existingDef.AllowFailure
+        $this.FailureDefault = $existingDef.FailureDefault
         $this.VariableValue = ""
         $this.VariableName = ""
 
@@ -1259,7 +1259,7 @@ class TestRunDefinition {
         $this.RegressionThreshold = $existingDef.RegressionThreshold
         $this.SharedEC = $script:SharedEC
         $this.XDP = $script:XDP
-        $this.AllowFailure = $existingDef.AllowFailure
+        $this.FailureDefault = $existingDef.FailureDefault
     }
 
     [string]ToString() {
@@ -1488,7 +1488,7 @@ class ExecutableSpec {
 class TestDefinition {
     [string]$TestName;
     [boolean]$SkipKernel;
-    [boolean]$AllowFailure;
+    [string]$FailureDefault;
     [ExecutableSpec]$Local;
     [VariableSpec[]]$Variables;
     [int]$Iterations;

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -605,12 +605,16 @@ function Get-MedianTestResults($FullResults) {
     }
 }
 
-function Get-TestResult($Results, $Matcher) {
+function Get-TestResult($Results, $Matcher, $AllowFailure = $false) {
     $Found = $Results -match $Matcher
     if ($Found) {
         return $Matches
     } else {
-        Write-Error "Error Processing Results:`n`n$Results"
+        if($AllowFailure) {
+            return "0.0";
+        } else {
+            Write-Error "Error Processing Results:`n`n$Results"
+        }
     }
 }
 
@@ -1177,6 +1181,7 @@ class TestRunDefinition {
     [hashtable]$VariableValues;
     [boolean]$Loopback;
     [boolean]$AllowLoopback;
+    [boolean]$AllowFailure;
     [boolean]$SharedEC;
     [boolean]$XDP;
     [string[]]$Formats;
@@ -1203,6 +1208,7 @@ class TestRunDefinition {
         $this.RegressionThreshold = $existingDef.RegressionThreshold
         $this.SharedEC = $script:SharedEC
         $this.XDP = $script:XDP
+        $this.AllowFailure = $existingDef.AllowFailure
     }
 
     TestRunDefinition (
@@ -1217,6 +1223,8 @@ class TestRunDefinition {
         $this.AllowLoopback = $existingDef.AllowLoopback
         $this.Formats = $existingDef.Formats
         $this.RegressionThreshold = $existingDef.RegressionThreshold
+        $this.AllowFailure =
+        $existingDef.AllowFailure
         $this.VariableValue = ""
         $this.VariableName = ""
 
@@ -1251,6 +1259,7 @@ class TestRunDefinition {
         $this.RegressionThreshold = $existingDef.RegressionThreshold
         $this.SharedEC = $script:SharedEC
         $this.XDP = $script:XDP
+        $this.AllowFailure = $existingDef.AllowFailure
     }
 
     [string]ToString() {
@@ -1479,6 +1488,7 @@ class ExecutableSpec {
 class TestDefinition {
     [string]$TestName;
     [boolean]$SkipKernel;
+    [boolean]$AllowFailure;
     [ExecutableSpec]$Local;
     [VariableSpec[]]$Variables;
     [int]$Iterations;

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -473,7 +473,7 @@ function Invoke-Test {
             Write-LogAndDebug "Running Local: $LocalExe Args: $LocalArguments"
             $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir
             Write-LogAndDebug $LocalResults
-            $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher -AllowFailure $Test.AllowFailure
+            $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher -FailureDefault $Test.FailureDefault
             $AllRunsResults += $AllLocalParsedResults
             if ($PGO) {
                 # Merge client PGO Counts

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -473,7 +473,7 @@ function Invoke-Test {
             Write-LogAndDebug "Running Local: $LocalExe Args: $LocalArguments"
             $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir
             Write-LogAndDebug $LocalResults
-            $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher
+            $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher -AllowFailure $Test.AllowFailure
             $AllRunsResults += $AllLocalParsedResults
             if ($PGO) {
                 # Merge client PGO Counts

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -76,10 +76,6 @@ ThroughputClient::Init(
     TryGetValue(argc, argv, "download", &DownloadLength);
     TryGetValue(argc, argv, "stats", &PrintStats);
 
-    if (UseTcp) {
-        Port = 9233;
-    }
-
     if (UploadLength && DownloadLength) {
         WriteOutput("Must specify only one of '-upload' or '-download' argument!\n");
         return QUIC_STATUS_INVALID_PARAMETER;

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -76,6 +76,10 @@ ThroughputClient::Init(
     TryGetValue(argc, argv, "download", &DownloadLength);
     TryGetValue(argc, argv, "stats", &PrintStats);
 
+    if (UseTcp) {
+        Port = 9233;
+    }
+
     if (UploadLength && DownloadLength) {
         WriteOutput("Must specify only one of '-upload' or '-download' argument!\n");
         return QUIC_STATUS_INVALID_PARAMETER;
@@ -614,7 +618,7 @@ ThroughputClient::OnTcpConnectionComplete(
     if (Connection) {
         Connection->Close();
     }
-    //CxPlatEventSet(*StopEvent);
+    CxPlatEventSet(*StopEvent);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -614,7 +614,7 @@ ThroughputClient::OnTcpConnectionComplete(
     if (Connection) {
         Connection->Close();
     }
-    CxPlatEventSet(*StopEvent);
+    //CxPlatEventSet(*StopEvent);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)


### PR DESCRIPTION
## Description

Make TCP connection failures not kill the perf pipeline. The test isn't that important, so skip any failures here

Closes #2527


Do not merge until I remove the tcp change that forces it to always fail.