### PR TITLE
QUIC_PARAM_STREAM_ID is get only

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -166,7 +166,7 @@ These parameters are access by calling [GetParam](./api/GetParam.md) or [SetPara
 
 | Setting                                           | Type              | Get/Set   | Description                                                                           |
 |---------------------------------------------------|-------------------|-----------|---------------------------------------------------------------------------------------|
-| `QUIC_PARAM_STREAM_ID`<br> 0                      | QUIC_UINT62       | Set-only  | Must be called on a stream before [StreamStart](./api/StreamStart.md) is called.      |
+| `QUIC_PARAM_STREAM_ID`<br> 0                      | QUIC_UINT62       | Get-only  | Must be called on a stream before [StreamStart](./api/StreamStart.md) is called.      |
 | `QUIC_PARAM_STREAM_0RTT_LENGTH`<br> 1             | uint64_t          | Get-only  | Length of 0-RTT data received from peer.                                              |
 | `QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE`<br> 2  | uint64_t - bytes  | Get-only  | Ideal buffer size to queue to the stream. Assumes only one stream sends steadily.     |
 


### PR DESCRIPTION
## Description
Set goes to QUIC_STATUS_INVALID_PARAMETER
https://github.com/microsoft/msquic/blob/0fffdc076abd52a61a2d4d8d699cf6a5f80e56e5/src/core/stream.c#L563-L580

