### PR TITLE
Expose Parameter for TLS Provider

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -90,6 +90,7 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_GLOBAL_VERSION_SETTINGS`<br> 7        | QUIC_VERSIONS_SETTINGS  | Both      | Globally change version settings for all subsequent connections.                                      |
 | `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH`<br> 8        | char[64]                | Get-only  | Git hash used to build MsQuic (null terminated string)                                                |
 | `QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS`<br> 9      | uint16_t[]              | Both      | Globally change the list of CPUs that datapath can use. Must be set before opening registration.  |
+| `QUIC_PARAM_GLOBAL_TLS_PROVIDER`<br> 10      | QUIC_TLS_PROVIDER | Get-Only | The TLS provider being used by MsQuic for the TLS handshake. |
 
 
 ### Registration Parameters

--- a/scripts/generate-dotnet.ps1
+++ b/scripts/generate-dotnet.ps1
@@ -53,6 +53,7 @@ Invoke-Expression "$ToolExe $FullArgs"
     -replace '\(anonymous union.+\)\"', "(anonymous union)`"" `
     -replace "public enum .*?_FLAGS","[System.Flags]`n    `$0" `
     -replace "const int", "const uint" `
+    -replace "  QUIC_TLS_PROVIDER_", "  " `
     -replace "  QUIC_EXECUTION_PROFILE_TYPE_", "  " `
     -replace "  QUIC_EXECUTION_PROFILE_", "  " `
     -replace "  QUIC_LOAD_BALANCING_", "  " `

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1216,6 +1216,25 @@ QuicLibraryGetGlobalParam(
         Status = QUIC_STATUS_SUCCESS;
         break;
 
+    case QUIC_PARAM_GLOBAL_TLS_PROVIDER:
+
+        if (*BufferLength < sizeof(QUIC_TLS_PROVIDER)) {
+            *BufferLength = sizeof(QUIC_TLS_PROVIDER);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *BufferLength = sizeof(QUIC_TLS_PROVIDER);
+        *(QUIC_TLS_PROVIDER*)Buffer = CxPlatTlsGetProvider();
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
     case QUIC_PARAM_GLOBAL_VERSION_NEGOTIATION_ENABLED:
 
         if (*BufferLength < sizeof(BOOLEAN)) {

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Quic
     {
     }
 
+    internal enum QUIC_TLS_PROVIDER
+    {
+        SCHANNEL = 0x0000,
+        OPENSSL = 0x0001,
+    }
+
     internal enum QUIC_EXECUTION_PROFILE
     {
         LOW_LATENCY,
@@ -2591,6 +2597,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS 0x01000009")]
         internal const uint QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS = 0x01000009;
+
+        [NativeTypeName("#define QUIC_PARAM_GLOBAL_TLS_PROVIDER 0x0100000A")]
+        internal const uint QUIC_PARAM_GLOBAL_TLS_PROVIDER = 0x0100000A;
 
         [NativeTypeName("#define QUIC_PARAM_CONFIGURATION_SETTINGS 0x03000000")]
         internal const uint QUIC_PARAM_CONFIGURATION_SETTINGS = 0x03000000;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -70,6 +70,11 @@ typedef _In_range_(0, QUIC_UINT62_MAX) uint64_t QUIC_UINT62;
 //
 #define QUIC_MAX_RESUMPTION_APP_DATA_LENGTH     1000
 
+typedef enum QUIC_TLS_PROVIDER {
+    QUIC_TLS_PROVIDER_SCHANNEL                  = 0x0000,
+    QUIC_TLS_PROVIDER_OPENSSL                   = 0x0001,
+} QUIC_TLS_PROVIDER;
+
 typedef enum QUIC_EXECUTION_PROFILE {
     QUIC_EXECUTION_PROFILE_LOW_LATENCY,         // Default
     QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT,
@@ -710,6 +715,7 @@ void
 #endif
 #define QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH              0x01000008  // char[64]
 #define QUIC_PARAM_GLOBAL_DATAPATH_PROCESSORS           0x01000009  // uint16_t[]
+#define QUIC_PARAM_GLOBAL_TLS_PROVIDER                  0x0100000A  // QUIC_TLS_PROVIDER
 
 //
 // Parameters for Registration.

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -342,6 +342,15 @@ void
 typedef CXPLAT_SEC_CONFIG_CREATE_COMPLETE *CXPLAT_SEC_CONFIG_CREATE_COMPLETE_HANDLER;
 
 //
+// Returns the type of TLS provider in use.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_TLS_PROVIDER
+CxPlatTlsGetProvider(
+    void
+    );
+
+//
 // Creates a new TLS security configuration.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,11 @@ impl Status {
     }
 }
 
+/// The different possible TLS providers used by MsQuic.
+pub type TlsProvider = u32;
+pub const TLS_PROVIDER_SCHANNEL: TlsProvider = 0;
+pub const TLS_PROVIDER_OPENSSL : TlsProvider = 1;
+
 /// Configures how to process a registration's workload.
 pub type ExecutionProfile = u32;
 pub const EXECUTION_PROFILE_LOW_LATENCY: ExecutionProfile = 0;
@@ -669,6 +674,8 @@ pub const PARAM_GLOBAL_SETTINGS: u32 = 0x01000005;
 pub const PARAM_GLOBAL_GLOBAL_SETTINGS: u32 = 0x01000006;
 pub const PARAM_GLOBAL_VERSION_SETTINGS: u32 = 0x01000007;
 pub const PARAM_GLOBAL_LIBRARY_GIT_HASH: u32 = 0x01000008;
+pub const PARAM_GLOBAL_DATAPATH_PROCESSORS: u32 = 0x01000009;
+pub const PARAM_GLOBAL_TLS_PROVIDER: u32 = 0x0100000A;
 
 pub const PARAM_CONFIGURATION_SETTINGS: u32 = 0x03000000;
 pub const PARAM_CONFIGURATION_TICKET_KEYS: u32 = 0x03000001;

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -290,7 +290,7 @@ CxPlatTlsCertificateVerifyCallback(
                (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_USE_PORTABLE_CERTIFICATES)) {
         //
         // We need to get certificates provided by peer if we going to pass them via Callbacks.CertificateReceived.
-        // We don't really care about validation status but without calling X509_verify_cert() x509_ctx has 
+        // We don't really care about validation status but without calling X509_verify_cert() x509_ctx has
         // no certificates attached to it and that impacts validation of custom certificate chains.
         //
         // OpenSSL 3 has X509_build_chain() to build just the chain.
@@ -926,6 +926,15 @@ CXPLAT_STATIC_ASSERT(
 CXPLAT_STATIC_ASSERT(
     FIELD_OFFSET(QUIC_CERTIFICATE_FILE, CertificateFile) == FIELD_OFFSET(QUIC_CERTIFICATE_FILE_PROTECTED, CertificateFile),
     "Mismatch (certificate file) in certificate file structs");
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_TLS_PROVIDER
+CxPlatTlsGetProvider(
+    void
+    )
+{
+    return QUIC_TLS_PROVIDER_OPENSSL;
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -919,6 +919,15 @@ CxPlatTlsAchWorker(
 
 #endif
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_TLS_PROVIDER
+CxPlatTlsGetProvider(
+    void
+    )
+{
+    return QUIC_TLS_PROVIDER_SCHANNEL;
+}
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 CxPlatTlsSecConfigCreate(

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -23,6 +23,24 @@ void QuicTestValidateApi()
         MsQuicOpen2(nullptr));
 
     MsQuicClose(nullptr);
+
+    // TODO - Move these into GetParam/SetParam tests
+    QUIC_TLS_PROVIDER TlsProvider;
+    uint32_t BufferLength = sizeof(TlsProvider);
+    TEST_QUIC_SUCCEEDED(
+        MsQuic->GetParam(
+            nullptr,
+            QUIC_PARAM_GLOBAL_TLS_PROVIDER,
+            &BufferLength,
+            &TlsProvider));
+
+    TEST_EQUAL(
+        MsQuic->SetParam(
+            nullptr,
+            QUIC_PARAM_GLOBAL_TLS_PROVIDER,
+            BufferLength,
+            &TlsProvider),
+        QUIC_STATUS_INVALID_PARAMETER);
 }
 
 void QuicTestValidateRegistration()


### PR DESCRIPTION
## Description

Fixes #2761. Adds a new parameter that can be called via GetParam to query the compiled in TLS provider. This allows application code to handle any TLS provider specific differences.

cc @rzikm

## Testing

Added get/set test.

## Documentation

Updated for new parameter.
