### PR TITLE
Support multiple expected certificate validation results in tests

### DIFF
--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         chmod +x artifacts/bin/linux/${{matrix.arch}}_Release_${{matrix.tls}}/msquictest
         $env:LD_LIBRARY_PATH = Join-Path (Get-Location).Path "artifacts/bin/linux/${{matrix.arch}}_Release_${{matrix.tls}}"
-        scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*CredValidation*:*ConnectClientCertificate*
+        scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*CredValidation*
     - name: Run Tests (Windows)
       if: runner.os == 'Windows'
       run: scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         chmod +x artifacts/bin/linux/${{matrix.arch}}_Release_${{matrix.tls}}/msquictest
         $env:LD_LIBRARY_PATH = Join-Path (Get-Location).Path "artifacts/bin/linux/${{matrix.arch}}_Release_${{matrix.tls}}"
-        scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*CredValidation*
+        scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*CredValidation*:*ConnectClientCertificate*
     - name: Run Tests (Windows)
       if: runner.os == 'Windows'
       run: scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.arch }} -Tls ${{ matrix.tls }} -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -123,9 +123,11 @@ ListenerAcceptConnection(
         (*AcceptContext->NewConnection)->SetExpectedTransportCloseStatus(
             AcceptContext->ExpectedTransportCloseStatus);
     }
-    if (AcceptContext->ExpectedClientCertValidationResult != QUIC_STATUS_SUCCESS) {
-        (*AcceptContext->NewConnection)->SetExpectedClientCertValidationResult(
-            AcceptContext->ExpectedClientCertValidationResult);
+    if (AcceptContext->ExpectedClientCertValidationResultCount > 0) {
+        for (unsigned i = 0; i < AcceptContext->ExpectedClientCertValidationResultCount; i++) {
+            (*AcceptContext->NewConnection)->AddExpectedClientCertValidationResult(
+                AcceptContext->ExpectedClientCertValidationResult[i]);
+        }
     }
     if (AcceptContext->PeerCertEventReturnStatus != QUIC_STATUS_SUCCESS) {
         (*AcceptContext->NewConnection)->SetPeerCertEventReturnStatus(
@@ -2281,9 +2283,9 @@ QuicTestConnectClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_CERT_UNTRUSTED_ROOT;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
             if (!UseClientCertificate) {
-                ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_CERT_NO_CERT;
+                ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_NO_CERT);
                 ServerAcceptCtx.PeerCertEventReturnStatus = QUIC_STATUS_CONNECTION_REFUSED;
                 ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_REQUIRED_CERTIFICATE;
             }
@@ -2578,7 +2580,7 @@ QuicTestConnectValidClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_SUCCESS;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_SUCCESS);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2641,7 +2643,7 @@ QuicTestConnectExpiredClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_CERT_EXPIRED;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_EXPIRED);
             Listener.Context = &ServerAcceptCtx;
 
             {

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -67,7 +67,8 @@ class TestConnection
     bool ExpectedResumed    : 1;
     QUIC_STATUS ExpectedTransportCloseStatus;
     QUIC_UINT62 ExpectedPeerCloseErrorCode;
-    QUIC_STATUS ExpectedClientCertValidationResult;
+    QUIC_STATUS ExpectedClientCertValidationResult[2];
+    uint32_t ExpectedClientCertValidationResultCount;
     bool ExpectedCustomValidationResult;
     QUIC_STATUS PeerCertEventReturnStatus;
 
@@ -208,8 +209,13 @@ public:
     void SetExpectedCustomValidationResult(bool AcceptCert) { CustomValidationResultSet = true; ExpectedCustomValidationResult = AcceptCert; }
     void SetAsyncCustomValidationResult(bool Async) { AsyncCustomValidation = Async; }
 
-    QUIC_STATUS GetExpectedClientCertValidationResult() const { return ExpectedClientCertValidationResult; }
-    void SetExpectedClientCertValidationResult(QUIC_STATUS Status) { ExpectedClientCertValidationResult = Status; }
+    const QUIC_STATUS* GetExpectedClientCertValidationResult() const { return ExpectedClientCertValidationResult; }
+    void AddExpectedClientCertValidationResult(QUIC_STATUS Status) {
+        CXPLAT_FRE_ASSERTMSG(
+            ExpectedClientCertValidationResultCount < ARRAYSIZE(ExpectedClientCertValidationResult),
+            "Only two expected values supported.");
+        ExpectedClientCertValidationResult[ExpectedClientCertValidationResultCount++] = Status;
+    }
 
     void SetPeerCertEventReturnStatus(QUIC_STATUS Value) { PeerCertEventReturnStatus = Value; }
 

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -80,7 +80,8 @@ struct ServerAcceptContext {
     CXPLAT_EVENT NewConnectionReady;
     TestConnection** NewConnection;
     QUIC_STATUS ExpectedTransportCloseStatus{QUIC_STATUS_SUCCESS};
-    QUIC_STATUS ExpectedClientCertValidationResult{QUIC_STATUS_SUCCESS};
+    QUIC_STATUS ExpectedClientCertValidationResult[2]{};
+    uint32_t ExpectedClientCertValidationResultCount{0};
     QUIC_STATUS PeerCertEventReturnStatus{false};
     ServerAcceptContext(TestConnection** _NewConnection) :
         NewConnection(_NewConnection) {
@@ -88,6 +89,12 @@ struct ServerAcceptContext {
     }
     ~ServerAcceptContext() {
         CxPlatEventUninitialize(NewConnectionReady);
+    }
+    void AddExpectedClientCertValidationResult(QUIC_STATUS Status) {
+        CXPLAT_FRE_ASSERTMSG(
+            ExpectedClientCertValidationResultCount < ARRAYSIZE(ExpectedClientCertValidationResult),
+            "Only two expected values supported.");
+        ExpectedClientCertValidationResult[ExpectedClientCertValidationResultCount++] = Status;
     }
 };
 


### PR DESCRIPTION
## Description

Fixes #2758, but will need to be backported to the 2.0 release in order for the tests to pass.

## Testing

CI.

## Documentation

N/A
