### PR TITLE
Add synchronization for EC contexts

### DIFF
--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -445,12 +445,12 @@ BOOLEAN
 
 typedef struct CXPLAT_EXECUTION_CONTEXT {
 
+    CXPLAT_SLIST_ENTRY Entry;
     void* Context;
     void* CxPlatContext;
     CXPLAT_EXECUTION_FN Callback;
 
-    QUIC_CACHEALIGN CXPLAT_SLIST_ENTRY Entry;
-    QUIC_CACHEALIGN uint64_t NextTimeUs;
+    uint64_t NextTimeUs;
     QUIC_CACHEALIGN BOOLEAN Ready;
 
 } CXPLAT_EXECUTION_CONTEXT;

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -449,10 +449,9 @@ typedef struct CXPLAT_EXECUTION_CONTEXT {
     void* CxPlatContext;
     CXPLAT_EXECUTION_FN Callback;
 
-    QUIC_CACHEALIGN
-    CXPLAT_SLIST_ENTRY Entry;
-    uint64_t NextTimeUs;
-    BOOLEAN Ready;
+    QUIC_CACHEALIGN CXPLAT_SLIST_ENTRY Entry;
+    QUIC_CACHEALIGN uint64_t NextTimeUs;
+    QUIC_CACHEALIGN BOOLEAN Ready;
 
 } CXPLAT_EXECUTION_CONTEXT;
 

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -449,7 +449,6 @@ typedef struct CXPLAT_EXECUTION_CONTEXT {
     void* Context;
     void* CxPlatContext;
     CXPLAT_EXECUTION_FN Callback;
-
     uint64_t NextTimeUs;
     QUIC_CACHEALIGN BOOLEAN Ready;
 

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -449,7 +449,7 @@ typedef struct CXPLAT_EXECUTION_CONTEXT {
     void* CxPlatContext;
     CXPLAT_EXECUTION_FN Callback;
 
-    DECLSPEC_CACHEALIGN
+    QUIC_CACHEALIGN
     CXPLAT_SLIST_ENTRY Entry;
     uint64_t NextTimeUs;
     BOOLEAN Ready;

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -445,10 +445,12 @@ BOOLEAN
 
 typedef struct CXPLAT_EXECUTION_CONTEXT {
 
-    CXPLAT_SLIST_ENTRY Entry;
     void* Context;
     void* CxPlatContext;
     CXPLAT_EXECUTION_FN Callback;
+
+    DECLSPEC_CACHEALIGN
+    CXPLAT_SLIST_ENTRY Entry;
     uint64_t NextTimeUs;
     BOOLEAN Ready;
 

--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -224,15 +224,9 @@ CxPlatRunExecutionContexts(
 {
     Worker->ECsReady = FALSE;
     Worker->ECsReadyTime = UINT64_MAX;
-    CXPLAT_SLIST_ENTRY** EC;
-    CXPLAT_SLIST_ENTRY* ListHead;
 
     CxPlatLockAcquire(&Worker->ECLock);
-    ListHead = Worker->ExecutionContexts;
-    Worker->ExecutionContexts = NULL;
-    CxPlatLockRelease(&Worker->ECLock);
-
-    EC = &ListHead;
+    CXPLAT_SLIST_ENTRY** EC = &Worker->ExecutionContexts;
     while (*EC != NULL) {
         CXPLAT_EXECUTION_CONTEXT* Context =
             CXPLAT_CONTAINING_RECORD(*EC, CXPLAT_EXECUTION_CONTEXT, Entry);
@@ -250,13 +244,7 @@ CxPlatRunExecutionContexts(
         }
         EC = &Context->Entry.Next;
     }
-
-    if (ListHead) {
-        CxPlatLockAcquire(&Worker->ECLock);
-        *EC = Worker->ExecutionContexts;
-        Worker->ExecutionContexts = ListHead;
-        CxPlatLockRelease(&Worker->ECLock);
-    }
+    CxPlatLockRelease(&Worker->ECLock);
 }
 
 #endif

--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -47,7 +47,7 @@ typedef struct QUIC_CACHEALIGN CXPLAT_WORKER {
     //
     // Serializes access to the execution contexts.
     //
-    CXPLAT_DISPATCH_LOCK ECLock;
+    CXPLAT_LOCK ECLock;
 
     //
     // The set of actively registered execution contexts.

--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -133,7 +133,9 @@ CxPlatWorkersInit(
     CxPlatZeroMemory(CxPlatWorkers, WorkersSize);
     for (uint32_t i = 0; i < CxPlatWorkerCount; ++i) {
         CxPlatWorkers[i].Running = TRUE;
+#ifdef QUIC_USE_EXECUTION_CONTEXTS
         CxPlatLockInitialize(&CxPlatWorkers[i].ECLock);
+#endif // QUIC_USE_EXECUTION_CONTEXTS
         CxPlatEventInitialize(&CxPlatWorkers[i].WakeEvent, FALSE, FALSE);
         ThreadConfig.IdealProcessor = (uint16_t)i;
         ThreadConfig.Context = &CxPlatWorkers[i];
@@ -153,7 +155,9 @@ Error:
         CxPlatEventSet(CxPlatWorkers[i].WakeEvent);
         CxPlatThreadWait(&CxPlatWorkers[i].Thread);
         CxPlatThreadDelete(&CxPlatWorkers[i].Thread);
+#ifdef QUIC_USE_EXECUTION_CONTEXTS
         CxPlatLockUninitialize(&CxPlatWorkers[i].ECLock);
+#endif // QUIC_USE_EXECUTION_CONTEXTS
         CxPlatEventUninitialize(CxPlatWorkers[i].WakeEvent);
     }
 
@@ -174,7 +178,9 @@ CxPlatWorkersUninit(
         CxPlatEventSet(CxPlatWorkers[i].WakeEvent);
         CxPlatThreadWait(&CxPlatWorkers[i].Thread);
         CxPlatThreadDelete(&CxPlatWorkers[i].Thread);
+#ifdef QUIC_USE_EXECUTION_CONTEXTS
         CxPlatLockUninitialize(&CxPlatWorkers[i].ECLock);
+#endif // QUIC_USE_EXECUTION_CONTEXTS
         CxPlatEventUninitialize(CxPlatWorkers[i].WakeEvent);
     }
 

--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -190,10 +190,6 @@ CxPlatWorkersUninit(
 
 #ifdef QUIC_USE_EXECUTION_CONTEXTS
 
-//
-// TODO - Add synchronization around ExecutionContexts
-//
-
 void
 CxPlatAddExecutionContext(
     _Inout_ CXPLAT_EXECUTION_CONTEXT* Context,


### PR DESCRIPTION
## Description

Add synchronization for EC contexts to solve #2763. Since EC contexts are uncontended except for registration init/uninit, simply taking a CS lock to synchronize the access should be performant enough.

## Testing

CI