### PR TITLE
GetParam for QUIC_PARAM_STREAM_ID must be called 'after' StreamStart

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -178,7 +178,7 @@ These parameters are access by calling [GetParam](./api/GetParam.md) or [SetPara
 
 | Setting                                           | Type              | Get/Set   | Description                                                                           |
 |---------------------------------------------------|-------------------|-----------|---------------------------------------------------------------------------------------|
-| `QUIC_PARAM_STREAM_ID`<br> 0                      | QUIC_UINT62       | Get-only  | Must be called on a stream before [StreamStart](./api/StreamStart.md) is called.      |
+| `QUIC_PARAM_STREAM_ID`<br> 0                      | QUIC_UINT62       | Get-only  | Must be called on a stream after [StreamStart](./api/StreamStart.md) is called.      |
 | `QUIC_PARAM_STREAM_0RTT_LENGTH`<br> 1             | uint64_t          | Get-only  | Length of 0-RTT data received from peer.                                              |
 | `QUIC_PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE`<br> 2  | uint64_t - bytes  | Get-only  | Ideal buffer size to queue to the stream. Assumes only one stream sends steadily.     |
 


### PR DESCRIPTION
## Description

before -> after
https://github.com/microsoft/msquic/blob/033e621493decdaa13f482fdcab5e94cde1ce16c/src/core/stream.c#L642-L651

## Testing

N/A

## Documentation

This is doc
