### PR TITLE
Changing BPF filter to avoid collisions when selecting CPU between HW interruptions and socket managing  

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -914,6 +914,7 @@ CxPlatSocketConfigureRss(
 
     struct sock_filter BpfCode[] = {
         {BPF_LD | BPF_W | BPF_ABS, 0, 0, SKF_AD_OFF | SKF_AD_CPU},
+        {BPF_ALU | BPF_ADD, 0, 0, 3},
         {BPF_ALU | BPF_MOD, 0, 0, SocketCount},
         {BPF_RET | BPF_A, 0, 0, 0}
     };


### PR DESCRIPTION
## Description

I discovered that when using the throughput test downloading, the client opens a socket in CPU X, sends the requests and then it receives traffic and HW interruptions are handle in CPU Y (because of RSS hash assignation). Y and X may be the same but it is not common. On the other way, when uploading the socket and the HW interruptions are colliding in the same CPU because of the port sharing sockets and the filter (that I changed).

## Testing

throughput test comparing upload and download version should be enough


