### PR TITLE
Handle port set rule not found during socket deletion gracefully

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -1293,7 +1293,7 @@ CxPlatDpRawPlumbRulesOnSocket(
                 }
             } else {
                 //
-                // Due to memory allocation falures, we might not have this rule programmed on the interface.
+                // Due to memory allocation failures, we might not have this rule programmed on the interface.
                 //
                 if (Rule) {
                     CxPlatDpRawClearPortBit(

--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -1292,9 +1292,13 @@ CxPlatDpRawPlumbRulesOnSocket(
                     CxPlatDpRawInterfaceAddRules(Interface, &NewRule, 1);
                 }
             } else {
-                CXPLAT_DBG_ASSERT(Rule);
-                CxPlatDpRawClearPortBit(
-                    Rule->Pattern.IpPortSet.PortSet.PortSet, Socket->LocalAddress.Ipv4.sin_port);
+                //
+                // Due to memory allocation falures, we might not have this rule programmed on the interface.
+                //
+                if (Rule) {
+                    CxPlatDpRawClearPortBit(
+                        Rule->Pattern.IpPortSet.PortSet.PortSet, Socket->LocalAddress.Ipv4.sin_port);
+                }
                 CxPlatLockRelease(&Interface->RuleLock);
             }
         }


### PR DESCRIPTION
## Description

It's possible that due to memory allocation failures, the port set rule isn't programmed on the interface during socket creation and during socket deletion, we incorrectly assume we can always find the corresponding rule for the socket.

Fixes #2793.

## Testing

CI
