### PR TITLE
Clean up datapath on route resolution init failure

### DIFF
--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -114,8 +114,8 @@ CxPlatDataPathInitialize(
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const size_t DatapathSize = CxPlatDpRawGetDatapathSize(Config);
-    BOOLEAN DpRawInit = FALSE;
-    BOOLEAN SocketPoolInit = FALSE;
+    BOOLEAN DpRawInitialized = FALSE;
+    BOOLEAN SocketPoolInitialized = FALSE;
     CXPLAT_FRE_ASSERT(DatapathSize > sizeof(CXPLAT_DATAPATH));
 
     UNREFERENCED_PARAMETER(TcpCallbacks);
@@ -154,14 +154,14 @@ CxPlatDataPathInitialize(
         goto Error;
     }
 
-    SocketPoolInit = TRUE;
+    SocketPoolInitialized = TRUE;
 
     Status = CxPlatDpRawInitialize(*NewDataPath, ClientRecvContextLength, Config);
     if (QUIC_FAILED(Status)) {
         goto Error;
     }
 
-    DpRawInit = TRUE;
+    DpRawInitialized = TRUE;
 
     Status = CxPlatDataPathRouteWorkerInitialize(*NewDataPath);
     if (QUIC_FAILED(Status)) {
@@ -172,11 +172,11 @@ Error:
 
     if (QUIC_FAILED(Status)) {
         if (*NewDataPath != NULL) {
-            if (DpRawInit) {
+            if (DpRawInitialized) {
                 CxPlatDpRawUninitialize(*NewDataPath);
             }
 
-            if (SocketPoolInit) {
+            if (SocketPoolInitialized) {
                 CxPlatSockPoolUninitialize(&(*NewDataPath)->SocketPool);
             }
 

--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -160,6 +160,8 @@ CxPlatDataPathInitialize(
 
     Status = CxPlatDataPathRouteWorkerInitialize(*NewDataPath);
     if (QUIC_FAILED(Status)) {
+        CxPlatDpRawUninitialize(*NewDataPath);
+        CxPlatSockPoolUninitialize(&(*NewDataPath)->SocketPool);
         goto Error;
     }
 

--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -115,7 +115,7 @@ CxPlatDataPathInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const size_t DatapathSize = CxPlatDpRawGetDatapathSize(Config);
     BOOLEAN DpRawInitialized = FALSE;
-    BOOLEAN SocketPoolInitialized = FALSE;
+    BOOLEAN SockPoolInitialized = FALSE;
     CXPLAT_FRE_ASSERT(DatapathSize > sizeof(CXPLAT_DATAPATH));
 
     UNREFERENCED_PARAMETER(TcpCallbacks);
@@ -154,7 +154,7 @@ CxPlatDataPathInitialize(
         goto Error;
     }
 
-    SocketPoolInitialized = TRUE;
+    SockPoolInitialized = TRUE;
 
     Status = CxPlatDpRawInitialize(*NewDataPath, ClientRecvContextLength, Config);
     if (QUIC_FAILED(Status)) {
@@ -176,7 +176,7 @@ Error:
                 CxPlatDpRawUninitialize(*NewDataPath);
             }
 
-            if (SocketPoolInitialized) {
+            if (SockPoolInitialized) {
                 CxPlatSockPoolUninitialize(&(*NewDataPath)->SocketPool);
             }
 


### PR DESCRIPTION
## Description

Hit an assert in CI:
```
CXPLAT_FRE_ASSERTMSG(Worker->DatapathEC == NULL, "Only one datapath allowed!");

0d 00000062`504ff6c0 00007ff8`bd8e7aa3     msquic!CxPlatWorkerRegisterDataPath+0x76 [D:\a\1\msquic\src\platform\platform_worker.c @ 97] 
0e 00000062`504ff700 00007ff8`bd8dbe8b     msquic!CxPlatDpRawInitialize+0x683 [D:\a\1\msquic\src\platform\datapath_raw_xdp.c @ 1111] 
0f 00000062`504ff7f0 00007ff8`bd873ad4     msquic!CxPlatDataPathInitialize+0x24b [D:\a\1\msquic\src\platform\datapath_raw.c @ 155] 
10 00000062`504ff860 00007ff6`7b4139fd     msquic!MsQuicRegistrationOpen+0x214 [D:\a\1\msquic\src\core\registration.c @ 70] 
11 00000062`504ff960 00007ff8`f6f64ed0     spinquic!RunThread+0x2cd [D:\a\1\msquic\src\tools\spin\spinquic.cpp @ 965] 
```
DatapathEC isn't null when registering the datapath EC during datapath initialization. This is because in CxPlatDataPathInitialize, we don't do proper clean-up for the CxPlatDpRawInitialize call if later CxPlatDataPathRouteWorkerInitialize fails.


## Testing

CI