### PR TITLE
Fix RECEIVE BufferCount SAL Annotation

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1234,7 +1234,7 @@ typedef struct QUIC_STREAM_EVENT {
             /* inout */ uint64_t TotalBufferLength;
             _Field_size_(BufferCount)
             /* in */    const QUIC_BUFFER* Buffers;
-            _Field_range_(1, UINT32_MAX)
+            _Field_range_(0, UINT32_MAX)
             /* in */    uint32_t BufferCount;
             /* in */    QUIC_RECEIVE_FLAGS Flags;
         } RECEIVE;


### PR DESCRIPTION
## Description

I noticed the SAL annotation on the RECEIVE event for a stream wasn't correctly indicating that the `BufferCount` could be zero (in the FIN only case).

## Testing

N/A

## Documentation

N/A
