### PR TITLE
Add NI_RELEASE to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -19,7 +19,8 @@ body:
       options:
         - label: All
         - label: Windows Server 2022
-        - label: Windows 11
+        - label: Windows 11, version 22H2
+        - label: Windows 11, version 21H2
         - label: Windows Insider Preview (specify affected build below)
         - label: Ubuntu
         - label: Debian


### PR DESCRIPTION
## Description
Renamed CO_RELEASE to "Windows 11, version 21H2" and added NI_RELEASE to the list of affected operating systems in the issue template.

## Testing
N/A

## Documentation
N/A
