### PR TITLE
Improvements to Latency of Receive Code Paths

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1264,8 +1264,9 @@ MsQuicStreamReceiveComplete(
             (uint32_t)QUIC_STATUS_INVALID_STATE);
         goto Exit;
     }
-    
-    if (Connection->WorkerThreadID == CxPlatCurThreadID()) {
+
+    if (Connection->WorkerThreadID == CxPlatCurThreadID() &&
+        Stream->Flags.ReceiveCallActive) {
 
         CXPLAT_PASSIVE_CODE();
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1269,9 +1269,6 @@ MsQuicStreamReceiveComplete(
 
         CXPLAT_PASSIVE_CODE();
 
-        //
-        // Execute this blocking API call inline if called on the worker thread.
-        //
         BOOLEAN AlreadyInline = Connection->State.InlineApiExecution;
         if (!AlreadyInline) {
             Connection->State.InlineApiExecution = TRUE;

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1281,7 +1281,7 @@ MsQuicStreamReceiveComplete(
             Connection->State.InlineApiExecution = FALSE;
         }
 
-        goto Error;
+        goto Exit;
     }
 
     Oper = InterlockedFetchAndClearPointer((void**)&Stream->ReceiveCompleteOperation);

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -150,10 +150,6 @@ typedef union QUIC_STREAM_FLAGS {
     };
 } QUIC_STREAM_FLAGS;
 
-CXPLAT_STATIC_ASSERT(
-    sizeof(QUIC_STREAM_FLAGS) == sizeof(QUIC_STREAM_FLAGS::AllFlags),
-    "QUIC_STREAM_FLAGS AllFlags size is mismatched.");
-
 typedef enum QUIC_STREAM_SEND_STATE {
     QUIC_STREAM_SEND_DISABLED,
     QUIC_STREAM_SEND_STARTED,

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -150,6 +150,10 @@ typedef union QUIC_STREAM_FLAGS {
     };
 } QUIC_STREAM_FLAGS;
 
+CXPLAT_STATIC_ASSERT(
+    sizeof(QUIC_STREAM_FLAGS) == sizeof(QUIC_STREAM_FLAGS::AllFlags),
+    "QUIC_STREAM_FLAGS AllFlags size is mismatched.");
+
 typedef enum QUIC_STREAM_SEND_STATE {
     QUIC_STREAM_SEND_DISABLED,
     QUIC_STREAM_SEND_STARTED,
@@ -390,6 +394,12 @@ typedef struct QUIC_STREAM {
     // The length of the pending receive call to the app.
     //
     uint64_t RecvPendingLength;
+
+    //
+    // The length of any inline receive complete call by the app. UINT64_MAX
+    // indicates that no inline call was made.
+    //
+    uint64_t RecvInlineCompletionLength;
 
     //
     // The error code for why the receive path was shutdown.

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -106,7 +106,7 @@ typedef struct QUIC_SEND_REQUEST {
 // Note - Keep quictypes.h's copy up to date.
 //
 typedef union QUIC_STREAM_FLAGS {
-    uint32_t AllFlags;
+    uint64_t AllFlags;
     struct {
         BOOLEAN Allocated               : 1;    // Allocated by Connection. Used for Debugging.
         BOOLEAN Initialized             : 1;    // Initialized successfully. Used for Debugging.
@@ -138,6 +138,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN ReceiveFlushQueued      : 1;    // The receive flush operation is queued.
         BOOLEAN ReceiveDataPending      : 1;    // Data (or FIN) is queued and ready for delivery.
         BOOLEAN ReceiveCallPending      : 1;    // There is an uncompleted receive to the app.
+        BOOLEAN ReceiveCallActive       : 1;    // There is an active receive to the app.
         BOOLEAN SendDelayed             : 1;    // A delayed send is currently queued.
 
         BOOLEAN HandleSendShutdown      : 1;    // Send shutdown complete callback delivered.
@@ -149,6 +150,10 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
     };
 } QUIC_STREAM_FLAGS;
+
+CXPLAT_STATIC_ASSERT(
+    sizeof(QUIC_STREAM_FLAGS) == sizeof(uint64_t),
+    "QUIC_STREAM_FLAGS AllFlags size is mismatched.");
 
 typedef enum QUIC_STREAM_SEND_STATE {
     QUIC_STREAM_SEND_DISABLED,

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -859,6 +859,16 @@ QuicStreamReceiveCompletePending(
     );
 
 //
+// Completes a receive call inline from a callback.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicStreamReceiveCompleteInline(
+    _In_ QUIC_STREAM* Stream,
+    _In_ uint64_t BufferLength
+    );
+
+//
 // Processes a received frame for the given stream.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -163,9 +163,9 @@ tracepoint(CLOG_STREAM_RECV_C, TreatFinAsReset , arg1);\
 // Decoder Ring for QueueRecvFlush
 // [strm][%p] Queuing recv flush
 // QuicTraceLogStreamVerbose(
-            QueueRecvFlush,
-            Stream,
-            "Queuing recv flush");
+                QueueRecvFlush,
+                Stream,
+                "Queuing recv flush");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_QueueRecvFlush
@@ -419,10 +419,10 @@ tracepoint(CLOG_STREAM_RECV_C, StreamRecvState , arg2, arg3);\
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
-                AllocFailure,
-                "Allocation of '%s' failed. (%llu bytes)",
-                "Flush Stream Recv operation",
-                0);
+                    AllocFailure,
+                    "Allocation of '%s' failed. (%llu bytes)",
+                    "Flush Stream Recv operation",
+                    0);
 // arg2 = arg2 = "Flush Stream Recv operation" = arg2
 // arg3 = arg3 = 0 = arg3
 ----------------------------------------------------------*/

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -138,9 +138,9 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, TreatFinAsReset,
 // Decoder Ring for QueueRecvFlush
 // [strm][%p] Queuing recv flush
 // QuicTraceLogStreamVerbose(
-            QueueRecvFlush,
-            Stream,
-            "Queuing recv flush");
+                QueueRecvFlush,
+                Stream,
+                "Queuing recv flush");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, QueueRecvFlush,
@@ -429,10 +429,10 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, StreamRecvState,
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
-                AllocFailure,
-                "Allocation of '%s' failed. (%llu bytes)",
-                "Flush Stream Recv operation",
-                0);
+                    AllocFailure,
+                    "Allocation of '%s' failed. (%llu bytes)",
+                    "Flush Stream Recv operation",
+                    0);
 // arg2 = arg2 = "Flush Stream Recv operation" = arg2
 // arg3 = arg3 = 0 = arg3
 ----------------------------------------------------------*/


### PR DESCRIPTION
## Description

1. Updates the receive flush code to run inline if it's the end of the buffer.
2. Optimizes for apps that call receive complete in the receive callback, instead of just returning success.

## Testing

Existing tests?

## Documentation

N/A?
