### PR TITLE
PTO is artificially inflated to the default worker queue delay

### DIFF
--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -234,9 +234,6 @@ QuicLossDetectionComputeProbeTimeout(
         4 * Path->RttVariance +
         (uint32_t)MS_TO_US(Connection->PeerTransportParams.MaxAckDelay);
     Pto *= Count;
-    if (Pto < Connection->Settings.MaxWorkerQueueDelayUs) {
-        Pto = Connection->Settings.MaxWorkerQueueDelayUs;
-    }
     return Pto;
 }
 


### PR DESCRIPTION
## Description

PTO is artificially inflated to the default worker queue delay when the calculated PTO value is less than that. Remove this inflation for now because it's causing long tails in lola perf tests.

## Testing

CI

