### PR TITLE
Expose Wire Format Error Code on Close

### DIFF
--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -18,6 +18,7 @@ typedef struct QUIC_CONNECTION_EVENT {
         } CONNECTED;
         struct {
             QUIC_STATUS Status;
+            QUIC_UINT62 ErrorCode; // Wire format error code.
         } SHUTDOWN_INITIATED_BY_TRANSPORT;
         struct {
             QUIC_UINT62 ErrorCode;
@@ -112,6 +113,10 @@ This event is delivered whenever the transport (e.g. QUIC layer) determines the 
 `Status`
 
 The platform status code that indicates the reason for the shutdown.
+
+`ErrorCode`
+
+The wire format error code that indicates the reason for the shutdown.
 
 ## QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1401,6 +1401,7 @@ QuicConnIndicateShutdownBegin(
     } else {
         Event.Type = QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT;
         Event.SHUTDOWN_INITIATED_BY_TRANSPORT.Status = Connection->CloseStatus;
+        Event.SHUTDOWN_INITIATED_BY_TRANSPORT.ErrorCode = Connection->CloseErrorCode;
         QuicTraceLogConnVerbose(
             IndicateShutdownByTransport,
             Connection,

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -2035,6 +2035,9 @@ namespace Microsoft.Quic
             {
                 [NativeTypeName("HRESULT")]
                 internal int Status;
+
+                [NativeTypeName("QUIC_UINT62")]
+                internal ulong ErrorCode;
             }
 
             internal partial struct _SHUTDOWN_INITIATED_BY_PEER_e__Struct

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1051,6 +1051,7 @@ typedef struct QUIC_CONNECTION_EVENT {
         } CONNECTED;
         struct {
             QUIC_STATUS Status;
+            QUIC_UINT62 ErrorCode; // Wire format error code.
         } SHUTDOWN_INITIATED_BY_TRANSPORT;
         struct {
             QUIC_UINT62 ErrorCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,7 +803,8 @@ pub struct ConnectionEventConnected {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ConnectionEventConnectionShutdownByTransport {
-    pub status: u64,
+    pub status: u32,
+    pub error_code: u62,
 }
 
 #[repr(C)]


### PR DESCRIPTION
## Description

Fixes #2851. It exposes the wire format error code to the app.

## Testing

No new tests were added.

## Documentation

Update API docs
