### PR TITLE
RPS Perf Client Custom Local Addresses

### DIFF
--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -24,6 +24,8 @@ PrintHelp(
         "RPS Client options:\n"
         "\n"
         "  -target:<####>              The target server to connect to.\n"
+        "  -bind:<addr>                Local IP address(es) to bind to.\n"
+        "  -addrs:<####>               The number of local addresses to use (def:%u).\n"
         "  -runtime:<####>             The total runtime (in ms). (def:%u)\n"
         "  -encrypt:<0/1>              Enables/disables encryption. (def:1)\n"
         "  -inline:<0/1>               Configured sending requests inline. (def:0)\n"
@@ -38,6 +40,7 @@ PrintHelp(
         "  -affinitize:<0/1>           Affinitizes threads to a core. (def:0)\n"
         "  -sendbuf:<0/1>              Whether to use send buffering. (def:0)\n"
         "\n",
+        RPS_MAX_CLIENT_PORT_COUNT,
         RPS_DEFAULT_RUN_TIME,
         PERF_DEFAULT_PORT,
         RPS_DEFAULT_CONNECTION_COUNT,
@@ -76,6 +79,29 @@ RpsClient::Init(
     CxPlatCopyMemory(Target.get(), target, Len);
     Target[Len] = '\0';
 
+    char* LocalAddress = nullptr;
+    if (TryGetValue(argc, argv, "bind", (const char**)&LocalAddress)) {
+        SpecificLocalAddresses = true;
+        LocalAddressCount = 0;
+        while (LocalAddress) {
+            char* AddrEnd = strchr(LocalAddress, ',');
+            if (AddrEnd) {
+                *AddrEnd = '\0';
+                AddrEnd++;
+            }
+            if (!ConvertArgToAddress(LocalAddress, 0, &LocalAddresses[LocalAddressCount++])) {
+                WriteOutput("Failed to decode IP address: '%s'!\nMust be *, a IPv4 or a IPv6 address.\n", LocalAddress);
+                PrintHelp();
+                return QUIC_STATUS_INVALID_PARAMETER;
+            }
+            LocalAddress = AddrEnd;
+        }
+    }
+
+    if (TryGetValue(argc, argv, "addrs", &LocalAddressCount) &&
+        LocalAddressCount > RPS_MAX_CLIENT_PORT_COUNT) {
+        LocalAddressCount = RPS_MAX_CLIENT_PORT_COUNT;
+    }
     TryGetValue(argc, argv, "runtime", &RunTime);
     TryGetValue(argc, argv, "encrypt", &UseEncryption);
     TryGetValue(argc, argv, "inline", &SendInline);
@@ -280,13 +306,13 @@ RpsClient::Start(
             }
         }
 
-        if (i >= RPS_MAX_CLIENT_PORT_COUNT) {
+        if (SpecificLocalAddresses || i >= LocalAddressCount) {
             Status =
                 MsQuic->SetParam(
                     Connections[i],
                     QUIC_PARAM_CONN_LOCAL_ADDRESS,
                     sizeof(QUIC_ADDR),
-                    &LocalAddresses[i % RPS_MAX_CLIENT_PORT_COUNT]);
+                    &LocalAddresses[i % LocalAddressCount]);
             if (QUIC_FAILED(Status)) {
                 WriteOutput("SetParam(CONN_LOCAL_ADDRESS) failed, 0x%x\n", Status);
                 return Status;

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -331,7 +331,7 @@ RpsClient::Start(
             return Status;
         }
 
-        if (i < RPS_MAX_CLIENT_PORT_COUNT) {
+        if (!SpecificLocalAddresses && i < RPS_MAX_CLIENT_PORT_COUNT) {
             uint32_t AddrLen = sizeof(QUIC_ADDR);
             Status =
                 MsQuic->GetParam(

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -24,7 +24,7 @@ PrintHelp(
         "RPS Client options:\n"
         "\n"
         "  -target:<####>              The target server to connect to.\n"
-        "  -bind:<addr>                Local IP address(es) to bind to.\n"
+        "  -bind:<addr>                Local IP address(es)/port(s) to bind to.\n"
         "  -addrs:<####>               The number of local addresses to use (def:%u).\n"
         "  -runtime:<####>             The total runtime (in ms). (def:%u)\n"
         "  -encrypt:<0/1>              Enables/disables encryption. (def:1)\n"

--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -120,6 +120,7 @@ class RpsClient : public PerfBase {
 public:
 
     RpsClient() {
+        CxPlatZeroMemory(LocalAddresses, sizeof(LocalAddresses));
         for (uint32_t i = 0; i < PERF_MAX_THREAD_COUNT; ++i) {
             Workers[i].Client = this;
         }
@@ -171,6 +172,7 @@ public:
             QUIC_CREDENTIAL_FLAG_CLIENT |
             QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION)};
     uint32_t WorkerCount;
+    QUIC_ADDR LocalIpAddr;
     uint16_t Port {PERF_DEFAULT_PORT};
     QUIC_ADDRESS_FAMILY RemoteFamily {QUIC_ADDRESS_FAMILY_UNSPEC};
     UniquePtr<char[]> Target;
@@ -194,6 +196,7 @@ public:
     QuicBufferScopeQuicAlloc RequestBuffer;
     CXPLAT_EVENT* CompletionEvent {nullptr};
     QUIC_ADDR LocalAddresses[RPS_MAX_CLIENT_PORT_COUNT];
+    uint32_t LocalAddressCount {RPS_MAX_CLIENT_PORT_COUNT};
     uint32_t ActiveConnections {0};
     CxPlatEvent AllConnected {true};
     uint64_t StartedRequests {0};
@@ -207,4 +210,5 @@ public:
     UniquePtr<RpsConnectionContext[]> Connections {nullptr};
     bool Running {true};
     bool AffinitizeWorkers {false};
+    bool SpecificLocalAddresses {false};
 };


### PR DESCRIPTION
## Description

Allows for the command line to specify a set of local addresses that are used for RPS perf testing.

## Testing

Locally tested

## Documentation

N/A
