### PR TITLE
Fix typo in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ impl Addr {
 pub struct Status {}
 
 impl Status {
-    /// Determines if a MsQuic status is considered a succes, which includes
+    /// Determines if a MsQuic status is considered a success, which includes
     /// both "no error" and "pending" status codes.
     #[cfg(target_os = "windows")]
     pub fn succeeded(status: u32) -> bool {


### PR DESCRIPTION
## Description

Fixes a typo in a comment.
