### PR TITLE
Update to OpenSSL 1.1.1q

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/quictls/openssl.git
-	branch = OpenSSL_1_1_1o+quic
+	branch = OpenSSL_1_1_1q+quic
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git


### PR DESCRIPTION
## Description

Full change log for OpenSSL can be found [here](https://www.openssl.org/news/cl111.txt). The CVE doesn't apply to MsQuic out of the box, but best to stay up to date.

## Testing

Existing automation

## Documentation

N/A
