### PR TITLE
Indicate Stream Start Abort Event from Send Start

### DIFF
--- a/src/core/operation.c
+++ b/src/core/operation.c
@@ -234,6 +234,12 @@ QuicOperationQueueClear(
                             QUIC_STREAM_SHUTDOWN_FLAG_ABORT | QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE,
                             0);
                     }
+                } else if (ApiCtx->Type == QUIC_API_TYPE_STRM_SEND &&
+                    !ApiCtx->STRM_START.Stream->Flags.Started) {
+                    QuicStreamShutdown(
+                        ApiCtx->STRM_START.Stream,
+                        QUIC_STREAM_SHUTDOWN_FLAG_ABORT | QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE,
+                        0);
                 }
             }
             QuicOperationFree(Worker, Oper);

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -438,11 +438,17 @@ QuicStreamIndicateStartComplete(
     _In_ QUIC_STATUS Status
     )
 {
+    if (Stream->Flags.StartedIndicated) {
+        return;
+    }
+    Stream->Flags.StartedIndicated = TRUE;
+
     QUIC_STREAM_EVENT Event;
     Event.Type = QUIC_STREAM_EVENT_START_COMPLETE;
     Event.START_COMPLETE.Status = Status;
     Event.START_COMPLETE.ID = Stream->ID;
     Event.START_COMPLETE.PeerAccepted =
+        QUIC_SUCCEEDED(Status) &&
         !(Stream->OutFlowBlockedReasons & QUIC_FLOW_BLOCKED_STREAM_ID_FLOW_CONTROL);
     QuicTraceLogStreamVerbose(
         IndicateStartComplete,

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -111,6 +111,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Allocated               : 1;    // Allocated by Connection. Used for Debugging.
         BOOLEAN Initialized             : 1;    // Initialized successfully. Used for Debugging.
         BOOLEAN Started                 : 1;    // The app has started the stream.
+        BOOLEAN StartedIndicated        : 1;    // The app received a start complete event.
         BOOLEAN Unidirectional          : 1;    // Sends/receives in 1 direction only.
         BOOLEAN Opened0Rtt              : 1;    // A 0-RTT packet opened the stream.
         BOOLEAN IndicatePeerAccepted    : 1;    // The app requested the PEER_ACCEPTED event.

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -378,6 +378,10 @@ QuicStreamCompleteSendRequest(
             !(Stream->SendBufferBookmark->Flags & QUIC_SEND_FLAG_BUFFERED));
     }
 
+    if (SendRequest->Flags & QUIC_SEND_FLAG_START && !Stream->Flags.Started) {
+        QuicStreamIndicateStartComplete(Stream, QUIC_STATUS_ABORTED);
+    }
+
     if (!(SendRequest->Flags & QUIC_SEND_FLAG_BUFFERED)) {
         QUIC_STREAM_EVENT Event;
         Event.Type = QUIC_STREAM_EVENT_SEND_COMPLETE;

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1198,7 +1198,7 @@ struct MsQuicStream {
     MsQuicStream(
         _In_ HQUIC StreamHandle,
         _In_ MsQuicCleanUpMode CleanUpMode,
-        _In_ MsQuicStreamCallback* Callback,
+        _In_ MsQuicStreamCallback* Callback = NoOpCallback,
         _In_ void* Context = nullptr
         ) noexcept : CleanUpMode(CleanUpMode), Callback(Callback), Context(Context) {
         Handle = StreamHandle;

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -27,11 +27,12 @@ typedef enum QUIC_HANDLE_TYPE {
 } QUIC_HANDLE_TYPE;
 
 typedef union QUIC_STREAM_FLAGS {
-    uint32_t AllFlags;
+    uint64_t AllFlags;
     struct {
         BOOLEAN Allocated               : 1;    // Allocated by Connection. Used for Debugging.
         BOOLEAN Initialized             : 1;    // Initialized successfully. Used for Debugging.
         BOOLEAN Started                 : 1;    // The app has started the stream.
+        BOOLEAN StartedIndicated        : 1;    // The app received a start complete event.
         BOOLEAN Unidirectional          : 1;    // Sends/receives in 1 direction only.
         BOOLEAN Opened0Rtt              : 1;    // A 0-RTT packet opened the stream.
         BOOLEAN IndicatePeerAccepted    : 1;    // The app requested the PEER_ACCEPTED event.
@@ -59,6 +60,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN ReceiveFlushQueued      : 1;    // The receive flush operation is queued.
         BOOLEAN ReceiveDataPending      : 1;    // Data (or FIN) is queued and ready for delivery.
         BOOLEAN ReceiveCallPending      : 1;    // There is an uncompleted receive to the app.
+        BOOLEAN ReceiveCallActive       : 1;    // There is an active receive to the app.
         BOOLEAN SendDelayed             : 1;    // A delayed send is currently queued.
 
         BOOLEAN HandleSendShutdown      : 1;    // Send shutdown complete callback delivered.
@@ -592,7 +594,7 @@ struct Stream : Struct {
 
     QUIC_STREAM_FLAGS Flags() {
         QUIC_STREAM_FLAGS Flags;
-        Flags.AllFlags = ReadType<ULONG>("Flags");
+        Flags.AllFlags = ReadType<ULONG64>("Flags");
         return Flags;
     }
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -36,6 +36,7 @@ void QuicTestValidateConfiguration();
 void QuicTestValidateListener();
 void QuicTestValidateConnection();
 void QuicTestValidateStream(bool Connect);
+void QuicTestCloseConnBeforeStreamFlush();
 void QuicTestGlobalParam();
 void QuicTestCommonParam();
 void QuicTestRegistrationParam();
@@ -1059,4 +1060,7 @@ typedef struct {
 #define IOCTL_QUIC_RUN_CONNECTION_CLOSE_FROM_CALLBACK \
     QUIC_CTL_CODE(98, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 98
+#define IOCTL_QUIC_RUN_CLOSE_CONN_BEFORE_STREAM_FLUSH \
+    QUIC_CTL_CODE(99, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 99

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -333,6 +333,15 @@ TEST_P(WithBool, ValidateStream) {
     }
 }
 
+TEST(ParameterValidation, CloseConnBeforeStreamFlush) {
+    TestLogger Logger("QuicTestCloseConnBeforeStreamFlush");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_CLOSE_CONN_BEFORE_STREAM_FLUSH));
+    } else {
+        QuicTestCloseConnBeforeStreamFlush();
+    }
+}
+
 TEST_P(WithValidateConnectionEventArgs, ValidateConnectionEvents) {
     TestLoggerT<ParamType> Logger("QuicTestValidateConnectionEvents", GetParam());
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -470,6 +470,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1247,6 +1248,10 @@ QuicTestCtlEvtIoDeviceControl(
 
     case IOCTL_QUIC_RUN_CONNECTION_CLOSE_FROM_CALLBACK:
         QuicTestCtlRun(QuicTestConnectionCloseFromCallback());
+        break;
+
+    case IOCTL_QUIC_RUN_CLOSE_CONN_BEFORE_STREAM_FLUSH:
+        QuicTestCtlRun(QuicTestCloseConnBeforeStreamFlush());
         break;
 
     default:

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -1804,6 +1804,59 @@ void QuicTestValidateStream(bool Connect)
     }
 }
 
+uint8_t RawNoopBuffer[100];
+QUIC_BUFFER NoopBuffer { sizeof(RawNoopBuffer), RawNoopBuffer };
+
+void QuicTestCloseConnBeforeStreamFlush()
+{
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings()
+            .SetPeerUnidiStreamCount(1),
+        ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings(),
+        MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    struct TestContext {
+        static QUIC_STATUS ServerCallback(_In_ MsQuicConnection*, _In_opt_ void*, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+            if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+                new(std::nothrow) MsQuicStream(Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete);
+            }
+            return QUIC_STATUS_SUCCESS;
+        }
+        static QUIC_STATUS ClientCallback(_In_ MsQuicConnection* Conn, _In_opt_ void*, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+            if (Event->Type == QUIC_CONNECTION_EVENT_CONNECTED) {
+                auto Stream = new(std::nothrow) MsQuicStream(*Conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL, CleanUpAutoDelete);
+                if (QUIC_FAILED(Stream->GetInitStatus()) ||
+                    QUIC_FAILED(Stream->Send(&NoopBuffer, 1, QUIC_SEND_FLAG_START | QUIC_SEND_FLAG_FIN))) {
+                    TEST_FAILURE("Stream creation or send failed.");
+                    delete Stream;
+                }
+                Conn->Close();
+            }
+            return QUIC_STATUS_SUCCESS;
+        }
+    };
+
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, TestContext::ServerCallback);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration,  CleanUpManual, TestContext::ClientCallback);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+
+    CxPlatSleep(50);
+}
+
 class SecConfigTestContext {
 public:
     CXPLAT_EVENT Event;


### PR DESCRIPTION
## Description

For #2869. Updates the send abort logic to indicate a start abort if the send has a start flag.

## Testing

Added new test.

## Documentation

N/A
