### PR TITLE
Include connection close details in stream's SHUTDOWN_COMPLETE

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -470,11 +470,17 @@ QuicStreamIndicateShutdownComplete(
             Stream->Connection->State.ClosedRemotely;
         Event.SHUTDOWN_COMPLETE.AppCloseInProgress =
             Stream->Flags.HandleClosed;
+        Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer =
+            Stream->Connection->State.AppClosed;
+        Event.SHUTDOWN_COMPLETE.ConnectionErrorCode =
+            Stream->Connection->CloseErrorCode;
         QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
-            Event.SHUTDOWN_COMPLETE.ConnectionShutdown);
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]",
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer,
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
         (void)QuicStreamIndicateEvent(Stream, &Event);
 
         Stream->ClientCallbackHandler = NULL;

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -2410,19 +2410,36 @@ namespace Microsoft.Quic
                     }
                 }
 
-                [NativeTypeName("BOOLEAN : 7")]
-                internal byte RESERVED
+                [NativeTypeName("BOOLEAN : 1")]
+                internal byte ConnectionShutdownByPeer
                 {
                     get
                     {
-                        return (byte)((_bitfield >> 1) & 0x7Fu);
+                        return (byte)((_bitfield >> 1) & 0x1u);
                     }
 
                     set
                     {
-                        _bitfield = (byte)((_bitfield & ~(0x7Fu << 1)) | ((value & 0x7Fu) << 1));
+                        _bitfield = (byte)((_bitfield & ~(0x1u << 1)) | ((value & 0x1u) << 1));
                     }
                 }
+
+                [NativeTypeName("BOOLEAN : 6")]
+                internal byte RESERVED
+                {
+                    get
+                    {
+                        return (byte)((_bitfield >> 2) & 0x3Fu);
+                    }
+
+                    set
+                    {
+                        _bitfield = (byte)((_bitfield & ~(0x3Fu << 2)) | ((value & 0x3Fu) << 2));
+                    }
+                }
+
+                [NativeTypeName("QUIC_UINT62")]
+                internal ulong ConnectionErrorCode;
             }
 
             internal partial struct _IDEAL_SEND_BUFFER_SIZE_e__Struct

--- a/src/generated/linux/stream.c.clog.h
+++ b/src/generated/linux/stream.c.clog.h
@@ -115,18 +115,22 @@ tracepoint(CLOG_STREAM_C, IndicateStartComplete , arg1, arg3, arg4, arg5);\
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamShutdownComplete
-// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]
+// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]
 // QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
-            Event.SHUTDOWN_COMPLETE.ConnectionShutdown);
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]",
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer,
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = Event.SHUTDOWN_COMPLETE.ConnectionShutdown = arg3
+// arg4 = arg4 = Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer = arg4
+// arg5 = arg5 = Event.SHUTDOWN_COMPLETE.ConnectionErrorCode = arg5
 ----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_IndicateStreamShutdownComplete
-#define _clog_4_ARGS_TRACE_IndicateStreamShutdownComplete(uniqueId, arg1, encoded_arg_string, arg3)\
-tracepoint(CLOG_STREAM_C, IndicateStreamShutdownComplete , arg1, arg3);\
+#ifndef _clog_6_ARGS_TRACE_IndicateStreamShutdownComplete
+#define _clog_6_ARGS_TRACE_IndicateStreamShutdownComplete(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5)\
+tracepoint(CLOG_STREAM_C, IndicateStreamShutdownComplete , arg1, arg3, arg4, arg5);\
 
 #endif
 

--- a/src/generated/linux/stream.c.clog.h.lttng.h
+++ b/src/generated/linux/stream.c.clog.h.lttng.h
@@ -95,22 +95,30 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStartComplete,
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamShutdownComplete
-// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]
+// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]
 // QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
-            Event.SHUTDOWN_COMPLETE.ConnectionShutdown);
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]",
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
+            Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer,
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = Event.SHUTDOWN_COMPLETE.ConnectionShutdown = arg3
+// arg4 = arg4 = Event.SHUTDOWN_COMPLETE.ConnectionShutdownByPeer = arg4
+// arg5 = arg5 = Event.SHUTDOWN_COMPLETE.ConnectionErrorCode = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStreamShutdownComplete,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned char, arg3,
+        unsigned char, arg4,
+        unsigned long long, arg5), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, arg1)
         ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned char, arg4, arg4)
+        ctf_integer(uint64_t, arg5, arg5)
     )
 )
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1254,8 +1254,10 @@ typedef struct QUIC_STREAM_EVENT {
         } SEND_SHUTDOWN_COMPLETE;
         struct {
             BOOLEAN ConnectionShutdown;
-            BOOLEAN AppCloseInProgress  : 1;
-            BOOLEAN RESERVED            : 7;
+            BOOLEAN AppCloseInProgress       : 1;
+            BOOLEAN ConnectionShutdownByPeer : 1;
+            BOOLEAN RESERVED                 : 6;
+            QUIC_UINT62 ConnectionErrorCode;
         } SHUTDOWN_COMPLETE;
         struct {
             uint64_t ByteCount;

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -5469,7 +5469,7 @@
     },
     "IndicateStreamShutdownComplete": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]",
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]",
       "UniqueId": "IndicateStreamShutdownComplete",
       "splitArgs": [
         {
@@ -5479,6 +5479,14 @@
         {
           "DefinationEncoding": "hhu",
           "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "llx",
+          "MacroVariableName": "arg5"
         }
       ],
       "macroName": "QuicTraceLogStreamVerbose"
@@ -13072,9 +13080,9 @@
         "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]"
       },
       {
-        "UniquenessHash": "8340b390-8b79-ab44-6593-7e449f0ec748",
+        "UniquenessHash": "afb4cdfa-5784-830e-c760-001c1eee800d",
         "TraceID": "IndicateStreamShutdownComplete",
-        "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu]"
+        "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByPeer=%hhu, ConnectionErrorCode=0x%llx]"
       },
       {
         "UniquenessHash": "e98e6411-dfab-d3a6-e7bd-d1782209846d",


### PR DESCRIPTION
## Description

This PR is **just a proposal of a change** that would eventually help us get rid of an explicit link from stream to connection. We'd like to adopt `SafeHandle` reference counting to keep connection alive for all the streams instead of a manual reference counting.

The event contains information whether it's happening due to connection closure, but it doesn't contain any details. As a result, the user has to manually keep reference between stream and connection if they want to use those details. This is the last thing that forces us to keep reference from stream to connection.

## Testing

Local test with System.Net.Quic and closing the connection via application and via idle timeout while stream is opened.

## Documentation

_Is there any documentation impact for this change?_
- ~~Yes. I can fill it in if this proposal gets a green light.~~
- I haven't found any reference to event details in the docs, but I've updated the log message.
