### PR TITLE
Update CUBIC to match rfc8312bis alpha_cubic algorithm tweak

### DIFF
--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -246,6 +246,7 @@ CubicCongestionControlOnCongestionEvent(
     //
     // Save previous state, just in case this ends up being spurious.
     //
+    Cubic->PrevWindowPrior = Cubic->WindowPrior;
     Cubic->PrevWindowMax = Cubic->WindowMax;
     Cubic->PrevWindowLastMax = Cubic->WindowLastMax;
     Cubic->PrevKCubic = Cubic->KCubic;
@@ -265,6 +266,7 @@ CubicCongestionControlOnCongestionEvent(
         Connection->Paths[0].Route.State = RouteSuspected;
 #endif
         Cubic->IsInPersistentCongestion = TRUE;
+        Cubic->WindowPrior =
         Cubic->WindowMax =
         Cubic->WindowLastMax =
         Cubic->SlowStartThreshold =
@@ -276,7 +278,9 @@ CubicCongestionControlOnCongestionEvent(
 
     } else {
 
-        Cubic->WindowMax = Cubic->CongestionWindow;
+        Cubic->WindowPrior =
+        Cubic->WindowMax =
+            Cubic->CongestionWindow;
         if (Cubic->WindowLastMax > Cubic->WindowMax) {
             //
             // Fast convergence.
@@ -494,16 +498,16 @@ CubicCongestionControlOnDataAcknowledged(
         // The required slope is derived in RFC 8312 to be [3*(1-BETA)/(1+BETA)].
         // For BETA=0.7, [3*(1-BETA)/(1+BETA)] ~= 0.5.
         //
-        // This slope of 0.5MSS/RTT is used until AimdWindow reaches WindowMax, and then
+        // This slope of 0.5MSS/RTT is used until AimdWindow reaches WindowPrior, and then
         // the slope is increased to 1MSS/RTT to match the aggressiveness of Reno.
         //
         // Algorithm adapted from RFC3465 (Appropriate Byte Counting). The idea here is to grow only by
         // multiples of MTU: we record ACKed bytes in an accumulator until at least a window
-        // (or two window, if AimdWindow < WindowMax) worth of bytes are ACKed, and then increase
+        // (or two windows, if AimdWindow < WindowPrior) worth of bytes are ACKed, and then increase
         // the window by 1 MTU.
         //
         CXPLAT_STATIC_ASSERT(TEN_TIMES_BETA_CUBIC == 7, "TEN_TIMES_BETA_CUBIC must be 7 for simplified calculation.");
-        if (Cubic->AimdWindow < Cubic->WindowMax) {
+        if (Cubic->AimdWindow < Cubic->WindowPrior) {
             Cubic->AimdAccumulator += BytesAcked / 2;
         } else {
             Cubic->AimdAccumulator += BytesAcked;
@@ -603,6 +607,7 @@ CubicCongestionControlOnSpuriousCongestionEvent(
     //
     // Revert to previous state.
     //
+    Cubic->WindowPrior = Cubic->PrevWindowPrior;
     Cubic->WindowMax = Cubic->PrevWindowMax;
     Cubic->WindowLastMax = Cubic->PrevWindowLastMax;
     Cubic->KCubic = Cubic->PrevKCubic;

--- a/src/core/cubic.h
+++ b/src/core/cubic.h
@@ -78,9 +78,11 @@ typedef struct QUIC_CONGESTION_CONTROL_CUBIC {
     uint64_t TimeOfCongAvoidStart; // microseconds
     uint32_t KCubic; // millisec
     uint32_t PrevKCubic; // millisec
-    uint32_t WindowMax; // bytes
+    uint32_t WindowPrior; // bytes (prior_cwnd from rfc8312bis)
+    uint32_t PrevWindowPrior; // bytes
+    uint32_t WindowMax; // bytes (W_max from rfc8312bis)
     uint32_t PrevWindowMax; // bytes
-    uint32_t WindowLastMax; // bytes
+    uint32_t WindowLastMax; // bytes (W_last_max from rfc8312bis)
     uint32_t PrevWindowLastMax; // bytes
 
     //


### PR DESCRIPTION
Updates the code to match this RFC update:
https://github.com/NTAP/rfc8312bis/pull/146/files 

During CA, the AIMD window increases with a 1/2-packet-per-ACK slope, which is
less aggressive than NewReno, then increases the slope to 1-packet-per-ACK once
CWnd hits W_max (WindowMax in the code). The committee determined that when
Fast Convergence kicks in and reduces WindowMax, this behavior becomes more
aggressive than it should be (seeing how Fast Convergence is really a "we should
slow down" indication). The solution is to maintain a second variable, prior_cwnd,
that is identical to W_max except with no Fast Convergence reduction logic, and
let this be the threshold for AIMD window slope change rather than W_max.