### PR TITLE
PR - support iOS11

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -329,7 +329,7 @@ function CMake-Generate {
     }
     if ($Platform -eq "ios") {
         $IosTCFile = Join-Path $RootDir cmake toolchains ios.cmake
-        $Arguments +=  " -DCMAKE_TOOLCHAIN_FILE=""$IosTCFile"" -DDEPLOYMENT_TARGET=""13.0"" -DENABLE_ARC=0 -DCMAKE_OSX_DEPLOYMENT_TARGET=""13.0"""
+        $Arguments +=  " -DCMAKE_TOOLCHAIN_FILE=""$IosTCFile"" -DDEPLOYMENT_TARGET=""11.0"" -DENABLE_ARC=0 -DCMAKE_OSX_DEPLOYMENT_TARGET=""13.0"""
         switch ($Arch) {
             "x64"   { $Arguments += " -DPLATFORM=SIMULATOR64"}
             "arm64" { $Arguments += " -DPLATFORM=OS64"}

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -431,43 +431,6 @@ CxPlatTimeUs64(
 }
 
 void
-CxPlatGetAbsoluteTime(
-    _In_ unsigned long DeltaMs,
-    _Out_ struct timespec *Time
-    )
-{
-    int ErrorCode = 0;
-
-    CxPlatZeroMemory(Time, sizeof(struct timespec));
-
-#if defined(CX_PLATFORM_LINUX)
-    ErrorCode = clock_gettime(CLOCK_MONOTONIC, Time);
-#elif defined(CX_PLATFORM_DARWIN)
-    //
-    // timespec_get is used on darwin, as CLOCK_MONOTONIC isn't actually
-    // monotonic according to our tests.
-    //
-    timespec_get(Time, TIME_UTC);
-#endif // CX_PLATFORM_DARWIN
-
-    CXPLAT_DBG_ASSERT(ErrorCode == 0);
-    UNREFERENCED_PARAMETER(ErrorCode);
-
-    Time->tv_sec += (DeltaMs / CXPLAT_MS_PER_SECOND);
-    Time->tv_nsec += ((DeltaMs % CXPLAT_MS_PER_SECOND) * CXPLAT_NANOSEC_PER_MS);
-
-    if (Time->tv_nsec >= CXPLAT_NANOSEC_PER_SEC)
-    {
-        Time->tv_sec += 1;
-        Time->tv_nsec -= CXPLAT_NANOSEC_PER_SEC;
-    }
-
-    CXPLAT_DBG_ASSERT(Time->tv_sec >= 0);
-    CXPLAT_DBG_ASSERT(Time->tv_nsec >= 0);
-    CXPLAT_DBG_ASSERT(Time->tv_nsec < CXPLAT_NANOSEC_PER_SEC);
-}
-
-void
 CxPlatSleep(
     _In_ uint32_t DurationMs
     )


### PR DESCRIPTION
## Description

support iOS11

two modifies is included:
1.  use pthread_cond_timedwait_relative_np instead of pthread_cond_timedwait   (asio use that method too)
2.  use SecTrustEvaluate instead of SecTrustEvaluateWithError (maybe controversial, SecTrustEvaluate  is deprecated but support ios9+)


## Testing

no

## Documentation

no
