### PR TITLE
Fix logging profile names

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -46,7 +46,7 @@ param (
     [switch]$Stream = $false,
 
     [Parameter(Mandatory = $false, ParameterSetName='Start')]
-    [ValidateSet("Basic.Light", "Datapath.Light", "Datapath.Verbose", "Stacks.Light", "RPS.Light", "RPS.Verbose", "Performance.Light", "Basic.Verbose", "Performance.Light", "Performance.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuic.Warnings")]
+    [ValidateSet("Basic.Light", "Datapath.Light", "Datapath.Verbose", "Stacks.Light", "RPS.Light", "RPS.Verbose", "Performance.Light", "Basic.Verbose", "Performance.Light", "Performance.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuicWarnings.Light")]
     [string]$Profile = "Full.Light",
 
     [Parameter(Mandatory = $false, ParameterSetName='Cancel')]

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -61,7 +61,7 @@ param (
     [switch]$InitialBreak = $false,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("None", "Basic.Light", "Basic.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuic.Warnings")]
+    [ValidateSet("None", "Basic.Light", "Basic.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuicWarnings.Light")]
     [string]$LogProfile = "None",
 
     [Parameter(Mandatory = $false)]

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -82,7 +82,7 @@ param (
     [switch]$InitialBreak = $false,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("None", "Basic.Light", "Basic.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuic.Warnings")]
+    [ValidateSet("None", "Basic.Light", "Basic.Verbose", "Full.Light", "Full.Verbose", "SpinQuic.Light", "SpinQuicWarnings.Light")]
     [string]$LogProfile = "None",
 
     [Parameter(Mandatory = $false)]

--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -274,7 +274,7 @@
     </Profile>
     <Profile Id="SpinQuic.Light.Memory" Base="SpinQuic.Light.File" Name="SpinQuic" Description="Used for SpinQuic Testing" LoggingMode="Memory" DetailLevel="Light"/>
 
-    <Profile Id="SpinQuic.Warnings.File" Name="SpinQuic" Description="Used for SpinQuic Testing" LoggingMode="File" DetailLevel="Light">
+    <Profile Id="SpinQuicWarnings.Light.File" Name="SpinQuicWarnings" Description="Used for SpinQuic Testing" LoggingMode="File" DetailLevel="Light">
       <Collectors>
         <EventCollectorId Value="EC_LowVolume">
           <EventProviders>
@@ -283,7 +283,7 @@
         </EventCollectorId>
       </Collectors>
     </Profile>
-    <Profile Id="SpinQuic.Warnings.Memory" Base="SpinQuic.Warnings.File" Name="SpinQuic" Description="Used for SpinQuic Testing" LoggingMode="Memory" DetailLevel="Light"/>
+    <Profile Id="SpinQuicWarnings.Light.Memory" Base="SpinQuicWarnings.Light.File" Name="SpinQuicWarnings" Description="Used for SpinQuic Testing" LoggingMode="Memory" DetailLevel="Light"/>
 
   </Profiles>
 </WindowsPerformanceRecorder>


### PR DESCRIPTION
## Description

#2685 Added a new logging profile for SpinQuic, which didn't follow the correct conventions and broke the ability for WPR to start logging.  This change fixes that by following the guidelines

## Testing

Ran log.ps1 locally to verify it parses the WPRP file without error.

