### PR TITLE
Always Flush ACKs on Stream Closure

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -180,6 +180,8 @@ QuicStreamFree(
     CxPlatDispatchLockUninitialize(&Stream->ApiSendRequestLock);
     CxPlatRefUninitialize(&Stream->RefCount);
 
+    QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_ACK);
+
     if (Stream->ReceiveCompleteOperation) {
         QuicOperationFree(Worker, Stream->ReceiveCompleteOperation);
     }


### PR DESCRIPTION
## Description

An attempt to force an immediate ACK on stream closure to handle process exist on HTTP request complete scenarios.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
