### PR TITLE
Add registry configuration for Version Settings.

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -64,6 +64,20 @@ The types map to registry types as follows:
 
 While `REG_DWORD` can hold values larger than `uint16_t`, the administrator should ensure they do not exceed the maximum value of 65,535 when configuring a `uint16_t` setting via the Windows Registry.
 
+The following settings are available via registry as well as via [QUIC_VERSION_SETTINGS](./Versions.md):
+
+| Setting                           | Type       | Registry Name            | Default           | Description                                                                                                                   |
+|-----------------------------------|------------|--------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Acceptable Versions List          | uint32_t[] | AcceptableVersions       | Unset             | Sets the list of versions that a given server instance will use if a client sends a first flight using them. |
+| Offered Versions List             | uint32_t[] | OfferedVersions          | Unset             | Sets the list of versions that a given server instance will send in a Version Negotiation packet if it receives a first flight from an unknown version. This list will most often be equal to the Acceptable Versions list. |
+| Fully-Deployed Versions List      | uint32_t[] | FullyDeployedVersions    | Unset             | Sets the list of QUIC versions that is supported and negotiated by every single QUIC server instance in this deployment. Used to generate the OtherVersions list in the Version Negotiation Extension Transport Parameter. |
+
+The `uint32_t[]` type is a `REG_BINARY` blob of the versions list, with each version in little-endian format.
+
+All restrictions and effects on the versions mentioned in [QUIC_VERSION_SETTINGS](./Versions.md) apply to the registry-set versions as well.
+
+Particularly, on server, these must be set **GLOBALLY** if you want them to take effect for servers.
+
 ## QUIC_SETTINGS
 
 A [QUIC_SETTINGS](./api/QUIC_SETTINGS.md) struct is used to configure settings on a `Configuration` handle, `Connection` handle, or globally.

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -580,6 +580,10 @@ CXPLAT_STATIC_ASSERT(
 
 #define QUIC_SETTING_VERSION_NEGOTIATION_EXT_ENABLE "VersionNegotiationExtEnabled"
 
+#define QUIC_SETTING_ACCEPTABLE_VERSIONS            "AcceptedVersions"
+#define QUIC_SETTING_FULLY_DEPLOYED_VERSIONS        "FullyDeployedVersions"
+#define QUIC_SETTING_OFFERED_VERSIONS               "OfferedVersions"
+
 #define QUIC_SETTING_MINIMUM_MTU                    "MinimumMtu"
 #define QUIC_SETTING_MAXIMUM_MTU                    "MaximumMtu"
 #define QUIC_SETTING_MTU_SEARCH_COMPLETE_TIMEOUT    "MtuDiscoverySearchCompleteTimeoutUs"

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -580,9 +580,9 @@ CXPLAT_STATIC_ASSERT(
 
 #define QUIC_SETTING_VERSION_NEGOTIATION_EXT_ENABLE "VersionNegotiationExtEnabled"
 
-#define QUIC_SETTING_ACCEPTABLE_VERSIONS            "AcceptedVersions"
-#define QUIC_SETTING_FULLY_DEPLOYED_VERSIONS        "FullyDeployedVersions"
+#define QUIC_SETTING_ACCEPTABLE_VERSIONS            "AcceptableVersions"
 #define QUIC_SETTING_OFFERED_VERSIONS               "OfferedVersions"
+#define QUIC_SETTING_FULLY_DEPLOYED_VERSIONS        "FullyDeployedVersions"
 
 #define QUIC_SETTING_MINIMUM_MTU                    "MinimumMtu"
 #define QUIC_SETTING_MAXIMUM_MTU                    "MaximumMtu"

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -870,23 +870,23 @@ QuicSettingsLoad(
     if (!Settings->IsSet.VersionSettings) {
         uint32_t OfferedVersionsSize = 0, AcceptableVersionsSize = 0, FullyDeployedVersionsSize = 0;
         if (QUIC_SUCCEEDED(
-                CxPlatStorageReadValue(
-                    Storage,
-                    QUIC_SETTING_OFFERED_VERSIONS,
-                    (uint8_t*)NULL,
-                    &OfferedVersionsSize)) &&
+            CxPlatStorageReadValue(
+                Storage,
+                QUIC_SETTING_OFFERED_VERSIONS,
+                (uint8_t*)NULL,
+                &OfferedVersionsSize)) &&
             QUIC_SUCCEEDED(
-                CxPlatStorageReadValue(
-                    Storage,
-                    QUIC_SETTING_ACCEPTABLE_VERSIONS,
-                    (uint8_t*)NULL,
-                    &AcceptableVersionsSize)) &&
+            CxPlatStorageReadValue(
+                Storage,
+                QUIC_SETTING_ACCEPTABLE_VERSIONS,
+                (uint8_t*)NULL,
+                &AcceptableVersionsSize)) &&
             QUIC_SUCCEEDED(
-                CxPlatStorageReadValue(
-                    Storage,
-                    QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
-                    (uint8_t*)NULL,
-                    &FullyDeployedVersionsSize)) &&
+            CxPlatStorageReadValue(
+                Storage,
+                QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
+                (uint8_t*)NULL,
+                &FullyDeployedVersionsSize)) &&
             OfferedVersionsSize && FullyDeployedVersionsSize && AcceptableVersionsSize) {
             QUIC_VERSION_SETTINGS* VersionSettings = NULL;
             size_t AllocSize =
@@ -910,11 +910,11 @@ QuicSettingsLoad(
             VersionSettings->AcceptableVersionsLength = AcceptableVersionsSize / sizeof(uint32_t);
             ValueLen = AcceptableVersionsSize;
             if (QUIC_FAILED(
-                    CxPlatStorageReadValue(
-                        Storage,
-                        QUIC_SETTING_ACCEPTABLE_VERSIONS,
-                        (uint8_t*)VersionSettings->AcceptableVersions,
-                        &ValueLen))) {
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_ACCEPTABLE_VERSIONS,
+                    (uint8_t*)VersionSettings->AcceptableVersions,
+                    &ValueLen))) {
                 goto VersionSettingsFail;
             }
 
@@ -923,11 +923,11 @@ QuicSettingsLoad(
             VersionSettings->OfferedVersionsLength = OfferedVersionsSize / sizeof(uint32_t);
             ValueLen = OfferedVersionsSize;
             if (QUIC_FAILED(
-                    CxPlatStorageReadValue(
-                        Storage,
-                        QUIC_SETTING_OFFERED_VERSIONS,
-                        (uint8_t*)VersionSettings->OfferedVersions,
-                        &ValueLen))) {
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_OFFERED_VERSIONS,
+                    (uint8_t*)VersionSettings->OfferedVersions,
+                    &ValueLen))) {
                 goto VersionSettingsFail;
             }
 
@@ -936,11 +936,11 @@ QuicSettingsLoad(
             VersionSettings->FullyDeployedVersionsLength = FullyDeployedVersionsSize / sizeof(uint32_t);
             ValueLen = FullyDeployedVersionsSize;
             if (QUIC_FAILED(
-                    CxPlatStorageReadValue(
-                        Storage,
-                        QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
-                        (uint8_t*)VersionSettings->FullyDeployedVersions,
-                        &ValueLen))) {
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
+                    (uint8_t*)VersionSettings->FullyDeployedVersions,
+                    &ValueLen))) {
                 goto VersionSettingsFail;
             }
             //
@@ -984,6 +984,7 @@ QuicSettingsLoad(
             }
             if (Settings->VersionSettings) {
                 CXPLAT_FREE(Settings->VersionSettings, QUIC_POOL_VERSION_SETTINGS);
+                Settings->VersionSettings = NULL;
             }
             Settings->VersionSettings = VersionSettings;
             VersionSettings = NULL;
@@ -991,6 +992,14 @@ VersionSettingsFail:
             if (VersionSettings != NULL) {
                 CXPLAT_FREE(VersionSettings, QUIC_POOL_VERSION_SETTINGS);
             }
+        } else if (Settings->VersionSettings != NULL) {
+            //
+            // Assume that the version settings were deleted from storage
+            // and free them from memory.
+            //
+            // REVIEW: This would delete versions from memory that are inherited, wouldn't it?
+            CXPLAT_FREE(Settings->VersionSettings, QUIC_POOL_VERSION_SETTINGS);
+            Settings->VersionSettings = NULL;
         }
     }
 
@@ -1577,7 +1586,7 @@ QuicSettingsGetVersionSettings(
 {
     uint32_t MinimumSize =
         sizeof(QUIC_VERSION_SETTINGS);
-    if (InternalSettings->IsSet.VersionSettings) {
+    if (InternalSettings->VersionSettings != NULL) {
         MinimumSize +=
             (InternalSettings->VersionSettings->AcceptableVersionsLength * sizeof(uint32_t)) +
             (InternalSettings->VersionSettings->OfferedVersionsLength * sizeof(uint32_t)) +
@@ -1593,7 +1602,7 @@ QuicSettingsGetVersionSettings(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    if (InternalSettings->IsSet.VersionSettings) {
+    if (InternalSettings->VersionSettings != NULL) {
         Settings->AcceptableVersions = (uint32_t*)(Settings + 1);
         Settings->AcceptableVersionsLength = InternalSettings->VersionSettings->AcceptableVersionsLength;
 

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -867,6 +867,106 @@ QuicSettingsLoad(
         Settings->VersionNegotiationExtEnabled = !!Value;
     }
 
+    if (!Settings->IsSet.VersionSettings) {
+        uint32_t OfferedVersionsSize = 0, AcceptableVersionsSize = 0, FullyDeployedVersionsSize = 0;
+        if (QUIC_SUCCEEDED(
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_OFFERED_VERSIONS,
+                    (uint8_t*)NULL,
+                    &OfferedVersionsSize)) &&
+            QUIC_SUCCEEDED(
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_ACCEPTABLE_VERSIONS,
+                    (uint8_t*)NULL,
+                    &AcceptableVersionsSize)) &&
+            QUIC_SUCCEEDED(
+                CxPlatStorageReadValue(
+                    Storage,
+                    QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
+                    (uint8_t*)NULL,
+                    &FullyDeployedVersionsSize)) &&
+            OfferedVersionsSize && FullyDeployedVersionsSize && AcceptableVersionsSize) {
+            QUIC_VERSION_SETTINGS* VersionSettings = NULL;
+            size_t AllocSize =
+                sizeof(*VersionSettings) +
+                OfferedVersionsSize +
+                AcceptableVersionsSize +
+                FullyDeployedVersionsSize;
+            VersionSettings =
+                CXPLAT_ALLOC_NONPAGED(
+                    AllocSize,
+                    QUIC_POOL_VERSION_SETTINGS);
+            if (VersionSettings == NULL) {
+                QuicTraceEvent(
+                    AllocFailure,
+                    "Allocation of '%s' failed. (%llu bytes)",
+                    "VersionSettings",
+                    AllocSize);
+                goto VersionSettingsFail;
+            }
+            VersionSettings->AcceptableVersions = (uint32_t*)(VersionSettings + 1);
+            VersionSettings->AcceptableVersionsLength = AcceptableVersionsSize / sizeof(uint32_t);
+            ValueLen = AcceptableVersionsSize;
+            if (QUIC_FAILED(
+                    CxPlatStorageReadValue(
+                        Storage,
+                        QUIC_SETTING_ACCEPTABLE_VERSIONS,
+                        (uint8_t*)VersionSettings->AcceptableVersions,
+                        &ValueLen))) {
+                goto VersionSettingsFail;
+            }
+
+            VersionSettings->OfferedVersions =
+                VersionSettings->AcceptableVersions + VersionSettings->AcceptableVersionsLength;
+            VersionSettings->OfferedVersionsLength = OfferedVersionsSize / sizeof(uint32_t);
+            ValueLen = OfferedVersionsSize;
+            if (QUIC_FAILED(
+                    CxPlatStorageReadValue(
+                        Storage,
+                        QUIC_SETTING_OFFERED_VERSIONS,
+                        (uint8_t*)VersionSettings->OfferedVersions,
+                        &ValueLen))) {
+                goto VersionSettingsFail;
+            }
+
+            VersionSettings->FullyDeployedVersions =
+                VersionSettings->OfferedVersions + VersionSettings->OfferedVersionsLength;
+            VersionSettings->FullyDeployedVersionsLength = FullyDeployedVersionsSize / sizeof(uint32_t);
+            ValueLen = FullyDeployedVersionsSize;
+            if (QUIC_FAILED(
+                    CxPlatStorageReadValue(
+                        Storage,
+                        QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
+                        (uint8_t*)VersionSettings->FullyDeployedVersions,
+                        &ValueLen))) {
+                goto VersionSettingsFail;
+            }
+            //
+            // This assumes storage is always in little-endian format.
+            //
+            for (uint32_t i = 0; i < VersionSettings->AcceptableVersionsLength; ++i) {
+                ((uint32_t*)VersionSettings->AcceptableVersions)[i] = CxPlatByteSwapUint32(VersionSettings->AcceptableVersions[i]);
+            }
+            for (uint32_t i = 0; i < VersionSettings->OfferedVersionsLength; ++i) {
+                ((uint32_t*)VersionSettings->OfferedVersions)[i] = CxPlatByteSwapUint32(VersionSettings->OfferedVersions[i]);
+            }
+            for (uint32_t i = 0; i < VersionSettings->FullyDeployedVersionsLength; ++i) {
+                ((uint32_t*)VersionSettings->FullyDeployedVersions)[i] = CxPlatByteSwapUint32(VersionSettings->FullyDeployedVersions[i]);
+            }
+            if (Settings->VersionSettings) {
+                CXPLAT_FREE(Settings->VersionSettings, QUIC_POOL_VERSION_SETTINGS);
+            }
+            Settings->VersionSettings = VersionSettings;
+            VersionSettings = NULL;
+VersionSettingsFail:
+            if (VersionSettings != NULL) {
+                CXPLAT_FREE(VersionSettings, QUIC_POOL_VERSION_SETTINGS);
+            }
+        }
+    }
+
     uint16_t MinimumMtu = Settings->MinimumMtu;
     uint16_t MaximumMtu = Settings->MaximumMtu;
     if (!Settings->IsSet.MinimumMtu) {
@@ -987,6 +1087,20 @@ QuicSettingsDump(
     QuicTraceLogVerbose(SettingDumpMaxBytesPerKey,          "[sett] MaxBytesPerKey         = %llu", Settings->MaxBytesPerKey);
     QuicTraceLogVerbose(SettingDumpServerResumptionLevel,   "[sett] ServerResumptionLevel  = %hhu", Settings->ServerResumptionLevel);
     QuicTraceLogVerbose(SettingDumpVersionNegoExtEnabled,   "[sett] Version Negotiation Ext Enabled = %hhu", Settings->VersionNegotiationExtEnabled);
+    if (Settings->VersionSettings) {
+        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
+        QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,       "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
+        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] FullyDeployedVerlength = %u", Settings->VersionSettings->FullyDeployedVersionsLength);
+        for (uint32_t i = 0; i < Settings->VersionSettings->AcceptableVersionsLength; ++i) {
+            QuicTraceLogVerbose(SettingDumpAcceptableVersions,      "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
+        }
+        for (uint32_t i = 0; i < Settings->VersionSettings->OfferedVersionsLength; ++i) {
+            QuicTraceLogVerbose(SettingDumpOfferedVersions,         "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
+        }
+        for (uint32_t i = 0; i < Settings->VersionSettings->FullyDeployedVersionsLength; ++i) {
+            QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);
+        }
+    }
     QuicTraceLogVerbose(SettingDumpMinimumMtu,              "[sett] MinimumMtu             = %hu", Settings->MinimumMtu);
     QuicTraceLogVerbose(SettingDumpMaximumMtu,              "[sett] MaximumMtu             = %hu", Settings->MaximumMtu);
     QuicTraceLogVerbose(SettingDumpMtuCompleteTimeout,      "[sett] MtuCompleteTimeout     = %llu", Settings->MtuDiscoverySearchCompleteTimeoutUs);

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -948,12 +948,39 @@ QuicSettingsLoad(
             //
             for (uint32_t i = 0; i < VersionSettings->AcceptableVersionsLength; ++i) {
                 ((uint32_t*)VersionSettings->AcceptableVersions)[i] = CxPlatByteSwapUint32(VersionSettings->AcceptableVersions[i]);
+                if (!QuicIsVersionSupported(VersionSettings->AcceptableVersions[i]) &&
+                    !QuicIsVersionReserved(VersionSettings->AcceptableVersions[i])) {
+                    QuicTraceLogError(
+                        SettingsLoadInvalidAcceptableVersion,
+                        "Invalid AcceptableVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->AcceptableVersions[i],
+                        (int32_t)i);
+                    goto VersionSettingsFail;
+                }
             }
             for (uint32_t i = 0; i < VersionSettings->OfferedVersionsLength; ++i) {
                 ((uint32_t*)VersionSettings->OfferedVersions)[i] = CxPlatByteSwapUint32(VersionSettings->OfferedVersions[i]);
+                if (!QuicIsVersionSupported(VersionSettings->OfferedVersions[i]) &&
+                    !QuicIsVersionReserved(VersionSettings->OfferedVersions[i])) {
+                    QuicTraceLogError(
+                        SettingsLoadInvalidOfferedVersion,
+                        "Invalid OfferedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->OfferedVersions[i],
+                        (int32_t)i);
+                    goto VersionSettingsFail;
+                }
             }
             for (uint32_t i = 0; i < VersionSettings->FullyDeployedVersionsLength; ++i) {
                 ((uint32_t*)VersionSettings->FullyDeployedVersions)[i] = CxPlatByteSwapUint32(VersionSettings->FullyDeployedVersions[i]);
+                if (!QuicIsVersionSupported(VersionSettings->FullyDeployedVersions[i]) &&
+                    !QuicIsVersionReserved(VersionSettings->FullyDeployedVersions[i])) {
+                    QuicTraceLogError(
+                        SettingsLoadInvalidFullyDeployedVersion,
+                        "Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->FullyDeployedVersions[i],
+                        (int32_t)i);
+                    goto VersionSettingsFail;
+                }
             }
             if (Settings->VersionSettings) {
                 CXPLAT_FREE(Settings->VersionSettings, QUIC_POOL_VERSION_SETTINGS);

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -872,27 +872,27 @@ QuicSettingsLoad(
         if (QUIC_SUCCEEDED(
             CxPlatStorageReadValue(
                 Storage,
-                QUIC_SETTING_OFFERED_VERSIONS,
-                (uint8_t*)NULL,
-                &OfferedVersionsSize)) &&
-            QUIC_SUCCEEDED(
-            CxPlatStorageReadValue(
-                Storage,
                 QUIC_SETTING_ACCEPTABLE_VERSIONS,
                 (uint8_t*)NULL,
                 &AcceptableVersionsSize)) &&
             QUIC_SUCCEEDED(
             CxPlatStorageReadValue(
                 Storage,
+                QUIC_SETTING_OFFERED_VERSIONS,
+                (uint8_t*)NULL,
+                &OfferedVersionsSize)) &&
+            QUIC_SUCCEEDED(
+            CxPlatStorageReadValue(
+                Storage,
                 QUIC_SETTING_FULLY_DEPLOYED_VERSIONS,
                 (uint8_t*)NULL,
                 &FullyDeployedVersionsSize)) &&
-            OfferedVersionsSize && FullyDeployedVersionsSize && AcceptableVersionsSize) {
+            AcceptableVersionsSize && OfferedVersionsSize && FullyDeployedVersionsSize) {
             QUIC_VERSION_SETTINGS* VersionSettings = NULL;
             size_t AllocSize =
                 sizeof(*VersionSettings) +
-                OfferedVersionsSize +
                 AcceptableVersionsSize +
+                OfferedVersionsSize +
                 FullyDeployedVersionsSize;
             VersionSettings =
                 CXPLAT_ALLOC_NONPAGED(

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -1088,14 +1088,14 @@ QuicSettingsDump(
     QuicTraceLogVerbose(SettingDumpServerResumptionLevel,   "[sett] ServerResumptionLevel  = %hhu", Settings->ServerResumptionLevel);
     QuicTraceLogVerbose(SettingDumpVersionNegoExtEnabled,   "[sett] Version Negotiation Ext Enabled = %hhu", Settings->VersionNegotiationExtEnabled);
     if (Settings->VersionSettings) {
-        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
-        QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,       "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
-        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] FullyDeployedVerlength = %u", Settings->VersionSettings->FullyDeployedVersionsLength);
+        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,  "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
+        QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,   "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
+        QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,  "[sett] FullyDeployedVerlength = %u", Settings->VersionSettings->FullyDeployedVersionsLength);
         for (uint32_t i = 0; i < Settings->VersionSettings->AcceptableVersionsLength; ++i) {
-            QuicTraceLogVerbose(SettingDumpAcceptableVersions,      "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
+            QuicTraceLogVerbose(SettingDumpAcceptableVersions,  "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
         }
         for (uint32_t i = 0; i < Settings->VersionSettings->OfferedVersionsLength; ++i) {
-            QuicTraceLogVerbose(SettingDumpOfferedVersions,         "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
+            QuicTraceLogVerbose(SettingDumpOfferedVersions, "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
         }
         for (uint32_t i = 0; i < Settings->VersionSettings->FullyDeployedVersionsLength; ++i) {
             QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);

--- a/src/generated/linux/settings.c.clog.h
+++ b/src/generated/linux/settings.c.clog.h
@@ -435,6 +435,84 @@ tracepoint(CLOG_SETTINGS_C, SettingDumpVersionNegoExtEnabled , arg2);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SettingDumpAcceptedVersionsLength
+// [sett] AcceptedVersionslength = %u
+// QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,  "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
+// arg2 = arg2 = Settings->VersionSettings->AcceptableVersionsLength = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_SettingDumpAcceptedVersionsLength
+#define _clog_3_ARGS_TRACE_SettingDumpAcceptedVersionsLength(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_SETTINGS_C, SettingDumpAcceptedVersionsLength , arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpOfferedVersionsLength
+// [sett] OfferedVersionslength  = %u
+// QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,   "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
+// arg2 = arg2 = Settings->VersionSettings->OfferedVersionsLength = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_SettingDumpOfferedVersionsLength
+#define _clog_3_ARGS_TRACE_SettingDumpOfferedVersionsLength(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_SETTINGS_C, SettingDumpOfferedVersionsLength , arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpAcceptableVersions
+// [sett] AcceptableVersions[%u]  = 0x%x
+// QuicTraceLogVerbose(SettingDumpAcceptableVersions,  "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->AcceptableVersions[i] = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_SettingDumpAcceptableVersions
+#define _clog_4_ARGS_TRACE_SettingDumpAcceptableVersions(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingDumpAcceptableVersions , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpOfferedVersions
+// [sett] OfferedVersions[%u]     = 0x%x
+// QuicTraceLogVerbose(SettingDumpOfferedVersions, "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->OfferedVersions[i] = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_SettingDumpOfferedVersions
+#define _clog_4_ARGS_TRACE_SettingDumpOfferedVersions(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingDumpOfferedVersions , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpFullyDeployedVersions
+// [sett] FullyDeployedVersion[%u]= 0x%x
+// QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->FullyDeployedVersions[i] = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_SettingDumpFullyDeployedVersions
+#define _clog_4_ARGS_TRACE_SettingDumpFullyDeployedVersions(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingDumpFullyDeployedVersions , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SettingDumpMinimumMtu
 // [sett] MinimumMtu             = %hu
 // QuicTraceLogVerbose(SettingDumpMinimumMtu,              "[sett] MinimumMtu             = %hu", Settings->MinimumMtu);
@@ -540,14 +618,19 @@ tracepoint(CLOG_SETTINGS_C, SettingCongestionControlAlgorithm , arg2);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpAcceptedVersionsLength
-// [sett] AcceptedVersionslength = %u
-// QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
-// arg2 = arg2 = Settings->VersionSettings->AcceptableVersionsLength = arg2
+// Decoder Ring for SettingsLoadInvalidAcceptableVersion
+// Invalid AcceptableVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidAcceptableVersion,
+                        "Invalid AcceptableVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->AcceptableVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->AcceptableVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_SettingDumpAcceptedVersionsLength
-#define _clog_3_ARGS_TRACE_SettingDumpAcceptedVersionsLength(uniqueId, encoded_arg_string, arg2)\
-tracepoint(CLOG_SETTINGS_C, SettingDumpAcceptedVersionsLength , arg2);\
+#ifndef _clog_4_ARGS_TRACE_SettingsLoadInvalidAcceptableVersion
+#define _clog_4_ARGS_TRACE_SettingsLoadInvalidAcceptableVersion(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingsLoadInvalidAcceptableVersion , arg2, arg3);\
 
 #endif
 
@@ -555,14 +638,19 @@ tracepoint(CLOG_SETTINGS_C, SettingDumpAcceptedVersionsLength , arg2);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpOfferedVersionsLength
-// [sett] OfferedVersionslength  = %u
-// QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,       "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
-// arg2 = arg2 = Settings->VersionSettings->OfferedVersionsLength = arg2
+// Decoder Ring for SettingsLoadInvalidOfferedVersion
+// Invalid OfferedVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidOfferedVersion,
+                        "Invalid OfferedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->OfferedVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->OfferedVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_SettingDumpOfferedVersionsLength
-#define _clog_3_ARGS_TRACE_SettingDumpOfferedVersionsLength(uniqueId, encoded_arg_string, arg2)\
-tracepoint(CLOG_SETTINGS_C, SettingDumpOfferedVersionsLength , arg2);\
+#ifndef _clog_4_ARGS_TRACE_SettingsLoadInvalidOfferedVersion
+#define _clog_4_ARGS_TRACE_SettingsLoadInvalidOfferedVersion(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingsLoadInvalidOfferedVersion , arg2, arg3);\
 
 #endif
 
@@ -570,47 +658,19 @@ tracepoint(CLOG_SETTINGS_C, SettingDumpOfferedVersionsLength , arg2);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpAcceptableVersions
-// [sett] AcceptableVersions[%u]  = 0x%x
-// QuicTraceLogVerbose(SettingDumpAcceptableVersions,      "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->AcceptableVersions[i] = arg3
+// Decoder Ring for SettingsLoadInvalidFullyDeployedVersion
+// Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidFullyDeployedVersion,
+                        "Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->FullyDeployedVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->FullyDeployedVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_SettingDumpAcceptableVersions
-#define _clog_4_ARGS_TRACE_SettingDumpAcceptableVersions(uniqueId, encoded_arg_string, arg2, arg3)\
-tracepoint(CLOG_SETTINGS_C, SettingDumpAcceptableVersions , arg2, arg3);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for SettingDumpOfferedVersions
-// [sett] OfferedVersions[%u]     = 0x%x
-// QuicTraceLogVerbose(SettingDumpOfferedVersions,         "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->OfferedVersions[i] = arg3
-----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_SettingDumpOfferedVersions
-#define _clog_4_ARGS_TRACE_SettingDumpOfferedVersions(uniqueId, encoded_arg_string, arg2, arg3)\
-tracepoint(CLOG_SETTINGS_C, SettingDumpOfferedVersions , arg2, arg3);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for SettingDumpFullyDeployedVersions
-// [sett] FullyDeployedVersion[%u]= 0x%x
-// QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->FullyDeployedVersions[i] = arg3
-----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_SettingDumpFullyDeployedVersions
-#define _clog_4_ARGS_TRACE_SettingDumpFullyDeployedVersions(uniqueId, encoded_arg_string, arg2, arg3)\
-tracepoint(CLOG_SETTINGS_C, SettingDumpFullyDeployedVersions , arg2, arg3);\
+#ifndef _clog_4_ARGS_TRACE_SettingsLoadInvalidFullyDeployedVersion
+#define _clog_4_ARGS_TRACE_SettingsLoadInvalidFullyDeployedVersion(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_SETTINGS_C, SettingsLoadInvalidFullyDeployedVersion , arg2, arg3);\
 
 #endif
 

--- a/src/generated/linux/settings.c.clog.h.lttng.h
+++ b/src/generated/linux/settings.c.clog.h.lttng.h
@@ -434,6 +434,95 @@ TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpVersionNegoExtEnabled,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SettingDumpAcceptedVersionsLength
+// [sett] AcceptedVersionslength = %u
+// QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,  "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
+// arg2 = arg2 = Settings->VersionSettings->AcceptableVersionsLength = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpAcceptedVersionsLength,
+    TP_ARGS(
+        unsigned int, arg2), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpOfferedVersionsLength
+// [sett] OfferedVersionslength  = %u
+// QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,   "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
+// arg2 = arg2 = Settings->VersionSettings->OfferedVersionsLength = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpOfferedVersionsLength,
+    TP_ARGS(
+        unsigned int, arg2), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpAcceptableVersions
+// [sett] AcceptableVersions[%u]  = 0x%x
+// QuicTraceLogVerbose(SettingDumpAcceptableVersions,  "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->AcceptableVersions[i] = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpAcceptableVersions,
+    TP_ARGS(
+        unsigned int, arg2,
+        unsigned int, arg3), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+        ctf_integer(unsigned int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpOfferedVersions
+// [sett] OfferedVersions[%u]     = 0x%x
+// QuicTraceLogVerbose(SettingDumpOfferedVersions, "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->OfferedVersions[i] = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpOfferedVersions,
+    TP_ARGS(
+        unsigned int, arg2,
+        unsigned int, arg3), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+        ctf_integer(unsigned int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingDumpFullyDeployedVersions
+// [sett] FullyDeployedVersion[%u]= 0x%x
+// QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);
+// arg2 = arg2 = i = arg2
+// arg3 = arg3 = Settings->VersionSettings->FullyDeployedVersions[i] = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpFullyDeployedVersions,
+    TP_ARGS(
+        unsigned int, arg2,
+        unsigned int, arg3), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+        ctf_integer(unsigned int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SettingDumpMinimumMtu
 // [sett] MinimumMtu             = %hu
 // QuicTraceLogVerbose(SettingDumpMinimumMtu,              "[sett] MinimumMtu             = %hu", Settings->MinimumMtu);
@@ -546,89 +635,69 @@ TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingCongestionControlAlgorithm,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpAcceptedVersionsLength
-// [sett] AcceptedVersionslength = %u
-// QuicTraceLogVerbose(SettingDumpAcceptedVersionsLength,      "[sett] AcceptedVersionslength = %u", Settings->VersionSettings->AcceptableVersionsLength);
-// arg2 = arg2 = Settings->VersionSettings->AcceptableVersionsLength = arg2
+// Decoder Ring for SettingsLoadInvalidAcceptableVersion
+// Invalid AcceptableVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidAcceptableVersion,
+                        "Invalid AcceptableVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->AcceptableVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->AcceptableVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpAcceptedVersionsLength,
-    TP_ARGS(
-        unsigned int, arg2), 
-    TP_FIELDS(
-        ctf_integer(unsigned int, arg2, arg2)
-    )
-)
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for SettingDumpOfferedVersionsLength
-// [sett] OfferedVersionslength  = %u
-// QuicTraceLogVerbose(SettingDumpOfferedVersionsLength,       "[sett] OfferedVersionslength  = %u", Settings->VersionSettings->OfferedVersionsLength);
-// arg2 = arg2 = Settings->VersionSettings->OfferedVersionsLength = arg2
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpOfferedVersionsLength,
-    TP_ARGS(
-        unsigned int, arg2), 
-    TP_FIELDS(
-        ctf_integer(unsigned int, arg2, arg2)
-    )
-)
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for SettingDumpAcceptableVersions
-// [sett] AcceptableVersions[%u]  = 0x%x
-// QuicTraceLogVerbose(SettingDumpAcceptableVersions,      "[sett] AcceptableVersions[%u]  = 0x%x", i, Settings->VersionSettings->AcceptableVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->AcceptableVersions[i] = arg3
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpAcceptableVersions,
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingsLoadInvalidAcceptableVersion,
     TP_ARGS(
         unsigned int, arg2,
-        unsigned int, arg3), 
+        int, arg3), 
     TP_FIELDS(
         ctf_integer(unsigned int, arg2, arg2)
-        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(int, arg3, arg3)
     )
 )
 
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpOfferedVersions
-// [sett] OfferedVersions[%u]     = 0x%x
-// QuicTraceLogVerbose(SettingDumpOfferedVersions,         "[sett] OfferedVersions[%u]     = 0x%x", i, Settings->VersionSettings->OfferedVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->OfferedVersions[i] = arg3
+// Decoder Ring for SettingsLoadInvalidOfferedVersion
+// Invalid OfferedVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidOfferedVersion,
+                        "Invalid OfferedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->OfferedVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->OfferedVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpOfferedVersions,
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingsLoadInvalidOfferedVersion,
     TP_ARGS(
         unsigned int, arg2,
-        unsigned int, arg3), 
+        int, arg3), 
     TP_FIELDS(
         ctf_integer(unsigned int, arg2, arg2)
-        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(int, arg3, arg3)
     )
 )
 
 
 
 /*----------------------------------------------------------
-// Decoder Ring for SettingDumpFullyDeployedVersions
-// [sett] FullyDeployedVersion[%u]= 0x%x
-// QuicTraceLogVerbose(SettingDumpFullyDeployedVersions,   "[sett] FullyDeployedVersion[%u]= 0x%x", i, Settings->VersionSettings->FullyDeployedVersions[i]);
-// arg2 = arg2 = i = arg2
-// arg3 = arg3 = Settings->VersionSettings->FullyDeployedVersions[i] = arg3
+// Decoder Ring for SettingsLoadInvalidFullyDeployedVersion
+// Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d
+// QuicTraceLogError(
+                        SettingsLoadInvalidFullyDeployedVersion,
+                        "Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d",
+                        VersionSettings->FullyDeployedVersions[i],
+                        (int32_t)i);
+// arg2 = arg2 = VersionSettings->FullyDeployedVersions[i] = arg2
+// arg3 = arg3 = (int32_t)i = arg3
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingDumpFullyDeployedVersions,
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingsLoadInvalidFullyDeployedVersion,
     TP_ARGS(
         unsigned int, arg2,
-        unsigned int, arg3), 
+        int, arg3), 
     TP_FIELDS(
         ctf_integer(unsigned int, arg2, arg2)
-        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(int, arg3, arg3)
     )
 )
 

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -387,6 +387,27 @@ public:
         AcceptableVersionsLength = OfferedVersionsLength = FullyDeployedVersionsLength = Length;
         return *this;
     }
+    QUIC_STATUS
+    SetGlobal() const noexcept {
+        const QUIC_VERSION_SETTINGS* Settings = this;
+        return
+            MsQuic->SetParam(
+                nullptr,
+                QUIC_PARAM_GLOBAL_VERSION_SETTINGS,
+                sizeof(*Settings),
+                Settings);
+    }
+    QUIC_STATUS
+    GetGlobal() noexcept {
+        QUIC_VERSION_SETTINGS* Settings = this;
+        uint32_t Size = sizeof(*Settings);
+        return
+            MsQuic->GetParam(
+                nullptr,
+                QUIC_PARAM_GLOBAL_VERSION_SETTINGS,
+                &Size,
+                Settings);
+    }
 };
 
 static_assert(sizeof(QUIC_VERSION_SETTINGS) == sizeof(MsQuicVersionSettings), "Cpp wrappers must not change size");
@@ -615,6 +636,20 @@ struct MsQuicConfiguration {
                 QUIC_PARAM_CONFIGURATION_VERSION_SETTINGS,
                 sizeof(*QSettings),
                 QSettings);
+    }
+
+    QUIC_STATUS
+    GetVersionSettings(
+        _Out_writes_bytes_(SettingsLength)
+            MsQuicVersionSettings& Settings,
+        _Inout_ uint32_t* SettingsLength) noexcept {
+        QUIC_VERSION_SETTINGS* VSettings = &Settings;
+        return
+            MsQuic->GetParam(
+                Handle,
+                QUIC_PARAM_CONFIGURATION_VERSION_SETTINGS,
+                SettingsLength,
+                VSettings);
     }
 
     QUIC_STATUS

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -640,8 +640,7 @@ struct MsQuicConfiguration {
 
     QUIC_STATUS
     GetVersionSettings(
-        _Out_writes_bytes_(SettingsLength)
-            MsQuicVersionSettings& Settings,
+        _Out_ MsQuicVersionSettings& Settings,
         _Inout_ uint32_t* SettingsLength) noexcept {
         QUIC_VERSION_SETTINGS* VSettings = &Settings;
         return

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -9769,6 +9769,54 @@
       ],
       "macroName": "QuicTraceLogError"
     },
+    "SettingsLoadInvalidAcceptableVersion": {
+      "ModuleProperites": {},
+      "TraceString": "Invalid AcceptableVersion loaded from storage! 0x%x at position %d",
+      "UniqueId": "SettingsLoadInvalidAcceptableVersion",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogError"
+    },
+    "SettingsLoadInvalidFullyDeployedVersion": {
+      "ModuleProperites": {},
+      "TraceString": "Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d",
+      "UniqueId": "SettingsLoadInvalidFullyDeployedVersion",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogError"
+    },
+    "SettingsLoadInvalidOfferedVersion": {
+      "ModuleProperites": {},
+      "TraceString": "Invalid OfferedVersion loaded from storage! 0x%x at position %d",
+      "UniqueId": "SettingsLoadInvalidOfferedVersion",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogError"
+    },
     "StartAckDelayTimer": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Starting ACK_DELAY timer for %u ms",
@@ -14512,6 +14560,21 @@
         "UniquenessHash": "dad8e0fd-193d-ff7c-1657-2f8eebc1d457",
         "TraceID": "SettingsInvalidOfferedVersion",
         "EncodingString": "Invalid OfferedVersion supplied to settings! 0x%x at position %d"
+      },
+      {
+        "UniquenessHash": "95a76c49-1ba7-e5f5-8081-e1ce724f1c60",
+        "TraceID": "SettingsLoadInvalidAcceptableVersion",
+        "EncodingString": "Invalid AcceptableVersion loaded from storage! 0x%x at position %d"
+      },
+      {
+        "UniquenessHash": "dda4318e-62b1-887b-ca54-83d63cdaf2d1",
+        "TraceID": "SettingsLoadInvalidFullyDeployedVersion",
+        "EncodingString": "Invalid FullyDeployedVersion loaded from storage! 0x%x at position %d"
+      },
+      {
+        "UniquenessHash": "81035efa-7e5c-22d0-3a02-16a2f7cc7f1f",
+        "TraceID": "SettingsLoadInvalidOfferedVersion",
+        "EncodingString": "Invalid OfferedVersion loaded from storage! 0x%x at position %d"
       },
       {
         "UniquenessHash": "3811b30b-84d6-43cc-8312-918d88c99d3e",

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -509,6 +509,10 @@ void
 QuicTestStorage(
     );
 
+void
+QuicTestVersionStorage(
+    );
+
 //
 // Platform Specific Functions
 //
@@ -1063,4 +1067,7 @@ typedef struct {
 #define IOCTL_QUIC_RUN_CLOSE_CONN_BEFORE_STREAM_FLUSH \
     QUIC_CTL_CODE(99, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 99
+#define IOCTL_QUIC_RUN_VERSION_STORAGE \
+    QUIC_CTL_CODE(100, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 100

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1808,6 +1808,18 @@ TEST(Basic, TestStorage) {
         QuicTestStorage();
     }
 }
+TEST(Basic, TestVersionStorage) {
+    if (!CanRunStorageTests) {
+        return;
+    }
+
+    TestLogger Logger("QuicTestVersionStorage");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STORAGE));
+    } else {
+        QuicTestVersionStorage();
+    }
+}
 
 #endif // _WIN32
 

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -471,6 +471,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1252,6 +1253,10 @@ QuicTestCtlEvtIoDeviceControl(
 
     case IOCTL_QUIC_RUN_CLOSE_CONN_BEFORE_STREAM_FLUSH:
         QuicTestCtlRun(QuicTestCloseConnBeforeStreamFlush());
+        break;
+
+    case IOCTL_QUIC_RUN_VERSION_STORAGE:
+        QuicTestCtlRun(QuicTestVersionStorage());
         break;
 
     default:

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -5329,11 +5329,13 @@ QuicTestVersionStorage()
     const uint32_t VersionListLength = ARRAYSIZE(VersionList);
 
 #ifdef _KERNEL_MODE
+#define __WIDEN(quote) L##quote
+#define WIDEN(quote) __WIDEN(quote)
     DECLARE_CONST_UNICODE_STRING(GlobalStoragePath, L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\MsQuic\\Parameters\\");
     DECLARE_CONST_UNICODE_STRING(AppStoragePath, L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\MsQuic\\Parameters\\Apps\\StorageTest\\");
-    DECLARE_CONST_UNICODE_STRING(AcceptableVersionsValueName, TEXT(QUIC_SETTING_ACCEPTABLE_VERSIONS));
-    DECLARE_CONST_UNICODE_STRING(OfferedVersionsValueName, TEXT(QUIC_SETTING_OFFERED_VERSIONS));
-    DECLARE_CONST_UNICODE_STRING(FullyDeployedVersionsValueName, TEXT(QUIC_SETTING_FULLY_DEPLOYED_VERSIONS));
+    DECLARE_CONST_UNICODE_STRING(AcceptableVersionsValueName, WIDEN(QUIC_SETTING_ACCEPTABLE_VERSIONS));
+    DECLARE_CONST_UNICODE_STRING(OfferedVersionsValueName, WIDEN(QUIC_SETTING_OFFERED_VERSIONS));
+    DECLARE_CONST_UNICODE_STRING(FullyDeployedVersionsValueName, WIDEN(QUIC_SETTING_FULLY_DEPLOYED_VERSIONS));
     HANDLE GlobalKey, AppKey;
     OBJECT_ATTRIBUTES GlobalAttributes, AppAttributes;
     InitializeObjectAttributes(

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -5476,8 +5476,6 @@ QuicTestVersionStorage()
             REG_BINARY,
             &VersionList,
             sizeof(VersionList)));
-#else
-    TEST_FAILURE("Storage tests not supported on this platform");
 #endif
 
     CxPlatSleep(100);
@@ -5502,7 +5500,6 @@ QuicTestVersionStorage()
     for (uint32_t i = 0; i < ReadSettings->FullyDeployedVersionsLength; i++) {
         TEST_EQUAL(CxPlatByteSwapUint32(ReadSettings->FullyDeployedVersions[i]), VersionList[i]);
     }
-
 
 #ifdef _KERNEL_MODE
     TEST_QUIC_SUCCEEDED(
@@ -5537,8 +5534,6 @@ QuicTestVersionStorage()
             HKEY_LOCAL_MACHINE,
             MSQUIC_GLOBAL_PARAMETERS_PATH,
             QUIC_SETTING_FULLY_DEPLOYED_VERSIONS));
-#else
-    TEST_FAILURE("Storage tests not supported on this platform");
 #endif
 
     CxPlatSleep(100);
@@ -5622,8 +5617,6 @@ QuicTestVersionStorage()
             REG_BINARY,
             &VersionList,
             sizeof(VersionList)));
-#else
-    TEST_FAILURE("Storage tests not supported on this platform");
 #endif
 
     CxPlatSleep(100);
@@ -5675,8 +5668,6 @@ QuicTestVersionStorage()
             HKEY_LOCAL_MACHINE,
             MSQUIC_APP_PARAMETERS_PATH,
             QUIC_SETTING_FULLY_DEPLOYED_VERSIONS));
-#else
-    TEST_FAILURE("Storage tests not supported on this platform");
 #endif
 
     CxPlatSleep(100);


### PR DESCRIPTION
## Description

Enable configuration of Version Settings via the Windows Registry.

## Testing

Manual testing with `quicinteropserver` and `quicinterop`.  

- [x] Automated tests should be written to cover the storage system.

## Documentation

- [x] Documentation should be updated to reflect the new Registry value names.
