### PR TITLE
Linux IP_PMTUDISC_PROBE

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1054,11 +1054,10 @@ CxPlatSocketContextInitialize(
 
     //
     // Windows: setsockopt IPPROTO_IP IP_DONTFRAGMENT TRUE.
-    // Linux: IP_DONTFRAGMENT option is not available. IPV6_MTU_DISCOVER is the
-    // apparent alternative.
-    // TODO: Verify this.
+    // Linux: IP_DONTFRAGMENT option is not available. IP_MTU_DISCOVER/IPV6_MTU_DISCOVER
+    // is the apparent alternative.
     //
-    Option = IP_PMTUDISC_DO;
+    Option = IP_PMTUDISC_PROBE;
     Result =
         setsockopt(
             SocketContext->SocketFd,
@@ -1074,6 +1073,23 @@ CxPlatSocketContextInitialize(
             Binding,
             Status,
             "setsockopt(IP_MTU_DISCOVER) failed");
+        goto Exit;
+    }
+    Result =
+        setsockopt(
+            SocketContext->SocketFd,
+            IPPROTO_IPV6,
+            IPV6_MTU_DISCOVER,
+            (const void*)&Option,
+            sizeof(Option));
+    if (Result == SOCKET_ERROR) {
+        Status = errno;
+        QuicTraceEvent(
+            DatapathErrorStatus,
+            "[data][%p] ERROR, %u, %s.",
+            Binding,
+            Status,
+            "setsockopt(IPV6_MTU_DISCOVER) failed");
         goto Exit;
     }
 


### PR DESCRIPTION
## Description

With socket option IP_MTU_DISCOVER=IP_PMTUDISC_DO a linux IPv4 socket rejects packets larger than route MTU (as shown by ip route get DST-IP) with EMSGSIZE. With IP_MTU_DISCOVER=IP_PMTUDISC_PROBE the linux socket ignores the route MTU.

To apply this also for an IPv6, I set IPV6_MTU_DISCOVER=IP_PMTUDISC_PROBE, too.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Probably not and maybe.

## Documentation

_Is there any documentation impact for this change?_

Probably not.