### PR TITLE
Rename QUIC_ACK_EVENT/QUIC_LOSS_EVENT fields to match their QUIC_LOSS_DETECTION counterparts

### DIFF
--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -12,9 +12,9 @@ typedef struct QUIC_ACK_EVENT {
 
     uint64_t TimeNow; // microsecond
 
-    uint64_t LargestPacketNumberAcked;
+    uint64_t LargestAck;
 
-    uint64_t LargestPacketNumberSent;
+    uint64_t LargestSentPacketNumber;
 
     //
     // Number of retransmittable bytes acked during the connection's lifetime
@@ -48,7 +48,7 @@ typedef struct QUIC_LOSS_EVENT {
 
     uint64_t LargestPacketNumberLost;
 
-    uint64_t LargestPacketNumberSent;
+    uint64_t LargestSentPacketNumber;
 
     uint32_t NumRetransmittableBytes;
 

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -380,7 +380,7 @@ CubicCongestionControlOnDataAcknowledged(
     Cubic->BytesInFlight -= BytesAcked;
 
     if (Cubic->IsInRecovery) {
-        if (AckEvent->LargestPacketNumberAcked > Cubic->RecoverySentPacketNumber) {
+        if (AckEvent->LargestAck > Cubic->RecoverySentPacketNumber) {
             //
             // Done recovering. Note that completion of recovery is defined a
             // bit differently here than in TCP: we simply require an ACK for a
@@ -571,7 +571,7 @@ CubicCongestionControlOnDataLost(
     if (!Cubic->HasHadCongestionEvent ||
         LossEvent->LargestPacketNumberLost > Cubic->RecoverySentPacketNumber) {
 
-        Cubic->RecoverySentPacketNumber = LossEvent->LargestPacketNumberSent;
+        Cubic->RecoverySentPacketNumber = LossEvent->LargestSentPacketNumber;
         CubicCongestionControlOnCongestionEvent(
             Cc,
             LossEvent->PersistentCongestion);

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1063,7 +1063,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
 
             QUIC_LOSS_EVENT LossEvent = {
                 .LargestPacketNumberLost = LargestLostPacketNumber,
-                .LargestPacketNumberSent = LossDetection->LargestSentPacketNumber,
+                .LargestSentPacketNumber = LossDetection->LargestSentPacketNumber,
                 .NumRetransmittableBytes = LostRetransmittableBytes,
                 .PersistentCongestion =
                     LossDetection->ProbeCount > QUIC_PERSISTENT_CONGESTION_THRESHOLD
@@ -1201,8 +1201,8 @@ QuicLossDetectionDiscardPackets(
         QUIC_ACK_EVENT AckEvent = {
             .IsImplicit = TRUE,
             .TimeNow = TimeNow,
-            .LargestPacketNumberAcked = LossDetection->LargestAck,
-            .LargestPacketNumberSent = LossDetection->LargestSentPacketNumber,
+            .LargestAck = LossDetection->LargestAck,
+            .LargestSentPacketNumber = LossDetection->LargestSentPacketNumber,
             .NumRetransmittableBytes = AckedRetransmittableBytes,
             .SmoothedRtt = Path->SmoothedRtt,
             .SmallestRttSample = 0,
@@ -1508,8 +1508,8 @@ QuicLossDetectionProcessAckBlocks(
         QUIC_ACK_EVENT AckEvent = {
             .IsImplicit = FALSE,
             .TimeNow = TimeNow,
-            .LargestPacketNumberAcked = LossDetection->LargestAck,
-            .LargestPacketNumberSent = LossDetection->LargestSentPacketNumber,
+            .LargestAck = LossDetection->LargestAck,
+            .LargestSentPacketNumber = LossDetection->LargestSentPacketNumber,
             .NumRetransmittableBytes = AckedRetransmittableBytes,
             .SmoothedRtt = Connection->Paths[0].SmoothedRtt,
             .SmallestRttSample = SmallestRtt,


### PR DESCRIPTION
These fields in QUIC_ACK_EVENT/QUIC_LOSS_EVENT are simply "what is the current value of
some field in the QUIC_LOSS_DETECTION". So I've renamed them to match exactly.