### PR TITLE
Backport #2758 to Release/2.0

### DIFF
--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -140,6 +140,7 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) throw() { return (ENUMTYP
 
 #define QUIC_STATUS_CERT_EXPIRED            QUIC_STATUS_CERT_ERROR(1)       // 0xBEBC401
 #define QUIC_STATUS_CERT_UNTRUSTED_ROOT     QUIC_STATUS_CERT_ERROR(2)       // 0xBEBC402
+#define QUIC_STATUS_CERT_NO_CERT            QUIC_STATUS_CERT_ERROR(3)       // 0xBEBC403
 
 typedef unsigned char BOOLEAN;
 typedef struct in_addr IN_ADDR;

--- a/src/inc/msquic_winkernel.h
+++ b/src/inc/msquic_winkernel.h
@@ -118,6 +118,7 @@ typedef UINT64 uint64_t;
 
 #define QUIC_STATUS_CERT_EXPIRED            ((NTSTATUS)0x800B0101L)     // CERT_E_EXPIRED
 #define QUIC_STATUS_CERT_UNTRUSTED_ROOT     ((NTSTATUS)0x800B0109L)     // CERT_E_UNTRUSTEDROOT
+#define QUIC_STATUS_CERT_NO_CERT            ((NTSTATUS)0x8009030EL)     // SEC_E_NO_CREDENTIALS
 
 //
 // Swaps byte orders between host and network endianness.

--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -121,6 +121,7 @@ Environment:
 
 #define QUIC_STATUS_CERT_EXPIRED            CERT_E_EXPIRED
 #define QUIC_STATUS_CERT_UNTRUSTED_ROOT     CERT_E_UNTRUSTEDROOT
+#define QUIC_STATUS_CERT_NO_CERT            SEC_E_NO_CREDENTIALS
 
 //
 // Swaps byte orders between host and network endianness.

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -115,9 +115,11 @@ ListenerAcceptConnection(
         (*AcceptContext->NewConnection)->SetExpectedTransportCloseStatus(
             AcceptContext->ExpectedTransportCloseStatus);
     }
-    if (AcceptContext->ExpectedClientCertValidationResult != QUIC_STATUS_SUCCESS) {
-        (*AcceptContext->NewConnection)->SetExpectedClientCertValidationResult(
-            AcceptContext->ExpectedClientCertValidationResult);
+    if (AcceptContext->ExpectedClientCertValidationResultCount > 0) {
+        for (unsigned i = 0; i < AcceptContext->ExpectedClientCertValidationResultCount; i++) {
+            (*AcceptContext->NewConnection)->AddExpectedClientCertValidationResult(
+                AcceptContext->ExpectedClientCertValidationResult[i]);
+        }
     }
     CxPlatEventSet(AcceptContext->NewConnectionReady);
     return true;
@@ -2209,8 +2211,10 @@ QuicTestConnectClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_CERT_UNTRUSTED_ROOT;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
             if (!UseClientCertificate) {
+                ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_NO_CERT);
+                ServerAcceptCtx.PeerCertEventReturnStatus = QUIC_STATUS_CONNECTION_REFUSED;
                 ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_REQUIRED_CERTIFICATE;
             }
             Listener.Context = &ServerAcceptCtx;
@@ -2504,7 +2508,7 @@ QuicTestConnectValidClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_SUCCESS;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_SUCCESS);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2567,7 +2571,7 @@ QuicTestConnectExpiredClientCertificate(
         {
             UniquePtr<TestConnection> Server;
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-            ServerAcceptCtx.ExpectedClientCertValidationResult = QUIC_STATUS_CERT_EXPIRED;
+            ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_EXPIRED);
             Listener.Context = &ServerAcceptCtx;
 
             {

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -24,7 +24,8 @@ TestConnection::TestConnection(
     IsShutdown(false), ShutdownTimedOut(false), AutoDelete(false), AsyncCustomValidation(false),
     CustomValidationResultSet(false), ExpectedResumed(false),
     ExpectedTransportCloseStatus(QUIC_STATUS_SUCCESS), ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
-    ExpectedClientCertValidationResult(QUIC_STATUS_SUCCESS), ExpectedCustomValidationResult(false),
+    ExpectedClientCertValidationResult{}, ExpectedClientCertValidationResultCount(0),
+    ExpectedCustomValidationResult(false), PeerCertEventReturnStatus(QUIC_STATUS_SUCCESS),
     EventDeleted(nullptr),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
@@ -52,7 +53,8 @@ TestConnection::TestConnection(
     IsShutdown(false), ShutdownTimedOut(false), AutoDelete(false), AsyncCustomValidation(false),
     CustomValidationResultSet(false), ExpectedResumed(false),
     ExpectedTransportCloseStatus(QUIC_STATUS_SUCCESS), ExpectedPeerCloseErrorCode(QUIC_TEST_NO_ERROR),
-    ExpectedClientCertValidationResult(QUIC_STATUS_SUCCESS), ExpectedCustomValidationResult(false),
+    ExpectedClientCertValidationResult{}, ExpectedClientCertValidationResultCount(0),
+    ExpectedCustomValidationResult(false), PeerCertEventReturnStatus(QUIC_STATUS_SUCCESS),
     EventDeleted(nullptr),
     NewStreamCallback(NewStreamCallbackHandler), ShutdownCompleteCallback(nullptr),
     DatagramsSent(0), DatagramsCanceled(0), DatagramsSuspectLost(0),
@@ -853,10 +855,32 @@ TestConnection::HandleConnectionEvent(
         if (CustomValidationResultSet && !ExpectedCustomValidationResult) {
             return QUIC_STATUS_INTERNAL_ERROR;
         }
-        if (Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus != ExpectedClientCertValidationResult) {
+        if (ExpectedClientCertValidationResultCount > 0) {
+            bool Match = false;
+            for (unsigned idx = 0; idx < ExpectedClientCertValidationResultCount; idx++) {
+                if (Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus == ExpectedClientCertValidationResult[idx]) {
+                    Match = true;
+                    break;
+                }
+            }
+            if (!Match) {
+                if (ExpectedClientCertValidationResultCount == 1) {
+                    TEST_FAILURE(
+                        "Unexpected Certificate Validation Status, expected=0x%x, actual=0x%x",
+                        ExpectedClientCertValidationResult[0],
+                        Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus);
+                } else if (ExpectedClientCertValidationResultCount == 2) {
+                    TEST_FAILURE(
+                        "Unexpected Certificate Validation Status, expected=0x%x or 0x%x, actual=0x%x",
+                        ExpectedClientCertValidationResult[0],
+                        ExpectedClientCertValidationResult[1],
+                        Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus);
+                }
+            }
+        } else if (Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus != QUIC_STATUS_SUCCESS) {
             TEST_FAILURE(
                 "Unexpected Certificate Validation Status, expected=0x%x, actual=0x%x",
-                ExpectedClientCertValidationResult,
+                QUIC_STATUS_SUCCESS,
                 Event->PEER_CERTIFICATE_RECEIVED.DeferredStatus);
         }
         break;

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -70,6 +70,7 @@ class TestConnection
     QUIC_STATUS ExpectedClientCertValidationResult[2];
     uint32_t ExpectedClientCertValidationResultCount;
     bool ExpectedCustomValidationResult;
+    QUIC_STATUS PeerCertEventReturnStatus;
 
     QUIC_STATUS TransportCloseStatus;
     QUIC_UINT62 PeerCloseErrorCode;
@@ -215,6 +216,8 @@ public:
             "Only two expected values supported.");
         ExpectedClientCertValidationResult[ExpectedClientCertValidationResultCount++] = Status;
     }
+
+    void SetPeerCertEventReturnStatus(QUIC_STATUS Value) { PeerCertEventReturnStatus = Value; }
 
     uint32_t GetDatagramsSent() const { return DatagramsSent; }
     uint32_t GetDatagramsCanceled() const { return DatagramsCanceled; }

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -67,7 +67,8 @@ class TestConnection
     bool ExpectedResumed    : 1;
     QUIC_STATUS ExpectedTransportCloseStatus;
     QUIC_UINT62 ExpectedPeerCloseErrorCode;
-    QUIC_STATUS ExpectedClientCertValidationResult;
+    QUIC_STATUS ExpectedClientCertValidationResult[2];
+    uint32_t ExpectedClientCertValidationResultCount;
     bool ExpectedCustomValidationResult;
 
     QUIC_STATUS TransportCloseStatus;
@@ -207,8 +208,13 @@ public:
     void SetExpectedCustomValidationResult(bool AcceptCert) { CustomValidationResultSet = true; ExpectedCustomValidationResult = AcceptCert; }
     void SetAsyncCustomValidationResult(bool Async) { AsyncCustomValidation = Async; }
 
-    QUIC_STATUS GetExpectedClientCertValidationResult() const { return ExpectedClientCertValidationResult; }
-    void SetExpectedClientCertValidationResult(QUIC_STATUS Status) { ExpectedClientCertValidationResult = Status; }
+    const QUIC_STATUS* GetExpectedClientCertValidationResult() const { return ExpectedClientCertValidationResult; }
+    void AddExpectedClientCertValidationResult(QUIC_STATUS Status) {
+        CXPLAT_FRE_ASSERTMSG(
+            ExpectedClientCertValidationResultCount < ARRAYSIZE(ExpectedClientCertValidationResult),
+            "Only two expected values supported.");
+        ExpectedClientCertValidationResult[ExpectedClientCertValidationResultCount++] = Status;
+    }
 
     uint32_t GetDatagramsSent() const { return DatagramsSent; }
     uint32_t GetDatagramsCanceled() const { return DatagramsCanceled; }

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -47,13 +47,21 @@ struct ServerAcceptContext {
     CXPLAT_EVENT NewConnectionReady;
     TestConnection** NewConnection;
     QUIC_STATUS ExpectedTransportCloseStatus{QUIC_STATUS_SUCCESS};
-    QUIC_STATUS ExpectedClientCertValidationResult{QUIC_STATUS_SUCCESS};
+    QUIC_STATUS ExpectedClientCertValidationResult[2]{};
+    uint32_t ExpectedClientCertValidationResultCount{0};
+    QUIC_STATUS PeerCertEventReturnStatus{false};
     ServerAcceptContext(TestConnection** _NewConnection) :
         NewConnection(_NewConnection) {
         CxPlatEventInitialize(&NewConnectionReady, TRUE, FALSE);
     }
     ~ServerAcceptContext() {
         CxPlatEventUninitialize(NewConnectionReady);
+    }
+    void AddExpectedClientCertValidationResult(QUIC_STATUS Status) {
+        CXPLAT_FRE_ASSERTMSG(
+            ExpectedClientCertValidationResultCount < ARRAYSIZE(ExpectedClientCertValidationResult),
+            "Only two expected values supported.");
+        ExpectedClientCertValidationResult[ExpectedClientCertValidationResultCount++] = Status;
     }
 };
 

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -49,7 +49,7 @@ struct ServerAcceptContext {
     QUIC_STATUS ExpectedTransportCloseStatus{QUIC_STATUS_SUCCESS};
     QUIC_STATUS ExpectedClientCertValidationResult[2]{};
     uint32_t ExpectedClientCertValidationResultCount{0};
-    QUIC_STATUS PeerCertEventReturnStatus{false};
+    QUIC_STATUS PeerCertEventReturnStatus{};
     ServerAcceptContext(TestConnection** _NewConnection) :
         NewConnection(_NewConnection) {
         CxPlatEventInitialize(&NewConnectionReady, TRUE, FALSE);


### PR DESCRIPTION
Backport #2758 to Release/2.0 with required variables and values.
