### PR TITLE
BBR: remove some unnecessary indirection

### DIFF
--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -103,7 +103,7 @@ const uint32_t kProbeRttTimeInUs = 200 * 1000;
 //
 // Time until a MinRtt measurement is expired.
 //
-const uint32_t kBbrMinRttExpirationInMicroSecs = 10 * 1000000;
+const uint32_t kBbrMinRttExpirationInMicroSecs = S_TO_US(10);
 
 const uint32_t kBbrMaxBandwidthFilterLen = 10;
 

--- a/src/core/bbr.h
+++ b/src/core/bbr.h
@@ -11,29 +11,6 @@
 
 #define kBbrDefaultFilterCapacity 3
 
-typedef struct BBR_RTT_STATS {
-
-    //
-    // TRUE if current RTT sample is expired
-    //
-    BOOLEAN RttSampleExpired: 1;
-
-    //
-    // TRUE if there has been at least one MinRtt
-    //
-    BOOLEAN MinRttTimestampValid: 1;
-
-    //
-    // The expire duration of last MinRtt
-    //
-    uint64_t Expiration; // microseconds
-
-    uint32_t MinRtt; // microseconds
-
-    uint64_t MinRttTimestamp; // microseconds
-
-} BBR_RTT_STATS;
-
 typedef struct BBR_BANDWIDTH_FILTER {
 
     //
@@ -91,6 +68,16 @@ typedef struct QUIC_CONGESTION_CONTROL_BBR {
     // If TRUE, ProbeRttEndTime is valid
     //
     BOOLEAN ProbeRttEndTimeValid : 1;
+
+    //
+    // If TRUE, current RTT sample is expired
+    //
+    BOOLEAN RttSampleExpired: 1;
+
+    //
+    // If TRUE, there has been at least one MinRtt sample
+    //
+    BOOLEAN MinRttTimestampValid: 1;
     
     //
     // The size of the initial congestion window in packets
@@ -212,13 +199,14 @@ typedef struct QUIC_CONGESTION_CONTROL_BBR {
     // The max filter tracking the recent maximum degree of aggregation in the path
     //
     QUIC_SLIDING_WINDOW_EXTREMUM MaxAckHeightFilter;
-
     QUIC_SLIDING_WINDOW_EXTREMUM_ENTRY MaxAckHeightFilterEntries[kBbrDefaultFilterCapacity];
 
+    uint32_t MinRtt; // microseconds
+
     //
-    // BBR estimates minimum RTT by the minimum recent RTT
+    // Time when MinRtt was sampled. Only valid if MinRttTimestampValid is set.
     //
-    BBR_RTT_STATS MinRttStats;
+    uint64_t MinRttTimestamp; // microseconds
 
     //
     // BBR estimates maximum bandwidth by the maximum recent bandwidth

--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -25,9 +25,15 @@ typedef struct QUIC_ACK_EVENT {
 
     uint32_t NumRetransmittableBytes;
 
+    //
+    // Connection's current SmoothedRtt.
+    //
     uint32_t SmoothedRtt;
 
-    uint32_t SmallestRttSample;
+    //
+    // The smallest calculated RTT of the packets that were just ACKed.
+    //
+    uint32_t MinRtt;
 
     //
     // Acked time minus ack delay.
@@ -40,7 +46,7 @@ typedef struct QUIC_ACK_EVENT {
 
     BOOLEAN IsLargestAckedPacketAppLimited : 1;
 
-    BOOLEAN MinRttSampleValid : 1;
+    BOOLEAN MinRttValid : 1;
 
 } QUIC_ACK_EVENT;
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1308,7 +1308,7 @@ QuicLossDetectionProcessAckBlocks(
     uint32_t AckedRetransmittableBytes = 0;
     QUIC_CONNECTION* Connection = QuicLossDetectionGetConnection(LossDetection);
     uint64_t TimeNow = CxPlatTimeUs64();
-    uint32_t MinRtt = (uint32_t)(-1);
+    uint32_t MinRtt = UINT32_MAX;
     BOOLEAN NewLargestAck = FALSE;
     BOOLEAN NewLargestAckRetransmittable = FALSE;
     BOOLEAN NewLargestAckDifferentPath = FALSE;
@@ -1485,7 +1485,7 @@ QuicLossDetectionProcessAckBlocks(
         // Update the current RTT with the smallest RTT calculated, which
         // should be for the most acknowledged retransmittable packet.
         //
-        CXPLAT_DBG_ASSERT(MinRtt != (uint32_t)(-1));
+        CXPLAT_DBG_ASSERT(MinRtt != UINT32_MAX);
         if ((uint64_t)MinRtt >= AckDelay) {
             //
             // The ACK delay looks reasonable.

--- a/src/generated/linux/bbr.c.clog.h
+++ b/src/generated/linux/bbr.c.clog.h
@@ -33,7 +33,7 @@ extern "C" {
             BbrCongestionControlGetCongestionWindow(Cc),
             Bbr->BytesInFlight,
             Bbr->BytesInFlightMax,
-            BbrCongestionControlGetMinRtt(Cc),
+            Bbr->MinRtt,
             BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
             BbrCongestionControlIsAppLimited(Cc));
 // arg2 = arg2 = Connection = arg2
@@ -42,7 +42,7 @@ extern "C" {
 // arg5 = arg5 = BbrCongestionControlGetCongestionWindow(Cc) = arg5
 // arg6 = arg6 = Bbr->BytesInFlight = arg6
 // arg7 = arg7 = Bbr->BytesInFlightMax = arg7
-// arg8 = arg8 = BbrCongestionControlGetMinRtt(Cc) = arg8
+// arg8 = arg8 = Bbr->MinRtt = arg8
 // arg9 = arg9 = BbrCongestionControlGetBandwidth(Cc) / BW_UNIT = arg9
 // arg10 = arg10 = BbrCongestionControlIsAppLimited(Cc) = arg10
 ----------------------------------------------------------*/

--- a/src/generated/linux/bbr.c.clog.h.lttng.h
+++ b/src/generated/linux/bbr.c.clog.h.lttng.h
@@ -13,7 +13,7 @@
             BbrCongestionControlGetCongestionWindow(Cc),
             Bbr->BytesInFlight,
             Bbr->BytesInFlightMax,
-            BbrCongestionControlGetMinRtt(Cc),
+            Bbr->MinRtt,
             BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
             BbrCongestionControlIsAppLimited(Cc));
 // arg2 = arg2 = Connection = arg2
@@ -22,7 +22,7 @@
 // arg5 = arg5 = BbrCongestionControlGetCongestionWindow(Cc) = arg5
 // arg6 = arg6 = Bbr->BytesInFlight = arg6
 // arg7 = arg7 = Bbr->BytesInFlightMax = arg7
-// arg8 = arg8 = BbrCongestionControlGetMinRtt(Cc) = arg8
+// arg8 = arg8 = Bbr->MinRtt = arg8
 // arg9 = arg9 = BbrCongestionControlGetBandwidth(Cc) / BW_UNIT = arg9
 // arg10 = arg10 = BbrCongestionControlIsAppLimited(Cc) = arg10
 ----------------------------------------------------------*/


### PR DESCRIPTION
-Removes several "helper" functions that make it less obvious what basic events trigger what logic.
-No more separate BBR_RTT_STATS struct with its own "constructor"- the fields are moved to QUIC_CONGESTION_CONTROL_BBR
 (except for the unnecessary Expiration field, which has just been removed).
-Some naming consistency fixes in the MinRtt bits.
-A few code comments.
