### PR TITLE
Correctly handle unsupported client cert on Windows Server 2022

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -772,6 +772,11 @@ CxPlatTlsSetClientCertPolicy(
             "SetCredentialsAttributesW(SECPKG_ATTR_CLIENT_CERT_POLICY) failed");
     }
 
+    if (SecStatus == SEC_E_UNSUPPORTED_FUNCTION)
+    {
+        return QUIC_STATUS_NOT_SUPPORTED;
+    }
+
     return SecStatusToQuicStatus(SecStatus);
 }
 

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1408,11 +1408,6 @@ CxPlatTlsSecConfigCreate(
     if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_REQUIRE_CLIENT_AUTHENTICATION) {
         Status = CxPlatTlsSetClientCertPolicy(AchContext->SecConfig);
         if (QUIC_FAILED(Status)) {
-            QuicTraceEvent(
-                LibraryErrorStatus,
-                "[ lib] ERROR, %u, %s.",
-                Status,
-                "CxPlatTlsSetClientCertPolicy");
             goto Error;
         }
     }

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1402,6 +1402,14 @@ CxPlatTlsSecConfigCreate(
 
     if (CredConfig->Flags & QUIC_CREDENTIAL_FLAG_REQUIRE_CLIENT_AUTHENTICATION) {
         Status = CxPlatTlsSetClientCertPolicy(AchContext->SecConfig);
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "CxPlatTlsSetClientCertPolicy");
+            goto Error;
+        }
     }
 
     QuicTraceLogVerbose(

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -772,8 +772,7 @@ CxPlatTlsSetClientCertPolicy(
             "SetCredentialsAttributesW(SECPKG_ATTR_CLIENT_CERT_POLICY) failed");
     }
 
-    if (SecStatus == SEC_E_UNSUPPORTED_FUNCTION)
-    {
+    if (SecStatus == SEC_E_UNSUPPORTED_FUNCTION) {
         return QUIC_STATUS_NOT_SUPPORTED;
     }
 


### PR DESCRIPTION
## Description

This PR adds check for failure statuses on `CxPlatTlsSetClientCertPolicy` when creating security config. Previously, attemt to require client certificates on Windows Server 2022 successfully created security config (although in debug builds it would hit an assert).

## Testing

Tested manually on Windows Server 2022.

## Documentation

No changes needed.
