### PR TITLE
Add ConnectionCloseStatus to Stream SHUTDOWN_DONE event

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -500,14 +500,17 @@ QuicStreamIndicateShutdownComplete(
             Stream->Connection->State.ClosedRemotely;
         Event.SHUTDOWN_COMPLETE.ConnectionErrorCode =
             Stream->Connection->CloseErrorCode;
+        Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus =
+            Stream->Connection->CloseStatus;
         QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]",
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]",
             Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
             Event.SHUTDOWN_COMPLETE.ConnectionShutdownByApp,
             Event.SHUTDOWN_COMPLETE.ConnectionClosedRemotely,
-            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode,
+            Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus);
         (void)QuicStreamIndicateEvent(Stream, &Event);
 
         Stream->ClientCallbackHandler = NULL;

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -2483,6 +2483,9 @@ namespace Microsoft.Quic
 
                 [NativeTypeName("QUIC_UINT62")]
                 internal ulong ConnectionErrorCode;
+
+                [NativeTypeName("HRESULT")]
+                internal int ConnectionCloseStatus;
             }
 
             internal partial struct _IDEAL_SEND_BUFFER_SIZE_e__Struct

--- a/src/generated/linux/stream.c.clog.h
+++ b/src/generated/linux/stream.c.clog.h
@@ -115,24 +115,26 @@ tracepoint(CLOG_STREAM_C, IndicateStartComplete , arg1, arg3, arg4, arg5);\
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamShutdownComplete
-// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]
+// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]
 // QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]",
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]",
             Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
             Event.SHUTDOWN_COMPLETE.ConnectionShutdownByApp,
             Event.SHUTDOWN_COMPLETE.ConnectionClosedRemotely,
-            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode,
+            Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = Event.SHUTDOWN_COMPLETE.ConnectionShutdown = arg3
 // arg4 = arg4 = Event.SHUTDOWN_COMPLETE.ConnectionShutdownByApp = arg4
 // arg5 = arg5 = Event.SHUTDOWN_COMPLETE.ConnectionClosedRemotely = arg5
 // arg6 = arg6 = Event.SHUTDOWN_COMPLETE.ConnectionErrorCode = arg6
+// arg7 = arg7 = Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus = arg7
 ----------------------------------------------------------*/
-#ifndef _clog_7_ARGS_TRACE_IndicateStreamShutdownComplete
-#define _clog_7_ARGS_TRACE_IndicateStreamShutdownComplete(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5, arg6)\
-tracepoint(CLOG_STREAM_C, IndicateStreamShutdownComplete , arg1, arg3, arg4, arg5, arg6);\
+#ifndef _clog_8_ARGS_TRACE_IndicateStreamShutdownComplete
+#define _clog_8_ARGS_TRACE_IndicateStreamShutdownComplete(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5, arg6, arg7)\
+tracepoint(CLOG_STREAM_C, IndicateStreamShutdownComplete , arg1, arg3, arg4, arg5, arg6, arg7);\
 
 #endif
 

--- a/src/generated/linux/stream.c.clog.h.lttng.h
+++ b/src/generated/linux/stream.c.clog.h.lttng.h
@@ -95,20 +95,22 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStartComplete,
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamShutdownComplete
-// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]
+// [strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]
 // QuicTraceLogStreamVerbose(
             IndicateStreamShutdownComplete,
             Stream,
-            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]",
+            "Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]",
             Event.SHUTDOWN_COMPLETE.ConnectionShutdown,
             Event.SHUTDOWN_COMPLETE.ConnectionShutdownByApp,
             Event.SHUTDOWN_COMPLETE.ConnectionClosedRemotely,
-            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode);
+            Event.SHUTDOWN_COMPLETE.ConnectionErrorCode,
+            Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = Event.SHUTDOWN_COMPLETE.ConnectionShutdown = arg3
 // arg4 = arg4 = Event.SHUTDOWN_COMPLETE.ConnectionShutdownByApp = arg4
 // arg5 = arg5 = Event.SHUTDOWN_COMPLETE.ConnectionClosedRemotely = arg5
 // arg6 = arg6 = Event.SHUTDOWN_COMPLETE.ConnectionErrorCode = arg6
+// arg7 = arg7 = Event.SHUTDOWN_COMPLETE.ConnectionCloseStatus = arg7
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStreamShutdownComplete,
     TP_ARGS(
@@ -116,13 +118,15 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStreamShutdownComplete,
         unsigned char, arg3,
         unsigned char, arg4,
         unsigned char, arg5,
-        unsigned long long, arg6), 
+        unsigned long long, arg6,
+        unsigned int, arg7), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, arg1)
         ctf_integer(unsigned char, arg3, arg3)
         ctf_integer(unsigned char, arg4, arg4)
         ctf_integer(unsigned char, arg5, arg5)
         ctf_integer(uint64_t, arg6, arg6)
+        ctf_integer(unsigned int, arg7, arg7)
     )
 )
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1275,6 +1275,7 @@ typedef struct QUIC_STREAM_EVENT {
             BOOLEAN ConnectionClosedRemotely : 1;
             BOOLEAN RESERVED                 : 5;
             QUIC_UINT62 ConnectionErrorCode;
+            QUIC_STATUS ConnectionCloseStatus;
         } SHUTDOWN_COMPLETE;
         struct {
             uint64_t ByteCount;

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -5517,7 +5517,7 @@
     },
     "IndicateStreamShutdownComplete": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]",
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]",
       "UniqueId": "IndicateStreamShutdownComplete",
       "splitArgs": [
         {
@@ -5539,6 +5539,10 @@
         {
           "DefinationEncoding": "llx",
           "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg7"
         }
       ],
       "macroName": "QuicTraceLogStreamVerbose"
@@ -13185,9 +13189,9 @@
         "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]"
       },
       {
-        "UniquenessHash": "47bd1eb9-3f80-aeef-c849-a6f74ef5c04e",
+        "UniquenessHash": "8e93c5ca-e390-1474-788f-e2ea6ae4d674",
         "TraceID": "IndicateStreamShutdownComplete",
-        "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx]"
+        "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [ConnectionShutdown=%hhu, ConnectionShutdownByApp=%hhu, ConnectionClosedRemotely=%hhu, ConnectionErrorCode=0x%llx, ConnectionCloseStatus=0x%x]"
       },
       {
         "UniquenessHash": "e98e6411-dfab-d3a6-e7bd-d1782209846d",

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -163,6 +163,9 @@ PingStreamShutdown(
         TEST_EQUAL(ConnState->Connection->GetPeerClosed(), Stream->GetClosedRemotely());
         TEST_EQUAL(ConnState->Connection->GetTransportClosed(), !Stream->GetShutdownByApp());
         TEST_EQUAL(ConnState->Connection->GetTransportClosed(), !Stream->GetClosedRemotely());
+        if (ConnState->Connection->GetTransportClosed()) {
+            TEST_EQUAL(ConnState->Connection->GetTransportCloseStatus(), Stream->GetConnectionCloseStatus());
+        }
         if (ConnState->Connection->GetPeerClosed()) {
             TEST_EQUAL(ConnState->Connection->GetExpectedPeerCloseErrorCode(), Stream->GetConnectionErrorCode());
         }
@@ -2481,6 +2484,7 @@ struct StreamDifferentAbortErrors {
     BOOLEAN ConnectionShutdownByApp {FALSE};
     BOOLEAN ConnectionClosedRemotely {FALSE};
     QUIC_UINT62 ConnectionErrorCode {0};
+    QUIC_STATUS ConnectionCloseStatus {0};
 
     CxPlatEvent StreamShutdownComplete;
 
@@ -2495,6 +2499,7 @@ struct StreamDifferentAbortErrors {
             TestContext->ConnectionShutdownByApp = Event->SHUTDOWN_COMPLETE.ConnectionShutdownByApp;
             TestContext->ConnectionClosedRemotely = Event->SHUTDOWN_COMPLETE.ConnectionClosedRemotely;
             TestContext->ConnectionErrorCode = Event->SHUTDOWN_COMPLETE.ConnectionErrorCode;
+            TestContext->ConnectionCloseStatus = Event->SHUTDOWN_COMPLETE.ConnectionCloseStatus;
             TestContext->StreamShutdownComplete.Set();
         }
         return QUIC_STATUS_SUCCESS;
@@ -2551,6 +2556,7 @@ QuicTestStreamDifferentAbortErrors(
     TEST_FALSE(Context.ConnectionShutdownByApp);
     TEST_FALSE(Context.ConnectionClosedRemotely);
     TEST_EQUAL(0, Context.ConnectionErrorCode);
+    TEST_EQUAL(0, Context.ConnectionCloseStatus);
 }
 
 struct StreamAbortRecvFinRace {

--- a/src/test/lib/TestStream.cpp
+++ b/src/test/lib/TestStream.cpp
@@ -24,7 +24,7 @@ TestStream::TestStream(
     IsUnidirectional(IsUnidirectional), IsPingSource(IsPingSource), UsedZeroRtt(false),
     AllDataSent(IsUnidirectional && !IsPingSource), AllDataReceived(IsUnidirectional && IsPingSource),
     SendShutdown(IsUnidirectional && !IsPingSource), RecvShutdown(IsUnidirectional && IsPingSource),
-    IsShutdown(false), ConnectionShutdown(false), ConnectionShutdownByApp(false), ConnectionClosedRemotely(false), ConnectionErrorCode(0),
+    IsShutdown(false), ConnectionShutdown(false), ConnectionShutdownByApp(false), ConnectionClosedRemotely(false), ConnectionErrorCode(0), ConnectionCloseStatus(0),
     BytesToSend(0), OutstandingSendRequestCount(0), BytesReceived(0),
     StreamShutdownCallback(StreamShutdownHandler), Context(nullptr)
 {
@@ -358,6 +358,7 @@ TestStream::HandleStreamEvent(
         ConnectionShutdownByApp = Event->SHUTDOWN_COMPLETE.ConnectionShutdownByApp;
         ConnectionClosedRemotely = Event->SHUTDOWN_COMPLETE.ConnectionClosedRemotely;
         ConnectionErrorCode = Event->SHUTDOWN_COMPLETE.ConnectionErrorCode;
+        ConnectionCloseStatus = Event->SHUTDOWN_COMPLETE.ConnectionCloseStatus;
         if (QUIC_SUCCEEDED(
             MsQuic->GetParam(
                 QuicStream,

--- a/src/test/lib/TestStream.h
+++ b/src/test/lib/TestStream.h
@@ -108,6 +108,7 @@ class TestStream
     bool ConnectionShutdownByApp  : 1;
     bool ConnectionClosedRemotely : 1;
     QUIC_UINT62 ConnectionErrorCode;
+    QUIC_STATUS ConnectionCloseStatus;
 
     volatile int64_t BytesToSend;
     volatile long OutstandingSendRequestCount;
@@ -219,6 +220,7 @@ public:
     bool GetShutdownByApp() const { return ConnectionShutdownByApp; }
     bool GetClosedRemotely() const { return ConnectionClosedRemotely; }
     QUIC_UINT62 GetConnectionErrorCode() const { return ConnectionErrorCode; }
+    QUIC_STATUS GetConnectionCloseStatus() const { return ConnectionCloseStatus; }
 
     uint64_t GetBytesToSend() const { return (uint64_t)BytesToSend; }
     uint32_t GetOutstandingSendRequestCount() const { return OutstandingSendRequestCount; };


### PR DESCRIPTION
This is another small follow-up on https://github.com/microsoft/msquic/pull/2872. It allows application to differentiate different transport-initiated shutdowns based on the Connection->CloseStatus (like CONNECTION_IDLE vs CONNECTION_TIMEOUT). without maintaining an explicit link to the main QUIC Connection object.

## Testing

Tests were updated to check the close status, also tested against local .NET runtime build.

## Documentation

No change (there are no docs for event data AFAICS).