### PR TITLE
Remove OpenSSL from 1.0 builds.

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -146,36 +146,13 @@ stages:
       arch: x64
       tls: schannel
       extraBuildArgs: -DisableTools -DisableTest
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-2019
-      platform: windows
-      arch: x64
-      tls: openssl
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-2019
-      platform: windows
-      arch: arm64
-      tls: openssl
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: windows-2019
-      platform: windows
-      arch: x86
-      tls: openssl
 
 - stage: build_linux
   displayName: Build Linux
   dependsOn: []
   jobs:
   # Officially supported configurations.
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: ubuntu-latest
-      platform: linux
-      arch: x64
-      tls: openssl
+  #   Removed due to OpenSSL upstream branch deletion causing build failures.
   # Other configurations.
   - template: ./templates/build-config-user.yml
     parameters:
@@ -184,24 +161,6 @@ stages:
       arch: x64
       tls: stub
       extraBuildArgs: -SanitizeAddress
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: ubuntu-latest
-      platform: linux
-      arch: x64
-      tls: openssl
-      extraBuildArgs: -Clang
-      skipArtifacts: true
-      extraName: 'clang'
-  - template: ./templates/build-config-user.yml
-    parameters:
-      image: ubuntu-latest
-      container: raspbian
-      platform: linux
-      arch: arm
-      tls: openssl
-      ubuntuVersion: 18.04
-      extraBuildArgs: -DisableLogs -ToolchainFile cmake/toolchains/arm-pi-gnueabihf.toolchain.cmake
 
 #
 # Windows Release BVTs
@@ -281,18 +240,6 @@ stages:
       extraArgs: -Filter -*Unreachable/0:CryptTest/CryptTest.Encryption/2:TlsTest.CertificateError
   - template: ./templates/run-bvt.yml
     parameters:
-      image: windows-latest
-      platform: windows
-      tls: openssl
-      extraArgs: -Filter -*TlsTest.CertificateError:ParameterValidation.ValidateServerSecConfig:Basic/WithFamilyArgs.Unreachable/0:AppData/*:Misc/*
-  - template: ./templates/run-bvt.yml
-    parameters:
-      image: ubuntu-latest
-      platform: linux
-      tls: openssl
-      extraArgs: -Filter -*TlsTest.CertificateError
-  - template: ./templates/run-bvt.yml
-    parameters:
       image: ubuntu-latest
       platform: linux
       tls: stub
@@ -320,19 +267,9 @@ stages:
       tls: stub
   - template: ./templates/run-spinquic.yml
     parameters:
-      image: windows-latest
-      platform: windows
-      tls: openssl
-  - template: ./templates/run-spinquic.yml
-    parameters:
       image: ubuntu-latest
       platform: linux
       tls: stub
-  - template: ./templates/run-spinquic.yml
-    parameters:
-      image: ubuntu-latest
-      platform: linux
-      tls: openssl
 
 #
 # Code Coverage
@@ -383,16 +320,6 @@ stages:
       image: windows-latest
       platform: windows
       tls: mitls
-  - template: ./templates/run-quicinterop.yml
-    parameters:
-      image: windows-latest
-      platform: windows
-      tls: openssl
-  - template: ./templates/run-quicinterop.yml
-    parameters:
-      image: ubuntu-latest
-      platform: linux
-      tls: openssl
 
 #
 # Mirror

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,6 @@
 [submodule "submodules/googletest"]
 	path = submodules/googletest
 	url = https://github.com/google/googletest
-[submodule "submodules/openssl"]
-	path = submodules/openssl
-	url = https://github.com/akamai/openssl.git
-	branch = master-alpha4-quic-support
 [submodule "submodules/everest"]
 	path = submodules/everest
 	url = https://github.com/nibanks/everest-dist.git


### PR DESCRIPTION
## Description

Remove OpenSSL submodule from Release/1.0 due to build failures.

## Testing

CI

## Documentation

OpenSSL wasn't officially supported on Release/1.0, and Linux support was in preview, so it's fine to remove.
