### PR TITLE
Disable Failing Loopback Tests on Shared EC Linux

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -451,7 +451,7 @@ stages:
         extraTestArgs: -ExtraArtifactDir _SharedEC
         ${{ if ne(parameters.testToRun, 'all') }}:
           testToRun: ${{ parameters.testToRun }}
-        testTypes: ${{ parameters.testTypes }}
+        testTypes: 'Remote'
         ${{ if eq(parameters.pgo_mode, false) }}:
           extraArgs: -SharedEC -Publish
         ${{ if eq(parameters.pgo_mode, true) }}:


### PR DESCRIPTION
## Description

Fix #2794 by disabling the slow tests.

## Testing

Automation

## Documentation

None
