### PR TITLE
add support for arm packages

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -61,6 +61,9 @@ while :; do
 
     lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
     case $lowerI in
+        -a|-arch|--arch)
+            ARCH=$1
+            ;;
         -d|-debug|--debug)
             CONFIG=Debug
             ;;

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -31,8 +31,16 @@ if [ "$OS" == 'Linux' ]; then
         ARCH='x64'
         LIBDIR="lib64"
     else
-        ARCH=x86
         LIBDIR="lib"
+        if [ "$ARCH" == "aarch64" ]; then
+            ARCH=arm64
+        else
+            if [ "$ARCH" == "armv7l" ]; then
+                ARCH=arm
+            else
+                ARCH=x86
+            fi
+        fi
     fi
 else
   if [ "$OS" == 'Darwin' ]; then
@@ -93,7 +101,7 @@ mkdir -p ${OUTPUT}
 
 if [ "$OS" == "linux" ]; then
   # Create symlink
-  ln -s "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}"
+  ln -sf "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}"
 
   # RedHat/CentOS
   FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -127,9 +127,16 @@ if [ "$OS" == "linux" ]; then
     ${FILES}
 
   # Debian/Ubuntu
-  if [ "$LIBDIR" == 'lib64' ]; then
+  if [ "$ARCH" == 'x64' ]; then
       LIBDIR="lib/x86_64-linux-gnu"
   fi
+  if [ "$ARCH" == 'arm64' ];then
+    LIBDIR="lib/aarch64-linux-gnu"
+  fi
+  if [ "$ARCH" == 'arm' ];then
+    LIBDIR="lib/arm-linux-gnueabihf"
+  fi
+
   FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
   FILES="${FILES} ${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}"
   if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ]; then

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -101,7 +101,7 @@ mkdir -p ${OUTPUT}
 
 if [ "$OS" == "linux" ]; then
   # Create symlink
-  ln -sf "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}"
+  ln -s "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}"
 
   # RedHat/CentOS
   FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"


### PR DESCRIPTION
## Description

This adds platform recognition for arm/arm64 on Linux
## Testing

script can now make arm packages
```
root@1284925c1f1c:~/msquic# ls -al artifacts/packages/linux/arm64_Release_openssl/
total 8816
drwxr-xr-x 2 root root    4096 Aug  4 21:26 .
drwxr-xr-x 6 root root    4096 Aug  4 16:24 ..
-rw-r--r-- 1 root root 4503356 Aug  4 21:26 libmsquic-2.1.0-1.aarch64.rpm
-rw-r--r-- 1 root root 4513350 Aug  4 21:26 libmsquic_2.1.0_arm64.deb
```

## Documentation

no.