### PR TITLE
Don't Check Minor Version in Test

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2295,7 +2295,6 @@ void QuicTestGlobalParam()
                     &Length,
                     &ActualVersion));
             TEST_EQUAL(ActualVersion[0], 2);
-            TEST_EQUAL(ActualVersion[1], 1);
             // value of idx 2 and 3 are decided at build time.
             // it is hard to verify the values at runtime.
         }


### PR DESCRIPTION
## Description

We can't test the minor version because it will 100% fail when run as a down-level test. To support running this with future versions of MsQuic, just validate the major version.

## Testing

Tests updated

## Documentation

N/A
