### PR TITLE
Harden Github Actions.

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -23,7 +23,21 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          azure.archive.ubuntu.com:80
+          crates.io:443
+          dc.services.visualstudio.com:443
+          github.com:443
+          launchpad.net:443
+          packages.microsoft.com:443
+          ppa.launchpad.net:80
+          rubygems.org:443
+          sh.rustup.rs:443
+          static.crates.io:443
+          static.rust-lang.org:443
+          www.cloudflare.com:443
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
     - name: Prepare Machine

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,18 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.nuget.org:443
+            azure.archive.ubuntu.com:80
+            boringssl.googlesource.com:443
+            dc.services.visualstudio.com:443
+            github.com:443
+            launchpad.net:443
+            packages.microsoft.com:443
+            ppa.launchpad.net:80
+            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,7 @@ jobs:
             registry-1.docker.io:443
             archive.ubuntu.com:80
             security.ubuntu.com:80
+            packages.microsoft.com:443
       - name: Checkout repository
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
       - name: Checkout repository
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,16 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            boringssl.googlesource.com:443
+            ghcr.io:443
+            github.com:443
+            pkg-containers.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
       - name: Checkout repository
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,8 @@ jobs:
             archive.ubuntu.com:80
             security.ubuntu.com:80
             packages.microsoft.com:443
+            api.nuget.org:443
+            dc.services.visualstudio.com:443
       - name: Checkout repository
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
         with:

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -38,7 +38,17 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          api.nuget.org:443
+          azure.archive.ubuntu.com:80
+          dc.services.visualstudio.com:443
+          github.com:443
+          launchpad.net:443
+          objects.githubusercontent.com:443
+          packages.microsoft.com:443
+          ppa.launchpad.net:80
+          rubygems.org:443
     - name: Checkout repository
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5
     - name: Prepare Machine


### PR DESCRIPTION
## Description

The Harden runner step produces policy to enforce based on auditing. This change implements the generated policy and enforces it.
**NOTE:** this may cause a build break if anything was missed. But it's trivial to fix as we go forward.

## Testing

Automated CI

## Documentation

N/A
