### PR TITLE
Fix kqueue behavior for FreeBSD

### DIFF
--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -425,6 +425,9 @@ QuicAddr4FromString(
         }
     }
     Addr->Ip.sa_family = QUIC_ADDRESS_FAMILY_INET;
+#if defined(__FreeBSD__)
+    Addr->Ipv4.sin_len = sizeof(struct sockaddr_in);
+#endif
     return TRUE;
 }
 
@@ -459,6 +462,9 @@ QuicAddr6FromString(
         }
     }
     Addr->Ip.sa_family = QUIC_ADDRESS_FAMILY_INET6;
+#if defined(__FreeBSD__)
+    Addr->Ipv6.sin6_len = sizeof(struct sockaddr_in6);
+#endif
     return TRUE;
 }
 

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -97,6 +97,10 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) throw() { return (ENUMTYP
 #define ENOKEY 126
 #endif // ENOKEY
 
+#ifndef ETIME // undefined on FreeBSD
+#define ETIME ETIMEDOUT
+#endif // ETIME
+
 #define ERROR_BASE                          200000000                       // 0xBEBC200
 #define TLS_ERROR_BASE                      256 + ERROR_BASE                // 0xBEBC300
 #define CERT_ERROR_BASE                     512 + ERROR_BASE                // 0xBEBC400

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -98,7 +98,7 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) throw() { return (ENUMTYP
 #endif // ENOKEY
 
 #ifndef ETIME // undefined on FreeBSD
-#define ETIME ETIMEDOUT
+#define ETIME 101 // same as macOS's: change this if 101 is added to errno.h
 #endif // ETIME
 
 #define ERROR_BASE                          200000000                       // 0xBEBC200

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -23,12 +23,14 @@ Environment:
 #error "Incorrectly including Posix Platform Header from unsupported platfrom"
 #endif
 
+/*
 // For FreeBSD
 #if defined(__FreeBSD__)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #define ETIME   ETIMEDOUT
 #endif
+*/
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -41,10 +43,10 @@ Environment:
 #include <stddef.h>
 #include <stdalign.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <unistd.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include "msquic_posix.h"
 #include <stdbool.h>
 #include <pthread.h>

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -23,15 +23,6 @@ Environment:
 #error "Incorrectly including Posix Platform Header from unsupported platfrom"
 #endif
 
-/*
-// For FreeBSD
-#if defined(__FreeBSD__)
-#include <sys/socket.h>
-#include <netinet/in.h>
-#define ETIME   ETIMEDOUT
-#endif
-*/
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdarg.h>


### PR DESCRIPTION
## Description

Fix kqueue behavior for FreeBSD and maybe MacOS.

## Testing

The fix will also affect MacOS and tests are needed.

## Documentation

It looks like
```
EV_SET(&Event, EVFILT_USER)
kevent(ProcContext->KqueueFd, &Event)
```
doesn't trigger an event at kevent() loop in CxPlatDataPathRunEC() and the loop blocks forever with FreeBSD.
Instead of adding EVFILT_USER event by kevent, I used fd created by pipe() and registered it to ProcContext->KqueueFd, then notified the loop by write(fd).
