### PR TITLE
Use isolated ACR for linux

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -34,10 +34,11 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
+  ONEBRANCH_AME_ACR_LOGIN: onebranch.azurecr.io, cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io
 
   WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2019:latest'
   WindowsContainerImage2: 'cdpxwin1809.azurecr.io/user/corenet/msquic:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
-  LinuxContainerImage: 'cdpxlinux.azurecr.io/user/corenet/msquic:latest'
+  LinuxContainerImage: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:20220811.5'
   LinuxContainerImage2: 'cdpxlinux.azurecr.io/global/ubuntu-1804:latest'
 
 resources:


### PR DESCRIPTION
## Description

Shared ACR for onebranch build pipeline is retiring soon. Use isolated ACR instead as suggested.

## Testing

OB CI