### PR TITLE
Remove main trigger for publish OBP

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -1,6 +1,8 @@
 #
 # Uploads a SIGNED package from a given URL to packages.microsoft.com.
 #
+trigger: none
+
 parameters:
 - name: PackageUrl
   displayName: Package URL


### PR DESCRIPTION
## Description

It seems that by default, azure pipelines are triggered by main branch. Remove it for this pipeline.

## Testing

OBP CI