### PR TITLE
Fix QUIC Statistics Size Helpers

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -492,8 +492,8 @@ typedef struct QUIC_STATISTICS_V2 {
 #define QUIC_STRUCT_SIZE_THRU_FIELD(Struct, Field) \
     (FIELD_OFFSET(Struct, Field) + sizeof(((Struct*)0)->Field))
 
-#define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)
-#define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendCongestionWindow)
+#define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)         // v2.0 final size
+#define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // v2.1 final size
 
 typedef struct QUIC_LISTENER_STATISTICS {
 


### PR DESCRIPTION
## Description

Updates `QUIC_STATISTICS_V2_SIZE_2` to reflect the correct final size for v2.1. Also adds comments explaining what these are for.

> *Note* - This must be backported to release/2.1

## Testing

Existing

## Documentation

N/A
