### PR TITLE
retry pthread create if it failes with ENOKEY

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -658,6 +658,12 @@ CxPlatThreadCreate(
             "[ lib] ERROR, %u, %s.",
             Status,
             "pthread_create failed");
+
+        // Try it again without attributes.
+        // pthread_create can fail with ENOKEY if we request affinity on CPU that is offline
+        if (Status == ENOKEY && pthread_create(Thread, NULL, Config->Callback, Config->Context) == 0) {
+            Status = QUIC_STATUS_SUCCESS;
+        }
     }
 
 #endif // !CXPLAT_USE_CUSTOM_THREAD_CONTEXT

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -652,7 +652,7 @@ CxPlatThreadCreate(
 #else // CXPLAT_USE_CUSTOM_THREAD_CONTEXT
 
     //
-    // If pthread_create fails eith ENOKEY, then try again without the attribute
+    // If pthread_create fails with ENOKEY, then try again without the attribute
     // because the CPU might be offline.
     //
     if (pthread_create(Thread, &Attr, Config->Callback, Config->Context) &&


### PR DESCRIPTION
## Description

when we try to set affinity on core that is offline pthread_create fails (on glibc) 
We should perhaps figure out better way how to do the core management but this is simple fix that unblocks .NET ARM testing. Performance may be sub-optimal but at least msquic is functional. 

## Testing

running .NET test suite on ARM64 box with some offline cores. 

## Documentation

no