### PR TITLE
Specify libssl1.1 dependency on deb package

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -134,6 +134,7 @@ if [ "$OS" == "linux" ]; then
     --name ${NAME} \
     --provides ${NAME} \
     --conflicts ${CONFLICTS} \
+    --depends "libssl1.1" \
     --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
     --description "${DESCRIPTION}" \
     --vendor "${VENDOR}" \


### PR DESCRIPTION
Fixes #2975 

## Description

This PR explicitly states that the deb package depends on libssl1.1 being installed. This makes the installation fail on e.g. Ubuntu 22.04 which is on OpenSSL 3.0 and the lib would fail to load unless user manually installs missing libssl1.1.

I wanted to change the rpm package as well, but I did not manage to make it work across RHEL/CentOS 8/9 since RHEL 8 uses `openssl-libs` and RHEL 9 uses `compat-openssl11` to install `libcrypto.so.1.1` (and specifying `libcrypto.so.1.1` directly as a dependency did not work). Suggestions welcome.

## Testing

Tested locally built deb package on:
- Ubuntu 20 - no functional change
- Ubuntu 22 - dpkg -i mentions that there are unmet dependencies, I assume that apt-get install would fail with meaningful error message. After manually installing libssl1.1 package (e.g. ttp://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb), the warning is gone.
- Debian buster - no functional changes
- Debian bookworm (preview) - same as Ubuntu 22

## Documentation

_Is there any documentation impact for this change?_

No
