### PR TITLE
Fix CI: Ignore Lint Check

### DIFF
--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1186,11 +1186,10 @@ QuicCryptoTlsEncodeTransportParameters(
     return TPBufBase;
 }
 
-
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
-BOOLEAN // NOLINT(readability-function-size)
-QuicCryptoTlsDecodeTransportParameters(
+BOOLEAN
+QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size)
     _In_opt_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN IsServerTP,
     _In_reads_(TPLen)

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1186,10 +1186,10 @@ QuicCryptoTlsEncodeTransportParameters(
     return TPBufBase;
 }
 
-// NOLINTBEGIN(readability-function-size)
+
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
-BOOLEAN
+BOOLEAN // NOLINT(readability-function-size)
 QuicCryptoTlsDecodeTransportParameters(
     _In_opt_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN IsServerTP,
@@ -1855,7 +1855,6 @@ Exit:
 
     return Result;
 }
-// NOLINTEND(readability-function-size)
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1189,7 +1189,7 @@ QuicCryptoTlsEncodeTransportParameters(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN
-QuicCryptoTlsDecodeTransportParameters( // NOLINT(*readability-function-size)
+QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, google-readability-function-size, hicpp-function-size)
     _In_opt_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN IsServerTP,
     _In_reads_(TPLen)

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1186,6 +1186,7 @@ QuicCryptoTlsEncodeTransportParameters(
     return TPBufBase;
 }
 
+// NOLINTBEGIN(readability-function-size)
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN
@@ -1854,6 +1855,7 @@ Exit:
 
     return Result;
 }
+// NOLINTEND(readability-function-size)
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1189,7 +1189,7 @@ QuicCryptoTlsEncodeTransportParameters(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN
-QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size)
+QuicCryptoTlsDecodeTransportParameters( // NOLINT(*readability-function-size)
     _In_opt_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN IsServerTP,
     _In_reads_(TPLen)


### PR DESCRIPTION
## Description

Fixing for Linux Non-Tested CI, ignore lint checks for readability size.

## Testing

N/A

## Documentation

N/A
