### PR TITLE
Convert throughput tests from data transferred to timed.

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -12,7 +12,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -46,7 +46,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -upload:2000000000 -tcp:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -tcp:1"
             },
             "Variables": [
             ],
@@ -66,7 +66,7 @@
                 "Tls": ["openssl"],
                 "Arch": ["x64", "arm"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -upload:2000000000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -100,7 +100,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -126,7 +126,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -download:2000000000 -tcp:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -tcp:1"
             },
             "Variables": [
             ],
@@ -146,7 +146,7 @@
                 "Tls": ["openssl"],
                 "Arch": ["x64", "arm"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -download:2000000000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:12000 -stats:1"
             },
             "Variables": [
                 {

--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -12,7 +12,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -upload:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -46,7 +46,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -tcp:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -upload:12000 -tcp:1"
             },
             "Variables": [
             ],
@@ -66,7 +66,7 @@
                 "Tls": ["openssl"],
                 "Arch": ["x64", "arm"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:12000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:1 -upload:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -100,7 +100,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -download:12000 -stats:1"
             },
             "Variables": [
                 {
@@ -126,7 +126,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:12000 -tcp:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -download:12000 -tcp:1"
             },
             "Variables": [
             ],
@@ -146,7 +146,7 @@
                 "Tls": ["openssl"],
                 "Arch": ["x64", "arm"],
                 "Exe": "secnetperf",
-                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:12000 -stats:1"
+                "Arguments": "-test:Throughput -target:$RemoteAddress -uni:1 -timed:1 -download:12000 -stats:1"
             },
             "Variables": [
                 {


### PR DESCRIPTION
## Description

Convert throughput tests to timer-based instead of data-transferred based. This will help the tests have more predictable results in a variety of scenarios.

## Testing

CI

## Documentation

N/A
