### PR TITLE
Remove unused YieldProcessor macros

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -90,16 +90,9 @@ extern "C" {
 #define __fallthrough // fall through
 #endif /* __GNUC__ >= 7 */
 
-
 //
 // Interlocked implementations.
 //
-
-#ifdef CX_PLATFORM_DARWIN
-#define YieldProcessor()
-#else
-#define YieldProcessor() pthread_yield()
-#endif
 
 inline
 long


### PR DESCRIPTION
These macros are unused and confusing due to similarity to the new CxPlatSchedulerYield.