### PR TITLE
Fix abstract comment in quic_platform_posix.h that just claims it's for linux

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -5,11 +5,12 @@
 
 Abstract:
 
-    This file contains linux platform implementation.
+    This file contains POSIX platform implementations of the
+    QUIC Platform Interfaces.
 
 Environment:
 
-    Linux user mode
+    POSIX user mode
 
 --*/
 


### PR DESCRIPTION
POSIX is just so much bigger than that