### PR TITLE
add 0x63 status code

### DIFF
--- a/src/cs/lib/MsQuicException.cs
+++ b/src/cs/lib/MsQuicException.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Quic
             else if (status == MsQuic.QUIC_STATUS_CERT_EXPIRED) return "QUIC_STATUS_CERT_EXPIRED";
             else if (status == MsQuic.QUIC_STATUS_CERT_UNTRUSTED_ROOT) return "QUIC_STATUS_CERT_UNTRUSTED_ROOT";
             else if (status == MsQuic.QUIC_STATUS_CERT_NO_CERT) return "QUIC_STATUS_CERT_NO_CERT";
+            else if (status == MsQuic.QUIC_STATUS_ADDRESS_NOT_AVAILABLE) return "QUIC_STATUS_ADDRESS_NOT_AVAILABLE";
             else return "Unknown status";
         }
 

--- a/src/cs/lib/msquic.cs
+++ b/src/cs/lib/msquic.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Quic
         public static int QUIC_ADDRESS_FAMILY_UNSPEC => OperatingSystem.IsWindows() ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_UNSPEC : (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) ? MsQuic_Linux.QUIC_ADDRESS_FAMILY_UNSPEC : MsQuic_Linux.QUIC_ADDRESS_FAMILY_UNSPEC;
         public static int QUIC_ADDRESS_FAMILY_INET => OperatingSystem.IsWindows() ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_INET : (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) ? MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET : MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET;
         public static int QUIC_ADDRESS_FAMILY_INET6 => OperatingSystem.IsWindows() ? MsQuic_Windows.QUIC_ADDRESS_FAMILY_INET6 : (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) ? MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET6 : MsQuic_Linux.QUIC_ADDRESS_FAMILY_INET6;
+        public static int QUIC_STATUS_ADDRESS_NOT_AVAILABLE => OperatingSystem.IsLinux() ? MsQuic_Linux.QUIC_STATUS_ADDRESS_NOT_AVAILABLE : OperatingSystem.IsMacOS() ? MsQuic_MacOS.QUIC_STATUS_ADDRESS_NOT_AVAILABLE : MsQuic_Linux.QUIC_STATUS_ADDRESS_NOT_AVAILABLE;
     }
 
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>

--- a/src/cs/lib/msquic_generated_linux.cs
+++ b/src/cs/lib/msquic_generated_linux.cs
@@ -114,6 +114,9 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_STATUS_CERT_NO_CERT QUIC_STATUS_CERT_ERROR(3)")]
         public const int QUIC_STATUS_CERT_NO_CERT = ((int)(3) + 512 + 200000000);
 
+        [NativeTypeName("#define QUIC_STATUS_ADDRESS_NOT_AVAILABLE ((QUIC_STATUS)EADDRNOTAVAIL)")]
+        public const int QUIC_STATUS_ADDRESS_NOT_AVAILABLE = ((int)(0x63));
+
         public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
         public const int QUIC_ADDRESS_FAMILY_INET = 2;
         public const int QUIC_ADDRESS_FAMILY_INET6 = 10;

--- a/src/cs/lib/msquic_generated_macos.cs
+++ b/src/cs/lib/msquic_generated_macos.cs
@@ -114,6 +114,9 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_STATUS_CERT_NO_CERT QUIC_STATUS_CERT_ERROR(3)")]
         public const int QUIC_STATUS_CERT_NO_CERT = ((int)(3) + 512 + 200000000);
 
+        [NativeTypeName("#define QUIC_STATUS_ADDRESS_NOT_AVAILABLE ((QUIC_STATUS)EADDRNOTAVAIL)")]
+        public const int QUIC_STATUS_ADDRESS_NOT_AVAILABLE = ((int)(0x63));
+
         public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
         public const int QUIC_ADDRESS_FAMILY_INET = 2;
         public const int QUIC_ADDRESS_FAMILY_INET6 = 30;


### PR DESCRIPTION
## Description

Fixes dotnet/runtime#74053 by introducing a new status code so dotnet runtime could display a friendly message when IPv6 is not supported.
