### PR TITLE
EADDRNOTAVAIL code is 49 on macos

### DIFF
--- a/src/cs/lib/msquic_generated_macos.cs
+++ b/src/cs/lib/msquic_generated_macos.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Quic
         public const int QUIC_STATUS_CERT_NO_CERT = ((int)(3) + 512 + 200000000);
 
         [NativeTypeName("#define QUIC_STATUS_ADDRESS_NOT_AVAILABLE ((QUIC_STATUS)EADDRNOTAVAIL)")]
-        public const int QUIC_STATUS_ADDRESS_NOT_AVAILABLE = ((int)(0x63));
+        public const int QUIC_STATUS_ADDRESS_NOT_AVAILABLE = ((int)(0x31));
 
         public const int QUIC_ADDRESS_FAMILY_UNSPEC = 0;
         public const int QUIC_ADDRESS_FAMILY_INET = 2;


### PR DESCRIPTION
## Description

Follow up PR for dotnet/runtime#74053. As mentioned by @rzikm, the code error for EADDRNOTAVAIL code is 49 on macos.

https://github.com/dotnet/runtime/pull/74780#discussion_r958375123
