### PR TITLE
Always creating worker threads without affinitization on error.

### DIFF
--- a/src/generated/linux/platform_posix.c.clog.h
+++ b/src/generated/linux/platform_posix.c.clog.h
@@ -14,6 +14,10 @@
 #include "platform_posix.c.clog.h.lttng.h"
 #endif
 #include <lttng/tracepoint-event.h>
+#ifndef _clog_MACRO_QuicTraceLogWarning
+#define _clog_MACRO_QuicTraceLogWarning  1
+#define QuicTraceLogWarning(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
+#endif
 #ifndef _clog_MACRO_QuicTraceLogInfo
 #define _clog_MACRO_QuicTraceLogInfo  1
 #define QuicTraceLogInfo(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
@@ -25,6 +29,22 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/*----------------------------------------------------------
+// Decoder Ring for PlatformThreadCreateFailed
+// [ lib] pthread_create failed, retrying without affinitization
+// QuicTraceLogWarning(
+            PlatformThreadCreateFailed,
+            "[ lib] pthread_create failed, retrying without affinitization");
+----------------------------------------------------------*/
+#ifndef _clog_2_ARGS_TRACE_PlatformThreadCreateFailed
+#define _clog_2_ARGS_TRACE_PlatformThreadCreateFailed(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_PLATFORM_POSIX_C, PlatformThreadCreateFailed );\
+
+#endif
+
+
+
+
 /*----------------------------------------------------------
 // Decoder Ring for PosixLoaded
 // [ dso] Loaded

--- a/src/generated/linux/platform_posix.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_posix.c.clog.h.lttng.h
@@ -2,6 +2,22 @@
 
 
 /*----------------------------------------------------------
+// Decoder Ring for PlatformThreadCreateFailed
+// [ lib] pthread_create failed, retrying without affinitization
+// QuicTraceLogWarning(
+            PlatformThreadCreateFailed,
+            "[ lib] pthread_create failed, retrying without affinitization");
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PLATFORM_POSIX_C, PlatformThreadCreateFailed,
+    TP_ARGS(
+), 
+    TP_FIELDS(
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for PosixLoaded
 // [ dso] Loaded
 // QuicTraceLogInfo(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -8195,6 +8195,13 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
+    "PlatformThreadCreateFailed": {
+      "ModuleProperites": {},
+      "TraceString": "[ lib] pthread_create failed, retrying without affinitization",
+      "UniqueId": "PlatformThreadCreateFailed",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogWarning"
+    },
     "PlatformWorkerThreadShutdown": {
       "ModuleProperites": {},
       "TraceString": "[ lib][%p] Worker shutdown",
@@ -14262,6 +14269,11 @@
         "UniquenessHash": "68f39cf7-bcf8-8314-a151-2316d10bead4",
         "TraceID": "PerfTcpStartTls",
         "EncodingString": "[perf][tcp][%p] Start TLS"
+      },
+      {
+        "UniquenessHash": "c77e1439-2c2d-7baf-4509-bd2f7eeea771",
+        "TraceID": "PlatformThreadCreateFailed",
+        "EncodingString": "[ lib] pthread_create failed, retrying without affinitization"
       },
       {
         "UniquenessHash": "a1966729-6907-53f2-9390-1d40ba5e9d4d",

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -665,11 +665,11 @@ CxPlatThreadCreate(
 #else // CXPLAT_USE_CUSTOM_THREAD_CONTEXT
 
     //
-    // If pthread_create fails with ENOKEY or ENOENT, then try again without the attribute
+    // If pthread_create fails with an error code, then try again without the attribute
     // because the CPU might be offline.
     //
     if (pthread_create(Thread, &Attr, Config->Callback, Config->Context) &&
-        ((errno != ENOKEY && errno != ENOENT) || pthread_create(Thread, NULL, Config->Callback, Config->Context))) {
+        pthread_create(Thread, NULL, Config->Callback, Config->Context)) {
         Status = errno;
         QuicTraceEvent(
             LibraryErrorStatus,

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -669,11 +669,9 @@ CxPlatThreadCreate(
     // because the CPU might be offline.
     //
     if (pthread_create(Thread, &Attr, Config->Callback, Config->Context)) {
-        QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] WARNING, %u, %s.",
-            errno,
-            "pthread_create failed, retrying without affinitization");
+        QuicTraceLogWarning(
+            PlatformThreadCreateFailed,
+            "[ lib] pthread_create failed, retrying without affinitization");
         if (pthread_create(Thread, NULL, Config->Callback, Config->Context)) {
             Status = errno;
             QuicTraceEvent(

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -668,14 +668,20 @@ CxPlatThreadCreate(
     // If pthread_create fails with an error code, then try again without the attribute
     // because the CPU might be offline.
     //
-    if (pthread_create(Thread, &Attr, Config->Callback, Config->Context) &&
-        pthread_create(Thread, NULL, Config->Callback, Config->Context)) {
-        Status = errno;
+    if (pthread_create(Thread, &Attr, Config->Callback, Config->Context)) {
         QuicTraceEvent(
             LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            Status,
-            "pthread_create failed");
+            "[ lib] WARNING, %u, %s.",
+            errno,
+            "pthread_create failed, retrying without affinitization");
+        if (pthread_create(Thread, NULL, Config->Callback, Config->Context)) {
+            Status = errno;
+            QuicTraceEvent(
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                Status,
+                "pthread_create failed");
+        }
     }
 
 #endif // !CXPLAT_USE_CUSTOM_THREAD_CONTEXT


### PR DESCRIPTION
## Description

On combination Docker+Debian11+ARM64, the call to pthread_create sometimes returns EINVAL when attempting thread affinitization. This PR always retries thread creation without thread affinitization when the first call to pthread_create fails.

Related to https://github.com/dotnet/runtime/issues/74952

## Testing

Tested manually on the affected platform.

## Documentation

NO
