### PR TITLE
Fix/suppress some new clang/cppcheck warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,12 +632,14 @@ if(QUIC_CODE_CHECK)
             -altera-*
             -android-cloexec-fopen
             -android-cloexec-socket
+            -bugprone-assignment-in-if-condition
             -bugprone-easily-swappable-parameters
             -bugprone-implicit-widening-of-multiplication-result
             -bugprone-macro-parentheses
             -bugprone-narrowing-conversions
             -bugprone-reserved-identifier
             -bugprone-sizeof-expression
+            -modernize-macro-to-enum
             -cert-dcl37-c
             -cert-dcl51-cpp
             -cert-err33-c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ if(QUIC_CODE_CHECK)
             -bugprone-sizeof-expression
             -cert-dcl37-c
             -cert-dcl51-cpp
+            -cert-err33-c
             -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
             -clang-diagnostic-microsoft-anon-tag
             -concurrency-mt-unsafe
@@ -653,7 +654,9 @@ if(QUIC_CODE_CHECK)
             -llvmlibc-restrict-system-libc-headers
             -misc-no-recursion # do you really need recursion?
             -readability-avoid-const-params-in-decls
+            -readability-duplicate-include
             -readability-function-cognitive-complexity
+            -readability-identifier-length
             -readability-isolate-declaration
             -readability-magic-numbers
             -readability-non-const-parameter

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -521,7 +521,7 @@ MsQuicConnectionSendResumptionTicket(
         goto Error;
     }
 
-    if (Flags > (QUIC_SEND_RESUMPTION_FLAG_FINAL | QUIC_SEND_RESUMPTION_FLAG_NONE)) { // cppcheck-suppress badBitmaskCheck
+    if (Flags > QUIC_SEND_RESUMPTION_FLAG_FINAL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -521,7 +521,7 @@ MsQuicConnectionSendResumptionTicket(
         goto Error;
     }
 
-    if (Flags > (QUIC_SEND_RESUMPTION_FLAG_FINAL | QUIC_SEND_RESUMPTION_FLAG_NONE)) {
+    if (Flags > (QUIC_SEND_RESUMPTION_FLAG_FINAL | QUIC_SEND_RESUMPTION_FLAG_NONE)) { // cppcheck-suppress badBitmaskCheck
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Error;
     }

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -134,14 +134,13 @@ BbrBandwidthFilterOnPacketAcked(
 
         uint64_t SendRate = UINT64_MAX;
         uint64_t AckRate = UINT64_MAX;
-        uint32_t AckElapsed = 0;
-        uint32_t SendElapsed = 0;
 
         if (AckedPacket->Flags.HasLastAckedPacketInfo) {
             CXPLAT_DBG_ASSERT(AckedPacket->TotalBytesSent >= AckedPacket->LastAckedPacketInfo.TotalBytesSent);
             CXPLAT_DBG_ASSERT(CxPlatTimeAtOrBefore32(AckedPacket->LastAckedPacketInfo.SentTime, AckedPacket->SentTime));
             
-            SendElapsed = CxPlatTimeDiff32(AckedPacket->LastAckedPacketInfo.SentTime, AckedPacket->SentTime);
+            uint32_t AckElapsed = 0;
+            uint32_t SendElapsed = CxPlatTimeDiff32(AckedPacket->LastAckedPacketInfo.SentTime, AckedPacket->SentTime);
 
             if (SendElapsed) {
                 SendRate = (kMicroSecsInSec * BW_UNIT *

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1247,15 +1247,15 @@ CxPlatSocketContextRecvComplete(
     _In_ ssize_t BytesTransferred
     )
 {
-    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS; // cppcheck-suppress unreadVariable
 
     CXPLAT_DBG_ASSERT(SocketContext->CurrentRecvBlock != NULL);
     CXPLAT_RECV_DATA* RecvPacket = &SocketContext->CurrentRecvBlock->RecvPacket;
     SocketContext->CurrentRecvBlock = NULL;
 
-    BOOLEAN FoundLocalAddr = FALSE;
-    BOOLEAN FoundTOS = FALSE;
-    BOOLEAN FoundIfIdx = FALSE;
+    BOOLEAN FoundLocalAddr = FALSE; // cppcheck-suppress unreadVariable
+    BOOLEAN FoundTOS = FALSE; // cppcheck-suppress unreadVariable
+    BOOLEAN FoundIfIdx = FALSE; // cppcheck-suppress unreadVariable
     QUIC_ADDR* LocalAddr = &RecvPacket->Route->LocalAddress;
     if (LocalAddr->Ipv6.sin6_family == AF_INET6) {
         LocalAddr->Ipv6.sin6_family = QUIC_ADDRESS_FAMILY_INET6;
@@ -1282,11 +1282,11 @@ CxPlatSocketContextRecvComplete(
                 CxPlatConvertFromMappedV6(LocalAddr, LocalAddr);
 
                 LocalAddr->Ipv6.sin6_scope_id = PktInfo6->ipi6_ifindex;
-                FoundLocalAddr = TRUE;
-                FoundIfIdx = TRUE;
+                FoundLocalAddr = TRUE; // cppcheck-suppress unreadVariable
+                FoundIfIdx = TRUE; // cppcheck-suppress unreadVariable
             } else if (CMsg->cmsg_type == IPV6_TCLASS) {
                 RecvPacket->TypeOfService = *(uint8_t *)CMSG_DATA(CMsg);
-                FoundTOS = TRUE;
+                FoundTOS = TRUE; // cppcheck-suppress unreadVariable
             }
         } else if (CMsg->cmsg_level == IPPROTO_IP) {
 #if defined(IP_PKTINFO)
@@ -1319,7 +1319,7 @@ CxPlatSocketContextRecvComplete(
 #endif
             else if (CMsg->cmsg_type == IP_TOS || CMsg->cmsg_type == IP_RECVTOS) {
                 RecvPacket->TypeOfService = *(uint8_t *)CMSG_DATA(CMsg);
-                FoundTOS = TRUE;
+                FoundTOS = TRUE; // cppcheck-suppress unreadVariable
             }
         }
     }

--- a/src/platform/hashtable.c
+++ b/src/platform/hashtable.c
@@ -841,9 +841,9 @@ Return Value:
         Signature = CXPLAT_HASH_ALT_SIGNATURE;
     }
 
-    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext = {0};
+    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext;
     CXPLAT_HASHTABLE_LOOKUP_CONTEXT* ContextPtr =
-        (Context != NULL) ? Context : &LocalContext;
+        (Context != NULL) ? Context : &LocalContext; // cppcheck-suppress uninitvar
 
     CxPlatPopulateContext(HashTable, ContextPtr, Signature);
 

--- a/src/platform/hashtable.c
+++ b/src/platform/hashtable.c
@@ -841,7 +841,7 @@ Return Value:
         Signature = CXPLAT_HASH_ALT_SIGNATURE;
     }
 
-    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext;
+    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext = {0};
     CXPLAT_HASHTABLE_LOOKUP_CONTEXT* ContextPtr =
         (Context != NULL) ? Context : &LocalContext;
 

--- a/src/platform/hashtable.c
+++ b/src/platform/hashtable.c
@@ -707,7 +707,7 @@ Arguments:
 
 --*/
 {
-    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext = {0};
+    CXPLAT_HASHTABLE_LOOKUP_CONTEXT LocalContext;
     CXPLAT_HASHTABLE_LOOKUP_CONTEXT* ContextPtr = NULL;
 
     if (Signature == CXPLAT_HASH_RESERVED_SIGNATURE) {


### PR DESCRIPTION
## Description

Fix/suppress some new clang/cppcheck warnings

## Testing

Should be covered by existing tests.

## Documentation

Nope.
