### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -238,3 +238,15 @@ To run the tests:
 ```
 cargo test
 ```
+
+# Installing from vcpkg
+
+You can download and install `MsQuic` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+./vcpkg integrate install
+./vcpkg install ms-quic
+```
+The `MsQuic` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`MsQuic` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `MsQuic` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `MsQuic`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/ms-quic/portfile.cmake). We try to keep the library maintained as close as possible to the original library.