### PR TITLE
Fix QUIC_STATUS_ALPN_IN_USE value in comments and C# interop

### DIFF
--- a/src/cs/lib/msquic_generated_linux.cs
+++ b/src/cs/lib/msquic_generated_linux.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Quic
         public const int QUIC_STATUS_STREAM_LIMIT_REACHED = ((int)(86));
 
         [NativeTypeName("#define QUIC_STATUS_ALPN_IN_USE (QUIC_STATUS)EPROTOTYPE")]
-        public const int QUIC_STATUS_ALPN_IN_USE = unchecked((int)(136));
+        public const int QUIC_STATUS_ALPN_IN_USE = unchecked((int)(91));
 
         [NativeTypeName("#define QUIC_STATUS_CLOSE_NOTIFY QUIC_STATUS_TLS_ALERT(0)")]
         public const int QUIC_STATUS_CLOSE_NOTIFY = ((int)(0xff & 0) + 256 + 200000000);

--- a/src/cs/lib/msquic_generated_macos.cs
+++ b/src/cs/lib/msquic_generated_macos.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Quic
         public const int QUIC_STATUS_STREAM_LIMIT_REACHED = ((int)(86));
 
         [NativeTypeName("#define QUIC_STATUS_ALPN_IN_USE (QUIC_STATUS)EPROTOTYPE")]
-        public const int QUIC_STATUS_ALPN_IN_USE = unchecked((int)(91));
+        public const int QUIC_STATUS_ALPN_IN_USE = unchecked((int)(41));
 
         [NativeTypeName("#define QUIC_STATUS_CLOSE_NOTIFY QUIC_STATUS_TLS_ALERT(0)")]
         public const int QUIC_STATUS_CLOSE_NOTIFY = ((int)(0xff & 0) + 256 + 200000000);

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -125,7 +125,7 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) throw() { return (ENUMTYP
 #define QUIC_STATUS_USER_CANCELED           ((QUIC_STATUS)EOWNERDEAD)       // 130  (105 on macOS)
 #define QUIC_STATUS_ALPN_NEG_FAILURE        ((QUIC_STATUS)ENOPROTOOPT)      // 92   (42 on macOS)
 #define QUIC_STATUS_STREAM_LIMIT_REACHED    ((QUIC_STATUS)ESTRPIPE)         // 86
-#define QUIC_STATUS_ALPN_IN_USE             ((QUIC_STATUS)EPROTOTYPE)       // 136  (91 on macOS)
+#define QUIC_STATUS_ALPN_IN_USE             ((QUIC_STATUS)EPROTOTYPE)       // 91   (41 on macOS)
 #define QUIC_STATUS_ADDRESS_NOT_AVAILABLE   ((QUIC_STATUS)EADDRNOTAVAIL)    // 99   (47 on macOS)
 
 #define QUIC_STATUS_TLS_ALERT(Alert)        ((QUIC_STATUS)(0xff & Alert) + TLS_ERROR_BASE)


### PR DESCRIPTION
## Description

This PR fixes the value of EPROTOTYPE (aliased as QUIC_STATUS_ALPN_IN_USE), on Linux, it seems to be 91 (see e.g. https://www.thegeekstuff.com/2010/10/linux-error-codes/), and on MacOS 41 (https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/errno.h). This PR also fixes the C# interop stubs.

## Testing

New values tested on Linux in CI when integrating the error status in .NET.

## Documentation

N/A
