### PR TITLE
Change Test TP to use 4 bytes for Type instead of 2.

### DIFF
--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -87,7 +87,7 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 #endif
 
 typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
-    uint16_t Type;
+    uint32_t Type;
     uint16_t Length;
     _Field_size_(Length)
     const uint8_t* Buffer;


### PR DESCRIPTION
## Description

Change the test transport parameter to use 4 bytes for `Type` instead of 2 bytes, allowing for the version negotiation extension transport parameter to be supplied.  This is needed for #3076.

## Testing

CI tests

## Documentation

N/A
