### PR TITLE
Fix VNE TP test.

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3357,7 +3357,7 @@ QuicTestOddSizeVNTP(
                     Client.Start(
                         ClientConfiguration,
                         QuicAddrFamily,
-                        QUIC_LOCALHOST_FOR_AF(QuicAddrFamily),
+                        QUIC_TEST_LOOPBACK_FOR_AF(QuicAddrFamily),
                         ServerLocalAddr.GetPort()));
 
                 if (!Client.WaitForConnectionComplete()) {


### PR DESCRIPTION
## Description

Fix the client to use the correct address to contact the server at to exercise XDP. "loopback" won't use XDP, and thus the connection will fail.
Bug introduced in #3076.

## Testing

CI

## Documentation

N/A