### PR TITLE
Disable Preview Feature Tests on Official Builds

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -336,6 +336,15 @@ stages:
       platform: linux
       arch: x64
       tls: openssl
+      extraBuildArgs: -OfficialRelease
+      extraName: 'official'
+
+  - template: ./templates/build-config-user.yml
+    parameters:
+      image: ubuntu-latest
+      platform: linux
+      arch: x64
+      tls: openssl
       extraBuildArgs: -Clang -ExtraArtifactDir Clang
       extraName: 'clang'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if openssl TLS" OFF)
 option(QUIC_HIGH_RES_TIMERS "Configure the system to use high resolution timers" OFF)
 option(QUIC_USE_XDP "Uses XDP instead of socket APIs" OFF)
 option(QUIC_DISABLE_POSIX_GSO "Disable GSO for systems that say they support it but don't" OFF)
+option(QUIC_OFFICIAL_RELEASE "Configured the build for an official release" OFF)
 set(QUIC_FOLDER_PREFIX "" CACHE STRING "Optional prefix for source group folders when using an IDE generator")
 set(QUIC_LIBRARY_NAME "msquic" CACHE STRING "Override the output library name")
 
@@ -324,6 +325,10 @@ endif()
 
 if(QUIC_USE_XDP)
     list(APPEND QUIC_COMMON_DEFINES QUIC_USE_RAW_DATAPATH=1)
+endif()
+
+if(QUIC_OFFICIAL_RELEASE)
+    list(APPEND QUIC_COMMON_DEFINES QUIC_OFFICIAL_RELEASE=1)
 endif()
 
 if(QUIC_TLS STREQUAL "schannel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ endif()
 
 if(QUIC_OFFICIAL_RELEASE)
     list(APPEND QUIC_COMMON_DEFINES QUIC_OFFICIAL_RELEASE=1)
+    message(STATUS "Configured for official release build")
 endif()
 
 if(QUIC_TLS STREQUAL "schannel")

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -276,6 +276,7 @@ if (!$OfficialRelease) {
             $OfficialRelease = $true
         }
     } catch { }
+    $LASTEXITCODE = 0
 }
 
 # Root directory of the project.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -75,6 +75,9 @@ This script provides helpers for building msquic.
 .PARAMETER CI
     Build is occuring from CI
 
+.PARAMETER OfficialRelease
+    Build is for an official (tag) release.
+
 .PARAMETER EnableTelemetryAsserts
     Enables telemetry asserts in release builds.
 
@@ -182,6 +185,9 @@ param (
     [switch]$CI = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$OfficialRelease = $false,
+
+    [Parameter(Mandatory = $false)]
     [switch]$EnableTelemetryAsserts = $false,
 
     [Parameter(Mandatory = $false)]
@@ -258,6 +264,11 @@ if ($Platform -eq "ios" -and !$Static) {
     $Static = $true
     Write-Host "iOS can only be built as static"
 }
+
+try {
+#    $env:GIT_REDIRECT_STDERR = '2>&1'
+#    $CurrentBranch = git branch --show-current
+} catch { }
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent
@@ -425,6 +436,9 @@ function CMake-Generate {
         }
         $Arguments += " -DQUIC_VER_BUILD_ID=$env:BUILD_BUILDID"
         $Arguments += " -DQUIC_VER_SUFFIX=-official"
+    }
+    if ($OfficialRelease) {
+        $Arguments += " -DQUIC_OFFICIAL_RELEASE=ON"
     }
     if ($EnableTelemetryAsserts) {
         $Arguments += " -DQUIC_TELEMETRY_ASSERTS=on"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -265,10 +265,18 @@ if ($Platform -eq "ios" -and !$Static) {
     Write-Host "iOS can only be built as static"
 }
 
-try {
-#    $env:GIT_REDIRECT_STDERR = '2>&1'
-#    $CurrentBranch = git branch --show-current
-} catch { }
+if (!$OfficialRelease) {
+    try {
+        $env:GIT_REDIRECT_STDERR = '2>&1'
+        # Thanks to https://stackoverflow.com/questions/3404936/show-which-git-tag-you-are-on
+        # for this magic git command!
+        $Output = git describe --exact-match --tags $(git log -n1 --pretty='%h')
+        if (!$Output.Contains("fatal: no tag exactly matches")) {
+            Write-Host "Configuring OfficialRelease for tag build"
+            $OfficialRelease = $true
+        }
+    } catch { }
+}
 
 # Root directory of the project.
 $RootDir = Split-Path $PSScriptRoot -Parent

--- a/src/core/unittest/SettingsTest.cpp
+++ b/src/core/unittest/SettingsTest.cpp
@@ -430,6 +430,7 @@ TEST(SettingsTest, GlobalSettingsSizesSet)
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST(SettingsTest, GlobalExecutionConfigSetAndGet)
 {
     uint8_t RawConfig[QUIC_EXECUTION_CONFIG_MIN_SIZE + 2 * sizeof(uint16_t)] = {0};
@@ -511,3 +512,4 @@ TEST(SettingsTest, GlobalRawDataPathProcsSetAfterDataPathInit)
             sizeof(RawConfig),
             Config));
 }
+#endif

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -110,8 +110,8 @@ typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
 #define QUIC_PARAM_GLOBAL_ALLOC_FAIL_CYCLE              0x81000002  // uint32_t
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 #define QUIC_PARAM_GLOBAL_VERSION_NEGOTIATION_ENABLED   0x81000003  // BOOLEAN
-#define QUIC_PARAM_GLOBAL_IN_USE                        0x81000004  // BOOLEAN
 #endif
+#define QUIC_PARAM_GLOBAL_IN_USE                        0x81000004  // BOOLEAN
 
 //
 // The different private parameters for Configuration.

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -137,6 +137,7 @@ QuicTestConnect(
     _In_ uint8_t RandomLossPercentage // 0 to 100
     );
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestVersionNegotiation(
     _In_ int Family
@@ -182,6 +183,7 @@ void
 QuicTestFailedVersionNegotiation(
     _In_ int Family
     );
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 void
 QuicTestCustomCertificateValidation(
@@ -220,14 +222,18 @@ QuicTestInterfaceBinding(
     _In_ int Family
     );
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestCibirExtension(
     _In_ int Family,
     _In_ uint8_t Mode // server = &1, client = &2
     );
+#endif
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestResumptionAcrossVersions();
+#endif
 
 void
 QuicTestChangeAlpn(
@@ -287,11 +293,13 @@ QuicTestClientBlockedSourcePort(
     _In_ int Family
     );
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestOddSizeVNTP(
     _In_ bool TestServer,
     _In_ uint16_t VNTPSize
     );
+#endif
 
 //
 // Post Handshake Tests
@@ -528,9 +536,11 @@ void
 QuicTestStorage(
     );
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestVersionStorage(
     );
+#endif
 
 //
 // Platform Specific Functions

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -9,7 +9,9 @@ Abstract:
 
 --*/
 
+#ifndef QUIC_OFFICIAL_RELEASE
 #define QUIC_API_ENABLE_PREVIEW_FEATURES
+#endif
 
 #include "msquic.hpp"
 

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1921,10 +1921,12 @@ INSTANTIATE_TEST_SUITE_P(
 
 #endif // QUIC_TEST_DATAPATH_HOOKS_ENABLED
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 INSTANTIATE_TEST_SUITE_P(
     Basic,
     WithVersionNegotiationExtArgs,
     testing::ValuesIn(VersionNegotiationExtArgs::Generate()));
+#endif
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -704,6 +704,7 @@ TEST_P(WithFamilyArgs, InterfaceBinding) {
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST_P(WithHandshakeArgs2, OldVersion) {
     TestLoggerT<ParamType> Logger("QuicTestConnect-OldVersion", GetParam());
     if (TestingKernelMode) {
@@ -732,6 +733,7 @@ TEST_P(WithHandshakeArgs2, OldVersion) {
             0);     // RandomLossPercentage
     }
 }
+#endif
 
 TEST_P(WithHandshakeArgs3, AsyncSecurityConfig) {
     TestLoggerT<ParamType> Logger("QuicTestConnect-AsyncSecurityConfig", GetParam());
@@ -1929,10 +1931,12 @@ INSTANTIATE_TEST_SUITE_P(
     WithHandshakeArgs1,
     testing::ValuesIn(HandshakeArgs1::Generate()));
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs2,
     testing::ValuesIn(HandshakeArgs2::Generate()));
+#endif
 
 INSTANTIATE_TEST_SUITE_P(
     Handshake,

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -360,6 +360,7 @@ TEST_P(WithValidateStreamEventArgs, ValidateStreamEvents) {
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST(ParameterValidation, ValidateVersionSettings) {
     TestLogger Logger("QuicTestVersionSettings");
     if (TestingKernelMode) {
@@ -368,6 +369,7 @@ TEST(ParameterValidation, ValidateVersionSettings) {
         QuicTestVersionSettings();
     }
 }
+#endif
 
 TEST(ParameterValidation, ValidateParamApi) {
     TestLogger Logger("QuicTestValidateParamApi");
@@ -760,6 +762,7 @@ TEST_P(WithHandshakeArgs3, AsyncSecurityConfig) {
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST_P(WithFamilyArgs, VersionNegotiation) {
     TestLoggerT<ParamType> Logger("QuicTestVersionNegotiation", GetParam());
     if (TestingKernelMode) {
@@ -855,6 +858,7 @@ TEST_P(WithFamilyArgs, FailedVersionNegotiation) {
         QuicTestFailedVersionNegotiation(GetParam().Family);
     }
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 TEST_P(WithHandshakeArgs5, CustomCertificateValidation) {
     TestLoggerT<ParamType> Logger("QuicTestCustomCertificateValidation", GetParam());
@@ -882,6 +886,7 @@ TEST_P(WithHandshakeArgs6, ConnectClientCertificate) {
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST_P(WithHandshakeArgs7, CibirExtension) {
     TestLoggerT<ParamType> Logger("QuicTestCibirExtension", GetParam());
     if (TestingKernelMode) {
@@ -894,6 +899,7 @@ TEST_P(WithHandshakeArgs7, CibirExtension) {
         QuicTestCibirExtension(GetParam().Family, GetParam().Mode);
     }
 }
+#endif
 
 // TEST(Handshake, ResumptionAcrossVersions) {
 //     if (TestingKernelMode) {
@@ -903,6 +909,7 @@ TEST_P(WithHandshakeArgs7, CibirExtension) {
 //     }
 // }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 #if QUIC_TEST_DISABLE_VNE_TP_GENERATION
 TEST_P(WithHandshakeArgs8, OddSizeVnTp) {
     TestLoggerT<ParamType> Logger("QuicTestOddSizeVNTP", GetParam());
@@ -916,6 +923,7 @@ TEST_P(WithHandshakeArgs8, OddSizeVnTp) {
         QuicTestOddSizeVNTP(GetParam().TestServer, GetParam().VnTpSize);
     }
 }
+#endif
 #endif
 
 #if QUIC_TEST_FAILING_TEST_CERTIFICATES
@@ -1854,6 +1862,8 @@ TEST(Basic, TestStorage) {
         QuicTestStorage();
     }
 }
+
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST(Basic, TestVersionStorage) {
     if (!CanRunStorageTests) {
         return;
@@ -1866,6 +1876,7 @@ TEST(Basic, TestVersionStorage) {
         QuicTestVersionStorage();
     }
 }
+#endif
 
 #endif // _WIN32
 
@@ -1947,16 +1958,20 @@ INSTANTIATE_TEST_SUITE_P(
     WithHandshakeArgs6,
     testing::ValuesIn(HandshakeArgs6::Generate()));
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs7,
     testing::ValuesIn(HandshakeArgs7::Generate()));
+#endif
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 #if QUIC_TEST_DISABLE_VNE_TP_GENERATION
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs8,
     testing::ValuesIn(HandshakeArgs8::Generate()));
+#endif
 #endif
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -766,10 +766,12 @@ QuicTestCtlEvtIoDeviceControl(
         QuicTestCtlRun(QuicTestValidateStreamEvents(Params->Test));
         break;
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     case IOCTL_QUIC_RUN_VERSION_NEGOTIATION:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestVersionNegotiation(Params->Family));
         break;
+#endif
 
     case IOCTL_QUIC_RUN_KEY_UPDATE:
         CXPLAT_FRE_ASSERT(Params != nullptr);
@@ -918,6 +920,7 @@ QuicTestCtlEvtIoDeviceControl(
                 Params->CustomCertValidationParams.AsyncValidation));
         break;
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     case IOCTL_QUIC_RUN_VERSION_NEGOTIATION_RETRY:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestVersionNegotiationRetry(Params->Family));
@@ -968,6 +971,7 @@ QuicTestCtlEvtIoDeviceControl(
     case IOCTL_QUIC_RUN_VALIDATE_VERSION_SETTINGS_SETTINGS:
         QuicTestCtlRun(QuicTestVersionSettings());
         break;
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
     case IOCTL_QUIC_RUN_CONNECT_CLIENT_CERT:
         CXPLAT_FRE_ASSERT(Params != nullptr);
@@ -1193,6 +1197,7 @@ QuicTestCtlEvtIoDeviceControl(
                 &Params->CredValidationParams.CredConfig));
         break;
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     case IOCTL_QUIC_RUN_CIBIR_EXTENSION:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(
@@ -1200,6 +1205,7 @@ QuicTestCtlEvtIoDeviceControl(
                 Params->CibirParams.Family,
                 Params->CibirParams.Mode));
         break;
+#endif
 
     case IOCTL_QUIC_RUN_STREAM_PRIORITY_INFINITE_LOOP:
         QuicTestCtlRun(QuicTestStreamPriorityInfiniteLoop());
@@ -1260,9 +1266,11 @@ QuicTestCtlEvtIoDeviceControl(
         QuicTestCtlRun(QuicTestCloseConnBeforeStreamFlush());
         break;
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     case IOCTL_QUIC_RUN_VERSION_STORAGE:
         QuicTestCtlRun(QuicTestVersionStorage());
         break;
+#endif
 
     case IOCTL_QUIC_RUN_CONNECT_AND_IDLE_FOR_DEST_CID_CHANGE:
         QuicTestCtlRun(QuicTestConnectAndIdleForDestCidChange());

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2111,6 +2111,7 @@ void QuicTestStatefulGlobalSetParam()
                 &Mode));
     }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     //
     // Set QUIC_PARAM_GLOBAL_EXECUTION_CONFIG when MsQuicLib.Datapath != NULL
     //
@@ -2126,6 +2127,7 @@ void QuicTestStatefulGlobalSetParam()
                 sizeof(Data),
                 &Data));
     }
+#endif
 }
 
 void QuicTestGlobalParam()
@@ -2442,6 +2444,7 @@ void QuicTestGlobalParam()
         }
     }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     //
     // QUIC_PARAM_GLOBAL_EXECUTION_CONFIG
     //
@@ -2505,6 +2508,7 @@ void QuicTestGlobalParam()
                 &BufferLength,
                 nullptr));
     }
+#endif
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
     //
@@ -4765,6 +4769,7 @@ QuicTestGetPerfCounters()
     TEST_EQUAL(BufferLength, (sizeof(uint64_t) * (QUIC_PERF_COUNTER_MAX - 4)));
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 ValidateVersionSettings(
     _In_ const QUIC_VERSION_SETTINGS* const OutputVersionSettings,
@@ -5016,6 +5021,7 @@ QuicTestVersionSettings()
         ValidateVersionSettings(OutputVersionSettings, ValidVersions, ARRAYSIZE(ValidVersions));
     }
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 void
 QuicTestValidateParamApi()
@@ -5300,6 +5306,7 @@ QuicTestStorage()
     TEST_NOT_EQUAL(Settings.InitialRttMs, SpecialInitialRtt);
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestVersionStorage()
 {
@@ -5658,3 +5665,4 @@ QuicTestVersionStorage()
     TEST_EQUAL(Settings.OfferedVersions, nullptr);
     TEST_EQUAL(Settings.FullyDeployedVersions, nullptr);
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -892,6 +892,7 @@ QuicTestConnectInvalidAddress(
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestVersionNegotiation(
     _In_ int Family
@@ -1676,6 +1677,7 @@ QuicTestFailedVersionNegotiation(
         QUIC_VERSION_1_H,
         Family);
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 void
 QuicTestConnectBadAlpn(
@@ -1694,7 +1696,7 @@ QuicTestConnectBadAlpn(
     TEST_TRUE(ServerConfiguration.IsValid());
 
     MsQuicCredentialConfig ClientCredConfig;
-    MsQuicConfiguration ClientConfiguration(Registration, "BanALPN", Settings, ClientCredConfig);
+    MsQuicConfiguration ClientConfiguration(Registration, "BadALPN", Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
@@ -2932,6 +2934,7 @@ QuicTestInterfaceBinding(
     TEST_TRUE(!Connection2.HandshakeComplete);
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
 QuicTestCibirExtension(
     _In_ int Family,
@@ -3057,6 +3060,7 @@ QuicTestResumptionAcrossVersions()
         }
     }
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 void
 QuicTestClientBlockedSourcePort(
@@ -3239,6 +3243,7 @@ QuicTestChangeAlpn(
     }
 }
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 _Function_class_(NEW_CONNECTION_CALLBACK)
 static
 bool
@@ -3377,3 +3382,4 @@ QuicTestOddSizeVNTP(
         }
     }
 }
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -295,6 +295,7 @@ TestConnection::SetQuicVersion(
     uint32_t value
     )
 {
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     MsQuicVersionSettings Settings;
     Settings.AcceptableVersions = &value;
     Settings.AcceptableVersionsLength = 1;
@@ -308,6 +309,10 @@ TestConnection::SetQuicVersion(
             QUIC_PARAM_CONN_VERSION_SETTINGS,
             sizeof(Settings),
             &Settings);
+#else
+    UNREFERENCED_PARAMETER(value);
+    return QUIC_STATUS_NOT_SUPPORTED;
+#endif
 }
 
 QUIC_STATUS

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -99,6 +99,7 @@ struct ServerAcceptContext {
     }
 };
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 struct ClearGlobalVersionListScope {
     ~ClearGlobalVersionListScope() {
         MsQuicVersionSettings Settings(nullptr, 0);
@@ -118,6 +119,7 @@ struct ClearGlobalVersionListScope {
                 &Default));
     }
 };
+#endif
 
 //
 // Simulating Connection's status to be QUIC_CONN_BAD_START_STATE
@@ -196,8 +198,12 @@ struct GlobalSettingScope {
                 Parameter,
                 &BufferLength,
                 nullptr);
+#ifndef QUIC_API_ENABLE_PREVIEW_FEATURES
+        TEST_TRUE(Status == QUIC_STATUS_BUFFER_TOO_SMALL);
+#else
         TEST_TRUE(Status == QUIC_STATUS_BUFFER_TOO_SMALL ||
             (Parameter == QUIC_PARAM_GLOBAL_EXECUTION_CONFIG && Status == QUIC_STATUS_SUCCESS));
+#endif
 
         OriginalValue = CXPLAT_ALLOC_NONPAGED(BufferLength, QUIC_POOL_TEST);
         if (OriginalValue == nullptr) {


### PR DESCRIPTION
## Description

Official builds need to disable the tests for preview features since those features may change in the future. We can't publish down-level tests for things that are expected to change in the future. Those tests will break.

## Testing

Ran locally. Added a CI for build. Should I onboard a test too?

## Documentation

N/A
