### PR TITLE
Fix Race Condition in HPS Client

### DIFF
--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -150,7 +150,7 @@ HpsClient::Start(
 
         Status = CxPlatDataPathResolveAddress(Datapath, Worker->Target.get(), &Worker->RemoteAddr);
         if (QUIC_FAILED(Status)) {
-            printf("Failed to resolve remote address!\n");
+            WriteOutput("Failed to resolve remote address!\n");
             break;
         }
 
@@ -210,7 +210,8 @@ HpsClient::Wait(
 
     uint32_t HPS = (uint32_t)((CompletedConnections * 1000ull) / (uint64_t)RunTime);
     if (HPS == 0) {
-        WriteOutput("Error: No handshakes were completed (%ull created, %ull started\n)", CreatedConnections, StartedConnections);
+        WriteOutput("Error: No handshakes were completed (%u created, %u started\n)",
+            (uint32_t)CreatedConnections, (uint32_t)StartedConnections);
     } else {
         WriteOutput("Result: %u HPS\n", HPS);
     }

--- a/src/perf/lib/HpsClient.cpp
+++ b/src/perf/lib/HpsClient.cpp
@@ -128,7 +128,7 @@ HpsClient::Start(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     CXPLAT_DATAPATH* Datapath = nullptr;
     if (QUIC_FAILED(Status = CxPlatDataPathInitialize(0, nullptr, nullptr, nullptr, &Datapath))) {
-        printf("Failed to initialize datapath for resolution!\n");
+        WriteOutput("Failed to initialize datapath for resolution!\n");
         return Status;
     }
 

--- a/src/perf/lib/HpsClient.h
+++ b/src/perf/lib/HpsClient.h
@@ -22,7 +22,7 @@ struct HpsBindingContext {
     QUIC_ADDR LocalAddr;
 };
 
-struct QUIC_CACHEALIGN HpsWorkerContext {
+struct HpsWorkerContext {
     class HpsClient* pThis {nullptr};
     UniquePtr<char[]> Target;
     QUIC_ADDR RemoteAddr;

--- a/src/perf/lib/HpsClient.h
+++ b/src/perf/lib/HpsClient.h
@@ -20,20 +20,17 @@ Abstract:
 struct HpsBindingContext {
     struct HpsWorkerContext* Worker;
     QUIC_ADDR LocalAddr;
-    CXPLAT_REF_COUNT RefCount;
-    void Release(HQUIC Connection) {
-        if (CxPlatRefDecrement(&RefCount)) {
-            MsQuic->ConnectionClose(Connection);
-        }
-    }
 };
 
-struct HpsWorkerContext {
+struct QUIC_CACHEALIGN HpsWorkerContext {
     class HpsClient* pThis {nullptr};
     UniquePtr<char[]> Target;
     QUIC_ADDR RemoteAddr;
     HpsBindingContext Bindings[HPS_BINDINGS_PER_WORKER];
     uint16_t Processor {0};
+    int64_t CreatedConnections {0};
+    int64_t StartedConnections {0};
+    int64_t CompletedConnections {0};
     long OutstandingConnections {0};
     uint32_t NextLocalAddr {0};
     CXPLAT_EVENT WakeEvent;
@@ -98,6 +95,7 @@ public:
 
     void StartConnection(HpsWorkerContext* Worker);
 
+    UniquePtr<char[]> Target;
     HpsWorkerContext Contexts[PERF_MAX_THREAD_COUNT];
     MsQuicRegistration Registration {
         "secnetperf-client-hps",
@@ -115,13 +113,9 @@ public:
             QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION)};
     uint32_t ActiveProcCount;
     uint16_t Port {PERF_DEFAULT_PORT};
-    UniquePtr<char[]> Target;
     uint32_t RunTime {HPS_DEFAULT_RUN_TIME};
     uint32_t Parallel {HPS_DEFAULT_PARALLEL_COUNT};
     uint8_t IncrementTarget {FALSE};
     CXPLAT_EVENT* CompletionEvent {nullptr};
-    uint64_t CreatedConnections {0};
-    uint64_t StartedConnections {0};
-    uint64_t CompletedConnections {0};
     bool Shutdown {false};
 };

--- a/src/perf/lib/HpsClient.h
+++ b/src/perf/lib/HpsClient.h
@@ -118,4 +118,5 @@ public:
     uint8_t IncrementTarget {FALSE};
     CXPLAT_EVENT* CompletionEvent {nullptr};
     bool Shutdown {false};
+    uint64_t StartTime {0};
 };


### PR DESCRIPTION
## Description

Fixes a race condition in the cleanup / error path of HPS client, where the connection would be freed early.

## Testing

Tested locally. Validated with perf automation.