### PR TITLE
Fix passing pointer-pointer, skip inevitable SEGV case

### DIFF
--- a/src/fuzzing/fuzz.cc
+++ b/src/fuzzing/fuzz.cc
@@ -9,6 +9,7 @@ Abstract:
 
 --*/
 
+#define QUIC_API_ENABLE_PREVIEW_FEATURES 1
 #define CX_PLATFORM_LINUX 1
 #define QUIC_TEST_APIS 1
 
@@ -27,11 +28,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	for (uint32_t Param = QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT;
 		Param <= QUIC_PARAM_GLOBAL_TLS_PROVIDER;
 		Param++) {
-		MsQuic->SetParam(
-			nullptr,
-			Param,
-			size,
-			&data);
+			if (Param == QUIC_PARAM_GLOBAL_VERSION_SETTINGS)
+				continue;
+			MsQuic->SetParam(
+				nullptr,
+				Param,
+				size,
+				data);
 	}
 
 	delete MsQuic;

--- a/src/fuzzing/fuzz.cc
+++ b/src/fuzzing/fuzz.cc
@@ -28,13 +28,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	for (uint32_t Param = QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT;
 		Param <= QUIC_PARAM_GLOBAL_TLS_PROVIDER;
 		Param++) {
-			if (Param == QUIC_PARAM_GLOBAL_VERSION_SETTINGS)
-				continue;
-			MsQuic->SetParam(
-				nullptr,
-				Param,
-				size,
-				data);
+	if (Param != QUIC_PARAM_GLOBAL_VERSION_SETTINGS) {
+	    MsQuic->SetParam(
+		    nullptr,
+		    Param,
+		    size,
+		    data);
+    }
 	}
 
 	delete MsQuic;

--- a/src/fuzzing/fuzz.cc
+++ b/src/fuzzing/fuzz.cc
@@ -20,7 +20,6 @@ Abstract:
 #include "msquic.hpp"
 #include "quic_platform.h"
 
-
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	const MsQuicApi* MsQuic = new(std::nothrow) MsQuicApi();
@@ -28,13 +27,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	for (uint32_t Param = QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT;
 		Param <= QUIC_PARAM_GLOBAL_TLS_PROVIDER;
 		Param++) {
-	if (Param != QUIC_PARAM_GLOBAL_VERSION_SETTINGS) {
-	    MsQuic->SetParam(
-		    nullptr,
-		    Param,
-		    size,
-		    data);
-    }
+        if (Param != QUIC_PARAM_GLOBAL_VERSION_SETTINGS) {
+            MsQuic->SetParam(
+                nullptr,
+                Param,
+                size,
+                data);
+        }
 	}
 
 	delete MsQuic;


### PR DESCRIPTION
## Description

Fix error reported from OSS-Fuzz
1. pointer-pointer was passed
2. SEGV by accessing random address when QUIC_PARAM_GLOBAL_VERSION_SETTINGS

## Testing

this is test

## Documentation

N/A
