### PR TITLE
Add test for Chosen Version mismatch

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2706,7 +2706,7 @@ QuicConnProcessPeerVersionNegotiationTP(
                 "Client Chosen Version doesn't match long header. 0x%x != 0x%x",
                 ClientVI.ChosenVersion,
                 Connection->Stats.QuicVersion);
-            QuicConnTransportError(Connection, QUIC_ERROR_VERSION_NEGOTIATION_ERROR);
+            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
 
@@ -2770,7 +2770,7 @@ QuicConnProcessPeerVersionNegotiationTP(
                 "Server Chosen Version doesn't match long header. 0x%x != 0x%x",
                 ServerVI.ChosenVersion,
                 Connection->Stats.QuicVersion);
-            QuicConnTransportError(Connection, QUIC_ERROR_VERSION_NEGOTIATION_ERROR);
+            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -295,9 +295,14 @@ QuicTestClientBlockedSourcePort(
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void
-QuicTestOddSizeVNTP(
+QuicTestVNTPOddSize(
     _In_ bool TestServer,
     _In_ uint16_t VNTPSize
+    );
+
+void
+QuicTestVNTPChosenVersionMismatch(
+    _In_ bool TestServer
     );
 #endif
 
@@ -1109,9 +1114,12 @@ typedef struct {
 typedef struct {
     BOOLEAN TestServer;
     uint8_t VnTpSize;
-} QUIC_RUN_ODD_SIZE_VN_TP_PARAMS;
+} QUIC_RUN_VN_TP_ODD_SIZE_PARAMS;
 
-#define IOCTL_QUIC_RUN_ODD_SIZE_VN_TP \
+#define IOCTL_QUIC_RUN_VN_TP_ODD_SIZE \
     QUIC_CTL_CODE(103, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 103
+#define IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_MISMATCH \
+    QUIC_CTL_CODE(104, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 104

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -914,15 +914,27 @@ TEST_P(WithHandshakeArgs7, CibirExtension) {
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 #if QUIC_TEST_DISABLE_VNE_TP_GENERATION
 TEST_P(WithHandshakeArgs8, OddSizeVnTp) {
-    TestLoggerT<ParamType> Logger("QuicTestOddSizeVNTP", GetParam());
+    TestLoggerT<ParamType> Logger("QuicTestVNTPOddSize", GetParam());
     if (TestingKernelMode) {
-        QUIC_RUN_ODD_SIZE_VN_TP_PARAMS Params = {
+        QUIC_RUN_VN_TP_ODD_SIZE_PARAMS Params = {
             GetParam().TestServer,
             GetParam().VnTpSize
         };
-        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_ODD_SIZE_VN_TP, Params));
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VN_TP_ODD_SIZE, Params));
     } else {
-        QuicTestOddSizeVNTP(GetParam().TestServer, GetParam().VnTpSize);
+        QuicTestVNTPOddSize(GetParam().TestServer, GetParam().VnTpSize);
+    }
+}
+
+TEST_P(WithHandshakeArgs9, VnTpChosenVersionMismatch) {
+    TestLoggerT<ParamType> Logger("QuicTestVNTPChosenVersionMismatch", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(
+            DriverClient.Run(
+                IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_MISMATCH,
+                (uint8_t)GetParam()));
+    } else {
+        QuicTestVNTPChosenVersionMismatch(GetParam());
     }
 }
 #endif
@@ -1980,6 +1992,11 @@ INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithHandshakeArgs8,
     testing::ValuesIn(HandshakeArgs8::Generate()));
+
+INSTANTIATE_TEST_SUITE_P(
+    Handshake,
+    WithHandshakeArgs9,
+    ::testing::Values(false, true));
 #endif
 #endif
 

--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -292,6 +292,10 @@ class WithHandshakeArgs8 : public testing::Test,
     public testing::WithParamInterface<HandshakeArgs8> {
 };
 
+class WithHandshakeArgs9 : public testing::Test,
+    public testing::WithParamInterface<bool> {
+};
+
 struct SendArgs1 {
     int Family;
     uint64_t Length;

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -474,7 +474,8 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
-    sizeof(QUIC_RUN_ODD_SIZE_VN_TP_PARAMS),
+    sizeof(QUIC_RUN_VN_TP_ODD_SIZE_PARAMS),
+    sizeof(UINT8),
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -507,7 +508,8 @@ typedef union {
     QUIC_RUN_REBIND_PARAMS RebindParams;
     UINT8 RejectByClosing;
     QUIC_RUN_CIBIR_EXTENSION CibirParams;
-    QUIC_RUN_ODD_SIZE_VN_TP_PARAMS OddSizeVnTpParams;
+    QUIC_RUN_VN_TP_ODD_SIZE_PARAMS OddSizeVnTpParams;
+    UINT8 TestServerVNTP;
 
 } QUIC_IOCTL_PARAMS;
 
@@ -1280,10 +1282,10 @@ QuicTestCtlEvtIoDeviceControl(
         QuicTestCtlRun(QuicTestChangeAlpn());
         break;
 
-    case IOCTL_QUIC_RUN_ODD_SIZE_VN_TP:
+    case IOCTL_QUIC_RUN_VN_TP_ODD_SIZE:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(
-            QuicTestOddSizeVNTP(
+            QuicTestVNTPOddSize(
                 Params->OddSizeVnTpParams.TestServer,
                 Params->OddSizeVnTpParams.VnTpSize));
         break;

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3281,36 +3281,15 @@ ListenerAcceptConnectionTestTP(
 }
 
 void
-QuicTestOddSizeVNTP(
+QuicTestCustomVNTP(
     _In_ bool TestServer,
-    _In_ uint16_t VNTPSize
+    _In_ QUIC_PRIVATE_TRANSPORT_PARAMETER* TestTP
     )
 {
-#define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0xFF73DB
     MsQuicRegistration Registration;
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
     MsQuicAlpn Alpn("MsQuicTest");
-
-    QUIC_PRIVATE_TRANSPORT_PARAMETER TestTP;
-    TestTP.Type = QUIC_TP_ID_VERSION_NEGOTIATION_EXT;
-    TestTP.Length = VNTPSize;
-    UniquePtr<uint8_t[]> TPData(
-        VNTPSize ? new(std::nothrow) uint8_t[VNTPSize] : nullptr);
-    TestTP.Buffer = TPData.get();
-
-    if (VNTPSize > 0) {
-        TEST_TRUE(TPData.get());
-        CxPlatZeroMemory(TPData.get(), VNTPSize);
-    }
-
-    if (VNTPSize >= sizeof(uint32_t)) {
-        uint32_t Latest = QUIC_VERSION_LATEST;
-        //
-        // Ensure that if a chosen_version can fit, it is a valid version.
-        //
-        CxPlatCopyMemory(TPData.get(), &Latest, sizeof(uint32_t));
-    }
 
     ClearGlobalVersionListScope ClearVersionsScope;
     BOOLEAN Enabled = TRUE;
@@ -3342,11 +3321,11 @@ QuicTestOddSizeVNTP(
             ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
             ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_INTERNAL_ERROR;
             Listener.Context = &ServerAcceptCtx;
-            ServerAcceptCtx.TestTP = &TestTP;
+            ServerAcceptCtx.TestTP = TestTP;
             {
                 TestConnection Client(Registration);
                 if (!TestServer) {
-                    Client.SetTestTransportParameter(&TestTP);
+                    Client.SetTestTransportParameter(TestTP);
                     BOOLEAN Disable = TRUE;
                     TEST_QUIC_SUCCEEDED(
                         MsQuic->SetParam(
@@ -3381,5 +3360,58 @@ QuicTestOddSizeVNTP(
 
         }
     }
+}
+
+void
+QuicTestVNTPOddSize(
+    _In_ bool TestServer,
+    _In_ uint16_t VNTPSize
+    )
+{
+#define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0xFF73DB
+
+    QUIC_PRIVATE_TRANSPORT_PARAMETER TestTP;
+    TestTP.Type = QUIC_TP_ID_VERSION_NEGOTIATION_EXT;
+    TestTP.Length = VNTPSize;
+    UniquePtr<uint8_t[]> TPData(
+        VNTPSize ? new(std::nothrow) uint8_t[VNTPSize] : nullptr);
+    TestTP.Buffer = TPData.get();
+
+    if (VNTPSize > 0) {
+        TEST_TRUE(TPData.get());
+        CxPlatZeroMemory(TPData.get(), VNTPSize);
+    }
+
+    if (VNTPSize >= sizeof(uint32_t)) {
+        uint32_t Latest = QUIC_VERSION_LATEST;
+        //
+        // Ensure that if a chosen_version can fit, it is a valid version.
+        //
+        CxPlatCopyMemory(TPData.get(), &Latest, sizeof(uint32_t));
+    }
+
+    QuicTestCustomVNTP(TestServer, &TestTP);
+}
+
+void
+QuicTestVNTPChosenVersionMismatch(
+    _In_ bool TestServer
+    )
+{
+    #define QUIC_TP_ID_VERSION_NEGOTIATION_EXT                  0xFF73DB
+    const uint32_t VNTPSize = 8;
+
+    QUIC_PRIVATE_TRANSPORT_PARAMETER TestTP;
+    TestTP.Type = QUIC_TP_ID_VERSION_NEGOTIATION_EXT;
+    TestTP.Length = VNTPSize;
+    UniquePtr<uint8_t[]> TPData(new(std::nothrow) uint8_t[VNTPSize]);
+    TestTP.Buffer = TPData.get();
+
+    const uint32_t WrongVersion = QUIC_VERSION_MS_1;
+
+    CxPlatCopyMemory(TPData.get(), &WrongVersion, sizeof(WrongVersion));
+    CxPlatCopyMemory(TPData.get() + sizeof(WrongVersion), &WrongVersion, sizeof(WrongVersion));
+
+    QuicTestCustomVNTP(TestServer, &TestTP);
 }
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES


### PR DESCRIPTION
## Description

Add test for scenario where the Version Info transport parameter has a Chosen Version field that doesn't match the Version field in the long header.

This is not a guarantee required by the spec, and may change in the future for future versions or extensions.

## Testing

Tests added.

## Documentation

N/A
