### PR TITLE
Add -StaticCRT switch to build script and never use partial static crt linking for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,7 +526,6 @@ if(WIN32)
     if(QUIC_STATIC_LINK_PARTIAL_CRT)
         message(STATUS "Configuring for partially statically-linked CRT")
         set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
-        set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib")
     endif()
 
 else() #!WIN32

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -51,6 +51,9 @@ This script provides helpers for building msquic.
 .PARAMETER DynamicCRT
     Builds msquic with dynamic C runtime (Windows-only).
 
+.PARAMETER StaticCRT
+    Builds msquic with static C runtime (Windows-only).
+
 .PARAMETER PGO
     Builds msquic with profile guided optimization support (Windows-only).
 
@@ -159,6 +162,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [switch]$DynamicCRT = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$StaticCRT = $false,
 
     [Parameter(Mandatory = $false)]
     [switch]$PGO = $false,
@@ -417,8 +423,13 @@ function CMake-Generate {
         }
         $Arguments += " -DCMAKE_BUILD_TYPE=" + $ConfigToBuild
     }
-    if ($DynamicCRT) {
-        $Arguments += " -DQUIC_STATIC_LINK_CRT=off -DQUIC_STATIC_LINK_PARTIAL_CRT=off"
+    if ($IsWindows) {
+        if ($DynamicCRT) {
+            $Arguments += " -DQUIC_STATIC_LINK_CRT=off -DQUIC_STATIC_LINK_PARTIAL_CRT=off"
+        }
+        if ($StaticCRT) {
+            $Arguments += " -DQUIC_STATIC_LINK_CRT=on -DQUIC_STATIC_LINK_PARTIAL_CRT=off"
+        }
     }
     if ($PGO) {
         $Arguments += " -DQUIC_PGO=on"


### PR DESCRIPTION
## Description

1. Add `-StaticCRT` to allow full static CRT linking.
2. Never apply partial static CRT linking to debug bits.

## Testing

CI
