### PR TITLE
Fix TCP Perf Test Race Condition on Shutdown

### DIFF
--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -214,17 +214,26 @@ CXPLAT_THREAD_CALLBACK(TcpWorker::WorkerThread, Context)
     CXPLAT_THREAD_RETURN(0);
 }
 
-void TcpWorker::QueueConnection(TcpConnection* Connection)
+bool TcpWorker::QueueConnection(TcpConnection* Connection)
 {
+    bool Result = true;
     CxPlatDispatchLockAcquire(&Lock);
+    //
+    // Try to queue the connection if we can add a ref. If we're shutting down
+    // the socket, it's possible a receive happens that would fail to add ref.
+    //
     if (!Connection->QueuedOnWorker) {
-        Connection->QueuedOnWorker = true;
-        Connection->AddRef();
-        *ConnectionsTail = Connection;
-        ConnectionsTail = &Connection->Next;
-        CxPlatEventSet(WakeEvent);
+        if (Connection->TryAddRef()) {
+            Connection->QueuedOnWorker = true;
+            *ConnectionsTail = Connection;
+            ConnectionsTail = &Connection->Next;
+            CxPlatEventSet(WakeEvent);
+        } else {
+            Result = false;
+        }
     }
     CxPlatDispatchLockRelease(&Lock);
+    return Result;
 }
 
 // ############################# SERVER #############################
@@ -371,6 +380,12 @@ TcpConnection::~TcpConnection()
         CxPlatTlsUninitialize(Tls);
     }
     if (Socket) {
+        CxPlatDispatchLockAcquire(&Lock);
+        CXPLAT_RECV_DATA* RecvDataChain = ReceiveData;
+        ReceiveData = nullptr;
+        CxPlatDispatchLockRelease(&Lock);
+        CxPlatRecvDataReturn(RecvDataChain);
+
         CxPlatSocketDelete(Socket);
     }
     if (!IsServer && SecConfig) {
@@ -424,11 +439,14 @@ TcpConnection::ReceiveCallback(
     }
     *Tail = RecvDataChain;
     CxPlatDispatchLockRelease(&This->Lock);
-    This->Queue();
+    if (!This->Queue()) {
+        CxPlatRecvDataReturn(This->ReceiveData); // No need to lock since the other thread is blocked in delete.
+        This->ReceiveData = nullptr;
+    }
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-    _Function_class_(CXPLAT_DATAPATH_SEND_COMPLETE_CALLBACK)
+_Function_class_(CXPLAT_DATAPATH_SEND_COMPLETE_CALLBACK)
 void
 TcpConnection::SendCompleteCallback(
     _In_ CXPLAT_SOCKET* /* Socket */,

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -440,8 +440,11 @@ TcpConnection::ReceiveCallback(
     *Tail = RecvDataChain;
     CxPlatDispatchLockRelease(&This->Lock);
     if (!This->Queue()) {
-        CxPlatRecvDataReturn(This->ReceiveData); // No need to lock since the other thread is blocked in delete.
+        CxPlatDispatchLockAcquire(&This->Lock);
+        RecvDataChain = This->ReceiveData;
         This->ReceiveData = nullptr;
+        CxPlatDispatchLockRelease(&This->Lock);
+        CxPlatRecvDataReturn(RecvDataChain);
     }
 }
 

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -118,7 +118,7 @@ class TcpWorker {
     bool Initialize(TcpEngine* _Engine);
     void Shutdown();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);
-    void QueueConnection(TcpConnection* Connection);
+    bool QueueConnection(TcpConnection* Connection);
 };
 
 class TcpServer {
@@ -235,7 +235,7 @@ class TcpConnection {
         _In_reads_(TicketLength) const uint8_t* Ticket
         );
     ~TcpConnection();
-    void Queue() { Worker->QueueConnection(this); }
+    bool Queue() { return Worker->QueueConnection(this); }
     void Process();
     bool InitializeTls();
     bool ProcessTls(const uint8_t* Buffer, uint32_t BufferLength);
@@ -249,7 +249,7 @@ class TcpConnection {
     QUIC_BUFFER* NewSendBuffer();
     void FreeSendBuffer(QUIC_BUFFER* SendBuffer);
     bool FinalizeSendBuffer(QUIC_BUFFER* SendBuffer);
-    void AddRef() { CxPlatRefIncrement(&Ref); }
+    bool TryAddRef() { return CxPlatRefIncrementNonZero(&Ref, 1) != FALSE; }
     void Release() { if (CxPlatRefDecrement(&Ref)) delete this; }
 public:
     void* Context{nullptr}; // App context


### PR DESCRIPTION
## Description

There is a window in which the receive callback can happen after we start deleting the connection object, but haven't yet deleted the socket (in the destructor). This updates the receive path to bail if it fails to queue in this case.

## Testing

Perf tests

## Documentation

No
