### PR TITLE
Add lock to avoid MsQuicOpen abort issue for statically linked spinquic

### DIFF
--- a/src/tools/spin/CMakeLists.txt
+++ b/src/tools/spin/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+if(NOT QUIC_BUILD_SHARED)
+    add_compile_definitions(QUIC_BUILD_STATIC)
+endif()
 add_quic_tool(spinquic spinquic.cpp)

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -940,9 +940,13 @@ CXPLAT_THREAD_CALLBACK(RunThread, Context)
             ASSERT_ON_NOT(Gb.Buffers[j].Buffer);
         }
 
+#ifdef QUIC_BUILD_STATIC
         CxPlatLockAcquire(&RunThreadLock);
         QUIC_STATUS Status = MsQuicOpen2(&Gb.MsQuic);
         CxPlatLockRelease(&RunThreadLock);
+#else
+        QUIC_STATUS Status = MsQuicOpen2(&Gb.MsQuic);
+#endif
         if (QUIC_FAILED(Status)) {
             break;
         }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -1078,9 +1078,9 @@ main(int argc, char **argv)
         PrintHelpText();
     }
 
-    CxPlatLockInitialize(&RunThreadLock);
     CxPlatSystemLoad();
     CxPlatInitialize();
+    CxPlatLockInitialize(&RunThreadLock);
 
     uint32_t RepeatCount = 1;
 
@@ -1173,5 +1173,6 @@ main(int argc, char **argv)
         }
     }
 
+    CxPlatLockUninitialize(&RunThreadLock);
     return 0;
 }


### PR DESCRIPTION
## Description

`CXPLAT_TEL_ASSERT(MsQuicLib.Loaded)` in MsQuicAddRef abort when libmsquic is statically linked with spinquic

## Testing

locally tested

## Documentation

N/A
