### PR TITLE
Add Tests for Zero version in VN TP.

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2695,6 +2695,15 @@ QuicConnProcessPeerVersionNegotiationTP(
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
 
+        if (ClientVI.ChosenVersion == 0) {
+            QuicTraceLogConnError(
+                VersionInfoChosenVersionZero,
+                Connection,
+                "Version Info Chosen Version is zero!");
+            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
+            return QUIC_STATUS_PROTOCOL_ERROR;
+        }
+
         //
         // Assume QuicVersion on the Connection is the long header value
         // and verify it matches the VNE TP.
@@ -2710,11 +2719,6 @@ QuicConnProcessPeerVersionNegotiationTP(
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
 
-        if (ClientVI.ChosenVersion == 0) {
-            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
-            return QUIC_STATUS_PROTOCOL_ERROR;
-        }
-
         //
         // Attempt to upgrade the connection to a compatible version the server prefers.
         //
@@ -2723,6 +2727,15 @@ QuicConnProcessPeerVersionNegotiationTP(
                 continue;
             }
             for (uint32_t ClientVersionIdx = 0; ClientVersionIdx < ClientVI.OtherVersionsCount; ++ClientVersionIdx) {
+                if (ClientVI.OtherVersions[ClientVersionIdx] == 0) {
+                    QuicTraceLogConnError(
+                        VersionInfoOtherVersionZero,
+                        Connection,
+                        "Version Info.OtherVersions contains a zero version! Index = %u",
+                        ClientVersionIdx);
+                    QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
+                    return QUIC_STATUS_PROTOCOL_ERROR;
+                }
                 if (!QuicIsVersionReserved(ClientVI.OtherVersions[ClientVersionIdx]) &&
                     ClientVI.OtherVersions[ClientVersionIdx] == SupportedVersions[ServerVersionIdx] &&
                     QuicVersionNegotiationExtAreVersionsCompatible(
@@ -2763,6 +2776,16 @@ QuicConnProcessPeerVersionNegotiationTP(
             QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
+
+        if (ServerVI.ChosenVersion == 0) {
+            QuicTraceLogConnError(
+                VersionInfoChosenVersionZero,
+                Connection,
+                "Version Info Chosen Version is zero!");
+            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
+            return QUIC_STATUS_PROTOCOL_ERROR;
+        }
+
         if (Connection->Stats.QuicVersion != ServerVI.ChosenVersion) {
             QuicTraceLogConnError(
                 ServerVersionInfoVersionMismatch,
@@ -2774,14 +2797,15 @@ QuicConnProcessPeerVersionNegotiationTP(
             return QUIC_STATUS_PROTOCOL_ERROR;
         }
 
-        if (ServerVI.ChosenVersion == 0) {
-            QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
-            return QUIC_STATUS_PROTOCOL_ERROR;
-        }
         uint32_t ClientChosenVersion = 0;
         BOOLEAN OriginalVersionFound = FALSE;
         for (uint32_t i = 0; i < ServerVI.OtherVersionsCount; ++i) {
-            if (ServerVI.OtherVersions[i] == 0){
+            if (ServerVI.OtherVersions[i] == 0) {
+                QuicTraceLogConnError(
+                    VersionInfoOtherVersionZero,
+                    Connection,
+                    "Version Info Other Versions contains a zero version! Index = %u",
+                    i);
                 QuicConnTransportError(Connection, QUIC_ERROR_TRANSPORT_PARAMETER_ERROR);
                 return QUIC_STATUS_PROTOCOL_ERROR;
             }

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -80,6 +80,24 @@ tracepoint(CLOG_CONNECTION_C, PacketRxNotAcked , arg2, arg3);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for VersionInfoChosenVersionZero
+// [conn][%p] Version Info Chosen Version is zero!
+// QuicTraceLogConnError(
+                VersionInfoChosenVersionZero,
+                Connection,
+                "Version Info Chosen Version is zero!");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_VersionInfoChosenVersionZero
+#define _clog_3_ARGS_TRACE_VersionInfoChosenVersionZero(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_CONNECTION_C, VersionInfoChosenVersionZero , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for ClientVersionInfoVersionMismatch
 // [conn][%p] Client Chosen Version doesn't match long header. 0x%x != 0x%x
 // QuicTraceLogConnError(
@@ -95,6 +113,26 @@ tracepoint(CLOG_CONNECTION_C, PacketRxNotAcked , arg2, arg3);\
 #ifndef _clog_5_ARGS_TRACE_ClientVersionInfoVersionMismatch
 #define _clog_5_ARGS_TRACE_ClientVersionInfoVersionMismatch(uniqueId, arg1, encoded_arg_string, arg3, arg4)\
 tracepoint(CLOG_CONNECTION_C, ClientVersionInfoVersionMismatch , arg1, arg3, arg4);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for VersionInfoOtherVersionZero
+// [conn][%p] Version Info.OtherVersions contains a zero version! Index = %u
+// QuicTraceLogConnError(
+                        VersionInfoOtherVersionZero,
+                        Connection,
+                        "Version Info.OtherVersions contains a zero version! Index = %u",
+                        ClientVersionIdx);
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = ClientVersionIdx = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_VersionInfoOtherVersionZero
+#define _clog_4_ARGS_TRACE_VersionInfoOtherVersionZero(uniqueId, arg1, encoded_arg_string, arg3)\
+tracepoint(CLOG_CONNECTION_C, VersionInfoOtherVersionZero , arg1, arg3);\
 
 #endif
 

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -44,6 +44,25 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, PacketRxNotAcked,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for VersionInfoChosenVersionZero
+// [conn][%p] Version Info Chosen Version is zero!
+// QuicTraceLogConnError(
+                VersionInfoChosenVersionZero,
+                Connection,
+                "Version Info Chosen Version is zero!");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_CONNECTION_C, VersionInfoChosenVersionZero,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for ClientVersionInfoVersionMismatch
 // [conn][%p] Client Chosen Version doesn't match long header. 0x%x != 0x%x
 // QuicTraceLogConnError(
@@ -65,6 +84,29 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ClientVersionInfoVersionMismatch,
         ctf_integer_hex(uint64_t, arg1, arg1)
         ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for VersionInfoOtherVersionZero
+// [conn][%p] Version Info.OtherVersions contains a zero version! Index = %u
+// QuicTraceLogConnError(
+                        VersionInfoOtherVersionZero,
+                        Connection,
+                        "Version Info.OtherVersions contains a zero version! Index = %u",
+                        ClientVersionIdx);
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = ClientVersionIdx = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_CONNECTION_C, VersionInfoOtherVersionZero,
+    TP_ARGS(
+        const void *, arg1,
+        unsigned int, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, arg1)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -11010,6 +11010,18 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
+    "VersionInfoChosenVersionZero": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Version Info Chosen Version is zero!",
+      "UniqueId": "VersionInfoChosenVersionZero",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnError"
+    },
     "VersionInfoDecodeFailed1": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Version info too short to contain Chosen Version (%hu bytes)",
@@ -11037,6 +11049,22 @@
         },
         {
           "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnError"
+    },
+    "VersionInfoOtherVersionZero": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Version Info.OtherVersions contains a zero version! Index = %u",
+      "UniqueId": "VersionInfoOtherVersionZero",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -15441,6 +15469,11 @@
         "EncodingString": "[conn][%p]   Ver[%d]: 0x%x"
       },
       {
+        "UniquenessHash": "0c7aa55b-0fac-8bf3-13f4-2a80e4a8b2ba",
+        "TraceID": "VersionInfoChosenVersionZero",
+        "EncodingString": "[conn][%p] Version Info Chosen Version is zero!"
+      },
+      {
         "UniquenessHash": "2222c403-3ef4-09ef-5b3c-aca16af3616d",
         "TraceID": "VersionInfoDecodeFailed1",
         "EncodingString": "[conn][%p] Version info too short to contain Chosen Version (%hu bytes)"
@@ -15449,6 +15482,11 @@
         "UniquenessHash": "3e7b261f-8077-d6f3-18ee-188f5cfe6b6b",
         "TraceID": "VersionInfoDecodeFailed2",
         "EncodingString": "[conn][%p] Version info too short to contain any Other Versions (%hu bytes)"
+      },
+      {
+        "UniquenessHash": "50beefb7-296c-9d5f-eecd-8a24023ac56e",
+        "TraceID": "VersionInfoOtherVersionZero",
+        "EncodingString": "[conn][%p] Version Info.OtherVersions contains a zero version! Index = %u"
       },
       {
         "UniquenessHash": "09622250-6902-8f51-16a4-41a81d9cfc14",

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -304,6 +304,16 @@ void
 QuicTestVNTPChosenVersionMismatch(
     _In_ bool TestServer
     );
+
+void
+QuicTestVNTPChosenVersionZero(
+    _In_ bool TestServer
+    );
+
+void
+QuicTestVNTPOtherVersionZero(
+    _In_ bool TestServer
+    );
 #endif
 
 //
@@ -1122,4 +1132,10 @@ typedef struct {
 #define IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_MISMATCH \
     QUIC_CTL_CODE(104, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 104
+#define IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_ZERO \
+    QUIC_CTL_CODE(105, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define IOCTL_QUIC_RUN_VN_TP_OTHER_VERSION_ZERO \
+    QUIC_CTL_CODE(106, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 106

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -937,6 +937,30 @@ TEST_P(WithHandshakeArgs9, VnTpChosenVersionMismatch) {
         QuicTestVNTPChosenVersionMismatch(GetParam());
     }
 }
+
+TEST_P(WithHandshakeArgs9, VnTpChosenVersionZero) {
+    TestLoggerT<ParamType> Logger("QuicTestVNTPChosenVersionZero", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(
+            DriverClient.Run(
+                IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_ZERO,
+                (uint8_t)GetParam()));
+    } else {
+        QuicTestVNTPChosenVersionZero(GetParam());
+    }
+}
+
+TEST_P(WithHandshakeArgs9, VnTpOtherVersionZero) {
+    TestLoggerT<ParamType> Logger("QuicTestVNTPOtherVersionZero", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(
+            DriverClient.Run(
+                IOCTL_QUIC_RUN_VN_TP_OTHER_VERSION_ZERO,
+                (uint8_t)GetParam()));
+    } else {
+        QuicTestVNTPOtherVersionZero(GetParam());
+    }
+}
 #endif
 #endif
 

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -476,6 +476,8 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     sizeof(QUIC_RUN_VN_TP_ODD_SIZE_PARAMS),
     sizeof(UINT8),
+    sizeof(UINT8),
+    sizeof(UINT8),
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1295,6 +1297,18 @@ QuicTestCtlEvtIoDeviceControl(
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(
             QuicTestVNTPChosenVersionMismatch(Params->TestServerVNTP != 0));
+        break;
+
+    case IOCTL_QUIC_RUN_VN_TP_CHOSEN_VERSION_ZERO:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(
+            QuicTestVNTPChosenVersionZero(Params->TestServerVNTP != 0));
+        break;
+
+    case IOCTL_QUIC_RUN_VN_TP_OTHER_VERSION_MISMATCH:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(
+            QuicTestVNTPOtherVersionZero(Params->TestServerVNTP != 0));
         break;
 #endif
 

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -1305,7 +1305,7 @@ QuicTestCtlEvtIoDeviceControl(
             QuicTestVNTPChosenVersionZero(Params->TestServerVNTP != 0));
         break;
 
-    case IOCTL_QUIC_RUN_VN_TP_OTHER_VERSION_MISMATCH:
+    case IOCTL_QUIC_RUN_VN_TP_OTHER_VERSION_ZERO:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(
             QuicTestVNTPOtherVersionZero(Params->TestServerVNTP != 0));

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3430,11 +3430,18 @@ QuicTestVNTPChosenVersionZero(
 
     const uint32_t ZeroVersion = 0;
     const uint32_t Version1 = QUIC_VERSION_1;
+    const uint32_t Version2 = QUIC_VERSION_2;
     uint8_t* Cursor = TPData.get();
 
     CxPlatCopyMemory(Cursor, &ZeroVersion, sizeof(ZeroVersion));
     Cursor += sizeof(uint32_t);
-    CxPlatCopyMemory(Cursor, &Version1, sizeof(Version1));
+    //
+    // Use Version 2 when testing server because the server will perform
+    // Compatible Version Negotiation, and if using Version1, the client
+    // will fail for the wrong reason: Long Header Version/Chosen Version
+    // mismatch.
+    //
+    CxPlatCopyMemory(Cursor, TestServer ? &Version2 : &Version1, sizeof(Version1));
     Cursor += sizeof(uint32_t);
     CxPlatCopyMemory(Cursor, &ZeroVersion, sizeof(ZeroVersion));
 

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3414,4 +3414,56 @@ QuicTestVNTPChosenVersionMismatch(
 
     QuicTestCustomVNTP(TestServer, &TestTP);
 }
+
+void
+QuicTestVNTPChosenVersionZero(
+    _In_ bool TestServer
+    )
+{
+    const uint32_t VNTPSize = 3 * sizeof(uint32_t);
+
+    QUIC_PRIVATE_TRANSPORT_PARAMETER TestTP;
+    TestTP.Type = QUIC_TP_ID_VERSION_NEGOTIATION_EXT;
+    TestTP.Length = VNTPSize;
+    UniquePtr<uint8_t[]> TPData(new(std::nothrow) uint8_t[VNTPSize]);
+    TestTP.Buffer = TPData.get();
+
+    const uint32_t ZeroVersion = 0;
+    const uint32_t Version1 = QUIC_VERSION_1;
+    uint8_t* Cursor = TPData.get();
+
+    CxPlatCopyMemory(Cursor, &ZeroVersion, sizeof(ZeroVersion));
+    Cursor += sizeof(uint32_t);
+    CxPlatCopyMemory(Cursor, &Version1, sizeof(Version1));
+    Cursor += sizeof(uint32_t);
+    CxPlatCopyMemory(Cursor, &ZeroVersion, sizeof(ZeroVersion));
+
+    QuicTestCustomVNTP(TestServer, &TestTP);
+}
+
+void
+QuicTestVNTPOtherVersionZero(
+    _In_ bool TestServer
+    )
+{
+    const uint32_t VNTPSize = 3 * sizeof(uint32_t);
+
+    QUIC_PRIVATE_TRANSPORT_PARAMETER TestTP;
+    TestTP.Type = QUIC_TP_ID_VERSION_NEGOTIATION_EXT;
+    TestTP.Length = VNTPSize;
+    UniquePtr<uint8_t[]> TPData(new(std::nothrow) uint8_t[VNTPSize]);
+    TestTP.Buffer = TPData.get();
+
+    const uint32_t ZeroVersion = 0;
+    const uint32_t Version1 = QUIC_VERSION_1;
+    uint8_t* Cursor = TPData.get();
+
+    CxPlatCopyMemory(Cursor, &Version1, sizeof(Version1));
+    Cursor += sizeof(uint32_t);
+    CxPlatCopyMemory(Cursor, &Version1, sizeof(Version1));
+    Cursor += sizeof(uint32_t);
+    CxPlatCopyMemory(Cursor, &ZeroVersion, sizeof(ZeroVersion));
+
+    QuicTestCustomVNTP(TestServer, &TestTP);
+}
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES


### PR DESCRIPTION
## Description

Add tests to ensure that client and server fail parsing the Version Info transport parameter when it contains a zero version.

## Testing

New testing.

## Documentation

N/A
