### PR TITLE
fix(test): allow QUIC_CONNECTION_EVENT_PEER_NEEDS_STREAMS

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -881,6 +881,8 @@ QuicAbortiveConnectionHandler(
             __fallthrough;
         case QUIC_CONNECTION_EVENT_RESUMED:
             __fallthrough;
+        case QUIC_CONNECTION_EVENT_PEER_NEEDS_STREAMS:
+            __fallthrough;
         case QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED:
             return QUIC_STATUS_SUCCESS;
         default:
@@ -1361,6 +1363,8 @@ QuicRecvResumeConnectionHandler(
         case QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED:
             __fallthrough;
         case QUIC_CONNECTION_EVENT_RESUMED:
+            __fallthrough;
+        case QUIC_CONNECTION_EVENT_PEER_NEEDS_STREAMS:
             __fallthrough;
         case QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED:
             return QUIC_STATUS_SUCCESS;


### PR DESCRIPTION
## Description

To make "test down level" pass in #3118 

## Testing

I have tested manually on ubuntu 20.04 with the msquic binary built from #3118 

## Documentation

N/A
