### PR TITLE
Save All Histograms from Perf

### DIFF
--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -353,15 +353,14 @@ stages:
           extraArgs: -PGO
           failOnRegression: 0
 
-- ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-  - stage: perf_post_process
-    displayName: Perf Post Processing
-    condition: succeededOrFailed()
-    dependsOn:
-    - perf_winkernel
-    - perf_winuser_schannel
-    - perf_winuser_xdp
-    - perf_winuser_openssl
-    - perf_linux_openssl
-    jobs:
-    - template: ./templates/post-process-performance.yml
+- stage: perf_post_process
+  displayName: Perf Post Processing
+  condition: succeededOrFailed()
+  dependsOn:
+  - perf_winkernel
+  - perf_winuser_schannel
+  - perf_winuser_xdp
+  - perf_winuser_openssl
+  - perf_linux_openssl
+  jobs:
+  - template: ./templates/post-process-performance.yml

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -522,14 +522,18 @@ function Log($msg) {
 
 function Invoke-LocalExe {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
-    param ($Exe, $RunArgs, $Timeout, $OutputDir, $ExtraFileName)
+    param ($Exe, $RunArgs, $Timeout, $OutputDir, $HistogramFileName)
     $BasePath = Split-Path $Exe -Parent
     if (!$IsWindows) {
         $env:LD_LIBRARY_PATH = $BasePath
         chmod +x $Exe | Out-Null
     }
-    $LocalExtraFile = Join-Path $OutputDir $ExtraFileName
-    $RunArgs = """--extraOutputFile:$LocalExtraFile"" $RunArgs"
+    $HistogramDir = Join-Path $OutputDir "histogram"
+    if (!(Test-Path $HistogramDir)) {
+        mkdir $HistogramDir | Out-Null
+    }
+    $HistogramFilePath = Join-Path $HistogramDir $HistogramFileName
+    $RunArgs = """--extraOutputFile:$HistogramFilePath"" $RunArgs"
     $TimeoutMs = ($Timeout - 5) * 1000;
     $RunArgs = "-watchdog:$TimeoutMs $RunArgs"
 

--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -522,13 +522,13 @@ function Log($msg) {
 
 function Invoke-LocalExe {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
-    param ($Exe, $RunArgs, $Timeout, $OutputDir)
+    param ($Exe, $RunArgs, $Timeout, $OutputDir, $ExtraFileName)
     $BasePath = Split-Path $Exe -Parent
     if (!$IsWindows) {
         $env:LD_LIBRARY_PATH = $BasePath
         chmod +x $Exe | Out-Null
     }
-    $LocalExtraFile = Join-Path $BasePath "ExtraRunFile.txt"
+    $LocalExtraFile = Join-Path $OutputDir $ExtraFileName
     $RunArgs = """--extraOutputFile:$LocalExtraFile"" $RunArgs"
     $TimeoutMs = ($Timeout - 5) * 1000;
     $RunArgs = "-watchdog:$TimeoutMs $RunArgs"
@@ -950,15 +950,6 @@ function Publish-RPSTestResults {
     param ([TestRunDefinition]$Test, $AllRunsFullResults, $CurrentCommitHash, $CurrentCommitDate, $PreviousResults, $OutputDir, $ExePath)
 
     $Request = [RPSRequest]::new($Test)
-
-    $BasePath = Split-Path $ExePath -Parent
-    $LocalExtraFile = Join-Path $BasePath "ExtraRunFile.txt"
-    if (Test-Path $LocalExtraFile -PathType Leaf) {
-        $ResultFile = Join-Path $OutputDir "histogram_$Test.txt"
-        Copy-Item -Path $LocalExtraFile -Destination $ResultFile
-    } else {
-        Write-Host "Extra file $LocalExtraFile not found when expected"
-    }
 
     $AllRunsResults = Get-TestResultAtIndex -FullResults $AllRunsFullResults -Index 1
     $MedianCurrentResult = Get-MedianTestResults -FullResults $AllRunsResults

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -478,7 +478,7 @@ function Invoke-Test {
     try {
         1..$NumIterations | ForEach-Object {
             Write-LogAndDebug "Running Local: $LocalExe Args: $LocalArguments"
-            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir
+            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir -ExtraFileName "histogram_$($_)_$Test.txt"
             Write-LogAndDebug $LocalResults
             $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher -FailureDefault $Test.FailureDefault
             $AllRunsResults += $AllLocalParsedResults

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -478,7 +478,7 @@ function Invoke-Test {
     try {
         1..$NumIterations | ForEach-Object {
             Write-LogAndDebug "Running Local: $LocalExe Args: $LocalArguments"
-            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir -ExtraFileName "histogram_$($_)_$Test.txt"
+            $LocalResults = Invoke-LocalExe -Exe $LocalExe -RunArgs $LocalArguments -Timeout $Timeout -OutputDir $OutputDir -HistogramFileName "$($Test)_run$($_).txt"
             Write-LogAndDebug $LocalResults
             $AllLocalParsedResults = Get-TestResult -Results $LocalResults -Matcher $Test.ResultsMatcher -FailureDefault $Test.FailureDefault
             $AllRunsResults += $AllLocalParsedResults


### PR DESCRIPTION
## Description

Depends on #3151.

- Saves all runs' histogram files from perf tests
- Moves histogram files into a separate folder
- Enables dry run perf publishing for PRs

## Testing

Perf pipeline

## Documentation

None
