### PR TITLE
Enable Stream Stats on Perf

### DIFF
--- a/scripts/RemoteTests.json
+++ b/scripts/RemoteTests.json
@@ -12,7 +12,7 @@
                 "Tls": ["schannel", "openssl"],
                 "Arch": ["x64", "x86", "arm", "arm64"],
                 "Exe": "secnetperf",
-                "Arguments": "-exec:maxtput -test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -upload:12000 -stats:1"
+                "Arguments": "-exec:maxtput -test:Throughput -target:$RemoteAddress -bind:$LocalAddress:4434 -ip:4 -uni:1 -timed:1 -upload:12000 -stats:1 -sstats:1"
             },
             "Variables": [
                 {
@@ -66,7 +66,7 @@
                 "Tls": ["openssl"],
                 "Arch": ["x64", "arm"],
                 "Exe": "secnetperf",
-                "Arguments": "-exec:maxtput -test:Throughput -target:$RemoteAddress -uni:1 -timed:1 -upload:12000 -stats:1"
+                "Arguments": "-exec:maxtput -test:Throughput -target:$RemoteAddress -uni:1 -timed:1 -upload:12000 -stats:1 -sstats:1"
             },
             "Variables": [
                 {

--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -419,6 +419,10 @@ function Invoke-Test {
         $RemoteArguments += " -stats:1"
     }
 
+    if ($LocalArguments.Contains("-sstats:1")) {
+        $RemoteArguments += " -sstats:1"
+    }
+
     if ($LocalArguments.Contains("-exec:maxtput")) {
         $RemoteArguments += " -exec:maxtput"
     }

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -582,34 +582,39 @@ ThroughputClient::StreamCallback(
         }
         MsQuic->StreamShutdown(StreamHandle, QUIC_STREAM_SHUTDOWN_FLAG_ABORT, 0);
         break;
-    case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
+    case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
         if (PrintStreamStats) {
             QUIC_STREAM_STATISTICS Stats = {0};
             uint32_t BufferLength = sizeof(Stats);
             MsQuic->GetParam(StreamHandle, QUIC_PARAM_STREAM_STATISTICS, &BufferLength, &Stats);
             WriteOutput("Flow blocked timing:\n");
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_SCHEDULING Time: %llu us\n",
+                "SCHEDULING:             %llu us\n",
                 (unsigned long long)Stats.ConnBlockedBySchedulingUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_PACING Time: %llu us\n",
+                "PACING:                 %llu us\n",
                 (unsigned long long)Stats.ConnBlockedByPacingUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_AMPLIFICATION_PROT Time: %llu us\n",
+                "AMPLIFICATION_PROT:     %llu us\n",
                 (unsigned long long)Stats.ConnBlockedByAmplificationProtUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_CONN_FLOW_CONTROL Time: %llu us\n",
+                "CONGESTION_CONTROL:     %llu us\n",
+                (unsigned long long)Stats.ConnBlockedByCongestionControlUs);
+            WriteOutput(
+                "CONN_FLOW_CONTROL:      %llu us\n",
                 (unsigned long long)Stats.ConnBlockedByFlowControlUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_STREAM_ID_FLOW_CONTROL Time: %llu us\n",
+                "STREAM_ID_FLOW_CONTROL: %llu us\n",
                 (unsigned long long)Stats.StreamBlockedByIdFlowControlUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_STREAM_FLOW_CONTROL Time: %llu us\n",
+                "STREAM_FLOW_CONTROL:    %llu us\n",
                 (unsigned long long)Stats.StreamBlockedByFlowControlUs);
             WriteOutput(
-                "Reason: QUIC_FLOW_BLOCKED_APP Time: %llu us\n",
+                "APP:                    %llu us\n",
                 (unsigned long long)Stats.StreamBlockedByAppUs);
         }
+        break;
+    case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
         OnStreamShutdownComplete(StrmContext);
         break;
     case QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE:


### PR DESCRIPTION
## Description

Collect stream-level stats for throughput perf runs. Also has a few fixes to when we add/remove blocked flags for streams.

## Testing

Perf pipeline

## Documentation

N/A
