### PR TITLE
More TPUT Stats Updates

### DIFF
--- a/src/perf/lib/PerfHelpers.h
+++ b/src/perf/lib/PerfHelpers.h
@@ -334,11 +334,13 @@ QuicPrintConnectionStatistics(
             &StatsSize,
             &Statistics))) {
         WriteOutput(
-            "[conn][%p] STATS: SendTotalPackets=%llu SendSuspectedLostPackets=%llu SendSpuriousLostPackets=%llu RecvTotalPackets=%llu RecvReorderedPackets=%llu RecvDroppedPackets=%llu RecvDuplicatePackets=%llu RecvDecryptionFailures=%llu\n",
+            "[conn][%p] STATS: RTT:%u us SendTotalPackets=%llu SendSuspectedLostPackets=%llu SendSpuriousLostPackets=%llu SendCongestionCount=%u RecvTotalPackets=%llu RecvReorderedPackets=%llu RecvDroppedPackets=%llu RecvDuplicatePackets=%llu RecvDecryptionFailures=%llu\n",
             Connection,
+            Statistics.Rtt,
             (unsigned long long)Statistics.SendTotalPackets,
             (unsigned long long)Statistics.SendSuspectedLostPackets,
             (unsigned long long)Statistics.SendSpuriousLostPackets,
+            Statistics.SendCongestionCount,
             (unsigned long long)Statistics.RecvTotalPackets,
             (unsigned long long)Statistics.RecvReorderedPackets,
             (unsigned long long)Statistics.RecvDroppedPackets,

--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -536,9 +536,6 @@ ThroughputClient::ConnectionCallback(
     ) {
     switch (Event->Type) {
     case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE:
-        if (PrintStats) {
-            QuicPrintConnectionStatistics(MsQuic, ConnectionHandle);
-        }
         MsQuic->ConnectionClose(ConnectionHandle);
         CxPlatEventSet(*StopEvent);
         break;
@@ -615,6 +612,9 @@ ThroughputClient::StreamCallback(
         }
         break;
     case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
+        if (PrintStats) {
+            QuicPrintConnectionStatistics(MsQuic, StreamHandle);
+        }
         OnStreamShutdownComplete(StrmContext);
         break;
     case QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE:


### PR DESCRIPTION
## Description

- Prints RTT and send congestion event count
- Moves stats print to stream shutdown complete (since that's when the transfer is really done)

## Testing

Perf pipeline

## Documentation

None
