### PR TITLE
Perf Counter Snapshot Improvements

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -159,6 +159,11 @@ QuicPerfCounterSnapShot(
         (uint8_t*)PerfCounterSamples,
         sizeof(PerfCounterSamples));
 
+    QuicTraceEvent(
+        PerfCountersRundown,
+        "[ lib] Perf counters Rundown, Counters=%!CID!",
+        CASTED_CLOG_BYTEARRAY(sizeof(PerfCounterSamples), PerfCounterSamples));
+
 // Ensure a perf counter stays below a given max Hz/frequency.
 #define QUIC_COUNTER_LIMIT_HZ(TYPE, LIMIT_PER_SECOND) \
     CXPLAT_TEL_ASSERT( \

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -374,7 +374,7 @@ QuicPerfCounterAdd(
 #define QuicPerfCounterIncrement(Type) QuicPerfCounterAdd(Type, 1)
 #define QuicPerfCounterDecrement(Type) QuicPerfCounterAdd(Type, -1)
 
-#define QUIC_PERF_SAMPLE_INTERVAL_S    30 // 30 seconds
+#define QUIC_PERF_SAMPLE_INTERVAL_S    1 // 1 second
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void

--- a/src/generated/linux/library.c.clog.h
+++ b/src/generated/linux/library.c.clog.h
@@ -322,6 +322,24 @@ tracepoint(CLOG_LIBRARY_C, LibraryLoadBalancingModeSetAfterInUse );\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for PerfCountersRundown
+// [ lib] Perf counters Rundown, Counters=%!CID!
+// QuicTraceEvent(
+        PerfCountersRundown,
+        "[ lib] Perf counters Rundown, Counters=%!CID!",
+        CASTED_CLOG_BYTEARRAY(sizeof(PerfCounterSamples), PerfCounterSamples));
+// arg2 = arg2 = CASTED_CLOG_BYTEARRAY(sizeof(PerfCounterSamples), PerfCounterSamples) = arg2
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_PerfCountersRundown
+#define _clog_4_ARGS_TRACE_PerfCountersRundown(uniqueId, encoded_arg_string, arg2, arg2_len)\
+tracepoint(CLOG_LIBRARY_C, PerfCountersRundown , arg2_len, arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
@@ -570,24 +588,6 @@ tracepoint(CLOG_LIBRARY_C, DataPathRundown , arg2);\
 #ifndef _clog_3_ARGS_TRACE_LibrarySendRetryStateUpdated
 #define _clog_3_ARGS_TRACE_LibrarySendRetryStateUpdated(uniqueId, encoded_arg_string, arg2)\
 tracepoint(CLOG_LIBRARY_C, LibrarySendRetryStateUpdated , arg2);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for PerfCountersRundown
-// [ lib] Perf counters Rundown, Counters=%!CID!
-// QuicTraceEvent(
-            PerfCountersRundown,
-            "[ lib] Perf counters Rundown, Counters=%!CID!",
-            CASTED_CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters));
-// arg2 = arg2 = CASTED_CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters) = arg2
-----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_PerfCountersRundown
-#define _clog_4_ARGS_TRACE_PerfCountersRundown(uniqueId, encoded_arg_string, arg2, arg2_len)\
-tracepoint(CLOG_LIBRARY_C, PerfCountersRundown , arg2_len, arg2);\
 
 #endif
 

--- a/src/generated/linux/library.c.clog.h.lttng.h
+++ b/src/generated/linux/library.c.clog.h.lttng.h
@@ -292,6 +292,27 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryLoadBalancingModeSetAfterInUse,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for PerfCountersRundown
+// [ lib] Perf counters Rundown, Counters=%!CID!
+// QuicTraceEvent(
+        PerfCountersRundown,
+        "[ lib] Perf counters Rundown, Counters=%!CID!",
+        CASTED_CLOG_BYTEARRAY(sizeof(PerfCounterSamples), PerfCounterSamples));
+// arg2 = arg2 = CASTED_CLOG_BYTEARRAY(sizeof(PerfCounterSamples), PerfCounterSamples) = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_LIBRARY_C, PerfCountersRundown,
+    TP_ARGS(
+        unsigned int, arg2_len,
+        const void *, arg2), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2_len, arg2_len)
+        ctf_sequence(char, arg2, arg2, unsigned int, arg2_len)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for AllocFailure
 // Allocation of '%s' failed. (%llu bytes)
 // QuicTraceEvent(
@@ -563,26 +584,5 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibrarySendRetryStateUpdated,
         unsigned char, arg2), 
     TP_FIELDS(
         ctf_integer(unsigned char, arg2, arg2)
-    )
-)
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for PerfCountersRundown
-// [ lib] Perf counters Rundown, Counters=%!CID!
-// QuicTraceEvent(
-            PerfCountersRundown,
-            "[ lib] Perf counters Rundown, Counters=%!CID!",
-            CASTED_CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters));
-// arg2 = arg2 = CASTED_CLOG_BYTEARRAY(sizeof(PerfCounters), PerfCounters) = arg2
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_LIBRARY_C, PerfCountersRundown,
-    TP_ARGS(
-        unsigned int, arg2_len,
-        const void *, arg2), 
-    TP_FIELDS(
-        ctf_integer(unsigned int, arg2_len, arg2_len)
-        ctf_sequence(char, arg2, arg2, unsigned int, arg2_len)
     )
 )


### PR DESCRIPTION
## Description

Two main updates to perf counter snapshots:

- Change interval from 30 seconds to 1 second
- Fire off the ETW event every time we snapshot

The goal here is that if we collect low volume logs, we implicitly will collect our perf counters.

TODO: Update WPA plugin to decode these counters for nice viewing.

## Testing

Perf pipeline to make sure there is no significant regression.

## Documentation

N/A
