### PR TITLE
Configure ECN socket option for winkernel

### DIFF
--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1618,6 +1618,44 @@ CxPlatSocketCreateUdp(
         CxPlatDataPathSetControlSocket(
             Binding,
             WskSetOption,
+            IPV6_ECN,
+            IPPROTO_IPV6,
+            sizeof(Option),
+            &Option);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            DatapathErrorStatus,
+            "[data][%p] ERROR, %u, %s.",
+            Binding,
+            Status,
+            "Set IPV6_ECN");
+        goto Error;
+    }
+
+    Option = TRUE;
+    Status =
+        CxPlatDataPathSetControlSocket(
+            Binding,
+            WskSetOption,
+            IP_ECN,
+            IPPROTO_IP,
+            sizeof(Option),
+            &Option);
+    if (QUIC_FAILED(Status)) {
+        QuicTraceEvent(
+            DatapathErrorStatus,
+            "[data][%p] ERROR, %u, %s.",
+            Binding,
+            Status,
+            "Set IP_ECN");
+        goto Error;
+    }
+
+    Option = TRUE;
+    Status =
+        CxPlatDataPathSetControlSocket(
+            Binding,
+            WskSetOption,
             IPV6_RECVERR,
             IPPROTO_IPV6,
             sizeof(Option),


### PR DESCRIPTION
## Description

Discovered by the ECN tests from #3168. We forgot to set the ECN socket option.

## Testing

CI in #3168