### PR TITLE
doc: no dup StreamReceiveComplete call

### DIFF
--- a/docs/api/StreamReceiveComplete.md
+++ b/docs/api/StreamReceiveComplete.md
@@ -21,7 +21,9 @@ void
 
 # Remarks
 
-**TODO**
+This is an asynchronous API but can run inline if called in a callback.
+The application must ensure that one `StreamReceiveComplete` call corresponds to one `QUIC_STREAM_EVENT_RECEIVE` event.
+Duplicate `StreamReceiveComplete` calls after one `QUIC_STREAM_EVENT_RECEIVE` event are ignored silently even with different `BufferLength`.
 
 # See Also
 


### PR DESCRIPTION
## Description

Clarify the handling of dup StreamReceiveComplete calls per `QUIC_STREAM_EVENT_RECEIVE` event in MsQuic


## Testing

no code change.

## Documentation

This is pure doc update.
