### PR TITLE
Increase BVT Timeout

### DIFF
--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -26,6 +26,7 @@ jobs:
       vmImage: ${{ parameters.image }}
   variables:
     runCodesignValidationInjection: false
+  timeoutInMinutes: 120
   steps:
   - checkout: self
 

--- a/.azure/templates/run-bvt.yml
+++ b/.azure/templates/run-bvt.yml
@@ -53,7 +53,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run BVTs
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     ${{ if eq(parameters.codeCoverage, true) }}:
       continueOnError: true
     inputs:


### PR DESCRIPTION
## Description

As we continue to add test cases we have started to timeout more often. additionally, ASAN on Windows seems to make it slow enough to timeout more often than not. In the future, we should look at parallelization to speed things up more.

## Testing

N/A

## Documentation

N/A
