### PR TITLE
Tests Wait Longer

### DIFF
--- a/src/plugins/trace/dll/Properties/launchSettings.json
+++ b/src/plugins/trace/dll/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "WPA": {
       "commandName": "Executable",
-      "executablePath": "f:\\xperf\\wpa.exe",
-      "commandLineArgs": "-addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\quictrace\\$(Configuration)",
+      "executablePath": "C:\\Users\\nibanks\\AppData\\Local\\Microsoft\\WindowsApps\\wpa.exe",
+      "commandLineArgs": "-nodefault -addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\quictrace\\$(Configuration)",
       "nativeDebugging": false
     }
   }

--- a/src/plugins/trace/dll/Properties/launchSettings.json
+++ b/src/plugins/trace/dll/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "WPA": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\nibanks\\AppData\\Local\\Microsoft\\WindowsApps\\wpa.exe",
-      "commandLineArgs": "-nodefault -addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\quictrace\\$(Configuration)",
+      "executablePath": "f:\\xperf\\wpa.exe",
+      "commandLineArgs": "-addsearchdir $(SolutionDir)..\\..\\artifacts\\bin\\quictrace\\$(Configuration)",
       "nativeDebugging": false
     }
   }

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -830,7 +830,7 @@ QuicTestValidateStreamEvents3(
             ServerLocalAddr.GetPort()));
     TEST_TRUE(Client.HandshakeComplete.WaitTimeout(1000));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -838,7 +838,7 @@ QuicTestValidateStreamEvents3(
             1,
             QUIC_SEND_FLAG_NONE,
             nullptr));
-    CxPlatSleep(20);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -847,7 +847,7 @@ QuicTestValidateStreamEvents3(
             QUIC_SEND_FLAG_NONE,
             nullptr));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamShutdown(
             ClientStream.Handle,
@@ -953,7 +953,7 @@ QuicTestValidateStreamEvents4(
             ServerLocalAddr.GetPort()));
     TEST_TRUE(Client.HandshakeComplete.WaitTimeout(1000));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -961,7 +961,7 @@ QuicTestValidateStreamEvents4(
             1,
             QUIC_SEND_FLAG_DELAY_SEND,
             nullptr));
-    CxPlatSleep(20);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -970,7 +970,7 @@ QuicTestValidateStreamEvents4(
             QUIC_SEND_FLAG_NONE,
             nullptr));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamShutdown(
             ClientStream.Handle,
@@ -1188,7 +1188,7 @@ QuicTestValidateStreamEvents6(
             ServerLocalAddr.GetPort()));
     TEST_TRUE(Client.HandshakeComplete.WaitTimeout(1000));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -1408,7 +1408,7 @@ QuicTestValidateStreamEvents8(
             ServerLocalAddr.GetPort()));
     TEST_TRUE(Client.HandshakeComplete.WaitTimeout(1000));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -1416,7 +1416,7 @@ QuicTestValidateStreamEvents8(
             1,
             QUIC_SEND_FLAG_START,
             nullptr));
-    CxPlatSleep(20);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamSend(
             ClientStream.Handle,
@@ -1425,7 +1425,7 @@ QuicTestValidateStreamEvents8(
             QUIC_SEND_FLAG_START,
             nullptr));
 
-    CxPlatSleep(100);
+    CxPlatSleep(200);
     TEST_QUIC_SUCCEEDED(
         MsQuic->StreamShutdown(
             ClientStream.Handle,


### PR DESCRIPTION
## Description

The Event tests fail occassionally, and at least in one case it's because the app thread didn't wait long enough. It only waited 20 ms and expected the QUIC thread to run, but it took over 100 ms for it to eventually run. This PR significantly increases wait time for these particular tests. We might want to do the same for other tests...

Fixes #3193

Likely need to backport for test reliability.

## Testing

Existing automation

## Documentation

N/A
