### PR TITLE
Test Specific Handshake Loss Patterns

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1179,13 +1179,14 @@ QuicConnReplaceRetiredCids(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicConnTimerSet(
+QuicConnTimerSetEx(
     _Inout_ QUIC_CONNECTION* Connection,
     _In_ QUIC_CONN_TIMER_TYPE Type,
-    _In_ uint64_t Delay
+    _In_ uint64_t Delay,
+    _In_ uint64_t TimeNow
     )
 {
-    const uint64_t NewExpirationTime = CxPlatTimeUs64() + Delay;
+    const uint64_t NewExpirationTime = TimeNow + Delay;
 
     QuicTraceEvent(
         ConnSetTimer,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1240,7 +1240,7 @@ QuicConnTimerSet(
         NewIndex = CurIndex;
     }
 
-    if (NewIndex == 0) {
+    if (NewIndex == 0 || CurIndex == 0) {
         //
         // The first timer was updated, so make sure the timer wheel is updated.
         //

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1291,11 +1291,25 @@ QuicConnUpdateRtt(
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicConnTimerSetEx(
+    _Inout_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_CONN_TIMER_TYPE Type,
+    _In_ uint64_t DelayUs,
+    _In_ uint64_t TimeNow
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+inline
+void
 QuicConnTimerSet(
     _Inout_ QUIC_CONNECTION* Connection,
     _In_ QUIC_CONN_TIMER_TYPE Type,
     _In_ uint64_t DelayUs
-    );
+    )
+{
+    const uint64_t TimeNow = CxPlatTimeUs64();
+    QuicConnTimerSetEx(Connection, Type, DelayUs, TimeNow);
+}
 
 //
 // Cancels a timer.

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -763,6 +763,13 @@ QuicConnGetDestCidFromSeq(
     _In_ BOOLEAN RemoveFromList
     );
 
+void
+QuicConnTimerSet(
+    _Inout_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_CONN_TIMER_TYPE Type,
+    _In_ uint64_t DelayUs
+    );
+
 uint8_t
 QuicPacketTraceType(
     _In_ const QUIC_SENT_PACKET_METADATA* Metadata

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -640,7 +640,7 @@ QuicWorkerLoop(
             "[wrkr][%p] IsActive = %hhu, Arg = %u",
             Worker,
             Worker->IsActive,
-            1);
+            (uint32_t)State->TimeNow);
     }
 
     //
@@ -709,7 +709,7 @@ QuicWorkerLoop(
         "[wrkr][%p] IsActive = %hhu, Arg = %u",
         Worker,
         Worker->IsActive,
-        UINT32_MAX);
+        (uint32_t)Worker->TimerWheel.NextExpirationTime);
     QuicWorkerResetQueueDelay(Worker);
     return TRUE;
 }

--- a/src/generated/linux/TestHelpers.h.clog.h
+++ b/src/generated/linux/TestHelpers.h.clog.h
@@ -142,6 +142,22 @@ tracepoint(CLOG_TESTHELPERS_H, TestHookDropPacketSelective );\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for TestHookDropPacketBitmap
+// [test][hook] Bitmap packet drop
+// QuicTraceLogVerbose(
+            TestHookDropPacketBitmap,
+            "[test][hook] Bitmap packet drop");
+----------------------------------------------------------*/
+#ifndef _clog_2_ARGS_TRACE_TestHookDropPacketBitmap
+#define _clog_2_ARGS_TRACE_TestHookDropPacketBitmap(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_TESTHELPERS_H, TestHookDropPacketBitmap );\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for TestHookReplaceAddrRecv
 // [test][hook] Recv Addr :%hu => :%hu
 // QuicTraceLogVerbose(

--- a/src/generated/linux/TestHelpers.h.clog.h.lttng.h
+++ b/src/generated/linux/TestHelpers.h.clog.h.lttng.h
@@ -120,6 +120,22 @@ TRACEPOINT_EVENT(CLOG_TESTHELPERS_H, TestHookDropPacketSelective,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for TestHookDropPacketBitmap
+// [test][hook] Bitmap packet drop
+// QuicTraceLogVerbose(
+            TestHookDropPacketBitmap,
+            "[test][hook] Bitmap packet drop");
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_TESTHELPERS_H, TestHookDropPacketBitmap,
+    TP_ARGS(
+), 
+    TP_FIELDS(
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for TestHookReplaceAddrRecv
 // [test][hook] Recv Addr :%hu => :%hu
 // QuicTraceLogVerbose(

--- a/src/generated/linux/datapath_raw_socket.c.clog.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h
@@ -122,6 +122,48 @@ tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathErrorStatus , arg2, arg3, arg4);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for DatapathGetRouteStart
+// [data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!
+// QuicTraceEvent(
+        DatapathGetRouteStart,
+        "[data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress));
+// arg2 = arg2 = Socket = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress) = arg4
+----------------------------------------------------------*/
+#ifndef _clog_7_ARGS_TRACE_DatapathGetRouteStart
+#define _clog_7_ARGS_TRACE_DatapathGetRouteStart(uniqueId, encoded_arg_string, arg2, arg3, arg3_len, arg4, arg4_len)\
+tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathGetRouteStart , arg2, arg3_len, arg3, arg4_len, arg4);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for DatapathGetRouteComplete
+// [data][%p] Query route result: %!ADDR!
+// QuicTraceEvent(
+        DatapathGetRouteComplete,
+        "[data][%p] Query route result: %!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress));
+// arg2 = arg2 = Socket = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress) = arg3
+----------------------------------------------------------*/
+#ifndef _clog_5_ARGS_TRACE_DatapathGetRouteComplete
+#define _clog_5_ARGS_TRACE_DatapathGetRouteComplete(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
+tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathGetRouteComplete , arg2, arg3_len, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for DatapathError
 // [data][%p] ERROR, %s.
 // QuicTraceEvent(

--- a/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
@@ -126,6 +126,62 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathErrorStatus,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for DatapathGetRouteStart
+// [data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!
+// QuicTraceEvent(
+        DatapathGetRouteStart,
+        "[data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress));
+// arg2 = arg2 = Socket = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress) = arg4
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathGetRouteStart,
+    TP_ARGS(
+        const void *, arg2,
+        unsigned int, arg3_len,
+        const void *, arg3,
+        unsigned int, arg4_len,
+        const void *, arg4), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg2, arg2)
+        ctf_integer(unsigned int, arg3_len, arg3_len)
+        ctf_sequence(char, arg3, arg3, unsigned int, arg3_len)
+        ctf_integer(unsigned int, arg4_len, arg4_len)
+        ctf_sequence(char, arg4, arg4, unsigned int, arg4_len)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for DatapathGetRouteComplete
+// [data][%p] Query route result: %!ADDR!
+// QuicTraceEvent(
+        DatapathGetRouteComplete,
+        "[data][%p] Query route result: %!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress));
+// arg2 = arg2 = Socket = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress) = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathGetRouteComplete,
+    TP_ARGS(
+        const void *, arg2,
+        unsigned int, arg3_len,
+        const void *, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg2, arg2)
+        ctf_integer(unsigned int, arg3_len, arg3_len)
+        ctf_sequence(char, arg3, arg3, unsigned int, arg3_len)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for DatapathError
 // [data][%p] ERROR, %s.
 // QuicTraceEvent(

--- a/src/generated/linux/worker.c.clog.h
+++ b/src/generated/linux/worker.c.clog.h
@@ -209,10 +209,10 @@ tracepoint(CLOG_WORKER_C, WorkerQueueDelayUpdated , arg2, arg3);\
             "[wrkr][%p] IsActive = %hhu, Arg = %u",
             Worker,
             Worker->IsActive,
-            1);
+            (uint32_t)State->TimeNow);
 // arg2 = arg2 = Worker = arg2
 // arg3 = arg3 = Worker->IsActive = arg3
-// arg4 = arg4 = 1 = arg4
+// arg4 = arg4 = (uint32_t)State->TimeNow = arg4
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_WorkerActivityStateUpdated
 #define _clog_5_ARGS_TRACE_WorkerActivityStateUpdated(uniqueId, encoded_arg_string, arg2, arg3, arg4)\

--- a/src/generated/linux/worker.c.clog.h.lttng.h
+++ b/src/generated/linux/worker.c.clog.h.lttng.h
@@ -208,10 +208,10 @@ TRACEPOINT_EVENT(CLOG_WORKER_C, WorkerQueueDelayUpdated,
             "[wrkr][%p] IsActive = %hhu, Arg = %u",
             Worker,
             Worker->IsActive,
-            1);
+            (uint32_t)State->TimeNow);
 // arg2 = arg2 = Worker = arg2
 // arg3 = arg3 = Worker->IsActive = arg3
-// arg4 = arg4 = 1 = arg4
+// arg4 = arg4 = (uint32_t)State->TimeNow = arg4
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_WORKER_C, WorkerActivityStateUpdated,
     TP_ARGS(

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1145,6 +1145,7 @@ private:
 struct MsQuicAutoAcceptListener : public MsQuicListener {
     const MsQuicConfiguration& Configuration;
     MsQuicConnectionCallback* ConnectionHandler;
+    MsQuicConnection* LastConnection {nullptr};
     void* ConnectionContext;
 #ifdef CX_PLATFORM_TYPE
     uint32_t AcceptedConnectionCount {0};
@@ -1187,6 +1188,7 @@ private:
                     Connection->Handle = nullptr;
                     delete Connection;
                 } else {
+                    pThis->LastConnection = Connection;
 #ifdef CX_PLATFORM_TYPE
                     InterlockedIncrement((long*)&pThis->AcceptedConnectionCount);
 #endif

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -1920,6 +1920,48 @@
                 outType="win:SocketAddress"
                 />
           </template>
+          <template tid="tid_UDP_ADDRESSES">
+            <data
+                inType="win:Pointer"
+                name="UdpBinding"
+                />
+            <data
+                inType="win:UInt8"
+                name="LocalAddrLength"
+                />
+            <data
+                inType="win:Binary"
+                length="LocalAddrLength"
+                name="LocalAddr"
+                outType="win:SocketAddress"
+                />
+            <data
+                inType="win:UInt8"
+                name="RemoteAddrLength"
+                />
+            <data
+                inType="win:Binary"
+                length="RemoteAddrLength"
+                name="RemoteAddr"
+                outType="win:SocketAddress"
+                />
+          </template>
+          <template tid="tid_UDP_ADDRESS">
+            <data
+                inType="win:Pointer"
+                name="UdpBinding"
+                />
+            <data
+                inType="win:UInt8"
+                name="LocalAddrLength"
+                />
+            <data
+                inType="win:Binary"
+                length="LocalAddrLength"
+                name="LocalAddr"
+                outType="win:SocketAddress"
+                />
+          </template>
           <template tid="tid_ID">
             <data
                 inType="win:UInt64"
@@ -3424,6 +3466,24 @@
               template="tid_UDP"
               value="9222"
               />
+          <event
+              keywords="ut:UDP ut:LowVolume"
+              level="win:Informational"
+              message="$(string.Etw.DatapathGetRouteStart)"
+              opcode="Datapath"
+              symbol="QuicDatapathGetRouteStart"
+              template="tid_UDP_ADDRESSES"
+              value="9223"
+              />
+          <event
+              keywords="ut:UDP ut:LowVolume"
+              level="win:Informational"
+              message="$(string.Etw.DatapathGetRouteComplete)"
+              opcode="Datapath"
+              symbol="QuicDatapathGetRouteComplete"
+              template="tid_UDP_ADDRESS"
+              value="9224"
+              />
           <!-- 10240 - 11263 | Logs (not events) -->
           <event
               keywords="ut:Log"
@@ -4067,6 +4127,14 @@
         <string
             id="Etw.DatapathDestroyed"
             value="[data][%1] Destroyed"
+            />
+        <string
+            id="Etw.DatapathGetRouteStart"
+            value="[data][%1] Querying route, local=%3, remote=%5"
+            />
+        <string
+            id="Etw.DatapathGetRouteComplete"
+            value="[data][%1] Query route result: %3"
             />
         <string
             id="Etw.ApiEnter"

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -10640,6 +10640,13 @@
       "splitArgs": [],
       "macroName": "QuicTraceLogVerbose"
     },
+    "TestHookDropPacketBitmap": {
+      "ModuleProperites": {},
+      "TraceString": "[test][hook] Bitmap packet drop",
+      "UniqueId": "TestHookDropPacketBitmap",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogVerbose"
+    },
     "TestHookDropPacketRandom": {
       "ModuleProperites": {},
       "TraceString": "[test][hook] Random packet drop",
@@ -15476,6 +15483,11 @@
         "UniquenessHash": "861bbb4e-e371-4334-b45d-03199c1cacda",
         "TraceID": "TestHookDropOldAddrSend",
         "EncodingString": "[test][hook] Dropping send to old addr"
+      },
+      {
+        "UniquenessHash": "a5664948-8711-00da-6c95-520e7c6ebab0",
+        "TraceID": "TestHookDropPacketBitmap",
+        "EncodingString": "[test][hook] Bitmap packet drop"
       },
       {
         "UniquenessHash": "ccf24f92-4b3c-0f17-5c84-1d454a788837",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2491,6 +2491,42 @@
       ],
       "macroName": "QuicTraceLogWarning"
     },
+    "DatapathGetRouteComplete": {
+      "ModuleProperites": {},
+      "TraceString": "[data][%p] Query route result: %!ADDR!",
+      "UniqueId": "DatapathGetRouteComplete",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
+    "DatapathGetRouteStart": {
+      "ModuleProperites": {},
+      "TraceString": "[data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!",
+      "UniqueId": "DatapathGetRouteStart",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg4"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "DatapathInitialize": {
       "ModuleProperites": {},
       "TraceString": "[data][%p] Datapath initialize",
@@ -12908,6 +12944,16 @@
         "UniquenessHash": "b940eb8b-74ec-f569-8167-e95ccc36510e",
         "TraceID": "DatapathFragmented",
         "EncodingString": "[%p] Dropping datagram with fragmented MDL."
+      },
+      {
+        "UniquenessHash": "0bf5791c-23b4-4100-a2ba-d7bd2cf64ea2",
+        "TraceID": "DatapathGetRouteComplete",
+        "EncodingString": "[data][%p] Query route result: %!ADDR!"
+      },
+      {
+        "UniquenessHash": "68173a72-1154-a450-6efe-ccd2fbeab3f9",
+        "TraceID": "DatapathGetRouteStart",
+        "EncodingString": "[data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!"
       },
       {
         "UniquenessHash": "b88fe9ef-f6ed-09b0-1711-28ec0fc2ab52",

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -370,7 +370,7 @@ CxPlatResolveRoute(
         Socket,
         CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress));
 
-    if (State == RouteSuspected && !QuicAddrCompare(&LocalAddress, &Route->LocalAddress)) {
+    if (State == RouteSuspected && !QuicAddrCompareIp(&LocalAddress, &Route->LocalAddress)) {
         //
         // We can't handle local address change here easily due to lack of full migration support.
         //

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -334,6 +334,13 @@ CxPlatResolveRoute(
 
     Route->State = RouteResolving;
 
+    QuicTraceEvent(
+        DatapathGetRouteStart,
+        "[data][%p] Querying route, local=%!ADDR!, remote=%!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress),
+        CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress));
+
     //
     // Find the best next hop IP address.
     //
@@ -356,6 +363,12 @@ CxPlatResolveRoute(
             "GetBestRoute2");
         goto Done;
     }
+
+    QuicTraceEvent(
+        DatapathGetRouteComplete,
+        "[data][%p] Query route result: %!ADDR!",
+        Socket,
+        CASTED_CLOG_BYTEARRAY(sizeof(LocalAddress), &LocalAddress));
 
     if (State == RouteSuspected && !QuicAddrCompare(&LocalAddress, &Route->LocalAddress)) {
         //

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -240,6 +240,11 @@ QuicTestChangeAlpn(
     void
     );
 
+void
+QuicTestHandshakeSpecificLossPatterns(
+    _In_ int Family
+    );
+
 //
 // Negative Handshake Tests
 //
@@ -1154,4 +1159,8 @@ typedef struct {
 #define IOCTL_QUIC_RUN_ECN \
     QUIC_CTL_CODE(108, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 108
+#define IOCTL_QUIC_RUN_HANDSHAKE_SPECIFIC_LOSS_PATTERNS \
+    QUIC_CTL_CODE(109, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // int - Family
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 109

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1385,6 +1385,15 @@ TEST_P(WithFamilyArgs, LoadBalanced) {
         QuicTestLoadBalancedHandshake(GetParam().Family);
     }
 }
+
+TEST_P(WithFamilyArgs, HandshakeSpecificLossPatterns) {
+    TestLoggerT<ParamType> Logger("QuicTestHandshakeSpecificLossPatterns", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_HANDSHAKE_SPECIFIC_LOSS_PATTERNS, GetParam().Family));
+    } else {
+        QuicTestHandshakeSpecificLossPatterns(GetParam().Family);
+    }
+}
 #endif // QUIC_TEST_DATAPATH_HOOKS_ENABLED
 
 TEST_P(WithSendArgs1, Send) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -480,6 +480,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     sizeof(UINT8),
     sizeof(BOOLEAN),
     sizeof(INT32),
+    sizeof(INT32),
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1322,6 +1323,11 @@ QuicTestCtlEvtIoDeviceControl(
     case IOCTL_QUIC_RUN_ECN:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestEcn(Params->Family));
+        break;
+
+    case IOCTL_QUIC_RUN_HANDSHAKE_SPECIFIC_LOSS_PATTERNS:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(QuicTestHandshakeSpecificLossPatterns(Params->Family));
         break;
 
     default:

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3499,7 +3499,7 @@ QuicTestHandshakeSpecificLossPatterns(
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
     for (uint64_t Bitmap = 1; Bitmap < 128; ++Bitmap) {
-        char Name[64]; sprintf_s(Name, sizeof(Name), "DoHandshake %llu", Bitmap);
+        char Name[64]; sprintf_s(Name, sizeof(Name), "DoHandshake %llu", (unsigned long long)Bitmap);
         TestScopeLogger logScope(Name);
         BitmapLossHelper LossHelper(Bitmap);
         MsQuicConnection Connection(Registration);

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3474,3 +3474,39 @@ QuicTestVNTPOtherVersionZero(
     QuicTestCustomVNTP(TestServer, &TestTP);
 }
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+
+void
+QuicTestHandshakeSpecificLossPatterns(
+    _In_ int Family
+    )
+{
+    MsQuicRegistration Registration;
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicSettings Settings;
+    Settings.SetIdleTimeoutMs(60000).SetDisconnectTimeoutMs(60000).SetInitialRttMs(20);
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", Settings, ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", Settings, MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    QuicAddr ServerLocalAddr((Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6);
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, MsQuicConnection::NoOpCallback);
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest", &ServerLocalAddr.SockAddr));
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    for (uint64_t Bitmap = 1; Bitmap < 128; ++Bitmap) {
+        char Name[64]; sprintf_s(Name, sizeof(Name), "DoHandshake %llu", Bitmap);
+        TestScopeLogger logScope(Name);
+        BitmapLossHelper LossHelper(Bitmap);
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+        TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout*20));
+        TEST_TRUE(Connection.HandshakeComplete);
+        Listener.LastConnection->Shutdown(0, QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT);
+    }
+}


### PR DESCRIPTION
## Description

New tests to improve upon our random loss tests. This explicitly tests different loss patterns. This led to the following additional changes:

1. Found/fixed bug in the timer wheel, when pushing back the first timer on a connection didn't result in updating the timer wheel (fixes #3206).
2. Improved/optimized the loss detection timer to not query time again every time.
3. Added extra logs to route resolution path (fixes #2635).
4. Fix route resolution issue with IP comparison.

## Testing

Automated testing

## Documentation

N/A
