### PR TITLE
Update to QuicTls (OpenSSL) 1.1.1s

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/quictls/openssl.git
-	branch = OpenSSL_1_1_1q+quic
+	branch = OpenSSL_1_1_1s+quic
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/quictls/openssl.git
-	branch = OpenSSL_1_1_1s+quic
+	branch = OpenSSL_1_1_1s+quic1
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git


### PR DESCRIPTION
## Description

Consume the new quictls release: https://github.com/quictls/openssl/releases/tag/OpenSSL_1_1_1s%2Bquic1

## Testing

Automation

## Documentation

None
