### PR TITLE
Fix modulo issue of MSB 1 with signed type

### DIFF
--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -121,9 +121,18 @@ T GetRandom(T UpperBound, uint16_t ThreadID = UINT16_MAX) {
     if (!FuzzData || ThreadID == UINT16_MAX) {
         return (T)(rand() % (int)UpperBound);
     }
-    T out = std::numeric_limits<T>::max();
-    (void)FuzzData->TryGetRandom(UpperBound, &out, ThreadID);
-    return out;
+    uint64_t out = 0;
+
+    if ((uint64_t)UpperBound <= 0xff) {
+        (void)FuzzData->TryGetRandom((uint8_t)UpperBound, (uint8_t*)&out, ThreadID);
+    } else if ((uint64_t)UpperBound <= 0xffff) {
+        (void)FuzzData->TryGetRandom((uint16_t)UpperBound, (uint16_t*)&out, ThreadID);
+    } else if ((uint64_t)UpperBound <= 0xffffffff) {
+        (void)FuzzData->TryGetRandom((uint32_t)UpperBound, (uint32_t*)&out, ThreadID);
+    } else {
+        (void)FuzzData->TryGetRandom((uint64_t)UpperBound, &out, ThreadID);
+    }
+    return (T)out;
 }
 #define GetRandom(UpperBound) GetRandom(UpperBound, ThreadID)
 


### PR DESCRIPTION
## Description

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52744&q=msquic&can=2&sort=-reported
GetRandom(int) cause unexpected value with fuzzer
e.g. 0xffffffff % 16 = 0xffffffff (-1 % 16 = -1)
This might fix another OSS-Fuzzer reported issues

## Testing

run locally

## Documentation

N/A
