### PR TITLE
Add info about usage with older Windows releases with OpenSSL

### DIFF
--- a/docs/Platforms.md
+++ b/docs/Platforms.md
@@ -12,7 +12,7 @@ On Windows, by default, MsQuic relies on built-in support from [Schannel](https:
 
 ### OpenSSL
 
-Optionally, `msquic.dll` can be built with OpenSSL (see below for more details) instead of Schannel on Windows. This removes the Windows OS dependency on TLS from MsQuic, so MsQuic should work on most Windows 10 based client and server versions.
+Optionally, `msquic.dll` can be built with OpenSSL (see below for more details) instead of Schannel on Windows. This removes the Windows OS dependency on TLS from MsQuic, so MsQuic should work on most Windows 10 based client and server versions (it potentially could work on older Windows versions, but supporting them is not the purpose for developers of MsQuic).
 
 ## Linux
 

--- a/docs/Platforms.md
+++ b/docs/Platforms.md
@@ -12,7 +12,7 @@ On Windows, by default, MsQuic relies on built-in support from [Schannel](https:
 
 ### OpenSSL
 
-Optionally, `msquic.dll` can be built with OpenSSL (see below for more details) instead of Schannel on Windows. This removes the Windows OS dependency on TLS from MsQuic, so MsQuic should work on most Windows 10 based client and server versions (it potentially could work on older Windows versions, but supporting them is not the purpose for developers of MsQuic).
+Optionally, `msquic.dll` can be built with OpenSSL (see below for more details) instead of Schannel on Windows. This removes the Windows OS dependency on TLS from MsQuic, so MsQuic should work on most Windows 10 based client and server versions (it may work on even older Windows releases but supporting them is not a goal for MsQuic).
 
 ## Linux
 


### PR DESCRIPTION
## Description

Add explicit statement about possible usage of MsQuic with older Windows version, when using OpenSSL.

## Testing

Changes are only made to documentation. 
MsQuic tested on Windows Server 2012.

## Documentation

Changes to documentation were made.
