### PR TITLE
Use Ubuntu 20.04 to Build OpenSSL-Systemcrypto Variant

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -387,7 +387,7 @@ stages:
       extraName: 'codecheck'
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -318,7 +318,7 @@ stages:
       config: Debug
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl


### PR DESCRIPTION
## Description

Fixes https://github.com/actions/runner-images/issues/6697 by making sure to use 20.04 to build, not latest.

## Testing

Existing CI.

## Documentation

N/A
