### PR TITLE
Use Ubuntu 20.04 for All Linux Builds

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -290,7 +290,7 @@ stages:
   jobs:
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
@@ -302,14 +302,14 @@ stages:
   jobs:
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
       config: Debug
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
@@ -332,7 +332,7 @@ stages:
   jobs:
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
@@ -341,7 +341,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
@@ -350,7 +350,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: android
       arch: arm64
       tls: openssl
@@ -359,7 +359,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: arm64
       tls: openssl
@@ -368,7 +368,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: android
       arch: x64
       tls: openssl
@@ -377,7 +377,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl
@@ -397,7 +397,7 @@ stages:
 
   - template: ./templates/build-config-user.yml
     parameters:
-      image: ubuntu-latest
+      image: ubuntu-20.04
       platform: linux
       arch: x64
       tls: openssl

--- a/.azure/azure-pipelines.perf.yml
+++ b/.azure/azure-pipelines.perf.yml
@@ -215,7 +215,7 @@ stages:
     jobs:
     - template: ./templates/build-config-user.yml
       parameters:
-        image: ubuntu-latest
+        image: ubuntu-20.04
         platform: linux
         arch: ${{ parameters.arch }}
         tls: openssl

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -50,7 +50,7 @@ jobs:
           toolchain: 'cmake/toolchains/aarch64-linux.cmake'
         - arch: arm64
           toolchain: 'cmake/toolchains/arm-linux.cmake'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ghcr.io/microsoft/msquic/linux-build-xcomp
     name: Build

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -24,11 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         release: ['2.0.6','2.1.5']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         arch: [x64]
         tls: [schannel, openssl]
         exclude:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           tls: schannel
         - os: windows-latest
           tls: openssl


### PR DESCRIPTION
## Description

Looks like more stuff is breaking by moving `-ubuntu-latest` to 22.04 (perf pipeline). Let's keep all builds on 20.04 for now (but let tests move to 22.04).

## Testing

Automation

## Documentation

N/A
