### PR TITLE
Fix CodeQL break

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,7 @@ jobs:
             launchpad.net:443
             packages.microsoft.com:443
             ppa.launchpad.net:80
+            api.launchpad.net:443
             uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
Update Security Hardener to allow URL used by CodeQL.