### PR TITLE
Always Poll on XDP Perf

### DIFF
--- a/scripts/performance.ps1
+++ b/scripts/performance.ps1
@@ -432,8 +432,8 @@ function Invoke-Test {
     }
 
     if ($XDP) {
-        $RemoteArguments += " -pollidle:10000"
-        $LocalArguments += " -pollidle:10000"
+        $RemoteArguments += " -pollidle:100000000"
+        $LocalArguments += " -pollidle:100000000"
     }
 
     if ($Kernel) {


### PR DESCRIPTION
## Description

Looking at the perf data shows that the first request on an XDP connection has a higher tail latency because we were interrupt mode; idle, waiting to be woken. This adds a significant latency, and doesn't really reflect what we want to test.

## Testing

Perf automation

## Documentation

N/A
