### PR TITLE
Don't invoke CancelIo in CxPlatSocketContextUninitialize

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3055,11 +3055,11 @@ CxPlatSocketContextUninitialize(
 
 QUIC_DISABLED_BY_FUZZER_START;
 
-    if (SocketProc->Parent->Type == CXPLAT_SOCKET_UDP) {
-        CancelIoEx((HANDLE)SocketProc->Socket, NULL);
-    } else {
-        CancelIo((HANDLE)SocketProc->Socket);
-    }
+    // if (SocketProc->Parent->Type == CXPLAT_SOCKET_UDP) {
+    //     CancelIoEx((HANDLE)SocketProc->Socket, NULL);
+    // } else {
+    //     CancelIo((HANDLE)SocketProc->Socket);
+    // }
 
     if (closesocket(SocketProc->Socket) == SOCKET_ERROR) {
         int WsaError = WSAGetLastError();

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3055,12 +3055,6 @@ CxPlatSocketContextUninitialize(
 
 QUIC_DISABLED_BY_FUZZER_START;
 
-    // if (SocketProc->Parent->Type == CXPLAT_SOCKET_UDP) {
-    //     CancelIoEx((HANDLE)SocketProc->Socket, NULL);
-    // } else {
-    //     CancelIo((HANDLE)SocketProc->Socket);
-    // }
-
     if (closesocket(SocketProc->Socket) == SOCKET_ERROR) {
         int WsaError = WSAGetLastError();
         QuicTraceEvent(


### PR DESCRIPTION
## Description
_Describe the purpose of and changes within this Pull Request._

Experiment: during RIO development, removing CancelIo in CxPlatSocketContextUninitialize caused an HPS perf regression from ~9500 HPS (main baseline) to ~4500 HPS (PR), so I ultimately did not remove the CancelIo call. Now, a set of perf runs comparing main to main without CancelIo shows a perf improvement from 4500 HPS (main) to 9500 HPS (PR) which is exact opposite of the previous findings.

Experiment with CancelIo and HPS tests to attempt to find the root cause of these inconsistencies.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
