### PR TITLE
check for Winsock unreachable error codes in addition to Win32

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -121,7 +121,10 @@ CXPLAT_STATIC_ASSERT(
     ErrorCode == ERROR_NETWORK_UNREACHABLE || \
     ErrorCode == ERROR_HOST_UNREACHABLE || \
     ErrorCode == ERROR_PROTOCOL_UNREACHABLE || \
-    ErrorCode == ERROR_PORT_UNREACHABLE \
+    ErrorCode == ERROR_PORT_UNREACHABLE || \
+    ErrorCode == WSAENETUNREACH || \
+    ErrorCode == WSAEHOSTUNREACH || \
+    ErrorCode == WSAECONNRESET \
 )
 
 typedef struct CXPLAT_DATAPATH_PROC CXPLAT_DATAPATH_PROC;   // Per-processor datapath state.


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

While RIO doesn't support UDP unreachable indications (yet) we should add support for those on the RIO path, which use Winsock rather than Win32 error codes.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tested locally on a prototype RIO implementation.

## Documentation

_Is there any documentation impact for this change?_
