### PR TITLE
Address onebranch pipeline warnings

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -36,7 +36,7 @@ variables:
   NUGET_XMLDOC_MODE: none
   ONEBRANCH_AME_ACR_LOGIN: onebranch.azurecr.io, cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io
 
-  WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2019:latest'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2019:latest'
   WindowsContainerImage2: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:20220812.8'
   LinuxContainerImage: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:xcomp2'
   LinuxContainerImage2: 'cdpxlinux.azurecr.io/global/ubuntu-1804:latest'

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -32,7 +32,7 @@ variables:
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
 
-  WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2019:latest'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2019:latest'
   WindowsContainerImage2: 'cdpxwin1809.azurecr.io/user/corenet/msquic:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   LinuxContainerImage: 'cdpxlinux.azurecr.io/user/corenet/msquic:latest'
 


### PR DESCRIPTION
## Description

We have been using deprecated docker images for onebranch pipelines, and we've got lots of warnings.

## Testing

OB CI
