### PR TITLE
Fall back to WinDbg if WinDbgX is not installed

### DIFF
--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -202,7 +202,11 @@ function Start-Executable {
             }
         }
         if ($Debugger) {
-            $pinfo.FileName = "windbgx"
+            if (Get-Command "windbgx.exe" -ErrorAction SilentlyContinue) {
+                $pinfo.FileName = "windbgx.exe"
+            } else {
+                $pinfo.FileName = "windbg.exe"
+            }
             if ($InitialBreak) {
                 $pinfo.Arguments = "-G $($Path) $($Arguments)"
             } else {

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -299,7 +299,11 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if ($IsWindows) {
         if ($Debugger) {
-            $pinfo.FileName = "windbgx"
+            if (Get-Command "windbgx.exe" -ErrorAction SilentlyContinue) {
+                $pinfo.FileName = "windbgx.exe"
+            } else {
+                $pinfo.FileName = "windbg.exe"
+            }
             if ($InitialBreak) {
                 $pinfo.Arguments = "-G $($Path) $($Arguments)"
             } else {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

A couple scripts have a `-Debugger` option that defaults to WinDbgX on Windows, which is only one of many possible debuggers. To support users who are still using the venerable WinDbg, support graceful fallback if WinDbgX is not installed.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tested locally without WinDbgX. Also swapped parameters to simulate WinDbgX without WinDbg.

## Documentation

_Is there any documentation impact for this change?_

Nope, both are debuggers.