### PR TITLE
gamecore_console: fix build with 10.0.20348.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,8 @@ if(NOT "${QUIC_LOGGING_TYPE}" MATCHES "^(etw|lttng|stdout|)$")
 endif()
 
 if (QUIC_GAMECORE_BUILD)
-    if(${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} VERSION_LESS "10.0.19041.0")
-        message(ERROR "gamecore builds require Windows 10 SDK version 19041 or later.")
+    if(${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} VERSION_LESS "10.0.20348.0")
+        message(ERROR "gamecore builds require Windows 10 SDK version 20348 or later.")
     endif()
 endif()
 

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -329,13 +329,11 @@ typedef struct _SecPkgContext_ConnectionInfo
 
 #if (defined(QUIC_GAMECORE_BUILD))
 #include <sdkddkver.h>
-#ifdef NTDDI_WIN10_CO
 typedef struct _UNICODE_STRING {
     USHORT Length;
     USHORT MaximumLength;
     PWSTR Buffer;
 } UNICODE_STRING, *PUNICODE_STRING;
-#endif
 #endif
 
 #include <schannel.h>


### PR DESCRIPTION
## Description

Fix `gamecore_console` build failure on SDK `10.0.20348.0`. `WINAPI_PARTITION_GAMES` never exposed `UNICODE_STRING`.  
Bumping the minimum required SDK version to >= `10.0.20348.0` as we are using a new API (`SetThreadIdealProcessor`) exposed to `WINAPI_PARTITION_GAMES` since `10.0.20348.0`.  
See #3343.  

## Testing

Built `10.0.20348.0`, `10.0.22000.0`, `10.0.22621.0` for `gamecore_console` and verified the build passed. Binaries produced no longer import `winmm.dll`.  

## Documentation

N/A
