### PR TITLE
build: fix onebranch pipelines

### DIFF
--- a/.azure/OneBranch.Docker.Official.yml
+++ b/.azure/OneBranch.Docker.Official.yml
@@ -106,7 +106,7 @@ extends:
               displayName: '🔒 Download artifacts'
               inputs:
                 targetPath: $(Build.SourcesDirectory)\dst\.azure\dockers\ob\windows
-                artifact: drop_main_download_external_libs
+                artifact: drop_docker_download_external_libs
             - task: onebranch.pipeline.imagebuildinfo@1
               inputs:
                 repositoryName: msquicbuild

--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -24,6 +24,10 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   displayName: 'Enable debug output'
   type: boolean
   default: false
+- name: 'WindowsContainerImage2DockerTag'
+  displayName: 'WindowsContainerImage2 DockerTag'
+  type: string
+  default: 'latest'
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
@@ -37,7 +41,7 @@ variables:
   ONEBRANCH_AME_ACR_LOGIN: onebranch.azurecr.io, cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io
 
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2019:latest'
-  WindowsContainerImage2: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:20220812.8'
+  WindowsContainerImage2: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:${{ parameters.WindowsContainerImage2DockerTag }}'
   LinuxContainerImage: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:xcomp2'
   LinuxContainerImage2: 'cdpxlinux.azurecr.io/global/ubuntu-1804:latest'
 

--- a/.azure/dockers/ob/windows/Dockerfile
+++ b/.azure/dockers/ob/windows/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM cdpxwin1809.azurecr.io/global/vse2019:latest
+FROM onebranch.azurecr.io/windows/ltsc2019/vse2019:latest
 
 # Default .NET FX images switch shell to PS. Switch it back.
 SHELL ["cmd", "/S", "/C"]
@@ -7,8 +7,11 @@ SHELL ["cmd", "/S", "/C"]
 COPY win-installer-helper.psm1 C:\
 COPY install*.* C:\
 COPY xgameplatform.lib C:\
+COPY vsconfig.2019 C:\
 
 RUN dir C:\
+
+RUN C:\install.cmd C:\install-workloads.ps1
 
 RUN C:\install.cmd C:\install-ewdk.ps1
 

--- a/.azure/dockers/ob/windows/install-workloads.ps1
+++ b/.azure/dockers/ob/windows/install-workloads.ps1
@@ -1,0 +1,34 @@
+
+if (Test-Path "$PSScriptRoot\win-installer-helper.psm1")
+{
+    Import-Module "$PSScriptRoot\win-installer-helper.psm1"
+}
+elseif (Test-Path "C:\win-installer-helper.psm1")
+{
+    Import-Module "C:\win-installer-helper.psm1"
+}
+
+$ProgressPreference = 'SilentlyContinue'
+
+Start-Setup
+
+try {
+
+    Write-Host "Installing additional visual studio workloads"
+
+    $vsInstallerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+
+    $installerArgs = "modify --config `"C:\vsconfig.2019`" --installPath `"${env:VS2019}`" --quiet --norestart --nocache"
+    Install-FromEXE -Path $vsInstallerPath -Arguments $installerArgs
+
+    Write-Output "Installed additional visual studio workloads"
+
+} catch {
+    Write-Host "Error during workloads installation"
+    dir $Env:TEMP -Filter *.log | where Length -gt 0 | Get-Content
+    dir $Env:TEMP -Filter *.txt | where Length -gt 0 | Get-Content
+    $_.Exception | Format-List -Force
+    exit 1
+} finally {
+    Stop-Setup
+}

--- a/.azure/dockers/ob/windows/vsconfig.2019
+++ b/.azure/dockers/ob/windows/vsconfig.2019
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
+    "Microsoft.VisualStudio.Component.Windows10SDK.20348"
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif()
 
 if (QUIC_GAMECORE_BUILD)
     if(${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} VERSION_LESS "10.0.20348.0")
-        message(ERROR "gamecore builds require Windows 10 SDK version 20348 or later.")
+        message(FATAL_ERROR "gamecore builds require Windows 10 SDK version 20348 or later.")
     endif()
 endif()
 


### PR DESCRIPTION
## Description

Follow-up PR to address the onebranch pipeline failures introduced by #3343.  
  
`gamecore_console` builds need to be on SDK `10.0.20348.0` or later and the latest SDK in our existing image is `10.0.19041.0`.  
The old base image (`cdpxwin1809.azurecr.io/global/vse2019:latest`) had some issues with installing the new SDK, so we've changed to a more recent onebranch base image for our builds.  
Also adding a new pipeline parameter to specify the base image tag to use, so we could test the official build against wip images. Defaulting to `latest` instead of `20220812.8`.  
  
Thanks to @csujedihy for helping out!  

## Testing

Through pipeline runs.  
`msquic-Official-Docker #20230113.3` publishing to `testing`, and subsequent `msquic-Official #20230113.2` based on the `testing` image.  
Waiting for the publish to `latest` in `msquic-Official-Docker #20230113.4`.  

## Documentation

N/A