### PR TITLE
Disable bouncing XDP TX buffers

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -218,6 +218,9 @@ function Install-Xdp-Driver {
 
     Write-Host "Installing XDP driver"
     netcfg.exe -l "$XdpPath\bin\xdp.inf" -c s -i ms_xdp
+
+    Write-Host "Setting XDP XskDisableTxBounce=1"
+    reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d 1 /t REG_DWORD /f
 }
 
 # Completely removes the XDP driver and SDK.


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

By default, generic AF_XDP copies all TX buffers from the UMEM into kernel-only buffers to avoid TOCTOU violations in kernel drivers. As an experiment, disable this protection and measure QUIC over AF_XDP performance.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
