### PR TITLE
fix build on Ubuntu 18

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1184,6 +1184,7 @@ CxPlatSocketContextInitialize(
         goto Exit;
     }
 
+#ifdef UDP_GRO
     if (SocketContext->DatapathProc->Datapath->Features & CXPLAT_DATAPATH_FEATURE_RECV_COALESCING) {
         Option = TRUE;
         Result =
@@ -1204,6 +1205,7 @@ CxPlatSocketContextInitialize(
             goto Exit;
         }
     }
+#endif
 
     //
     // The socket is shared by multiple QUIC endpoints, so increase the receive
@@ -1807,10 +1809,12 @@ CxPlatSocketContextRecvComplete(
                     CXPLAT_DBG_ASSERT(FALSE);
                 }
             } else if (CMsg->cmsg_level == IPPROTO_UDP) {
+#ifdef UDP_GRO
                 if (CMsg->cmsg_type == UDP_GRO) {
                     CXPLAT_DBG_ASSERT_CMSG(CMsg, uint16_t);
                     SegmentLength = *(uint16_t*)CMSG_DATA(CMsg);
                 }
+#endif
             } else {
                 CXPLAT_DBG_ASSERT(FALSE);
             }


### PR DESCRIPTION
it would fail as 
```
[ 86%] Building C object src/platform/CMakeFiles/platform.dir/certificates_posix.c.o
cd /home/furt/github/wfurt-msquic/build/linux/x64_openssl/src/platform && /usr/bin/cc -DCXPLAT_NUMA_AWARE -DCX_PLATFORM_LINUX -DHAS_SENDMMSG -DHAS_SYSCONF -DHAS__SC_PHYS_PAGES -DQUIC_CLOG -DQUIC_ENABLE_CA_CERTIFICATE_FILE_TESTS -DQUIC_SHARED_EPHEMERAL_WORKAROUND -DQUIC_TEST_OPENSSL_FLAGS=1 -DVER_BUILD_ID=0 -DVER_GIT_HASH=216fc71d3ef68c7b63cd5666306aba8bc564e5ef -DVER_SUFFIX=-private -D_GNU_SOURCE -I/home/furt/github/wfurt-msquic/src/inc -I/home/furt/github/wfurt-msquic/src/generated/common -I/home/furt/github/wfurt-msquic/src/generated/linux -I/home/furt/github/wfurt-msquic/build/linux/x64_openssl/_deps/opensslquic-build/openssl/include  -Og -ggdb3   -fms-extensions -fPIC -Werror -Wall -Wextra -Wformat=2 -Wno-type-limits -Wno-unknown-pragmas -Wno-multichar -Wno-missing-field-initializers -o CMakeFiles/platform.dir/certificates_posix.c.o   -c /home/furt/github/wfurt-msquic/src/platform/certificates_posix.c
/home/furt/github/wfurt-msquic/src/platform/datapath_epoll.c: In function ‘CxPlatSocketContextInitialize’:
/home/furt/github/wfurt-msquic/src/platform/datapath_epoll.c:1193:17: error: ‘UDP_GRO’ undeclared (first use in this function); did you mean ‘UDP_CORK’?
                 UDP_GRO,
                 ^~~~~~~
                 UDP_CORK
/home/furt/github/wfurt-msquic/src/platform/datapath_epoll.c:1193:17: note: each undeclared identifier is reported only once for each function it appears in
/home/furt/github/wfurt-msquic/src/platform/datapath_epoll.c: In function ‘CxPlatSocketContextRecvComplete’:
/home/furt/github/wfurt-msquic/src/platform/datapath_epoll.c:1810:40: error: ‘UDP_GRO’ undeclared (first use in this function); did you mean ‘UDP_CORK’?
                 if (CMsg->cmsg_type == UDP_GRO) {
                                        ^~~~~~~
                                        UDP_CORK
/home/furt/github/wfurt-msquic/src/platform/platform_posix.c:40:10: fatal error: numa.h: No such file or directory
 #include <numa.h>

```

it seems like UDP_GRO is not consistently guarded by `#ifdef`

The numa failure is fixable by installing `libnuma-dev` package. It would be _nice_ if the detection works better but the workaround is simple enough. 
