### PR TITLE
improve OpenSSL detection during build

### DIFF
--- a/scripts/get-buildconfig.ps1
+++ b/scripts/get-buildconfig.ps1
@@ -90,6 +90,28 @@ if ("" -eq $Tls) {
         $Tls = "schannel"
     } else {
         $Tls = "openssl"
+        try {
+            # If no Tls was specified, try to guess it based on default OpenSSL version
+            # This is more complicated in attempt to silently deal with missing openssl executable
+            #
+            $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+            $pinfo.FileName = "openssl"
+            $pinfo.Arguments = "version"
+            $pinfo.RedirectStandardError = $true
+            $pinfo.RedirectStandardOutput = $true
+            $pinfo.UseShellExecute = $false
+
+            $p = New-Object System.Diagnostics.Process
+            $p.StartInfo = $pinfo
+            $p.Start() | Out-Null
+            $p.WaitForExit()
+
+            $version = $p.StandardOutput.ReadToEnd()
+            if ($version -like "OpenSSL 3*")
+            {
+                $Tls = "openssl3"
+            }
+        } catch { }
     }
 }
 

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -339,7 +339,11 @@ else()
     if (QUIC_USE_SYSTEM_LIBCRYPTO)
         include(FindOpenSSL)
         if (OPENSSL_FOUND)
-            if (OPENSSL_VERSION VERSION_EQUAL EXPECTED_OPENSSL_VERSION OR OPENSSL_VERSION VERSION_GREATER EXPECTED_OPENSSL_VERSION)
+            # Get Major.Minor so 3.0 can match 3.0.2.
+            # We cannot use VERSION_GREATER as 3.0 would work for 1.1.1 but they are not compatible.
+            string(FIND ${OPENSSL_VERSION} "." VERSIONLEN REVERSE)
+            string(SUBSTRING ${OPENSSL_VERSION} 0 ${VERSIONLEN}  OPENSSL_MAJORMINOR)
+            if (OPENSSL_VERSION VERSION_EQUAL EXPECTED_OPENSSL_VERSION OR OPENSSL_MAJORMINOR VERSION_EQUAL EXPECTED_OPENSSL_VERSION)
                 target_link_libraries(OpenSSLQuic INTERFACE OpenSSL::Crypto)
             else()
                 message(FATAL_ERROR "OpenSSL ${EXPECTED_OPENSSL_VERSION} not found, found ${OPENSSL_VERSION}")


### PR DESCRIPTION
This is follow-up on https://github.com/microsoft/msquic/pull/3387#issuecomment-1412201754

I changed the check so 3.0.2 would be acceptable when we expect 3.0. 
The problem its that if we expect `1.1.1`, `3.0` would also work with `VERSION_GREATER`.

To fix that, I now construct subversion as `1.1` or '3.0' and I use that for comparison as well. 
The expected `1.1.1` would never match but the `3.0` would work as expected. 

Running "wrong" configure on Ubuntu 22 now produce
```
$ pwsh scripts/build.ps1 -Tls openssl -UseSystemOpenSSLCrypto
fatal: no tag exactly matches '28bc496577c067fc7657588f933d8178b79849b2'
[02/01/2023 12:36:07] Generating files...
Executing: -G "Unix Makefiles" "Unix Makefiles" -DQUIC_TLS=openssl -DQUIC_OUTPUT_DIR="/home/furt/github/msquic/artifacts/bin/linux/x64_Debug_openssl" -DQUIC_LINUX_LOG_ENCODER=lttng -DQUIC_ENABLE_LOGGING=on -DQUIC_BUILD_TOOLS=on -DQUIC_BUILD_TEST=on -DQUIC_BUILD_PERF=on -DCMAKE_BUILD_TYPE=Debug -DQUIC_USE_SYSTEM_LIBCRYPTO=on -DQUIC_LIBRARY_NAME=msquic ../../..
[02/01/2023 12:36:07] cmake -G "Unix Makefiles" "Unix Makefiles" -DQUIC_TLS=openssl -DQUIC_OUTPUT_DIR="/home/furt/github/msquic/artifacts/bin/linux/x64_Debug_openssl" -DQUIC_LINUX_LOG_ENCODER=lttng -DQUIC_ENABLE_LOGGING=on -DQUIC_BUILD_TOOLS=on -DQUIC_BUILD_TEST=on -DQUIC_BUILD_PERF=on -DCMAKE_BUILD_TYPE=Debug -DQUIC_USE_SYSTEM_LIBCRYPTO=on -DQUIC_LIBRARY_NAME=msquic ../../..
-- CMAKE Version: 3.22.1
-- Source Dir: /home/furt/github/msquic
-- Host System name: Linux
-- Setting policy 0091
-- System name: Linux
-- System version: 5.15.0-58-generic
-- Platform version:
-- Build type: Debug
-- QUIC Platform: linux
-- Version Build ID: 0
-- Version Suffix: -private
-- Choosing lttng as default logging type for platform
-- Enabling OpenSsl configuration tests
-- Configuring for LTTng logging
-- Found libatomic: /usr/lib/x86_64-linux-gnu/libatomic.so.1
-- Found libnuma: /usr/lib/x86_64-linux-gnu/libnuma.so.1
-- Enabling shared ephemeral port work around
-- Configuring for OpenSSL 1.1
-- Setting openssldir to /usr/lib/ssl
-- Configuring OpenSSL: /home/furt/github/msquic/submodules/openssl/config;CC=/usr/bin/cc;CXX=/usr/bin/c++ enable-tls1_3;no-makedepend;no-dgram;no-ssl3;no-psk;no-srp;no-zlib;no-egd;no-idea;no-rc5;no-rc4;no-afalgeng;no-comp;no-cms;no-ct;no-srp;no-srtp;no-ts;no-gost;no-dso;no-ec2m;no-tls1;no-tls1_1;no-tls1_2;no-dtls;no-dtls1;no-dtls1_2;no-ssl;no-ssl3-method;no-tls1-method;no-tls1_1-method;no-tls1_2-method;no-dtls1-method;no-dtls1_2-method;no-siphash;no-whirlpool;no-aria;no-bf;no-blake2;no-sm2;no-sm3;no-sm4;no-camellia;no-cast;no-md4;no-mdc2;no-ocb;no-rc2;no-rmd160;no-scrypt;no-weak-ssl-ciphers;no-shared;no-tests;--openssldir="/usr/lib/ssl";--prefix=/home/furt/github/msquic/build/linux/x64_openssl/_deps/opensslquic-build/openssl
CMake Error at submodules/CMakeLists.txt:349 (message):
  OpenSSL 1.1.1 not found, found 3.0.2
``` 

To make it somewhat more friendly I also updated the powershelgl build script to try to detect the correct version if no one is specified. 
```
pwsh  scripts/get-buildconfig.ps1

Name                           Value
----                           -----
Platform                       linux
Arch                           x64
Tls                            openssl3
ArtifactsDir                   /home/furt/github/msquic/artifacts/bin/linux/x64_Debug_openssl3
```

This will not help users like @ManickaP  when make is invoked directly, but it should make it easier for general consumers. 
Hopefully the error above would make it clear. 

