### PR TITLE
fix dependency for rpm packages

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -119,6 +119,9 @@ if [ "$OS" == "linux" ]; then
   if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ]; then
      FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
   fi
+  if [ "$PKGARCH" == 'aarch64' ] || [ "$PKGARCH" == 'x86_64' ]; then
+      BITS='64bit'
+  fi
   fpm \
     --force \
     --input-type dir \
@@ -126,6 +129,7 @@ if [ "$OS" == "linux" ]; then
     --architecture ${PKGARCH} \
     --name ${NAME} \
     --provides ${NAME} \
+    --depends "libcrypto.so.1.1()(${BITS})" \
     --conflicts ${CONFLICTS} \
     --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
     --description "${DESCRIPTION}" \


### PR DESCRIPTION
debian dependencies were fix in  #2995. As noted, the RPM package names differ among various distributions. 
Because of that, we need to claim dependency on the actual library. Without specifying the 64bits, package manager seems to pull in both x86_64 and i686 binaries.  I left ie empty for 32bit as it seems to be ok. (no testing on arm)

cc: @manickap @rzikm @omajid 


Fedora37
Comes with OpenSSL 3, pulls in openssl1.1 as dependency.

```
[root@3add993fe42c wfurt-msquic]# openssl version
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)
[root@3add993fe42c wfurt-msquic]# dnf  install artifacts/packages/linux/x64_Release_openssl/libmsquic-2.2.0-1.x86_64.rpm
Last metadata expiration check: 1:04:21 ago on Thu Feb  2 02:42:00 2023.
Dependencies resolved.
========================================================================================================================================================================================================================================================
 Package                                                    Architecture                                           Version                                                           Repository                                                    Size
========================================================================================================================================================================================================================================================
Installing:
 libmsquic                                                  x86_64                                                 2.2.0-1                                                           @commandline                                                 4.6 M
Installing dependencies:
 openssl1.1                                                 x86_64                                                 1:1.1.1q-2.fc37                                                   fedora                                                       1.5 M

Transaction Summary
========================================================================================================================================================================================================================================================
Install  2 Packages

Total size: 6.1 M
Total download size: 1.5 M
Installed size: 20 M
Is this ok [y/N]:

```

Centos Stream 8
Comes with OpenSSL 1.1.1 - no surprise there
```
[root@b7d160b2b43d wfurt-msquic]# openssl version
OpenSSL 1.1.1k  FIPS 25 Mar 2021
dnf  install artifacts/packages/linux/x64_Release_openssl/libmsquic-2.2.0-1.x86_64.rpm
Last metadata expiration check: 0:45:50 ago on Thu Feb  2 03:41:44 2023.
Dependencies resolved.
========================================================================================================================================================================================================================================================
 Package                                                     Architecture                                             Version                                                      Repository                                                      Size
========================================================================================================================================================================================================================================================
Installing:
 libmsquic                                                   x86_64                                                   2.2.0-1                                                      @commandline                                                   4.6 M

Transaction Summary
========================================================================================================================================================================================================================================================
Install  1 Package

Total size: 4.6 M
Installed size: 16 M
```

Centos Stream 9
Comes with OpenSSL 3, pulls in  compat-openssl11.
```
[root@83bf2d244e34 wfurt-msquic]# openssl version
OpenSSL 3.0.7 1 Nov 2022 (Library: OpenSSL 3.0.7 1 Nov 2022)
[root@83bf2d244e34 wfurt-msquic]#  dnf  install artifacts/packages/linux/x64_Release_openssl/libmsquic-2.2.0-1.x86_64.rpm
Last metadata expiration check: 0:40:18 ago on Thu Feb  2 03:48:23 2023.
Dependencies resolved.
========================================================================================================================================================================================================================================================
 Package                                                         Architecture                                          Version                                                        Repository                                                   Size
========================================================================================================================================================================================================================================================
Installing:
 libmsquic                                                       x86_64                                                2.2.0-1                                                        @commandline                                                4.6 M
Installing dependencies:
 compat-openssl11                                                x86_64                                                1:1.1.1k-4.el9                                                 appstream                                                   1.5 M

Transaction Summary
========================================================================================================================================================================================================================================================
Install  2 Packages

Total size: 6.1 M
Total download size: 1.5 M
Installed size: 20 M
```

contributes to #2975