### PR TITLE
CHANGED: Description of encrypt parameter in secnetperf

### DIFF
--- a/src/perf/lib/ThroughputClient.cpp
+++ b/src/perf/lib/ThroughputClient.cpp
@@ -32,7 +32,7 @@ PrintHelp(
         "  -port:<####>                 The UDP port of the server. (def:%u)\n"
         "  -ip:<0/4/6>                  A hint for the resolving the hostname to an IP address. (def:0)\n"
         "  -cibir:<hex_bytes>           A CIBIR well-known idenfitier.\n"
-        "  -encrypt:<0/1>               Enables/disables encryption. (def:1)\n"
+        "  -encrypt:<0/1>               Disables/enables encryption. (def:1)\n"
         "  -sendbuf:<0/1>               Whether to use send buffering. (def:0)\n"
         "  -pacing:<0/1>                Whether to use pacing. (def:1)\n"
         "  -timed:<0/1>                 Indicates the upload/download arg time (ms). (def:0)\n"


### PR DESCRIPTION
## Description

The description of parameter `encrypt` in `secnetperf` is confusing. 
Changed from 
`-encrypt:<0/1>               Disables/enables encryption. (def:1)`
to 
`-encrypt:<0/1>               Enables/disables encryption. (def:1)` 
to ensure 0 stands for "enables" and 1 for "disables".

## Testing

No tests are covering this change and no new tests are needed.

## Documentation

This impacts the `secnetperf` documentation of parameter `encrypt`.
