### PR TITLE
Disable Expensive Logging Stuff for LTTng

### DIFF
--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -120,12 +120,21 @@ extern QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 #ifdef QUIC_CLOG
 
+#if DEBUG
+#define QuicTraceLogStreamVerboseEnabled() TRUE
+#define QuicTraceLogErrorEnabled()   TRUE
+#define QuicTraceLogWarningEnabled() TRUE
+#define QuicTraceLogInfoEnabled()    TRUE
+#define QuicTraceLogVerboseEnabled() TRUE
+#define QuicTraceEventEnabled(x) TRUE
+#else
 #define QuicTraceLogStreamVerboseEnabled() FALSE
 #define QuicTraceLogErrorEnabled()   FALSE
 #define QuicTraceLogWarningEnabled() FALSE
 #define QuicTraceLogInfoEnabled()    FALSE
 #define QuicTraceLogVerboseEnabled() FALSE
 #define QuicTraceEventEnabled(x) FALSE
+#endif
 
 #define CASTED_CLOG_BYTEARRAY(Len, Data) CLOG_BYTEARRAY((unsigned char)(Len), (const unsigned char*)(Data))
 #else

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -120,12 +120,12 @@ extern QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 #ifdef QUIC_CLOG
 
-#define QuicTraceLogStreamVerboseEnabled() TRUE
-#define QuicTraceLogErrorEnabled()   TRUE
-#define QuicTraceLogWarningEnabled() TRUE
-#define QuicTraceLogInfoEnabled()    TRUE
-#define QuicTraceLogVerboseEnabled() TRUE
-#define QuicTraceEventEnabled(x) TRUE
+#define QuicTraceLogStreamVerboseEnabled() FALSE
+#define QuicTraceLogErrorEnabled()   FALSE
+#define QuicTraceLogWarningEnabled() FALSE
+#define QuicTraceLogInfoEnabled()    FALSE
+#define QuicTraceLogVerboseEnabled() FALSE
+#define QuicTraceEventEnabled(x) FALSE
 
 #define CASTED_CLOG_BYTEARRAY(Len, Data) CLOG_BYTEARRAY((unsigned char)(Len), (const unsigned char*)(Data))
 #else


### PR DESCRIPTION
## Description

Disable the code paths that were unnecessary triggered for logging (even when disabled).

## Testing

Automation

## Documentation

N/A
