### PR TITLE
Disable OneBranch Windows OpenSSL arm64 Builds

### DIFF
--- a/.azure/obtemplates/build-winuser.yml
+++ b/.azure/obtemplates/build-winuser.yml
@@ -38,7 +38,7 @@ jobs:
       arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm -CI
   - task: PowerShell@2
     displayName: ARM64
-    condition: ne('${{ parameters.platform }}', 'gamecore_console')
+    condition: and(ne('${{ parameters.platform }}', 'gamecore_console'), ne('${{ parameters.tls }}', 'openssl'))
     target: windows_build_container2
     inputs:
       pwsh: true


### PR DESCRIPTION
## Description

Our internal OneBranch builds were failing because of the known arm64 build failure. Disable those internal builds, just like we've done for the external.

## Testing

Automation

## Documentation

N/A
