### PR TITLE
Fix Stream Blocked

### DIFF
--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -533,7 +533,7 @@ QuicStreamSetNewLocalStream(
         if (Stream->Connection->State.PeerTransportParameterValid) {
             QuicSendSetSendFlag(
                 &Stream->Connection->Send,
-                STREAM_ID_IS_UNI_DIR(Stream->ID) ?
+                STREAM_ID_IS_UNI_DIR(Type) ?
                     QUIC_CONN_SEND_FLAG_UNI_STREAMS_BLOCKED : QUIC_CONN_SEND_FLAG_BIDI_STREAMS_BLOCKED);
         }
         Status = QUIC_STATUS_STREAM_LIMIT_REACHED;


### PR DESCRIPTION
## Description

While looking at the code, I noticed it was using the wrong variable to check if unidirectional or bidirectional streams were blocked. Updates the code to use the correct one.

## Testing

Existing automation. Ideally, it might be good to add a test case for this.

## Documentation

N/A
