### PR TITLE
Fix Client sock to bind same port as that of server

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1234,7 +1234,7 @@ CxPlatSocketContextInitialize(
     // Only set SO_REUSEPORT on a server socket, otherwise the client could be
     // assigned a server port (unless it's forcing sharing).
     //
-    if (ForceShare || RemoteAddress == NULL) {
+    if (ForceShare && RemoteAddress == NULL) {
         //
         // The port is shared across processors.
         //

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -946,9 +946,7 @@ QUIC_STATUS
 CxPlatSocketContextInitialize(
     _Inout_ CXPLAT_SOCKET_CONTEXT* SocketContext,
     _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress,
-    _In_ BOOLEAN ForceShare
-    )
+    _In_ const QUIC_ADDR* RemoteAddress)
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
@@ -1231,10 +1229,10 @@ CxPlatSocketContextInitialize(
     }
 
     //
-    // Only set SO_REUSEPORT on a server socket, otherwise the client could be
-    // assigned a server port (unless it's forcing sharing).
+    // Only set SO_REUSEPORT on a server socket (when RemoteAddress == NULL),
+    // otherwise the client could be assigned a server port.
     //
-    if (ForceShare && RemoteAddress == NULL) {
+    if (RemoteAddress == NULL) {
         //
         // The port is shared across processors.
         //
@@ -1552,8 +1550,7 @@ CxPlatSocketCreateUdp(
             CxPlatSocketContextInitialize(
                 &Binding->SocketContexts[i],
                 Config->LocalAddress,
-                Config->RemoteAddress,
-                Config->Flags & CXPLAT_SOCKET_FLAG_SHARE);
+                Config->RemoteAddress);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -946,7 +946,8 @@ QUIC_STATUS
 CxPlatSocketContextInitialize(
     _Inout_ CXPLAT_SOCKET_CONTEXT* SocketContext,
     _In_ const QUIC_ADDR* LocalAddress,
-    _In_ const QUIC_ADDR* RemoteAddress)
+    _In_ const QUIC_ADDR* RemoteAddress
+    )
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1553,7 +1553,7 @@ CxPlatSocketCreateUdp(
                 &Binding->SocketContexts[i],
                 Config->LocalAddress,
                 Config->RemoteAddress,
-                Config->Flags & CXPLAT_SOCKET_FLAG_SHARE);
+                Config->Flags & CXPLAT_SOCKET_FLAG_SHARE & IsServerSocket);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1553,7 +1553,7 @@ CxPlatSocketCreateUdp(
                 &Binding->SocketContexts[i],
                 Config->LocalAddress,
                 Config->RemoteAddress,
-                Config->Flags & CXPLAT_SOCKET_FLAG_SHARE & IsServerSocket);
+                Config->Flags & CXPLAT_SOCKET_FLAG_SHARE);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }


### PR DESCRIPTION
## Description

Fix of https://github.com/microsoft/msquic/issues/2396
SO_REUSEPORT is for server setting.
RemoteAddress == NULL is for server sock. The **or** condition was wrong

## Testing

Running locally.... and trying to run on CI

## Documentation

N/A
