### PR TITLE
fix MAC_CTX creation with OpenSSL 3

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -581,7 +581,6 @@ stages:
       platform: linux
       tls: openssl3
       config: Release
-      extraTestArgs: -Filter -*LoadBalanced*:*ResumeRejection*:*Reject0Rtt*
 
 - stage: test_bvt_winkernel_release
   displayName: BVT Windows Kernel Release
@@ -714,7 +713,6 @@ stages:
       image: ubuntu-latest
       platform: linux
       tls: openssl3
-      extraTestArgs: -Filter -*LoadBalanced*:*ResumeRejection*:*Reject0Rtt*
   - template: ./templates/run-bvt.yml
     parameters:
       image: macOS-12

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -770,7 +770,7 @@ CxPlatTlsOnSessionTicketKeyNeeded(
     )
 {
 #ifdef IS_OPENSSL_3
-    OSSL_PARAM params[2];
+    OSSL_PARAM params[3];
 #endif
     CXPLAT_TLS* TlsContext = SSL_get_app_data(Ssl);
     QUIC_TICKET_KEY_CONFIG* TicketKey = TlsContext->SecConfig->TicketKey;
@@ -803,6 +803,8 @@ CxPlatTlsOnSessionTicketKeyNeeded(
                 TicketKey->Material,
                 32);
         params[1] =
+            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, "sha256", 0);
+        params[2] =
             OSSL_PARAM_construct_end();
          EVP_MAC_CTX_set_params(hctx, params);
 #else
@@ -824,6 +826,8 @@ CxPlatTlsOnSessionTicketKeyNeeded(
                 TicketKey->Material,
                 32);
         params[1] =
+            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, "sha256", 0);
+        params[2] =
             OSSL_PARAM_construct_end();
          EVP_MAC_CTX_set_params(hctx, params);
 #else


### PR DESCRIPTION
Contributes to https://github.com/microsoft/msquic/issues/2039

it seems like the context was not created properly so handling of tickets was failing.
Interestingly, OpenSSL would just surface internal error so it was not obvious what was happening. 
With this, all the tests can now pass for me on Ubuntu 22.04. 