### PR TITLE
Update the Binding Lookup Logic to Match Server and Client Sockets

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1749,7 +1749,8 @@ QuicLibraryLookupBinding(
             // For client/connected bindings we need to match on both local and
             // remote addresses/ports.
             //
-            if (QuicAddrCompare(LocalAddress, &BindingLocalAddr)) {
+            if (RemoteAddress &&
+                QuicAddrCompare(LocalAddress, &BindingLocalAddr)) {
                 QUIC_ADDR BindingRemoteAddr;
                 QuicBindingGetRemoteAddress(Binding, &BindingRemoteAddr);
                 if (QuicAddrCompare(RemoteAddress, &BindingRemoteAddr)) {

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1744,26 +1744,34 @@ QuicLibraryLookupBinding(
         QUIC_ADDR BindingLocalAddr;
         QuicBindingGetLocalAddress(Binding, &BindingLocalAddr);
 
-        if (!QuicAddrCompare(LocalAddress, &BindingLocalAddr)) {
-            continue;
-        }
-
         if (Binding->Connected) {
-            if (RemoteAddress == NULL) {
-                continue;
+            //
+            // For client/connected bindings we need to match on both local and
+            // remote addresses/ports.
+            //
+            if (QuicAddrCompare(LocalAddress, &BindingLocalAddr)) {
+                QUIC_ADDR BindingRemoteAddr;
+                QuicBindingGetRemoteAddress(Binding, &BindingRemoteAddr);
+                if (QuicAddrCompare(RemoteAddress, &BindingRemoteAddr)) {
+                    return Binding;
+                }
             }
 
-            QUIC_ADDR BindingRemoteAddr;
-            QuicBindingGetRemoteAddress(Binding, &BindingRemoteAddr);
-            if (!QuicAddrCompare(RemoteAddress, &BindingRemoteAddr)) {
-                continue;
+        } else {
+            //
+            // For server (unconnected/listening) bindings we always use wildcard
+            // addresses, so we simply need to match on local port.
+            //
+            if (QuicAddrGetPort(&BindingLocalAddr) == QuicAddrGetPort(LocalAddress)) {
+                //
+                // Note: We don't check the remote address, because we want to
+                // return a match even if the caller is looking for a connected
+                // socket so that we can inform them there is already a listening
+                // socket using the local port.
+                //
+                return Binding;
             }
-
-        } else  if (RemoteAddress != NULL) {
-            continue;
         }
-
-        return Binding;
     }
 
     return NULL;
@@ -1779,9 +1787,10 @@ QuicLibraryGetBinding(
     QUIC_STATUS Status;
     QUIC_BINDING* Binding;
     QUIC_ADDR NewLocalAddress;
-    BOOLEAN PortUnspecified = UdpConfig->LocalAddress == NULL || QuicAddrGetPort(UdpConfig->LocalAddress) == 0;
-    BOOLEAN ShareBinding = !!(UdpConfig->Flags & CXPLAT_SOCKET_FLAG_SHARE);
-    BOOLEAN ServerOwned = !!(UdpConfig->Flags & CXPLAT_SOCKET_SERVER_OWNED);
+    const BOOLEAN PortUnspecified =
+        UdpConfig->LocalAddress == NULL || QuicAddrGetPort(UdpConfig->LocalAddress) == 0;
+    const BOOLEAN ShareBinding = !!(UdpConfig->Flags & CXPLAT_SOCKET_FLAG_SHARE);
+    const BOOLEAN ServerOwned = !!(UdpConfig->Flags & CXPLAT_SOCKET_SERVER_OWNED);
 
 #ifdef QUIC_SHARED_EPHEMERAL_WORKAROUND
     //


### PR DESCRIPTION
## Description

@ami-GS found an issue where our logic for preventing ephemeral matches on Linux wasn't working correctly between client and server sockets. The issue was that we weren't finding the matching server socket when the networking stack returned us a client socket that matched it.

The fix updates the `QuicLibraryLookupBinding` function to make sure the server socket is returned if it is using the same local port as the requested client socket. This will then trigger the fallback logic to start looking for a new socket instead.

**Note** - This *might* be a good candidate for backport to 2.1...

## Testing

Existing automation.

## Documentation

N/A
