### PR TITLE
Fix Race Condition Between Enqueue and Dequeue of Event Queue

### DIFF
--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -721,7 +721,7 @@ CxPlatEventQEnqueue(
     _In_opt_ void* user_data
     )
 {
-    CxPlatZeroMemory(sqe, sizeof(*sqe));
+    CxPlatZeroMemory(&sqe->Overlapped, sizeof(sqe->Overlapped));
     sqe->UserData = user_data;
     return PostQueuedCompletionStatus(*queue, 0, 0, &sqe->Overlapped) != 0;
 }
@@ -735,7 +735,7 @@ CxPlatEventQEnqueueEx( // Windows specific extension
     _In_opt_ void* user_data
     )
 {
-    CxPlatZeroMemory(sqe, sizeof(*sqe));
+    CxPlatZeroMemory(&sqe->Overlapped, sizeof(sqe->Overlapped));
     sqe->UserData = user_data;
     return PostQueuedCompletionStatus(*queue, num_bytes, 0, &sqe->Overlapped) != 0;
 }

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -683,6 +683,9 @@ typedef OVERLAPPED_ENTRY CXPLAT_CQE;
 typedef struct CXPLAT_SQE {
     void* UserData;
     OVERLAPPED Overlapped;
+#if DEBUG
+    BOOLEAN IsQueued; // Debug flag to catch double queueing.
+#endif
 } CXPLAT_SQE;
 
 inline
@@ -721,6 +724,10 @@ CxPlatEventQEnqueue(
     _In_opt_ void* user_data
     )
 {
+#if DEBUG
+    CXPLAT_DBG_ASSERT(!sqe->IsQueued);
+    sqe->IsQueued;
+#endif
     CxPlatZeroMemory(&sqe->Overlapped, sizeof(sqe->Overlapped));
     sqe->UserData = user_data;
     return PostQueuedCompletionStatus(*queue, 0, 0, &sqe->Overlapped) != 0;
@@ -735,6 +742,10 @@ CxPlatEventQEnqueueEx( // Windows specific extension
     _In_opt_ void* user_data
     )
 {
+#if DEBUG
+    CXPLAT_DBG_ASSERT(!sqe->IsQueued);
+    sqe->IsQueued;
+#endif
     CxPlatZeroMemory(&sqe->Overlapped, sizeof(sqe->Overlapped));
     sqe->UserData = user_data;
     return PostQueuedCompletionStatus(*queue, num_bytes, 0, &sqe->Overlapped) != 0;
@@ -753,6 +764,13 @@ CxPlatEventQDequeue(
     if (!GetQueuedCompletionStatusEx(*queue, events, count, &out_count, wait_time, FALSE)) return FALSE;
     CXPLAT_DBG_ASSERT(out_count != 0);
     CXPLAT_DBG_ASSERT(events[0].lpOverlapped != NULL || out_count == 1);
+#if DEBUG
+    if (events[0].lpOverlapped) {
+        for (uint32_t i = 0; i < (uint32_t)out_count; ++i) {
+            CXPLAT_CONTAINING_RECORD(events[i].lpOverlapped, CXPLAT_SQE, Overlapped)->IsQueued = FALSE;
+        }
+    }
+#endif
     return events[0].lpOverlapped == NULL ? 0 : (uint32_t)out_count;
 }
 

--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -332,14 +332,17 @@ CxPlatAddExecutionContext(
 
     Context->CxPlatContext = Worker;
     CxPlatLockAcquire(&Worker->ECLock);
+    const BOOLEAN QueueEvent = Worker->PendingECs == NULL;
     Context->Entry.Next = Worker->PendingECs;
     Worker->PendingECs = &Context->Entry;
     CxPlatLockRelease(&Worker->ECLock);
 
-    CxPlatEventQEnqueue(
-        &Worker->EventQ,
-        &Worker->UpdatePollSqe,
-        (void*)&WorkerUpdatePollEventPayload);
+    if (QueueEvent) {
+        CxPlatEventQEnqueue(
+            &Worker->EventQ,
+            &Worker->UpdatePollSqe,
+            (void*)&WorkerUpdatePollEventPayload);
+    }
 }
 
 void


### PR DESCRIPTION
## Description

There is a very small race condition in event queue processing on Windows where we could dequeue an event on one thread and then another thread tries to enqueue it again, but zeros out the important user data before the dequeue thread has a chance to read it.

This PR fixes that by not ever zero'ing out the user data.

## Testing

Existing automation

## Documentation

N/A
