### PR TITLE
Fix Listener Use after Free in Cleanup Path

### DIFF
--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -437,10 +437,16 @@ QuicListenerStopComplete(
         QuicListenerDetachSilo();
     }
 
+    const BOOLEAN CleanupOnExit = Listener->NeedsCleanup;
+
+    //
+    // If !Listener->NeedsCleanup, then another thread is waiting on this event
+    // and may immediately free the listener after setting the stop event.
+    //
     Listener->Stopped = TRUE;
     CxPlatEventSet(Listener->StopEvent);
 
-    if (Listener->NeedsCleanup) {
+    if (CleanupOnExit) {
         QuicListenerFree(Listener);
     }
 }


### PR DESCRIPTION
## Description

Seen in https://github.com/microsoft/msquic/actions/runs/4196169506/jobs/7276764256, the listener was checking a flag after it was freed on a different thread.

This updates the code to cache the variable that decided if we free the listener before setting the stop event, which wakes the other thread to free the listener first (in some cases).

## Testing

Existing automation

## Documentation

N/A
