### PR TITLE
fix packaging for OpenSSL 3

### DIFF
--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -12,6 +12,8 @@ PKGARCH=${ARCH}
 FPM=`which fpm` 2>/dev/null
 CONFIG=Release
 NAME=libmsquic
+TLS=openssl
+TLSVERSION=1.1
 CONFLICTS=
 DESCRIPTION="Microsoft implementation of the IETF QUIC protocol"
 VENDOR="Microsoft"
@@ -75,13 +77,27 @@ while :; do
         -d|-debug|--debug)
             CONFIG=Debug
             ;;
-        -config|--config)
+        -c|-config|--config)
             shift
             CONFIG=$1
             ;;
         -o|-output|--output)
             shift
             OUTPUT=$1
+            ;;
+       -t|-tls|--tls)
+            shift
+            TLS=$1
+            case $TLS in
+                'openssl')
+                    ;;
+                'openssl3')
+                    TLSVERSION=3
+                    ;;
+                *)
+                    echo "Unknown TLS version '$TLS'."
+                    exit 1
+            esac
             ;;
        -\?|-h|--help)
             usage
@@ -102,10 +118,10 @@ else
   CONFLICTS='libmsquic-debug'
 fi
 
-ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
+ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_${TLS}"
 
 if [ -z ${OUTPUT} ]; then
-    OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_openssl"
+    OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_${TLS}"
 fi
 
 echo "ARCH=$ARCH PKGARCH=$PKGARCH ARTIFACTS=$ARTIFACTS"
@@ -129,7 +145,7 @@ if [ "$OS" == "linux" ]; then
     --architecture ${PKGARCH} \
     --name ${NAME} \
     --provides ${NAME} \
-    --depends "libcrypto.so.1.1()(${BITS})" \
+    --depends "libcrypto.so.${TLSVERSION}()(${BITS})" \
     --conflicts ${CONFLICTS} \
     --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
     --description "${DESCRIPTION}" \
@@ -165,7 +181,7 @@ if [ "$OS" == "linux" ]; then
     --name ${NAME} \
     --provides ${NAME} \
     --conflicts ${CONFLICTS} \
-    --depends "libssl1.1" \
+    --depends "libssl${TLSVERSION}" \
     --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
     --description "${DESCRIPTION}" \
     --vendor "${VENDOR}" \

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -85,7 +85,7 @@ while :; do
             shift
             OUTPUT=$1
             ;;
-       -t|-tls|--tls)
+        -t|-tls|--tls)
             shift
             TLS=$1
             case $TLS in


### PR DESCRIPTION
## Description

This adds option to package msquic with 'openssl3' tls
## Testing

```
$./scripts/make-packages.sh -c Release -t openssl3

$rpm -qpR artifacts/packages/linux/x64_Release_openssl3/libmsquic-2.2.0-1.x86_64.rpm
libcrypto.so.3()(64bit)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1

$ dpkg -I   artifacts/packages/linux/x64_Release_openssl3/libmsquic_2.2.0_amd64.deb
 new Debian package, version 2.0.
 size 5482352 bytes: control archive=540 bytes.
     373 bytes,    14 lines      control
     233 bytes,     3 lines      md5sums
 Package: libmsquic
 Version: 2.2.0
 License: MIT
 Vendor: Microsoft
 Architecture: amd64
 Maintainer: Microsoft QUIC Team [quicdev@microsoft.com](mailto:quicdev@microsoft.com)
 Installed-Size: 16628
 Depends: libssl3
 Conflicts: libmsquic-debug
 Provides: libmsquic
 Section: default
 Priority: optional
 Homepage: https://github.com/microsoft/msquic
 Description: Microsoft implementation of the IETF QUIC protocol
```
## Documentation

probably not. 


cc: @ManickaP @CarnaViire

fixes #3443