### PR TITLE
Fix loopback test to use same port as that of server

### DIFF
--- a/src/test/lib/PathTest.cpp
+++ b/src/test/lib/PathTest.cpp
@@ -98,8 +98,9 @@ QuicTestLocalPathChanges(
     TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(OrigLocalAddr));
     ReplaceAddressHelper AddrHelper(OrigLocalAddr.SockAddr, OrigLocalAddr.SockAddr);
 
-    for (int i = 0; i < 50; i++) {
-        QuicAddrSetPort(&AddrHelper.New, QuicAddrGetPort(&AddrHelper.New) + 1);
+    int Loop = 50;
+    QuicAddrSetPort(&AddrHelper.New, QuicAddrGetPort(&AddrHelper.New) + 1);
+    for (int i = 0; i < Loop; i++) {
         Connection.SetSettings(MsQuicSettings{}.SetKeepAlive(25));
 
         TEST_TRUE(Context.PeerAddrChangedEvent.WaitTimeout(1500));
@@ -110,5 +111,13 @@ QuicTestLocalPathChanges(
         Connection.SetSettings(MsQuicSettings{}.SetKeepAlive(0));
         TEST_TRUE(PeerStreamsChanged.WaitTimeout(1500));
         PeerStreamsChanged.Reset();
+
+        uint16_t NextPort = QuicAddrGetPort(&AddrHelper.New) + 1;
+        if (NextPort == ServerPort) {
+            // Skip the port if it is same as that of server
+            // This is to avoid Loopback test failure
+            NextPort++;
+        }
+        QuicAddrSetPort(&AddrHelper.New, NextPort);
     }
 }


### PR DESCRIPTION
## Description

https://github.com/microsoft/msquic/issues/1805
The test is incrementing client port by hooking server side interface.
The test timed out by (maybe) client port is changed to that of server.
This fix is just skip when server side hook try to change client port to same as server

## Testing

test fix

## Documentation

N/A
