### PR TITLE
Fix DatagramSend test by expecting multiple loss

### DIFF
--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -225,7 +225,7 @@ QuicTestDatagramSend(
                 TEST_EQUAL(1, Client.GetDatagramsAcknowledged());
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
-                uint32_t CurrentLostCount = Client.GetDatagramsSuspectLost();
+                const uint32_t InitialLostCount = Client.GetDatagramsSuspectLost();
                 LossHelper.DropPackets(1);
 
                 TEST_QUIC_SUCCEEDED(
@@ -252,10 +252,10 @@ QuicTestDatagramSend(
                 //      state changes to LOST_SUSPECT before the first datagram acked (line 225)
                 //      However line 225 (DatagramsAcknowledged) becomes true by treating state 5 (ACKNOWLEDGED_SPURIOUS) as 4 (ACKNOWLEDGED)
                 Tries = 0;
-                while (Client.GetDatagramsSuspectLost() == CurrentLostCount && ++Tries < 10) {
+                while (Client.GetDatagramsSuspectLost() == InitialLostCount && ++Tries < 10) {
                     CxPlatSleep(100);
                 }
-                TEST_TRUE(Client.GetDatagramsSuspectLost() > CurrentLostCount);
+                TEST_TRUE(Client.GetDatagramsSuspectLost() > InitialLostCount);
                 CxPlatSleep(100);
 #endif
 

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -245,7 +245,15 @@ QuicTestDatagramSend(
                 while (Client.GetDatagramsSuspectLost() != 1 && ++Tries < 10) {
                     CxPlatSleep(100);
                 }
-                TEST_EQUAL(1, Client.GetDatagramsSuspectLost());
+                // NOTE:
+                // There are two cases of DATAGRAM_SEND_STATE_CHANGED
+                // 1. 1->4->1->2->3
+                //      This is expected state changes. 99.99...% cases
+                // 2. 1->2->5->1->2
+                //      This is unexpected. 0.0...1% cases
+                //      state changes to LOST_SUSPECT before the first datagram acked (line 225)
+                //      However line 225 (DatagramsAcknowledged) becomes true by treating state 5 (ACKNOWLEDGED_SPURIOUS) as 4 (ACKNOWLEDGED)
+                TEST_TRUE(Client.GetDatagramsSuspectLost() == 1 || Client.GetDatagramsSuspectLost() == 2);
                 CxPlatSleep(100);
 #endif
 

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -242,15 +242,12 @@ QuicTestDatagramSend(
                 }
                 TEST_EQUAL(2, Client.GetDatagramsSent());
 
-
-                // NOTE:
-                // There are two cases of DATAGRAM_SEND_STATE_CHANGED
-                // 1. 1->4,   1->2->3
-                //      This is expected state changes. 99.99...% cases
-                // 2. 1->2-5, 1->2
-                //      This is unexpected. 0.0...1% cases
-                //      state changes to LOST_SUSPECT before the first datagram acked (line 225)
-                //      However line 225 (DatagramsAcknowledged) becomes true by treating state 5 (ACKNOWLEDGED_SPURIOUS) as 4 (ACKNOWLEDGED)
+                //
+                // Even though the test only drops a single packet, it is
+                // possible that an oversubscribed VM may result in additional
+                // packet drops. Account for this by ensuring at least one new
+                // packet is dropped by this test.
+                //
                 Tries = 0;
                 while (Client.GetDatagramsSuspectLost() == InitialLostCount && ++Tries < 10) {
                     CxPlatSleep(100);

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -255,7 +255,7 @@ QuicTestDatagramSend(
                 while (Client.GetDatagramsSuspectLost() == CurrentLostCount && ++Tries < 10) {
                     CxPlatSleep(100);
                 }
-                TEST_TRUE(Client.GetDatagramsSuspectLost() >= CurrentLostCount);
+                TEST_TRUE(Client.GetDatagramsSuspectLost() > CurrentLostCount);
                 CxPlatSleep(100);
 #endif
 
@@ -265,7 +265,7 @@ QuicTestDatagramSend(
                 }
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
-                TEST_EQUAL(1, Client.GetDatagramsLost());
+                TEST_TRUE(Client.GetDatagramsLost() >= 1);
 #endif
 
                 TEST_FALSE(Client.GetPeerClosed());


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/msquic/issues/1994
Datagram get lost at unexpected point. Which causes failure by validating the number of packets get lost.

## Testing

Running some hours.....

## Documentation

