### PR TITLE
Improve Send Cleanup Path to Fix Benign Assert

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -42,7 +42,9 @@ QuicSendUninitialize(
     _In_ QUIC_SEND* Send
     )
 {
+    Send->Uninitialized = TRUE;
     Send->DelayedAckTimerActive = FALSE;
+    Send->SendFlags = 0;
 
     if (Send->InitialToken != NULL) {
         CXPLAT_FREE(Send->InitialToken, QUIC_POOL_INITIAL_TOKEN);
@@ -215,6 +217,10 @@ QuicSendValidate(
     _In_ QUIC_SEND* Send
     )
 {
+    if (Send->Uninitialized) {
+        return;
+    }
+
     QUIC_CONNECTION* Connection = QuicSendGetConnection(Send);
 
     BOOLEAN HasAckElicitingPacketsToAcknowledge = FALSE;

--- a/src/core/send.h
+++ b/src/core/send.h
@@ -246,6 +246,11 @@ typedef struct QUIC_SEND {
     BOOLEAN TailLossProbeNeeded : 1;
 
     //
+    // Indicates the connection is cleaning up.
+    //
+    BOOLEAN Uninitialized : 1;
+
+    //
     // The next packet number to use.
     //
     uint64_t NextPacketNumber;


### PR DESCRIPTION
## Description

Fixes #3478, which is a benign assert during connection uninitialization where some send flags were left over and not matching the expected state.

## Testing

Existing CI

## Documentation

N/A
