### PR TITLE
Fix Remote Addr Tests Down Level (v2.1)

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -3346,7 +3346,7 @@ void QuicTestConnectionParam()
             TestScopeLogger LogScope1("SetParam");
             {
                 //
-                // QUIC_CONN_BAD_START_STATE
+                // QUIC_STATUS_INVALID_STATE (connection failed to started)
                 //
                 {
                     TestScopeLogger LogScope2("QUIC_CONN_BAD_START_STATE");
@@ -3355,11 +3355,28 @@ void QuicTestConnectionParam()
                     SimulateConnBadStartState(Connection, ClientConfiguration);
 
                     QUIC_ADDR Dummy = {};
+                    TEST_TRUE(QuicAddrFromString("127.0.0.1", 0, &Dummy));
                     TEST_QUIC_STATUS(
                         QUIC_STATUS_INVALID_STATE,
                         Connection.SetParam(
                             QUIC_PARAM_CONN_REMOTE_ADDRESS,
                             sizeof(Dummy),
+                            &Dummy));
+                }
+
+                //
+                // QUIC_STATUS_INVALID_PARAMETER (too small)
+                //
+                {
+                    MsQuicConnection Connection(Registration);
+                    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+                    QUIC_ADDR Dummy = {};
+                    TEST_TRUE(QuicAddrFromString("127.0.0.1", 0, &Dummy));
+                    TEST_QUIC_STATUS(
+                        QUIC_STATUS_INVALID_PARAMETER,
+                        Connection.SetParam(
+                            QUIC_PARAM_CONN_REMOTE_ADDRESS,
+                            sizeof(Dummy)-1,
                             &Dummy));
                 }
 
@@ -3370,6 +3387,7 @@ void QuicTestConnectionParam()
                     MsQuicConnection Connection(Registration);
                     TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
                     QUIC_ADDR Dummy = {};
+                    TEST_TRUE(QuicAddrFromString("127.0.0.1", 0, &Dummy));
                     TEST_QUIC_SUCCEEDED(
                         Connection.SetParam(
                             QUIC_PARAM_CONN_REMOTE_ADDRESS,


### PR DESCRIPTION
## Description

We are fixing the product code up-level to 0.0.0.0 being set to remote addr, and it caused these tests to fail.

## Testing

Existing CI

## Documentation

N/A
