### PR TITLE
[release/2.1] make chacha optional on Linux 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,6 +639,10 @@ if(QUIC_TLS STREQUAL "openssl")
     )
 endif()
 
+if (QUIC_USE_SYSTEM_LIBCRYPTO)
+    list(APPEND QUIC_COMMON_DEFINES CXPLAT_SYSTEM_CRYPTO)
+endif()
+
 if(QUIC_CODE_CHECK)
     find_program(CLANGTIDY NAMES clang-tidy)
     if(CLANGTIDY)

--- a/src/generated/linux/tls_openssl.c.clog.h
+++ b/src/generated/linux/tls_openssl.c.clog.h
@@ -549,10 +549,10 @@ tracepoint(CLOG_TLS_OPENSSL_C, TlsErrorStatus , arg2, arg3, arg4);\
 // Decoder Ring for LibraryErrorStatus
 // [ lib] ERROR, %u, %s.
 // QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            CredConfig->AllowedCipherSuites,
-            "No valid cipher suites presented");
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                CredConfig->AllowedCipherSuites,
+                "No valid cipher suites presented");
 // arg2 = arg2 = CredConfig->AllowedCipherSuites = arg2
 // arg3 = arg3 = "No valid cipher suites presented" = arg3
 ----------------------------------------------------------*/

--- a/src/generated/linux/tls_openssl.c.clog.h.lttng.h
+++ b/src/generated/linux/tls_openssl.c.clog.h.lttng.h
@@ -587,10 +587,10 @@ TRACEPOINT_EVENT(CLOG_TLS_OPENSSL_C, TlsErrorStatus,
 // Decoder Ring for LibraryErrorStatus
 // [ lib] ERROR, %u, %s.
 // QuicTraceEvent(
-            LibraryErrorStatus,
-            "[ lib] ERROR, %u, %s.",
-            CredConfig->AllowedCipherSuites,
-            "No valid cipher suites presented");
+                LibraryErrorStatus,
+                "[ lib] ERROR, %u, %s.",
+                CredConfig->AllowedCipherSuites,
+                "No valid cipher suites presented");
 // arg2 = arg2 = CredConfig->AllowedCipherSuites = arg2
 // arg3 = arg3 = "No valid cipher suites presented" = arg3
 ----------------------------------------------------------*/

--- a/src/inc/quic_crypt.h
+++ b/src/inc/quic_crypt.h
@@ -372,6 +372,11 @@ CxPlatHashCompute(
         uint8_t* const Output
     );
 
+BOOLEAN
+CxPlatCryptSupports(
+    CXPLAT_AEAD_TYPE AeadType
+    );
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/platform/crypt_bcrypt.c
+++ b/src/platform/crypt_bcrypt.c
@@ -281,6 +281,23 @@ Error:
 #endif
 }
 
+BOOLEAN
+CxPlatCryptSupports(
+    CXPLAT_AEAD_TYPE AeadType
+    )
+{
+    switch (AeadType) {
+    case CXPLAT_AEAD_AES_128_GCM:
+        return TRUE;
+    case CXPLAT_AEAD_AES_256_GCM:
+        return TRUE;
+    case CXPLAT_AEAD_CHACHA20_POLY1305:
+        return  CXPLAT_CHACHA20_POLY1305_ALG_HANDLE != NULL;
+    default:
+        return FALSE;
+    }
+}
+
 void
 CxPlatCryptUninitialize(
     void

--- a/src/platform/crypt_openssl.c
+++ b/src/platform/crypt_openssl.c
@@ -91,15 +91,21 @@ CxPlatCryptInitialize(
     //
     // Try to load ChaCha20 ciphers dynamically. They may or may not exist when using system crypto.
     //
+    void* handle = dlopen("libcrypto.so.1.1", RTLD_LAZY | RTLD_GLOBAL);
     EVP_CIPHER* (*func)(void) = NULL;
-    func = dlsym(NULL, "EVP_chacha20");
-    if (func != NULL) {
-        CXPLAT_CHACHA20_ALG_HANDLE = (*func)();
-    }
+    if (handle != NULL) {
+        func = dlsym(handle, "EVP_chacha20");
+        if (func != NULL) {
+            CXPLAT_CHACHA20_ALG_HANDLE = (*func)();
 
-    func = dlsym(NULL, "EVP_chacha20_poly1305");
-    if (func != NULL) {
-        CXPLAT_CHACHA20_POLY1305_ALG_HANDLE = (*func)();
+            func = dlsym(handle, "EVP_chacha20_poly1305");
+            if (func != NULL) {
+                CXPLAT_CHACHA20_POLY1305_ALG_HANDLE = (*func)();
+                EVP_add_cipher(CXPLAT_CHACHA20_POLY1305_ALG_HANDLE);
+            }
+        } else {
+            dlclose(handle);
+        }
     }
 #endif
     return QUIC_STATUS_SUCCESS;

--- a/src/platform/crypt_openssl.c
+++ b/src/platform/crypt_openssl.c
@@ -118,9 +118,8 @@ CxPlatCryptSupports(
 {
     switch (AeadType) {
     case CXPLAT_AEAD_AES_128_GCM:
-        return true;
     case CXPLAT_AEAD_AES_256_GCM:
-        return true;
+        return TRUE;
     case CXPLAT_AEAD_CHACHA20_POLY1305:
         return CXPLAT_CHACHA20_ALG_HANDLE != NULL;
     default:

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -214,6 +214,7 @@ CxPlatInitialize(
     }
 
     if (!CxPlatWorkersInit()) {
+        CxPlatCryptUninitialize();
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Exit;
     }
@@ -244,6 +245,7 @@ CxPlatUninitialize(
     )
 {
     CxPlatWorkersUninit();
+    CxPlatCryptUninitialize();
     close(RandomFd);
     QuicTraceLogInfo(
         PosixUninitialized,

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -205,6 +205,14 @@ CxPlatInitialize(
         goto Exit;
     }
 
+    Status = CxPlatCryptInitialize();
+    if (QUIC_FAILED(Status)) {
+        if (RandomFd != -1) {
+            close(RandomFd);
+        }
+        return Status;
+    }
+
     if (!CxPlatWorkersInit()) {
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Exit;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -964,9 +964,11 @@ TEST_F(TlsTest, HandshakeParamInfoChaCha20)
     CxPlatServerSecConfig ServerConfig(
         QUIC_CREDENTIAL_FLAG_SET_ALLOWED_CIPHER_SUITES,
         QUIC_ALLOWED_CIPHER_SUITE_CHACHA20_POLY1305_SHA256);
+
     TlsContext ServerContext, ClientContext;
     ClientContext.InitializeClient(ClientConfig);
     ServerContext.InitializeServer(ServerConfig);
+    ASSERT_NE(ServerConfig.SecConfig, nullptr);
     DoHandshake(ServerContext, ClientContext);
 
     QUIC_HANDSHAKE_INFO HandshakeInfo;


### PR DESCRIPTION
backport of two changes to load msquic on Centos 7 and Mariner Linux 2.0 

fixes #3422
 