### PR TITLE
Update CodeQL Security Scanner to Audit

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,19 +29,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            api.nuget.org:443
-            azure.archive.ubuntu.com:80
-            boringssl.googlesource.com:443
-            dc.services.visualstudio.com:443
-            github.com:443
-            launchpad.net:443
-            packages.microsoft.com:443
-            ppa.launchpad.net:80
-            api.launchpad.net:443
-            uploads.github.com:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
         with:


### PR DESCRIPTION
## Description

step-security/harden-runner was preventing a CodeQL connection it seems, failing all the CI. It might be more pain that it's worth...

## Testing

Automation

## Documentation

N/A
