### PR TITLE
Fix QUIC_TLS_SECRETS on Server and Client.

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1538,7 +1538,6 @@ QuicCryptoProcessTlsCompletion(
             Crypto->TlsState.BufferLength > 0) {
 
             QuicCryptoTlsReadClientRandom(
-                Connection,
                 Crypto->TlsState.Buffer,
                 Crypto->TlsState.BufferLength,
                 Connection->TlsSecrets);
@@ -1882,7 +1881,6 @@ QuicCryptoProcessData(
                 // so now the ClientRandom can be copied.
                 //
                 QuicCryptoTlsReadClientRandom(
-                    Connection,
                     Buffer.Buffer,
                     Buffer.Length,
                     Connection->TlsSecrets);

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1874,9 +1874,9 @@ QuicCryptoProcessData(
                 Connection,
                 &Info);
 
-            if (!Connection->State.HandleClosed &&
-                Connection->State.ExternalOwner &&
-                Connection->TlsSecrets != NULL) {
+            if (Connection->TlsSecrets != NULL &&
+                !Connection->State.HandleClosed &&
+                Connection->State.ExternalOwner) {
                 //
                 // At this point, the connection was accepted by the listener,
                 // so now the ClientRandom can be copied.

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1881,10 +1881,12 @@ QuicCryptoProcessData(
                 Connection,
                 &Info);
 
-            if (!Connection->State.HandleClosed && Connection->State.ExternalOwner && Connection->TlsSecrets != NULL) {
+            if (!Connection->State.HandleClosed &&
+                Connection->State.ExternalOwner &&
+                Connection->TlsSecrets != NULL) {
                 //
-                // At this point, if the connection was accepted by the listener, and
-                // the app requests the TLS secrets, now they can be copied.
+                // At this point, the connection was accepted by the listener,
+                // and the app requests TLS secrets, so now they can be copied.
                 //
                 Status =
                     QuicCryptoTlsReadInitial(

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1536,12 +1536,11 @@ QuicCryptoProcessTlsCompletion(
             (Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_INITIAL ||
                 Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_0_RTT) &&
             Crypto->TlsState.BufferLength > 0) {
-            QUIC_NEW_CONNECTION_INFO Info = { 0 };
-            QuicCryptoTlsReadInitial(
+
+            QuicCryptoTlsReadClientRandom(
                 Connection,
                 Crypto->TlsState.Buffer,
                 Crypto->TlsState.BufferLength,
-                &Info,
                 Connection->TlsSecrets);
             //
             // Connection is done with TlsSecrets, clean up.
@@ -1838,14 +1837,7 @@ QuicCryptoProcessData(
                     Connection,
                     Buffer.Buffer,
                     Buffer.Length,
-                    &Info,
-                    //
-                    // On server, TLS is initialized before the listener
-                    // is told about the connection, so TlsSecrets is still
-                    // NULL.
-                    //
-                    NULL
-                    );
+                    &Info);
             if (QUIC_FAILED(Status)) {
                 QuicConnTransportError(
                     Connection,
@@ -1889,13 +1881,11 @@ QuicCryptoProcessData(
                 // At this point, the connection was accepted by the listener,
                 // so now the ClientRandom can be copied.
                 //
-                Status =
-                    QuicCryptoTlsReadInitial(
-                        Connection,
-                        Buffer.Buffer,
-                        Buffer.Length,
-                        &Info,
-                        Connection->TlsSecrets);
+                QuicCryptoTlsReadClientRandom(
+                    Connection,
+                    Buffer.Buffer,
+                    Buffer.Length,
+                    Connection->TlsSecrets);
             }
             return Status;
         }

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1533,7 +1533,8 @@ QuicCryptoProcessTlsCompletion(
         //
         if (Connection->TlsSecrets != NULL &&
             QuicConnIsClient(Connection) &&
-            Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_INITIAL &&
+            (Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_INITIAL ||
+                Crypto->TlsState.WriteKey == QUIC_PACKET_KEY_0_RTT) &&
             Crypto->TlsState.BufferLength > 0) {
             QUIC_NEW_CONNECTION_INFO Info = { 0 };
             QuicCryptoTlsReadInitial(
@@ -1886,7 +1887,7 @@ QuicCryptoProcessData(
                 Connection->TlsSecrets != NULL) {
                 //
                 // At this point, the connection was accepted by the listener,
-                // and the app requests TLS secrets, so now they can be copied.
+                // so now the ClientRandom can be copied.
                 //
                 Status =
                     QuicCryptoTlsReadInitial(

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1880,6 +1880,20 @@ QuicCryptoProcessData(
                 Connection->Paths[0].Binding,
                 Connection,
                 &Info);
+
+            if (!Connection->State.HandleClosed && Connection->State.ExternalOwner && Connection->TlsSecrets != NULL) {
+                //
+                // At this point, if the connection was accepted by the listener, and
+                // the app requests the TLS secrets, now they can be copied.
+                //
+                Status =
+                    QuicCryptoTlsReadInitial(
+                        Connection,
+                        Buffer.Buffer,
+                        Buffer.Length,
+                        &Info,
+                        Connection->TlsSecrets);
+            }
             return Status;
         }
     }

--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -314,12 +314,11 @@ QuicCryptoTlsReadInitial(
 
 //
 // Reads only the ClientRandom out of the initial CRYPTO data.
-// MUST ONLY BE CALLED AFTER QuicCryptoTlsReadInitial
+// MUST ONLY BE CALLED AFTER QuicCryptoTlsReadInitial!!
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicCryptoTlsReadClientRandom(
-    _In_ QUIC_CONNECTION* Connection,
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength,

--- a/src/core/crypto.h
+++ b/src/core/crypto.h
@@ -309,8 +309,21 @@ QuicCryptoTlsReadInitial(
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength,
-    _Inout_ QUIC_NEW_CONNECTION_INFO* Info,
-    _Inout_opt_ QUIC_TLS_SECRETS* TlsSecrets
+    _Inout_ QUIC_NEW_CONNECTION_INFO* Info
+    );
+
+//
+// Reads only the ClientRandom out of the initial CRYPTO data.
+// MUST ONLY BE CALLED AFTER QuicCryptoTlsReadInitial
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicCryptoTlsReadClientRandom(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_reads_(BufferLength)
+        const uint8_t* Buffer,
+    _In_ uint32_t BufferLength,
+    _Inout_ QUIC_TLS_SECRETS* TlsSecrets
     );
 
 //

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1744,6 +1744,9 @@ QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, goo
 
         case QUIC_TP_ID_VERSION_NEGOTIATION_EXT:
             if (Length > 0) {
+                if (TransportParams->VersionInfo != NULL) {
+                    CXPLAT_FREE(TransportParams->VersionInfo, QUIC_POOL_VERSION_INFO);
+                }
                 TransportParams->VersionInfo = CXPLAT_ALLOC_NONPAGED(Length, QUIC_POOL_VERSION_INFO);
                 if (TransportParams->VersionInfo == NULL) {
                     QuicTraceEvent(

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -659,7 +659,6 @@ QuicCryptoTlsReadInitial(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicCryptoTlsReadClientRandom(
-    _In_ QUIC_CONNECTION* Connection,
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength,

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -666,14 +666,9 @@ QuicCryptoTlsReadClientRandom(
     _Inout_ QUIC_TLS_SECRETS* TlsSecrets
     )
 {
-    if (BufferLength < TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t) + TLS_RANDOM_LENGTH) {
-        QuicTraceEvent(
-            ConnError,
-            "[conn][%p] ERROR, %s.",
-            Connection,
-            "TLS Initial too small to contain ClientRandom");
-        return QUIC_STATUS_INVALID_PARAMETER;
-    }
+    CXPLAT_DBG_ASSERT(
+        BufferLength >=
+        TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t) + TLS_RANDOM_LENGTH);
 
     Buffer += TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t);
     memcpy(TlsSecrets->ClientRandom, Buffer, TLS_RANDOM_LENGTH);

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -665,6 +665,7 @@ QuicCryptoTlsReadClientRandom(
     _Inout_ QUIC_TLS_SECRETS* TlsSecrets
     )
 {
+    UNREFERENCED_PARAMETER(BufferLength);
     CXPLAT_DBG_ASSERT(
         BufferLength >=
         TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t) + TLS_RANDOM_LENGTH);

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -440,8 +440,7 @@ QuicCryptoTlsReadClientHello(
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength,
-    _Inout_ QUIC_NEW_CONNECTION_INFO* Info,
-    _Inout_opt_ QUIC_TLS_SECRETS* TlsSecrets
+    _Inout_ QUIC_NEW_CONNECTION_INFO* Info
     )
 {
     /*
@@ -485,10 +484,6 @@ QuicCryptoTlsReadClientHello(
             Connection,
             "Parse error. ReadTlsClientHello #2");
         return QUIC_STATUS_INVALID_PARAMETER;
-    }
-    if (TlsSecrets != NULL) {
-        memcpy(TlsSecrets->ClientRandom, Buffer, TLS_RANDOM_LENGTH);
-        TlsSecrets->IsSet.ClientRandom = TRUE;
     }
     BufferLength -= TLS_RANDOM_LENGTH;
     Buffer += TLS_RANDOM_LENGTH;
@@ -605,8 +600,7 @@ QuicCryptoTlsReadInitial(
     _In_reads_(BufferLength)
         const uint8_t* Buffer,
     _In_ uint32_t BufferLength,
-    _Inout_ QUIC_NEW_CONNECTION_INFO* Info,
-    _Inout_opt_ QUIC_TLS_SECRETS* TlsSecrets
+    _Inout_ QUIC_NEW_CONNECTION_INFO* Info
     )
 {
     do {
@@ -633,9 +627,7 @@ QuicCryptoTlsReadInitial(
                 Connection,
                 Buffer + TLS_MESSAGE_HEADER_LENGTH,
                 MessageLength,
-                Info,
-                TlsSecrets
-                );
+                Info);
         if (QUIC_FAILED(Status)) {
             return Status;
         }
@@ -660,6 +652,32 @@ QuicCryptoTlsReadInitial(
             Connection,
             "No SNI extension present");
     }
+
+    return QUIC_STATUS_SUCCESS;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicCryptoTlsReadClientRandom(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_reads_(BufferLength)
+        const uint8_t* Buffer,
+    _In_ uint32_t BufferLength,
+    _Inout_ QUIC_TLS_SECRETS* TlsSecrets
+    )
+{
+    if (BufferLength < TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t) + TLS_RANDOM_LENGTH) {
+        QuicTraceEvent(
+            ConnError,
+            "[conn][%p] ERROR, %s.",
+            Connection,
+            "TLS Initial too small to contain ClientRandom");
+        return QUIC_STATUS_INVALID_PARAMETER;
+    }
+
+    Buffer += TLS_MESSAGE_HEADER_LENGTH + sizeof(uint16_t);
+    memcpy(TlsSecrets->ClientRandom, Buffer, TLS_RANDOM_LENGTH);
+    TlsSecrets->IsSet.ClientRandom = TRUE;
 
     return QUIC_STATUS_SUCCESS;
 }
@@ -1744,9 +1762,6 @@ QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, goo
 
         case QUIC_TP_ID_VERSION_NEGOTIATION_EXT:
             if (Length > 0) {
-                if (TransportParams->VersionInfo != NULL) {
-                    CXPLAT_FREE(TransportParams->VersionInfo, QUIC_POOL_VERSION_INFO);
-                }
                 TransportParams->VersionInfo = CXPLAT_ALLOC_NONPAGED(Length, QUIC_POOL_VERSION_INFO);
                 if (TransportParams->VersionInfo == NULL) {
                     QuicTraceEvent(

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -487,12 +487,6 @@ CxPlatTlsSetEncryptionSecretsCallback(
     }
 
     if (TlsContext->TlsSecrets != NULL) {
-        if (!TlsContext->TlsSecrets->IsSet.ClientRandom) {
-            if (SSL_get_client_random(Ssl, TlsContext->TlsSecrets->ClientRandom, sizeof(TlsContext->TlsSecrets->ClientRandom)) > 0) {
-                TlsContext->TlsSecrets->IsSet.ClientRandom = TRUE;
-            }
-        }
-
         TlsContext->TlsSecrets->SecretLength = (uint8_t)SecretLen;
         switch (KeyType) {
         case QUIC_PACKET_KEY_HANDSHAKE:

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -518,7 +518,11 @@ CxPlatTlsSetEncryptionSecretsCallback(
             TlsContext->TlsSecrets = NULL;
             break;
         case QUIC_PACKET_KEY_0_RTT:
-            if (!TlsContext->IsServer) {
+            if (TlsContext->IsServer) {
+                CXPLAT_FRE_ASSERT(ReadSecret != NULL);
+                memcpy(TlsContext->TlsSecrets->ClientEarlyTrafficSecret, ReadSecret, SecretLen);
+                TlsContext->TlsSecrets->IsSet.ClientEarlyTrafficSecret = TRUE;
+            } else {
                 CXPLAT_FRE_ASSERT(WriteSecret != NULL);
                 memcpy(TlsContext->TlsSecrets->ClientEarlyTrafficSecret, WriteSecret, SecretLen);
                 TlsContext->TlsSecrets->IsSet.ClientEarlyTrafficSecret = TRUE;

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2398,6 +2398,15 @@ CxPlatTlsWriteDataToSchannel(
             Result |= CXPLAT_TLS_RESULT_READ_KEY_UPDATED;
             if (NewPeerTrafficSecrets[i]->TrafficSecretType == SecTrafficSecret_ClientEarlyData) {
                 CXPLAT_FRE_ASSERT(FALSE); // TODO - Finish the 0-RTT logic.
+                CXPLAT_FRE_ASSERT(TlsContext->IsServer);
+                if (TlsContext->TlsSecrets != NULL) {
+                    TlsContext->TlsSecrets->SecretLength = (uint8_t)NewPeerTrafficSecrets[i]->TrafficSecretSize;
+                    memcpy(
+                        TlsContext->TlsSecrets->ClientEarlyTrafficSecret,
+                        NewPeerTrafficSecrets[i]->TrafficSecret,
+                        NewPeerTrafficSecrets[i]->TrafficSecretSize);
+                    TlsContext->TlsSecrets->IsSet.ClientEarlyTrafficSecret = TRUE;
+                }
             } else {
                 if (State->ReadKey == QUIC_PACKET_KEY_INITIAL) {
                     if (!QuicPacketKeyCreate(

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -387,8 +387,8 @@ QuicTestConnectAndPing(
         //
         // Currently only works with a single 0-RTT connection.
         //
-        ClientSecrets.reset((QUIC_TLS_SECRETS*)malloc(sizeof(*ClientSecrets)));
-        ServerSecrets.reset((QUIC_TLS_SECRETS*)malloc(sizeof(*ServerSecrets)));
+        ClientSecrets.reset(new(std::nothrow) QUIC_TLS_SECRETS);
+        ServerSecrets.reset(new(std::nothrow) QUIC_TLS_SECRETS);
         if (ClientSecrets == nullptr || ServerSecrets == nullptr) {
             return;
         }

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -957,7 +957,8 @@ TestConnection::HandleConnectionEvent(
 }
 
 uint32_t
-TestConnection::GetDestCidUpdateCount() {
+TestConnection::GetDestCidUpdateCount()
+{
     QUIC_STATISTICS_V2 Stats;
     uint32_t StatsSize = sizeof(Stats);
     QUIC_STATUS Status =
@@ -974,11 +975,26 @@ TestConnection::GetDestCidUpdateCount() {
 }
 
 const uint8_t*
-TestConnection::GetNegotiatedAlpn() const {
+TestConnection::GetNegotiatedAlpn() const
+{
     return NegotiatedAlpn;
 }
 
 uint8_t
-TestConnection::GetNegotiatedAlpnLength() const {
+TestConnection::GetNegotiatedAlpnLength() const
+{
     return NegotiatedAlpnLength;
+}
+
+QUIC_STATUS
+TestConnection::SetTlsSecrets(
+    QUIC_TLS_SECRETS* Secrets
+    )
+{
+    return
+        MsQuic->SetParam(
+            QuicConnection,
+            QUIC_PARAM_CONN_TLS_SECRETS,
+            sizeof(*Secrets),
+            Secrets);
 }

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -305,4 +305,6 @@ public:
 
     const uint8_t* GetNegotiatedAlpn() const;
     uint8_t GetNegotiatedAlpnLength() const;
+
+    QUIC_STATUS SetTlsSecrets(QUIC_TLS_SECRETS* Secrets);
 };

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -80,6 +80,7 @@ struct ServerAcceptContext {
     CXPLAT_EVENT NewConnectionReady;
     TestConnection** NewConnection;
     void* NewStreamHandler{nullptr};
+    QUIC_TLS_SECRETS* TlsSecrets{nullptr};
     QUIC_STATUS ExpectedTransportCloseStatus{QUIC_STATUS_SUCCESS};
     QUIC_STATUS ExpectedClientCertValidationResult[2]{};
     uint32_t ExpectedClientCertValidationResultCount{0};


### PR DESCRIPTION
## Description

 Fixes #2344
Specifically,
* Copies the ClientRandom on server side.
* Copies the ClientEarlyTrafficSecret on server side.
* Copies the ClientRandom on client side when 0-RTT is used.

## Testing

* Manual testing with quicinteropserver to ensure the ClientRandom is logged.
* New automated tests.

## Documentation

N/A