### PR TITLE
Handle sending path challenge on paths that have not resolved route yet

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1049,7 +1049,6 @@ QuicSendPathChallenges(
         // We need to set the path challenge flag back on so that when route is resolved,
         // we know we need to continue to send the challenge.
         //
-        CXPLAT_DBG_ASSERT(Path->IsActive);
         CXPLAT_DBG_ASSERT(Path->Route.State != RouteSuspected);
         if (Path->Route.State == RouteUnresolved) {
             QuicConnAddRef(Connection, QUIC_CONN_REF_ROUTE);

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1028,6 +1028,8 @@ QuicSendPathChallenges(
     _In_ QUIC_SEND* Send
     )
 {
+#pragma warning(push)
+#pragma warning(disable:6001) // Using uninitialized memory
     QUIC_CONNECTION* Connection = QuicSendGetConnection(Send);
 
     CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL);
@@ -1039,6 +1041,39 @@ QuicSendPathChallenges(
             Connection->Paths[i].Allowance < QUIC_MIN_SEND_ALLOWANCE) {
             continue;
         }
+
+#ifdef QUIC_USE_RAW_DATAPATH
+        //
+        // Make sure the route is resolved before sending the path challenge.
+        //
+        // We need to set the path challenge flag back on so that when route is resolved,
+        // we know we need to continue to send the challenge.
+        //
+        CXPLAT_DBG_ASSERT(Path->IsActive);
+        CXPLAT_DBG_ASSERT(Path->Route.State != RouteSuspected);
+        if (Path->Route.State == RouteUnresolved) {
+            QuicConnAddRef(Connection, QUIC_CONN_REF_ROUTE);
+            QUIC_STATUS Status =
+                CxPlatResolveRoute(
+                    Path->Binding->Socket, &Path->Route, Path->ID, (void*)Connection, QuicConnQueueRouteCompletion);
+            if (Status == QUIC_STATUS_SUCCESS) {
+                QuicConnRelease(Connection, QUIC_CONN_REF_ROUTE);
+            } else {
+                //
+                // Route resolution failed or pended. We need to pause sending.
+                //
+                CXPLAT_DBG_ASSERT(Status == QUIC_STATUS_PENDING || QUIC_FAILED(Status));
+                Send->SendFlags |= QUIC_CONN_SEND_FLAG_PATH_CHALLENGE;
+                continue;
+            }
+        } else if (Path->Route.State == RouteResolving) {
+            //
+            // Can't send now. Once route resolution completes, we will resume sending.
+            //
+            Send->SendFlags |= QUIC_CONN_SEND_FLAG_PATH_CHALLENGE;
+            continue;
+        }
+#endif
 
         QUIC_PACKET_BUILDER Builder = { 0 };
         if (!QuicPacketBuilderInitialize(&Builder, Connection, Path)) {
@@ -1101,6 +1136,7 @@ QuicSendPathChallenges(
         QuicPacketBuilderFinalize(&Builder, TRUE);
         QuicPacketBuilderCleanup(&Builder);
     }
+#pragma warning(pop)
 }
 
 typedef enum QUIC_SEND_RESULT {


### PR DESCRIPTION
## Description

It's possible that when sending a path challenge, the route is not yet resolved. We need to pause and resume path challenge when that happens.

## Testing

CI
