### PR TITLE
Disable PMTUD on Datagram Send Test

### DIFF
--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -147,6 +147,7 @@ QuicTestDatagramSend(
 
     MsQuicSettings Settings;
     Settings.SetDatagramReceiveEnabled(true);
+    Settings.SetMinimumMtu(1280).SetMaximumMtu(1280);
 
     MsQuicCredentialConfig ClientCredConfig;
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);


### PR DESCRIPTION
## Description

Fixes #3561 by disabling PMTUD which was interfering with the lost indication the test expected.

## Testing

Automation

## Documentation

N/A
