### PR TITLE
Fix QTIP tests in release branch

### DIFF
--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -145,7 +145,7 @@
     <Profile Id="RPS.Verbose.File" Name="RPS" Description="RPS related MsQuic ETW Events" LoggingMode="File" DetailLevel="Verbose">
       <Collectors>
         <SystemCollectorId Value="SC_HighVolume">
-          <SystemProviderId Value="SP_SystemThreadExecutionDetail" />
+          <SystemProviderId Value="SP_SystemThreadExecution" />
         </SystemCollectorId>
         <EventCollectorId Value="EC_HighVolume">
           <EventProviders>

--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -145,7 +145,7 @@
     <Profile Id="RPS.Verbose.File" Name="RPS" Description="RPS related MsQuic ETW Events" LoggingMode="File" DetailLevel="Verbose">
       <Collectors>
         <SystemCollectorId Value="SC_HighVolume">
-          <SystemProviderId Value="SP_SystemThreadExecution" />
+          <SystemProviderId Value="SP_SystemThreadExecutionDetail" />
         </SystemCollectorId>
         <EventCollectorId Value="EC_HighVolume">
           <EventProviders>

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -13,7 +13,7 @@
 bool TestingKernelMode = false;
 bool PrivateTestLibrary = false;
 bool UseDuoNic = false;
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 bool UseQTIP = false;
 #endif
 const MsQuicApi* MsQuic;
@@ -81,7 +81,7 @@ public:
             printf("Initializing for User Mode tests\n");
             MsQuic = new(std::nothrow) MsQuicApi();
             ASSERT_TRUE(QUIC_SUCCEEDED(MsQuic->GetInitStatus()));
-#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
             if (UseQTIP) {
                 QUIC_EXECUTION_CONFIG Config = {QUIC_EXECUTION_CONFIG_FLAG_QTIP, 10000, 0};
                 ASSERT_TRUE(QUIC_SUCCEEDED(
@@ -91,7 +91,7 @@ public:
                         sizeof(Config),
                         &Config)));
             }
-#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+#endif
             memcpy(&ServerSelfSignedCredConfig, SelfSignedCertParams, sizeof(QUIC_CREDENTIAL_CONFIG));
             memcpy(&ServerSelfSignedCredConfigClientAuth, SelfSignedCertParams, sizeof(QUIC_CREDENTIAL_CONFIG));
             ServerSelfSignedCredConfigClientAuth.Flags |=
@@ -1458,7 +1458,7 @@ TEST_P(WithFamilyArgs, ClientBlockedSourcePort) {
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
 TEST_P(WithFamilyArgs, RebindPort) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // NAT rebind doesn't make sense for TCP and QTIP.
@@ -1479,7 +1479,7 @@ TEST_P(WithFamilyArgs, RebindPort) {
 }
 
 TEST_P(WithRebindPaddingArgs, RebindPortPadded) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // NAT rebind doesn't make sense for TCP and QTIP.
@@ -1500,7 +1500,7 @@ TEST_P(WithRebindPaddingArgs, RebindPortPadded) {
 }
 
 TEST_P(WithFamilyArgs, RebindAddr) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // NAT rebind doesn't make sense for TCP and QTIP.
@@ -1521,7 +1521,7 @@ TEST_P(WithFamilyArgs, RebindAddr) {
 }
 
 TEST_P(WithRebindPaddingArgs, RebindAddrPadded) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // NAT rebind doesn't make sense for TCP and QTIP.
@@ -1705,7 +1705,7 @@ TEST_P(WithSendArgs3, SendIntermittently) {
 #ifndef QUIC_DISABLE_0RTT_TESTS
 
 TEST_P(WithSend0RttArgs1, Send0Rtt) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // QTIP doesn't work with 0-RTT. QTIP only pauses and caches 1 packet during
@@ -1754,7 +1754,7 @@ TEST_P(WithSend0RttArgs1, Send0Rtt) {
 }
 
 TEST_P(WithSend0RttArgs2, Reject0Rtt) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     if (UseQTIP) {
         //
         // QTIP doesn't work with 0-RTT. QTIP only pauses and caches 1 packet during
@@ -2375,7 +2375,7 @@ int main(int argc, char** argv) {
         } else if (strcmp("--duoNic", argv[i]) == 0) {
             UseDuoNic = true;
         } else if (strcmp("--useQTIP", argv[i]) == 0) {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
             UseQTIP = true;
 #else
             printf("QTIP is not supported in this build.\n");

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -81,7 +81,7 @@ public:
             printf("Initializing for User Mode tests\n");
             MsQuic = new(std::nothrow) MsQuicApi();
             ASSERT_TRUE(QUIC_SUCCEEDED(MsQuic->GetInitStatus()));
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
             if (UseQTIP) {
                 QUIC_EXECUTION_CONFIG Config = {QUIC_EXECUTION_CONFIG_FLAG_QTIP, 10000, 0};
                 ASSERT_TRUE(QUIC_SUCCEEDED(

--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -20,7 +20,7 @@
 #endif
 
 extern bool TestingKernelMode;
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 
@@ -346,7 +346,7 @@ struct SendArgs2 {
         for (bool UseZeroRtt : { false })
 #endif
         {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
             if (UseQTIP && UseZeroRtt) {
                 continue;
             }

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -16,7 +16,7 @@ Abstract:
 
 #pragma warning(disable:6387)  // '_Param_(1)' could be '0':  this does not adhere to the specification for the function
 
-#ifdef QUIC_USE_RAW_DATAPATH
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 extern bool UseQTIP;
 #endif
 
@@ -2514,7 +2514,6 @@ void QuicTestGlobalParam()
             SimpleGetParamTest(nullptr, QUIC_PARAM_GLOBAL_EXECUTION_CONFIG, DataLength, Data);
         }
 
-#ifdef QUIC_USE_RAW_DATAPATH
         if (!UseQTIP) {
             //
             // Good GetParam with length == 0 when QTIP is not in use.
@@ -2527,18 +2526,6 @@ void QuicTestGlobalParam()
                     &BufferLength,
                     nullptr));
         }
-#else
-        //
-        // Good GetParam with length == 0
-        //
-        uint32_t BufferLength = 0;
-        TEST_QUIC_SUCCEEDED(
-            MsQuic->GetParam(
-                nullptr,
-                QUIC_PARAM_GLOBAL_EXECUTION_CONFIG,
-                &BufferLength,
-                nullptr));
-#endif
     }
 #endif
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -16,7 +16,7 @@ Abstract:
 
 #pragma warning(disable:6387)  // '_Param_(1)' could be '0':  this does not adhere to the specification for the function
 
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 
@@ -2513,7 +2513,7 @@ void QuicTestGlobalParam()
             //
             SimpleGetParamTest(nullptr, QUIC_PARAM_GLOBAL_EXECUTION_CONFIG, DataLength, Data);
         }
-
+#ifdef QUIC_USE_RAW_DATAPATH
         if (!UseQTIP) {
             //
             // Good GetParam with length == 0 when QTIP is not in use.
@@ -2526,6 +2526,18 @@ void QuicTestGlobalParam()
                     &BufferLength,
                     nullptr));
         }
+#else
+        //
+        // Good GetParam with length == 0
+        //
+        uint32_t BufferLength = 0;
+        TEST_QUIC_SUCCEEDED(
+            MsQuic->GetParam(
+                nullptr,
+                QUIC_PARAM_GLOBAL_EXECUTION_CONFIG,
+                &BufferLength,
+                nullptr));
+#endif // QUIC_USE_RAW_DATAPATH
     }
 #endif
 

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -14,7 +14,7 @@ Abstract:
 #include "DataTest.cpp.clog.h"
 #endif
 
-#ifdef QUIC_USE_RAW_DATAPATH
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 
@@ -475,7 +475,7 @@ QuicTestConnectAndPing(
                     }
                     TEST_QUIC_SUCCEEDED(Connections.get()[i]->SetRemoteAddr(RemoteAddr));
 
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
                     if (!UseQTIP && i != 0) {
                         Connections.get()[i]->SetLocalAddr(LocalAddr);
                     }
@@ -490,7 +490,7 @@ QuicTestConnectAndPing(
                             QuicAddrFamily,
                             ClientZeroRtt ? QUIC_LOCALHOST_FOR_AF(QuicAddrFamily) : nullptr,
                             ServerLocalAddr.GetPort()));
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
                     if (!UseQTIP && i == 0) {
                         Connections.get()[i]->GetLocalAddr(LocalAddr);
                     }

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -475,7 +475,7 @@ QuicTestConnectAndPing(
                     }
                     TEST_QUIC_SUCCEEDED(Connections.get()[i]->SetRemoteAddr(RemoteAddr));
 
-#ifdef QUIC_USE_RAW_DATAPATH
+#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
                     if (!UseQTIP && i != 0) {
                         Connections.get()[i]->SetLocalAddr(LocalAddr);
                     }
@@ -490,7 +490,7 @@ QuicTestConnectAndPing(
                             QuicAddrFamily,
                             ClientZeroRtt ? QUIC_LOCALHOST_FOR_AF(QuicAddrFamily) : nullptr,
                             ServerLocalAddr.GetPort()));
-#ifdef QUIC_USE_RAW_DATAPATH
+#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
                     if (!UseQTIP && i == 0) {
                         Connections.get()[i]->GetLocalAddr(LocalAddr);
                     }

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -475,7 +475,7 @@ QuicTestConnectAndPing(
                     }
                     TEST_QUIC_SUCCEEDED(Connections.get()[i]->SetRemoteAddr(RemoteAddr));
 
-#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
                     if (!UseQTIP && i != 0) {
                         Connections.get()[i]->SetLocalAddr(LocalAddr);
                     }
@@ -490,7 +490,7 @@ QuicTestConnectAndPing(
                             QuicAddrFamily,
                             ClientZeroRtt ? QUIC_LOCALHOST_FOR_AF(QuicAddrFamily) : nullptr,
                             ServerLocalAddr.GetPort()));
-#ifdef defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
                     if (!UseQTIP && i == 0) {
                         Connections.get()[i]->GetLocalAddr(LocalAddr);
                     }

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -49,7 +49,7 @@ struct ResetSettings {
 void
 QuicTestMtuSettings()
 {
-#ifdef QUIC_USE_RAW_DATAPATH
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     const uint16_t DefaultMaximumMtu = UseQTIP ? 1488 : 1500; // reserve 12B for TCP header
 #else
     const uint16_t DefaultMaximumMtu = 1500;
@@ -315,7 +315,7 @@ QuicTestMtuDiscovery(
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
     const uint16_t MinimumMtu = RaiseMinimumMtu ? 1360 : 1248;
-#ifdef QUIC_USE_RAW_DATAPATH
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     const uint16_t MaximumMtu = UseQTIP ? 1488 : 1500; // reserve 12B for TCP header
 #else
     const uint16_t MaximumMtu = 1500;

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -49,7 +49,7 @@ struct ResetSettings {
 void
 QuicTestMtuSettings()
 {
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     const uint16_t DefaultMaximumMtu = UseQTIP ? 1488 : 1500; // reserve 12B for TCP header
 #else
     const uint16_t DefaultMaximumMtu = 1500;
@@ -315,7 +315,7 @@ QuicTestMtuDiscovery(
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
     const uint16_t MinimumMtu = RaiseMinimumMtu ? 1360 : 1248;
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#if defined(QUIC_USE_RAW_DATAPATH) && defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
     const uint16_t MaximumMtu = UseQTIP ? 1488 : 1500; // reserve 12B for TCP header
 #else
     const uint16_t MaximumMtu = 1500;


### PR DESCRIPTION
## Description

Test code references the flag `UseQTIP` defined in quic_gtest.cpp unconditionally for RAW datapath. However, the definition of UseQTIP is gated behind QUIC_API_ENABLE_PREVIEW_FEATURES.

This PR gates all references behind the same macro, QUIC_API_ENABLE_PREVIEW_FEATURES and QUIC_USE_RAW_DATAPATH.

## Testing

CI