### PR TITLE
Automatic linux package publish pipeline Part 2

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -7,12 +7,47 @@ resources:
   pipelines:
   - pipeline: onebranch   # Name of the pipeline resource
     source: msquic-Official # Name of the pipeline referenced by the pipeline resource
-    trigger: true
+    trigger:
+      tags:
+        include:
+        - v*
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
 variables:
   DisableDockerDetector: true
+
+parameters:
+- name: opensslrpmrepos
+  type: object
+  default:
+  - 582bd4c5ae062a5d0fec5b8b # microsoft-rhel7.3-prod
+  - 584a0f48d6a6e37205720776 # microsoft-sles12-prod
+  - 59d40cdcf3c7fa07032ce385 # microsoft-centos7-prod
+  - 5c38ea9dea0fc9f93bd67db4 # microsoft-opensuse15-pro
+  - 5c3d1796ea0fc9f93bd67def # microsoft-sles15-prod
+  - 5e5ed94a523a8019fe47607e # microsoft-centos8-prod
+  - 5e8526cde45fff4588da61f9 # microsoft-fedora32-prod
+  - 5f7e2cfb68e42e6e7085f4df # microsoft-fedora33-prod
+  - 6001dd94435efd1330acd076 # microsoft-rhel8.1-prod
+  - 606e1da573e50659b0803a7b # microsoft-fedora34-prod
+  - 6271bc683ac6d73aa84d6737 # microsoft-fedora36-prod
+  - 6400e6f92dd6874e6880b590 # microsoft-fedora37-prod
+- name: openssldebrepos
+  type: object
+  default:
+  - 582bd623ae062a5d0fec5b8c # microsoft-ubuntu-xenial-prod
+  - 599211761cc20bce4a8ab950 # microsoft-debian-stretch-prod
+  - 5a9dc3f2424a5c053cc3ff2e # microsoft-ubuntu-bionic-prod
+  - 5d23b16c9a6e3b375bbba42e # microsoft-debian-buster-prod
+  - 5e852952e45fffa1beda61fe # microsoft-ubuntu-focal-prod
+  - 5f7e2d6668e42e03f785f4e0 # microsoft-ubuntu-groovy-prod
+  - 606e057173e5060519803a74 # microsoft-ubuntu-hirsute-prod
+  - 611ab3a32acdcd0744c8c841 # microsoft-debian-bullseye-prod
+- name: openssl3debrepos
+  type: object
+  default:
+  - 61faea6cea3a770ab120ac8a # microsoft-ubuntu-jammy-prod
 
 stages:
 - stage: UploadPackage_stage
@@ -22,18 +57,6 @@ stages:
       clean: all
     pool:
       vmImage: 'ubuntu-latest'
-    strategy:
-      matrix:
-        openssl:
-          openssl_name: openssl
-          artifact_suffix: '_openssl'
-          rpmrepos: 'opensslrpmrepos'
-          debrepos: 'openssldebrepos'
-        openssl3:
-          openssl_name: openssl3
-          artifact_suffix: '_openssl3'
-          rpmrepos: ''
-          debrepos: 'openssl3debrepos'
     variables:
     - group: MsQuicAADApp
     steps:
@@ -45,15 +68,29 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_$(artifact_suffix)
-          path: $(Build.SourcesDirectory)/artifacts/signed/$(openssl_name)
+          artifact: drop_package_linux_distribution_openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/openssl
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_openssl3
+          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: Docker@2
         displayName: Login to ACR
         inputs:
           command: login
           containerRegistry: msquicdockerregistry
-      - template: ./obtemplates/upload-linux-packages.yml@self
-        parameters:
-          package_path: $(Build.SourcesDirectory)/artifacts/signed/$(openssl_name)
-          rpmrepos: $(rpmrepos)
-          debrepos: $(debrepos)
+      - ${{ each repo in parameters.opensslrpmrepos }}:
+        - script: sh scripts/upload-linux-packages.sh -i $(ClientId) -s $(ClientId) -f $(Build.SourcesDirectory)/artifacts/signed/openssl -r ${{ repo }} -n "*.rpm"
+          displayName: Upload openssl RPM packages to ${{ repo }}
+      - ${{ each repo in parameters.openssldebrepos }}:
+        - script: sh scripts/upload-linux-packages.sh -i $(ClientId) -s $(ClientId) -f $(Build.SourcesDirectory)/artifacts/signed/openssl -r ${{ repo }} -n "*.deb"
+          displayName: Upload openssl DEB packages to ${{ repo }}
+      - ${{ each repo in parameters.openssl3debrepos }}:
+        - script: sh scripts/upload-linux-packages.sh -i $(ClientId) -s $(ClientId) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3 -r ${{ repo }} -n "*.deb"
+          displayName: Upload openssl3 DEB packages to ${{ repo }}

--- a/.azure/dockers/ob/pkg-publish/publish-packages.sh
+++ b/.azure/dockers/ob/pkg-publish/publish-packages.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
-while getopts i:s:f: flag
+while getopts i:s:f:r: flag
 do
     case "${flag}" in
         i) AADClientId=${OPTARG};;
         s) AADClientSecret=${OPTARG};;
         f) FilePath=${OPTARG};;
+        r) Repo=${OPTARG};;
     esac
 done
-Extension=`echo "${FilePath##*.}" | tr '[:upper:]' '[:lower:]'`
 echo "AADClientId: $AADClientId"
 echo "FilePath: $FilePath"
 ls -lsa $FilePath
-echo "Ext: $Extension"
 ConfigString="
 {
     \"server\": \"azure-apt-cat.cloudapp.net\",
@@ -24,84 +23,10 @@ ConfigString="
     \"repositoryId\": \"5ca39edc03f790615107e1e1\"
 }
 "
-# Repos where libmsquic has been published:
-# yum|582bd4c5ae062a5d0fec5b8b|microsoft-rhel7.3-prod
-# yum|584a0f48d6a6e37205720776|microsoft-sles12-prod
-# yum|59d40cdcf3c7fa07032ce385|microsoft-centos7-prod
-# yum|5c38ea9dea0fc9f93bd67db4|microsoft-opensuse15-prod
-# yum|5c3d1796ea0fc9f93bd67def|microsoft-sles15-prod
-# yum|5e5ed94a523a8019fe47607e|microsoft-centos8-prod
-# yum|5e8526cde45fff4588da61f9|microsoft-fedora32-prod
-# yum|5f7e2cfb68e42e6e7085f4df|microsoft-fedora33-prod
-# yum|6001dd94435efd1330acd076|microsoft-rhel8.1-prod
-# yum|606e1da573e50659b0803a7b|microsoft-fedora34-prod
-# yum|6271bc683ac6d73aa84d6737|microsoft-fedora36-prod
-# yum|6400e6f92dd6874e6880b590|microsoft-fedora37-prod
-# yum|60b80feccb16ed2040bca3dd|cbl-mariner-1.0-prod-Microsoft-x86_64-rpms
-# yum|61a6c6d4ea3a77190f1f6795|cbl-mariner-2.0-prod-Microsoft-x86_64
-# yum|61a6c6d4ea3a7731681f6796|cbl-mariner-2.0-prod-Microsoft-aarch64
-# apt|582bd623ae062a5d0fec5b8c|microsoft-ubuntu-xenial-prod
-# apt|599211761cc20bce4a8ab950|microsoft-debian-stretch-prod
-# apt|5a9dc3f2424a5c053cc3ff2e|microsoft-ubuntu-bionic-prod
-# apt|5d23b16c9a6e3b375bbba42e|microsoft-debian-buster-prod
-# apt|5e852952e45fffa1beda61fe|microsoft-ubuntu-focal-prod
-# apt|5f7e2d6668e42e03f785f4e0|microsoft-ubuntu-groovy-prod
-# apt|606e057173e5060519803a74|microsoft-ubuntu-hirsute-prod
-# apt|611ab3a32acdcd0744c8c841|microsoft-debian-bullseye-prod
-# apt|61faea6cea3a770ab120ac8a|microsoft-ubuntu-jammy-prod
-DebRepos=(
-    582bd623ae062a5d0fec5b8c
-    599211761cc20bce4a8ab950
-    5a9dc3f2424a5c053cc3ff2e
-    5d23b16c9a6e3b375bbba42e
-    5e852952e45fffa1beda61fe
-    5f7e2d6668e42e03f785f4e0
-    606e057173e5060519803a74
-    611ab3a32acdcd0744c8c841
-    61faea6cea3a770ab120ac8a
-    5d16326637164fbc1139c4e1
-    )
-RPMRepos=(
-    582bd4c5ae062a5d0fec5b8b
-    584a0f48d6a6e37205720776
-    59d40cdcf3c7fa07032ce385
-    5c38ea9dea0fc9f93bd67db4
-    5c3d1796ea0fc9f93bd67def
-    5e5ed94a523a8019fe47607e
-    5e8526cde45fff4588da61f9
-    5f7e2cfb68e42e6e7085f4df
-    6001dd94435efd1330acd076
-    606e1da573e50659b0803a7b
-    60b80feccb16ed2040bca3dd
-    60b80feccb16edcf4bbca3de
-    61a6c6d4ea3a77190f1f6795
-    61a6c6d4ea3a7731681f6796
-    6271bc683ac6d73aa84d6737
-    6400e6f92dd6874e6880b590
-    )
+
 echo $ConfigString | jq > ~/.repoclient/prodconfig.json
-jsonOut=""
-if [ $Extension = "rpm" ]
-then
-    echo "Uploading the package to RPM repos..."
-    for Repo in "${RPMRepos[@]}"
-    do
-        echo "Uploading to repo $Repo"
-        res=`repoclient -s pmc -v v3 package add -k $FilePath -r $Repo`
-        echo $res | jq
-        jsonOut+=$res
-    done
-fi
-if [ $Extension = "deb" ]
-then
-    echo "Uploading the package to DEB repos..."
-    for Repo in "${DebRepos[@]}"
-    do
-        echo "Uploading to repo $Repo"
-        res=`repoclient -s pmc -v v3 package add -k $FilePath -r $Repo`
-        echo $res | jq
-        jsonOut+=$res
-    done
-fi
-echo "submissionIds:"
-echo $jsonOut | jq -r '.message.submissionId?'
+echo "publish-docker: Uploading to $FilePath to repo $Repo"
+res=`repoclient -s pmc -v v3 package add -k $FilePath -r $Repo`
+echo $res | jq
+echo "publish-docker: submissionId:"
+echo $res | jq -r '.message.submissionId?'

--- a/.azure/obtemplates/upload-linux-package.yml
+++ b/.azure/obtemplates/upload-linux-package.yml
@@ -1,7 +1,0 @@
-parameters:
-  package_path: ''
-  rpmrepos: ''
-  debrepos: ''
-
-steps:
-  - script: echo ${{ parameters.packagae_path }}

--- a/scripts/upload-linux-packages.sh
+++ b/scripts/upload-linux-packages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+while getopts i:s:f:r:n: flag
+do
+    case "${flag}" in
+        i) AADClientId=${OPTARG};;
+        s) AADClientSecret=${OPTARG};;
+        f) Folder=${OPTARG};;
+        r) Repo=${OPTARG};;
+        n) NameFilter=${OPTARG};;
+    esac
+done
+
+for filename in `find $Folder -maxdepth 1 -type f -name "$NameFilter"`; do
+    basefilename=`basename $filename`
+    echo "Uploading $filename to $Repo"
+    docker run -v $Folder:/usr/src/hostpwd msquicdockerregistry.azurecr.io/private/msquic/publish-linux-packages:vnext -i $AADClientId -s $AADClientSecret -f /usr/src/hostpwd/$basefilename -r $Repo
+done


### PR DESCRIPTION
## Description

Automatically upload signed linux packages to PMC repos. Triggered by tags.

Currently, intentionally not use the correct secret to avoid accidentally uploading unexpected packages to PMC repos. After we create the new release and tag, we will need to change `-s $(Client)` to `-s $(Secret)` in .azure/dockers/ob/pkg-publish/publish-packages.sh.

## Testing

Tested in OB pipeline when the trigger is always on.