### PR TITLE
Use vse2022:latest to avoid onebranch warnings

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -27,7 +27,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'WindowsContainerImage2DockerTag'
   displayName: 'WindowsContainerImage2 DockerTag'
   type: string
-  default: 'vse2022.2'
+  default: 'vse2022.5'
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning

--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -40,7 +40,7 @@ variables:
   NUGET_XMLDOC_MODE: none
   ONEBRANCH_AME_ACR_LOGIN: onebranch.azurecr.io, cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io
 
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:vnext'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   WindowsContainerImage2: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:${{ parameters.WindowsContainerImage2DockerTag }}'
   LinuxContainerImage: 'ghcr.io/microsoft/msquic/linux-build-xcomp:22.04'
   LinuxContainerImage2: 'ghcr.io/microsoft/msquic/linux-build-xcomp:20.04'

--- a/.azure/dockers/ob/windows/Dockerfile
+++ b/.azure/dockers/ob/windows/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM onebranch.azurecr.io/windows/ltsc2022/vse2022:vnext
+FROM onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 # Default .NET FX images switch shell to PS. Switch it back.
 SHELL ["cmd", "/S", "/C"]


### PR DESCRIPTION
## Description

Use vse2022:latest to avoid onebranch warnings

## Testing

OB CI