### PR TITLE
Scheduled windows docker update pipeline

### DIFF
--- a/.azure/OneBranch.Docker.Official.yml
+++ b/.azure/OneBranch.Docker.Official.yml
@@ -1,31 +1,33 @@
 #
 # Run this OBP will generate a docker image and push it to isolated ACR hosted by Onebranch.
 #
-# Set enable_isolated_acr_push and enable_service_tree_acr_path to true when the docker(s)
-# are ready to be uploaded.
-#
-# By default, this pipeline does not build dockers if RunFor* is not set.
+# The pipeline also runs regularly per the schedule defined below. Since we do not frequently
+# change the Dockerfile, most scheduled runs should be no-op, i.e. nothing is really pushed to
+# the Onebranch isolated ACR. Only when the base image gets updated, the updated subsequent layers
+# will be rebuilt and pushed.
 #
 
-trigger: none # https://aka.ms/obpipelines/triggers
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - .azure/dockers/ob/windows/*
+
+schedules:
+- cron: '0 0 * * Sat' # Every Saturday
+  displayName: Weekly docker build
+  branches:
+    include:
+    - main
 
 parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'debug'
   displayName: 'Enable debug output'
   type: boolean
   default: false
-- name: 'RunForLinux'
-  displayName: 'Build docker image for Linux'
-  type: boolean
-  default: false
-- name: 'RunForWindows'
-  displayName: 'Build docker image for Windows'
-  type: boolean
-  default: false
-- name: 'DockerTag'
-  displayName: 'Docker tag'
-  type: string
-  default: 'latest'
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
@@ -36,7 +38,7 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
-  LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-1804:latest'
+  LinuxContainerImage: 'mcr.microsoft.com/onebranch/cbl-mariner/build:2.0'
 
 resources:
   repositories:
@@ -48,18 +50,25 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
+    cloudvault: # https://aka.ms/obpipelines/cloudvault
+      enabled: false
+    globalSdl: # https://aka.ms/obpipelines/sdl
+      sbom:
+        validate: false
+      tsa:
+        enabled: false # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.azure\CredScanSuppressions.json
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.azure\openssl.gdnsuppress
     featureFlags:
       skipPoliciesValidation: true
       WindowsHostVersion: '1ESWindows2022'
-    globalSdl: # https://aka.ms/obpipelines/sdl
-      tsa:
-        enabled: false # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
 
     stages:
-      - stage: docker
+      - stage: build_and_push_docker
         jobs:
         - job: download_external_libs
-          condition: eq('${{ parameters.RunForWindows }}', 'true')
           displayName: Download external libs
           pool:
             type: linux  # read more about custom job types at https://aka.ms/obpipelines/yaml/jobs
@@ -75,30 +84,9 @@ extends:
                 echo Copying $(xgameplatformlib.secureFilePath) to artifacts...
                 mkdir -p $(Build.SourcesDirectory)/out
                 cp $(xgameplatformlib.secureFilePath) $(Build.SourcesDirectory)/out
-        - job: linuxContainers # build linux images
-          condition: eq('${{ parameters.RunForLinux }}', 'true')
-          displayName: Build docker image for linux
-          variables:
-            ob_git_checkout: true
-          pool:
-            type: docker
-            os: linux
-          steps:
-            - task: onebranch.pipeline.imagebuildinfo@1
-              inputs:
-                repositoryName: msquicbuild
-                dockerFileRelPath: .azure/dockers/ob/linux/Dockerfile
-                dockerFileContextPath: .azure/dockers/ob/linux
-                saveImageToPath: msquicbuild-linux.tar
-                enable_network: true
-                build_tag: ${{ parameters.DockerTag }}
-                enable_isolated_acr_push: true
-                enable_service_tree_acr_path: true
         - job: windowsContainers # build windows images
           dependsOn: download_external_libs
           displayName: Build docker image for windows
-          variables:
-            ob_git_checkout: true
           pool:
             type: docker
             os: windows
@@ -114,7 +102,6 @@ extends:
                 dockerFileRelPath: .azure\dockers\ob\windows\Dockerfile
                 dockerFileContextPath: .azure\dockers\ob\windows
                 enable_network: true
-                build_tag: ${{ parameters.DockerTag }}
+                build_tag: '$(Build.BuildNumber)'
                 enable_isolated_acr_push: true
                 enable_service_tree_acr_path: true
-

--- a/.azure/OneBranch.Docker.Official.yml
+++ b/.azure/OneBranch.Docker.Official.yml
@@ -38,7 +38,7 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
-  LinuxContainerImage: 'mcr.microsoft.com/onebranch/cbl-mariner/build:2.0'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
 
 resources:
   repositories:
@@ -66,12 +66,12 @@ extends:
       WindowsHostVersion: '1ESWindows2022'
 
     stages:
-      - stage: build_and_push_docker
+      - stage: docker
         jobs:
         - job: download_external_libs
           displayName: Download external libs
           pool:
-            type: linux  # read more about custom job types at https://aka.ms/obpipelines/yaml/jobs
+            type: windows  # read more about custom job types at https://aka.ms/obpipelines/yaml/jobs
           variables: # More settings at https://aka.ms/obpipelines/yaml/jobs
             ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault
           steps:
@@ -81,15 +81,16 @@ extends:
               inputs:
                 secureFile: 'xgameplatform.lib'
             - script: |
-                echo Copying $(xgameplatformlib.secureFilePath) to artifacts...
-                mkdir -p $(Build.SourcesDirectory)/out
-                cp $(xgameplatformlib.secureFilePath) $(Build.SourcesDirectory)/out
+                mkdir -p $(Build.SourcesDirectory)\out
+                copy $(xgameplatformlib.secureFilePath) $(Build.SourcesDirectory)\out
         - job: windowsContainers # build windows images
           dependsOn: download_external_libs
           displayName: Build docker image for windows
           pool:
             type: docker
             os: windows
+          variables:
+            ob_git_checkout: true
           steps:
             - task: DownloadPipelineArtifact@2
               displayName: '🔒 Download artifacts'


### PR DESCRIPTION
## Description

1. Clean up the official docker image build pipeline and make it run on every Saturday.
2. Make the pipeline triggered by any changes to the docker file.
3. The task for linux build docker has been removed because we don't use onebranch hosted docker images for linux builds.

## Testing

OB CI