### PR TITLE
Disable Tests for Global Execution Config in Kernel

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2478,6 +2478,7 @@ void QuicTestGlobalParam()
         }
     }
 
+#ifndef _KERNEL_MODE
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     //
     // QUIC_PARAM_GLOBAL_EXECUTION_CONFIG
@@ -2556,7 +2557,8 @@ void QuicTestGlobalParam()
                 nullptr));
 #endif // QUIC_USE_RAW_DATAPATH
     }
-#endif
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+#endif // !_KERNEL_MODE
 
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED
     //


### PR DESCRIPTION
## Description

When these tests are run on Windows, replacing the official msquic.sys, we cannot control if other *real* users run in parallel. So these tests that assume we run in a completely uninitialized global state cannot be run.

## Testing

Automation, but really, must ingest to validate.

## Documentation

N/A
