### PR TITLE
Prevent Path Removal Underflow

### DIFF
--- a/src/core/path.c
+++ b/src/core/path.c
@@ -53,7 +53,12 @@ QuicPathRemove(
     _In_ uint8_t Index
     )
 {
-    CXPLAT_DBG_ASSERT(Index < Connection->PathsCount);
+    CXPLAT_DBG_ASSERT(Connection->PathsCount > 0);
+    CXPLAT_TEL_ASSERTMSG(Index < Connection->PathsCount, "Invalid path removal!");
+    if (Index >= Connection->PathsCount) {
+        return;
+    }
+
     const QUIC_PATH* Path = &Connection->Paths[Index];
     QuicTraceLogConnInfo(
         PathRemoved,
@@ -250,6 +255,7 @@ QuicConnGetPathForDatagram(
             (Connection->PathsCount - 1) * sizeof(QUIC_PATH));
     }
 
+    CXPLAT_DBG_ASSERT(Connection->PathsCount < QUIC_MAX_PATH_COUNT);
     QUIC_PATH* Path = &Connection->Paths[1];
     QuicPathInitialize(Connection, Path);
     Connection->PathsCount++;

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -54,8 +54,8 @@ QuicPathRemove(
     )
 {
     CXPLAT_DBG_ASSERT(Connection->PathsCount > 0);
-    CXPLAT_TEL_ASSERTMSG(Index < Connection->PathsCount, "Invalid path removal!");
     if (Index >= Connection->PathsCount) {
+        CXPLAT_TEL_ASSERTMSG(Index < Connection->PathsCount, "Invalid path removal!");
         return;
     }
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -50,6 +50,11 @@ typedef struct QUIC_PATH {
     uint8_t ID;
 
     //
+    // Indicates the path object is actively in use.
+    //
+    BOOLEAN InUse : 1;
+
+    //
     // Indicates this is the primary path being used by the connection.
     //
     BOOLEAN IsActive : 1;


### PR DESCRIPTION
## Description

Add check for invalid path removal case. It shouldn't ever happen, but from some crashes I've seen, I suspect it might be happening.

## Testing

Existing automation

## Documentation

N/A
