### PR TITLE
Shutdown Stream on Send/Start Failure

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1141,7 +1141,7 @@ MsQuicStreamSend(
             Oper->API_CALL.Context = &Connection->BackupApiContext;
             Oper->API_CALL.Context->Type = QUIC_API_TYPE_CONN_SHUTDOWN;
             Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
-            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = QUIC_STATUS_OUT_OF_MEMORY;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = (QUIC_VAR_INT)QUIC_STATUS_OUT_OF_MEMORY;
             Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
             Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = TRUE;
             QuicConnQueueOper(Connection, Oper);

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -244,6 +244,7 @@ MsQuicConnectionShutdown(
     Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = Flags;
     Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = ErrorCode;
     Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
+    Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = FALSE;
 
     //
     // Queue the operation but don't wait for the completion.
@@ -1140,8 +1141,9 @@ MsQuicStreamSend(
             Oper->API_CALL.Context = &Connection->BackupApiContext;
             Oper->API_CALL.Context->Type = QUIC_API_TYPE_CONN_SHUTDOWN;
             Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
-            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = 0;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = QUIC_STATUS_OUT_OF_MEMORY;
             Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = TRUE;
             QuicConnQueueOper(Connection, Oper);
             goto Exit;
         }

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1040,6 +1040,11 @@ MsQuicStreamSend(
         (Connection->WorkerThreadID == CxPlatCurThreadID()) ||
         !Connection->State.HandleClosed);
 
+    if (Connection->State.ClosedRemotely) {
+        Status = QUIC_STATUS_ABORTED;
+        goto Exit;
+    }
+
     TotalLength = 0;
     for (uint32_t i = 0; i < BufferCount; ++i) {
         TotalLength += Buffers[i].Length;

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1142,6 +1142,7 @@ MsQuicStreamSend(
             Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
             Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = 0;
             Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
+            QuicConnQueueOper(Connection, Oper);
             goto Exit;
         }
         Oper->API_CALL.Context->Type = QUIC_API_TYPE_STRM_SEND;

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1359,8 +1359,9 @@ Exit:
             Oper->API_CALL.Context = &NewConnection->BackupApiContext;
             Oper->API_CALL.Context->Type = QUIC_API_TYPE_CONN_SHUTDOWN;
             Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
-            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = 0;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = QUIC_STATUS_INTERNAL_ERROR;
             Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = TRUE;
             QuicConnQueueOper(NewConnection, Oper);
         }
 #pragma warning(pop)

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1359,7 +1359,7 @@ Exit:
             Oper->API_CALL.Context = &NewConnection->BackupApiContext;
             Oper->API_CALL.Context->Type = QUIC_API_TYPE_CONN_SHUTDOWN;
             Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
-            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = QUIC_STATUS_INTERNAL_ERROR;
+            Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = (QUIC_VAR_INT)QUIC_STATUS_INTERNAL_ERROR;
             Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
             Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = TRUE;
             QuicConnQueueOper(NewConnection, Oper);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -438,7 +438,8 @@ QuicConnShutdown(
     _In_ QUIC_CONNECTION* Connection,
     _In_ uint32_t Flags,
     _In_ QUIC_VAR_INT ErrorCode,
-    _In_ BOOLEAN ShutdownFromRegistration
+    _In_ BOOLEAN ShutdownFromRegistration,
+    _In_ BOOLEAN ShutdownFromTransport
     )
 {
     if (ShutdownFromRegistration &&
@@ -447,7 +448,8 @@ QuicConnShutdown(
         return;
     }
 
-    uint32_t CloseFlags = QUIC_CLOSE_APPLICATION;
+    uint32_t CloseFlags =
+        ShutdownFromTransport ? QUIC_CLOSE_INTERNAL : QUIC_CLOSE_APPLICATION;
     if (Flags & QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT ||
         (!Connection->State.Started && QuicConnIsClient(Connection))) {
         CloseFlags |= QUIC_CLOSE_SILENT;
@@ -3330,6 +3332,7 @@ QuicConnQueueRouteCompletion(
         Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
         Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = QUIC_ERROR_INTERNAL_ERROR;
         Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = FALSE;
+        Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = TRUE;
         QuicConnQueueHighestPriorityOper(Connection, Oper);
     }
 
@@ -7312,7 +7315,8 @@ QuicConnProcessApiOperation(
             Connection,
             ApiCtx->CONN_SHUTDOWN.Flags,
             ApiCtx->CONN_SHUTDOWN.ErrorCode,
-            ApiCtx->CONN_SHUTDOWN.RegistrationShutdown);
+            ApiCtx->CONN_SHUTDOWN.RegistrationShutdown,
+            ApiCtx->CONN_SHUTDOWN.TransportShutdown);
         break;
 
     case QUIC_API_TYPE_CONN_START:

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -477,6 +477,7 @@ QuicConnUninitialize(
         Connection,
         QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT,
         QUIC_ERROR_NO_ERROR,
+        FALSE,
         FALSE);
 
     //
@@ -1870,7 +1871,7 @@ QuicConnStart(
     CxPlatDispatchLockRelease(&Connection->Registration->ConnectionLock);
 
     if (RegistrationShutingDown) {
-        QuicConnShutdown(Connection, ShutdownFlags, ShutdownErrorCode, FALSE);
+        QuicConnShutdown(Connection, ShutdownFlags, ShutdownErrorCode, FALSE, FALSE);
         if (ServerName != NULL) {
             CXPLAT_FREE(ServerName, QUIC_POOL_SERVERNAME);
         }

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -97,7 +97,8 @@ typedef struct QUIC_API_CONTEXT {
         } CONN_CLOSED;
         struct {
             QUIC_CONNECTION_SHUTDOWN_FLAGS Flags;
-            BOOLEAN RegistrationShutdown;
+            BOOLEAN RegistrationShutdown : 1;
+            BOOLEAN TransportShutdown : 1;
             QUIC_VAR_INT ErrorCode;
         } CONN_SHUTDOWN;
         struct {

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -240,6 +240,7 @@ MsQuicRegistrationShutdown(
                 Oper->API_CALL.Context->CONN_SHUTDOWN.Flags = Flags;
                 Oper->API_CALL.Context->CONN_SHUTDOWN.ErrorCode = ErrorCode;
                 Oper->API_CALL.Context->CONN_SHUTDOWN.RegistrationShutdown = TRUE;
+                Oper->API_CALL.Context->CONN_SHUTDOWN.TransportShutdown = FALSE;
                 QuicConnQueueHighestPriorityOper(Connection, Oper);
             }
 

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -609,7 +609,7 @@ QuicStreamSendFlush(
     if (Start) {
         (void)QuicStreamStart(
             Stream,
-            QUIC_STREAM_START_FLAG_IMMEDIATE,
+            QUIC_STREAM_START_FLAG_IMMEDIATE | QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL,
             FALSE);
     }
 


### PR DESCRIPTION
## Description

Fixes #3638 and #3639. In the rare case (OOM) that stream start fails when you use the `QUIC_SEND_FLAG_START` flag, it should be delivering a shutdown complete event to indicate this failure to start. Also fixes more event issues in the case of OOM in the send flush operation alloc path.

## Testing

Existing automation and manual testing from original bug opener.

## Documentation

N/A
