### PR TITLE
Build Processor Info for Max Processors

### DIFF
--- a/src/generated/linux/platform_winuser.c.clog.h
+++ b/src/generated/linux/platform_winuser.c.clog.h
@@ -63,8 +63,8 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserUnloaded );\
 // QuicTraceLogInfo(
         WindowsUserProcessorStateV2,
         "[ dll] Processors:%u, Groups:%u",
-        ActiveProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
-// arg2 = arg2 = ActiveProcessorCount = arg2
+        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
+// arg2 = arg2 = MaxProcessorCount = arg2
 // arg3 = arg3 = (uint32_t)Info->Group.ActiveGroupCount = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_WindowsUserProcessorStateV2
@@ -161,9 +161,9 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserUninitialized );\
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "CxPlatProcessorInfo",
-            ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
+            MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
 // arg2 = arg2 = "CxPlatProcessorInfo" = arg2
-// arg3 = arg3 = ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO) = arg3
+// arg3 = arg3 = MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO) = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_AllocFailure
 #define _clog_4_ARGS_TRACE_AllocFailure(uniqueId, encoded_arg_string, arg2, arg3)\

--- a/src/generated/linux/platform_winuser.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_winuser.c.clog.h.lttng.h
@@ -39,8 +39,8 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserUnloaded,
 // QuicTraceLogInfo(
         WindowsUserProcessorStateV2,
         "[ dll] Processors:%u, Groups:%u",
-        ActiveProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
-// arg2 = arg2 = ActiveProcessorCount = arg2
+        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
+// arg2 = arg2 = MaxProcessorCount = arg2
 // arg3 = arg3 = (uint32_t)Info->Group.ActiveGroupCount = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV2,
@@ -151,9 +151,9 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserUninitialized,
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "CxPlatProcessorInfo",
-            ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
+            MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
 // arg2 = arg2 = "CxPlatProcessorInfo" = arg2
-// arg3 = arg3 = ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO) = arg3
+// arg3 = arg3 = MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO) = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, AllocFailure,
     TP_ARGS(

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -86,21 +86,21 @@ CxPlatProcessorInfoInit(
     SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Info = NULL;
     uint32_t CurrentProcessorCount;
 
-    const uint32_t ActiveProcessorCount = CxPlatProcActiveCount();
+    const uint32_t MaxProcessorCount = CxPlatProcMaxCount();
 
-    CXPLAT_DBG_ASSERT(ActiveProcessorCount > 0);
-    CXPLAT_DBG_ASSERT(ActiveProcessorCount <= UINT16_MAX);
+    CXPLAT_DBG_ASSERT(MaxProcessorCount > 0);
+    CXPLAT_DBG_ASSERT(MaxProcessorCount <= UINT16_MAX);
     CXPLAT_DBG_ASSERT(CxPlatProcessorInfo == NULL);
     CxPlatProcessorInfo =
         CXPLAT_ALLOC_NONPAGED(
-            ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO),
+            MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO),
             QUIC_POOL_PLATFORM_PROC);
     if (CxPlatProcessorInfo == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
             "CxPlatProcessorInfo",
-            ActiveProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
+            MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO));
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
@@ -129,7 +129,7 @@ CxPlatProcessorInfoInit(
     QuicTraceLogInfo(
         WindowsUserProcessorStateV2,
         "[ dll] Processors:%u, Groups:%u",
-        ActiveProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
+        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
 
     CXPLAT_DBG_ASSERT(CxPlatProcessorGroupInfo == NULL);
     CxPlatProcessorGroupInfo =
@@ -150,13 +150,13 @@ CxPlatProcessorInfoInit(
     for (WORD i = 0; i < Info->Group.ActiveGroupCount; ++i) {
         CxPlatProcessorGroupInfo[i].Mask = Info->Group.GroupInfo[i].ActiveProcessorMask;
         CxPlatProcessorGroupInfo[i].Offset = CurrentProcessorCount;
-        CurrentProcessorCount += Info->Group.GroupInfo[i].ActiveProcessorCount;
+        CurrentProcessorCount += Info->Group.GroupInfo[i].MaximumProcessorCount;
     }
 
-    for (uint32_t Proc = 0; Proc < ActiveProcessorCount; ++Proc) {
+    for (uint32_t Proc = 0; Proc < MaxProcessorCount; ++Proc) {
         for (WORD Group = 0; Group < Info->Group.ActiveGroupCount; ++Group) {
             if (Proc >= CxPlatProcessorGroupInfo[Group].Offset &&
-                Proc < CxPlatProcessorGroupInfo[Group].Offset + Info->Group.GroupInfo[Group].ActiveProcessorCount) {
+                Proc < CxPlatProcessorGroupInfo[Group].Offset + Info->Group.GroupInfo[Group].MaximumProcessorCount) {
                 CxPlatProcessorInfo[Proc].Group = Group;
                 CxPlatProcessorInfo[Proc].Index = (Proc - CxPlatProcessorGroupInfo[Group].Offset);
                 QuicTraceLogInfo(
@@ -609,7 +609,7 @@ CxPlatProcActiveCount(
 
     Count = 0;
     for (WORD i = 0; i < ProcInfo->Group.ActiveGroupCount; i++) {
-        Count += ProcInfo->Group.GroupInfo[i].ActiveProcessorCount;
+        Count += ProcInfo->Group.GroupInfo[i].MaxProcessorCount;
     }
     CXPLAT_FREE(ProcInfo, QUIC_POOL_PLATFORM_TMP_ALLOC);
     CXPLAT_DBG_ASSERT(Count != 0);

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -609,7 +609,7 @@ CxPlatProcActiveCount(
 
     Count = 0;
     for (WORD i = 0; i < ProcInfo->Group.ActiveGroupCount; i++) {
-        Count += ProcInfo->Group.GroupInfo[i].MaxProcessorCount;
+        Count += ProcInfo->Group.GroupInfo[i].ActiveProcessorCount;
     }
     CXPLAT_FREE(ProcInfo, QUIC_POOL_PLATFORM_TMP_ALLOC);
     CXPLAT_DBG_ASSERT(Count != 0);


### PR DESCRIPTION
## Description

We're incorrectly building our processor mapping tables for only the active processor count, but then using max to look up in the table.

## Testing

Existing + manual (WIP)

## Documentation

N/A
