### PR TITLE
Fix transport error code for new alpn negotiation

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -2697,7 +2697,7 @@ QuicCryptoReNegotiateAlpn(
             "No ALPN match found");
         QuicConnTransportError(
             Connection,
-            QUIC_ERROR_INTERNAL_ERROR);
+            QUIC_ERROR_CRYPTO_NO_APPLICATION_PROTOCOL);
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -3410,14 +3410,14 @@ QuicTestChangeAlpn(
             {
                 UniquePtr<TestConnection> Server;
                 ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
-                ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_INTERNAL_ERROR;
+                ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_ALPN_NEG_FAILURE;
                 Listener.Context = &ServerAcceptCtx;
 
                 {
                     TestConnection Client(Registration);
                     TEST_TRUE(Client.IsValid());
 
-                    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_INTERNAL_ERROR);
+                    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_ALPN_NEG_FAILURE);
 
                     TEST_QUIC_SUCCEEDED(
                         Client.Start(


### PR DESCRIPTION
## Description

Currently, while we're narrowing down the ALPN list with ReNegotiation, if we can't negotiate with client on ALPN, we're closing the connection with `QUIC_ERROR_INTERNAL_ERROR`, but looks like it should be `QUIC_ERROR_CRYPTO_NO_APPLICATION_PROTOCOL`.

## Testing

I've updated the necessary unit test, but this is a breaking change since we're changing close status behavior.

## Documentation

No
