### PR TITLE
Current Partition instead of Current Processor

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1637,7 +1637,7 @@ QuicBindingReceive(
     // connection it was delivered to.
     //
 
-    uint32_t Proc = CxPlatProcCurrentNumber();
+    uint16_t Proc = QuicLibraryGetCurrentPartition();
     uint64_t ProcShifted = ((uint64_t)Proc + 1) << 40;
 
     CXPLAT_RECV_DATA* Datagram;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -64,7 +64,7 @@ QuicConnAlloc(
     )
 {
     BOOLEAN IsServer = Datagram != NULL;
-    uint32_t CurProcIndex = CxPlatProcCurrentNumber();
+    uint16_t CurProcIndex = QuicLibraryGetCurrentPartition();
     *NewConnection = NULL;
     QUIC_STATUS Status;
 
@@ -402,7 +402,7 @@ QuicConnFree(
     if (Connection->HandshakeTP != NULL) {
         QuicCryptoTlsCleanupTransportParameters(Connection->HandshakeTP);
         CxPlatPoolFree(
-            &MsQuicLib.PerProc[CxPlatProcCurrentNumber()].TransportParamPool,
+            &QuicLibraryGetPerProc()->TransportParamPool,
             Connection->HandshakeTP);
         Connection->HandshakeTP = NULL;
     }
@@ -423,7 +423,7 @@ QuicConnFree(
         "[conn][%p] Destroyed",
         Connection);
     CxPlatPoolFree(
-        &MsQuicLib.PerProc[CxPlatProcCurrentNumber()].ConnectionPool,
+        &QuicLibraryGetPerProc()->ConnectionPool,
         Connection);
 
 #if DEBUG
@@ -2305,7 +2305,7 @@ QuicConnCleanupServerResumptionState(
         if (Connection->HandshakeTP != NULL) {
             QuicCryptoTlsCleanupTransportParameters(Connection->HandshakeTP);
             CxPlatPoolFree(
-                &MsQuicLib.PerProc[CxPlatProcCurrentNumber()].TransportParamPool,
+                &MsQuicLib.PerProc[QuicLibraryGetCurrentPartition()].TransportParamPool,
                 Connection->HandshakeTP);
             Connection->HandshakeTP = NULL;
         }
@@ -7208,7 +7208,7 @@ QuicConnApplyNewSettings(
             Connection->HandshakeTP == NULL) {
             CXPLAT_DBG_ASSERT(!Connection->State.Started);
             Connection->HandshakeTP =
-                CxPlatPoolAlloc(&MsQuicLib.PerProc[CxPlatProcCurrentNumber()].TransportParamPool);
+                CxPlatPoolAlloc(&QuicLibraryGetPerProc()->TransportParamPool);
             if (Connection->HandshakeTP == NULL) {
                 QuicTraceEvent(
                     AllocFailure,

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -145,6 +145,11 @@ QuicLibraryGetCurrentPartition(
     void
     );
 
+QUIC_LIBRARY_PP*
+QuicLibraryGetPerProc(
+    void
+    );
+
 _IRQL_requires_max_(DISPATCH_LEVEL)
 uint16_t
 QuicPartitionIdCreate(

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -2319,16 +2319,16 @@ QuicLibraryGenerateStatelessResetToken(
     )
 {
     uint8_t HashOutput[CXPLAT_HASH_SHA256_SIZE];
-    uint32_t CurProcIndex = CxPlatProcCurrentNumber();
-    CxPlatLockAcquire(&MsQuicLib.PerProc[CurProcIndex].ResetTokenLock);
+    QUIC_LIBRARY_PP* PerProc = QuicLibraryGetPerProc();
+    CxPlatLockAcquire(&PerProc->ResetTokenLock);
     QUIC_STATUS Status =
         CxPlatHashCompute(
-            MsQuicLib.PerProc[CurProcIndex].ResetTokenHash,
+            PerProc->ResetTokenHash,
             CID,
             MsQuicLib.CidTotalLength,
             sizeof(HashOutput),
             HashOutput);
-    CxPlatLockRelease(&MsQuicLib.PerProc[CurProcIndex].ResetTokenLock);
+    CxPlatLockRelease(&PerProc->ResetTokenLock);
     if (QUIC_SUCCEEDED(Status)) {
         CxPlatCopyMemory(
             ResetToken,

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -300,6 +300,16 @@ QuicLibraryGetCurrentPartition(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 inline
+QUIC_LIBRARY_PP*
+QuicLibraryGetPerProc(
+    void
+    )
+{
+    return &MsQuicLib.PerProc[QuicLibraryGetCurrentProcessor()];
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+inline
 uint16_t
 QuicPartitionIdCreate(
     uint16_t BaseIndex
@@ -366,9 +376,7 @@ QuicPerfCounterAdd(
     )
 {
     CXPLAT_DBG_ASSERT(Type >= 0 && Type < QUIC_PERF_COUNTER_MAX);
-    uint32_t ProcIndex = CxPlatProcCurrentNumber();
-    CXPLAT_DBG_ASSERT(ProcIndex < (uint32_t)MsQuicLib.PartitionCount);
-    InterlockedExchangeAdd64(&(MsQuicLib.PerProc[ProcIndex].PerfCounters[Type]), Value);
+    InterlockedExchangeAdd64(&(QuicLibraryGetPerProc()->PerfCounters[Type]), Value);
 }
 
 #define QuicPerfCounterIncrement(Type) QuicPerfCounterAdd(Type, 1)

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -305,7 +305,7 @@ QuicLibraryGetPerProc(
     void
     )
 {
-    return &MsQuicLib.PerProc[QuicLibraryGetCurrentProcessor()];
+    return &MsQuicLib.PerProc[QuicLibraryGetCurrentPartition()];
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -218,7 +218,7 @@ QuicPacketBuilderPrepare(
     // the current one doesn't match, finalize it and then start a new one.
     //
 
-    uint32_t Proc = CxPlatProcCurrentNumber();
+    uint16_t Proc = QuicLibraryGetCurrentPartition();
     uint64_t ProcShifted = ((uint64_t)Proc + 1) << 40;
 
     BOOLEAN NewQuicPacket = FALSE;

--- a/src/core/packet_space.c
+++ b/src/core/packet_space.c
@@ -23,8 +23,7 @@ QuicPacketSpaceInitialize(
     _Out_ QUIC_PACKET_SPACE** NewPackets
     )
 {
-    uint32_t CurProcIndex = CxPlatProcCurrentNumber();
-    QUIC_PACKET_SPACE* Packets = CxPlatPoolAlloc(&MsQuicLib.PerProc[CurProcIndex].PacketSpacePool);
+    QUIC_PACKET_SPACE* Packets = CxPlatPoolAlloc(&QuicLibraryGetPerProc()->PacketSpacePool);
     if (Packets == NULL) {
         QuicTraceEvent(
             AllocFailure,
@@ -62,9 +61,7 @@ QuicPacketSpaceUninitialize(
     }
 
     QuicAckTrackerUninitialize(&Packets->AckTracker);
-
-    uint32_t CurProcIndex = CxPlatProcCurrentNumber();
-    CxPlatPoolFree(&MsQuicLib.PerProc[CurProcIndex].PacketSpacePool, Packets);
+    CxPlatPoolFree(&QuicLibraryGetPerProc()->PacketSpacePool, Packets);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)


### PR DESCRIPTION
## Description

Updates the code to use current partition everywhere instead of current processor directly, because current processor may be beyond the allowable partitions.

## Testing

Automation

## Documentation

N/A
