### PR TITLE
Correctly handle XdpOpenAPi failure

### DIFF
--- a/src/platform/datapath_raw_xdp.c
+++ b/src/platform/datapath_raw_xdp.c
@@ -1054,13 +1054,13 @@ CxPlatDpRawInitialize(
     QUIC_STATUS Status;
     const uint16_t* ProcessorList;
 
+    CxPlatListInitializeHead(&Xdp->Interfaces);
     if (QUIC_FAILED(XdpOpenApi(XDP_VERSION_PRERELEASE, &Xdp->XdpApi))) {
         Status = QUIC_STATUS_NOT_SUPPORTED;
         goto Error;
     }
 
     CxPlatXdpReadConfig(Xdp);
-    CxPlatListInitializeHead(&Xdp->Interfaces);
     Xdp->PollingIdleTimeoutUs = Config ? Config->PollingIdleTimeoutUs : 0;
 
     if (Config && Config->ProcessorCount) {


### PR DESCRIPTION
## Description

The interface list is initialized after calling XdpOpenAPI. When XdpOpenAPI fails, the code checks an uninitialized list, which triggers an AV.

Found by @pongba.

## Testing

Not covered.
