### PR TITLE
Support Delaying Stream ID FC Updates to StreamClose

### DIFF
--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -176,6 +176,8 @@ Value | Meaning
 **QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL**<br>1 | A unidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_0_RTT**<br>2 | The stream was received in 0-RTT.
 
+If a server wishes to use `QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES` for the newly started stream, it may append this flag to `Flags` before it returns from the callback.
+
 ## QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE
 
 This event indicates the number of streams the peer is willing to accept has changed.

--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -176,7 +176,7 @@ Value | Meaning
 **QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL**<br>1 | A unidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_0_RTT**<br>2 | The stream was received in 0-RTT.
 
-If a server wishes to use `QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES` for the newly started stream, it may append this flag to `Flags` before it returns from the callback.
+If a server wishes to use `QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES` for the newly started stream, it may append this flag to `Flags` before it returns from the callback.
 
 ## QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE
 

--- a/docs/api/StreamOpen.md
+++ b/docs/api/StreamOpen.md
@@ -34,7 +34,7 @@ Value | Meaning
 **QUIC_STREAM_OPEN_FLAG_NONE**<br>0 | No special behavior. Defaults to bidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL**<br>1 | Opens a unidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_0_RTT**<br>2 | Indicates that the stream may be sent in 0-RTT.
-**QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES**<br>4 | Indicates stream flow control limit updates for the connection should be delayed to StreamClose.
+**QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES**<br>4 | Indicates stream flow control limit updates for the connection should be delayed to StreamClose.
 
 `Handler`
 

--- a/docs/api/StreamOpen.md
+++ b/docs/api/StreamOpen.md
@@ -34,6 +34,7 @@ Value | Meaning
 **QUIC_STREAM_OPEN_FLAG_NONE**<br>0 | No special behavior. Defaults to bidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL**<br>1 | Opens a unidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_0_RTT**<br>2 | Indicates that the stream may be sent in 0-RTT.
+**QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES**<br>4 | Indicates stream flow control limit updates for the connection should be delayed to StreamClose.
 
 `Handler`
 

--- a/docs/api/StreamOpen.md
+++ b/docs/api/StreamOpen.md
@@ -34,7 +34,7 @@ Value | Meaning
 **QUIC_STREAM_OPEN_FLAG_NONE**<br>0 | No special behavior. Defaults to bidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL**<br>1 | Opens a unidirectional stream.
 **QUIC_STREAM_OPEN_FLAG_0_RTT**<br>2 | Indicates that the stream may be sent in 0-RTT.
-**QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES**<br>4 | Indicates stream flow control limit updates for the connection should be delayed to StreamClose.
+**QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES**<br>4 | Indicates stream ID flow control limit updates for the connection should be delayed to StreamClose.
 
 `Handler`
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -658,13 +658,7 @@ MsQuicStreamOpen(
         goto Error;
     }
 
-    Status =
-        QuicStreamInitialize(
-            Connection,
-            FALSE,
-            !!(Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL),
-            !!(Flags & QUIC_STREAM_OPEN_FLAG_0_RTT),
-            (QUIC_STREAM**)NewStream);
+    Status = QuicStreamInitialize(Connection, FALSE, Flags, (QUIC_STREAM**)NewStream);
     if (QUIC_FAILED(Status)) {
         goto Error;
     }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1561,6 +1561,12 @@ QuicConnTryClose(
         return;
     }
 
+    if (ClosedRemotely) {
+        Connection->State.ClosedRemotely = TRUE;
+    } else {
+        Connection->State.ClosedLocally = TRUE;
+    }
+
     if (!ClosedRemotely) {
 
         if ((Flags & QUIC_CLOSE_APPLICATION) &&
@@ -1674,12 +1680,6 @@ QuicConnTryClose(
         }
 
         IsFirstCloseForConnection = FALSE;
-    }
-
-    if (ClosedRemotely) {
-        Connection->State.ClosedRemotely = TRUE;
-    } else {
-        Connection->State.ClosedLocally = TRUE;
     }
 
     if (IsFirstCloseForConnection) {

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -56,8 +56,8 @@ QuicStreamInitialize(
     Stream->ID = UINT64_MAX;
     Stream->Flags.Unidirectional = !!(Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL);
     Stream->Flags.Opened0Rtt = !!(Flags & QUIC_STREAM_OPEN_FLAG_0_RTT);
-    Stream->Flags.DelayFCUpdate = !!(Flags & QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES);
-    if (Stream->Flags.DelayFCUpdate) {
+    Stream->Flags.DelayIdFcUpdate = !!(Flags & QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES);
+    if (Stream->Flags.DelayIdFcUpdate) {
         QuicTraceLogStreamVerbose(
             ConfiguredForDelayedFC,
             Stream,
@@ -394,7 +394,7 @@ QuicStreamClose(
         }
     }
 
-    if (Stream->Flags.DelayFCUpdate && Stream->Flags.ShutdownComplete) {
+    if (Stream->Flags.DelayIdFcUpdate && Stream->Flags.ShutdownComplete) {
         //
         // Indicate the stream is completely shut down to the connection.
         //
@@ -607,7 +607,7 @@ QuicStreamTryCompleteShutdown(
         //
         // Indicate the stream is completely shut down to the connection.
         //
-        if (!Stream->Flags.DelayFCUpdate || Stream->Flags.HandleClosed) {
+        if (!Stream->Flags.DelayIdFcUpdate || Stream->Flags.HandleClosed) {
             QuicStreamSetReleaseStream(&Stream->Connection->Streams, Stream);
         }
     }

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -390,17 +390,17 @@ QuicStreamClose(
             // since nothing else can be done with it now.
             //
             Stream->Flags.ShutdownComplete = TRUE;
+            CXPLAT_DBG_ASSERT(!Stream->Flags.InStreamTable);
         }
-    }
 
-    Stream->ClientCallbackHandler = NULL;
-
-    if (Stream->Flags.DelayFCUpdate) {
+    } else if (Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //
         QuicStreamSetReleaseStream(&Stream->Connection->Streams, Stream);
     }
+
+    Stream->ClientCallbackHandler = NULL;
 
     QuicStreamRelease(Stream, QUIC_STREAM_REF_APP);
 }

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -57,6 +57,12 @@ QuicStreamInitialize(
     Stream->Flags.Unidirectional = !!(Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL);
     Stream->Flags.Opened0Rtt = !!(Flags & QUIC_STREAM_OPEN_FLAG_0_RTT);
     Stream->Flags.DelayFCUpdate = !!(Flags & QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES);
+    if (Stream->Flags.DelayFCUpdate) {
+        QuicTraceLogStreamVerbose(
+            ConfiguredForDelayedFC,
+            Stream,
+            "Configured for delayed FC updates");
+    }
     Stream->Flags.Allocated = TRUE;
     Stream->Flags.SendEnabled = TRUE;
     Stream->Flags.ReceiveEnabled = TRUE;

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -393,7 +393,9 @@ QuicStreamClose(
             CXPLAT_DBG_ASSERT(!Stream->Flags.InStreamTable);
         }
 
-    } else if (Stream->Flags.DelayFCUpdate) {
+    }
+
+    if (Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -388,7 +388,7 @@ QuicStreamClose(
 
     Stream->ClientCallbackHandler = NULL;
 
-    if (Stream->Flags.Started && Stream->Flags.DelayFCUpdate) {
+    if (Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //
@@ -532,7 +532,7 @@ QuicStreamOnShutdownComplete(
         Stream->ClientCallbackHandler = NULL;
     }
 
-    if (Stream->Flags.Started && !Stream->Flags.DelayFCUpdate) {
+    if (!Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -376,19 +376,19 @@ QuicStreamClose(
                 QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE,
             QUIC_ERROR_NO_ERROR);
 
-            if (!Stream->Flags.Started) {
-                //
-                // The stream was abandoned before it could be successfully
-                // started. Just mark it as completing the shutdown process now
-                // since nothing else can be done with it now.
-                //
-                Stream->Flags.ShutdownComplete = TRUE;
-            }
+        if (!Stream->Flags.Started) {
+            //
+            // The stream was abandoned before it could be successfully
+            // started. Just mark it as completing the shutdown process now
+            // since nothing else can be done with it now.
+            //
+            Stream->Flags.ShutdownComplete = TRUE;
+        }
     }
 
     Stream->ClientCallbackHandler = NULL;
 
-    if (Stream->Flags.DelayFCUpdate) {
+    if (Stream->Flags.Started && Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -491,6 +491,7 @@ QuicStreamIndicateShutdownComplete(
     _In_ QUIC_STREAM* Stream
     )
 {
+    Stream->Flags.ShutdownComplete = TRUE;
     if (!Stream->Flags.HandleShutdown) {
         Stream->Flags.HandleShutdown = TRUE;
 
@@ -593,7 +594,6 @@ QuicStreamTryCompleteShutdown(
         // Mark the stream as shut down and deliver the completion notification
         // to the application layer.
         //
-        Stream->Flags.ShutdownComplete = TRUE;
         QuicStreamIndicateShutdownComplete(Stream);
 
         if (!Stream->Flags.DelayFCUpdate) {

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -532,7 +532,7 @@ QuicStreamOnShutdownComplete(
         Stream->ClientCallbackHandler = NULL;
     }
 
-    if (!Stream->Flags.DelayFCUpdate) {
+    if (Stream->Flags.Started && !Stream->Flags.DelayFCUpdate) {
         //
         // Indicate the stream is completely shut down to the connection.
         //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -59,9 +59,9 @@ QuicStreamInitialize(
     Stream->Flags.DelayIdFcUpdate = !!(Flags & QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES);
     if (Stream->Flags.DelayIdFcUpdate) {
         QuicTraceLogStreamVerbose(
-            ConfiguredForDelayedFC,
+            ConfiguredForDelayedIDFC,
             Stream,
-            "Configured for delayed FC updates");
+            "Configured for delayed ID FC updates");
     }
     Stream->Flags.Allocated = TRUE;
     Stream->Flags.SendEnabled = TRUE;

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -360,7 +360,7 @@ QuicStreamClose(
 
     if (!Stream->Flags.ShutdownComplete) {
 
-        if (Stream->Flags.Started) {
+        if (Stream->Flags.Started && !Stream->Flags.HandleShutdown) {
             //
             // TODO - If the stream hasn't been aborted already, then this is a
             // fatal error for the connection. The QUIC transport cannot "just

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -392,10 +392,9 @@ QuicStreamClose(
             Stream->Flags.ShutdownComplete = TRUE;
             CXPLAT_DBG_ASSERT(!Stream->Flags.InStreamTable);
         }
-
     }
 
-    if (Stream->Flags.DelayFCUpdate) {
+    if (Stream->Flags.DelayFCUpdate && Stream->Flags.ShutdownComplete) {
         //
         // Indicate the stream is completely shut down to the connection.
         //
@@ -608,10 +607,7 @@ QuicStreamTryCompleteShutdown(
         //
         // Indicate the stream is completely shut down to the connection.
         //
-        if (!Stream->Flags.DelayFCUpdate) {
-            //
-            // Indicate the stream is completely shut down to the connection.
-            //
+        if (!Stream->Flags.DelayFCUpdate || Stream->Flags.HandleClosed) {
             QuicStreamSetReleaseStream(&Stream->Connection->Streams, Stream);
         }
     }

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -150,6 +150,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Uninitialized           : 1;    // Uninitialize started/completed. Used for Debugging.
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
+        BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
         BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -149,6 +149,8 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN ShutdownComplete        : 1;    // Both directions have been shutdown and acknowledged.
         BOOLEAN Uninitialized           : 1;    // Uninitialize started/completed. Used for Debugging.
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
+
+        BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;
 
@@ -528,8 +530,7 @@ QUIC_STATUS
 QuicStreamInitialize(
     _In_ QUIC_CONNECTION* Connection,
     _In_ BOOLEAN OpenedRemotely,
-    _In_ BOOLEAN Unidirectional,
-    _In_ BOOLEAN Opened0Rtt,
+    _In_ QUIC_STREAM_OPEN_FLAGS Flags,
     _Outptr_ _At_(*Stream, __drv_allocatesMem(Mem))
         QUIC_STREAM** Stream
     );

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -151,7 +151,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
         BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
-        BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
+        BOOLEAN DelayIdFcUpdate         : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;
 

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -110,6 +110,7 @@ QuicStreamSetInsertStream(
             return FALSE;
         }
     }
+    Stream->Flags.InStreamTable = TRUE;
     CxPlatHashtableInsert(
         StreamSet->StreamTable,
         &Stream->TableEntry,
@@ -177,6 +178,11 @@ QuicStreamSetReleaseStream(
     _In_ QUIC_STREAM* Stream
     )
 {
+    if (!Stream->Flags.InStreamTable) {
+        return;
+    }
+    Stream->Flags.InStreamTable = FALSE;
+
     //
     // Remove the stream from the list of open streams.
     //

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -723,8 +723,8 @@ QuicStreamSetGetStreamForPeer(
                 CXPLAT_FRE_ASSERTMSG(
                     Stream->ClientCallbackHandler != NULL,
                     "App MUST set callback handler!");
-                if (Event.PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES) {
-                    Stream->Flags.DelayFCUpdate = TRUE;
+                if (Event.PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES) {
+                    Stream->Flags.DelayIdFcUpdate = TRUE;
                     QuicTraceLogStreamVerbose(
                         ConfiguredForDelayedFC,
                         Stream,

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -726,9 +726,9 @@ QuicStreamSetGetStreamForPeer(
                 if (Event.PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES) {
                     Stream->Flags.DelayIdFcUpdate = TRUE;
                     QuicTraceLogStreamVerbose(
-                        ConfiguredForDelayedFC,
+                        ConfiguredForDelayedIDFC,
                         Stream,
-                        "Configured for delayed FC updates");
+                        "Configured for delayed ID FC updates");
                 }
             }
 

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -725,6 +725,10 @@ QuicStreamSetGetStreamForPeer(
                     "App MUST set callback handler!");
                 if (Event.PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES) {
                     Stream->Flags.DelayFCUpdate = TRUE;
+                    QuicTraceLogStreamVerbose(
+                        ConfiguredForDelayedFC,
+                        Stream,
+                        "Configured for delayed FC updates");
                 }
             }
 

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Quic
         NONE = 0x0000,
         UNIDIRECTIONAL = 0x0001,
         ZERO_RTT = 0x0002,
+        DELAY_FC_UPDATES = 0x0004,
     }
 
     [System.Flags]

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Quic
         NONE = 0x0000,
         UNIDIRECTIONAL = 0x0001,
         ZERO_RTT = 0x0002,
-        DELAY_FC_UPDATES = 0x0004,
+        DELAY_ID_FC_UPDATES = 0x0004,
     }
 
     [System.Flags]

--- a/src/generated/linux/stream.c.clog.h
+++ b/src/generated/linux/stream.c.clog.h
@@ -90,6 +90,24 @@ tracepoint(CLOG_STREAM_C, UpdatePriority , arg1, arg3);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for ConfiguredForDelayedFC
+// [strm][%p] Configured for delayed FC updates
+// QuicTraceLogStreamVerbose(
+            ConfiguredForDelayedFC,
+            Stream,
+            "Configured for delayed FC updates");
+// arg1 = arg1 = Stream = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedFC
+#define _clog_3_ARGS_TRACE_ConfiguredForDelayedFC(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_STREAM_C, ConfiguredForDelayedFC , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for IndicateStartComplete
 // [strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]
 // QuicTraceLogStreamVerbose(

--- a/src/generated/linux/stream.c.clog.h
+++ b/src/generated/linux/stream.c.clog.h
@@ -90,17 +90,17 @@ tracepoint(CLOG_STREAM_C, UpdatePriority , arg1, arg3);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConfiguredForDelayedFC
-// [strm][%p] Configured for delayed FC updates
+// Decoder Ring for ConfiguredForDelayedIDFC
+// [strm][%p] Configured for delayed ID FC updates
 // QuicTraceLogStreamVerbose(
-            ConfiguredForDelayedFC,
+            ConfiguredForDelayedIDFC,
             Stream,
-            "Configured for delayed FC updates");
+            "Configured for delayed ID FC updates");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedFC
-#define _clog_3_ARGS_TRACE_ConfiguredForDelayedFC(uniqueId, arg1, encoded_arg_string)\
-tracepoint(CLOG_STREAM_C, ConfiguredForDelayedFC , arg1);\
+#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedIDFC
+#define _clog_3_ARGS_TRACE_ConfiguredForDelayedIDFC(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_STREAM_C, ConfiguredForDelayedIDFC , arg1);\
 
 #endif
 

--- a/src/generated/linux/stream.c.clog.h.lttng.h
+++ b/src/generated/linux/stream.c.clog.h.lttng.h
@@ -63,6 +63,25 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, UpdatePriority,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for ConfiguredForDelayedFC
+// [strm][%p] Configured for delayed FC updates
+// QuicTraceLogStreamVerbose(
+            ConfiguredForDelayedFC,
+            Stream,
+            "Configured for delayed FC updates");
+// arg1 = arg1 = Stream = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_STREAM_C, ConfiguredForDelayedFC,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for IndicateStartComplete
 // [strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]
 // QuicTraceLogStreamVerbose(

--- a/src/generated/linux/stream.c.clog.h.lttng.h
+++ b/src/generated/linux/stream.c.clog.h.lttng.h
@@ -63,15 +63,15 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, UpdatePriority,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConfiguredForDelayedFC
-// [strm][%p] Configured for delayed FC updates
+// Decoder Ring for ConfiguredForDelayedIDFC
+// [strm][%p] Configured for delayed ID FC updates
 // QuicTraceLogStreamVerbose(
-            ConfiguredForDelayedFC,
+            ConfiguredForDelayedIDFC,
             Stream,
-            "Configured for delayed FC updates");
+            "Configured for delayed ID FC updates");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_STREAM_C, ConfiguredForDelayedFC,
+TRACEPOINT_EVENT(CLOG_STREAM_C, ConfiguredForDelayedIDFC,
     TP_ARGS(
         const void *, arg1), 
     TP_FIELDS(

--- a/src/generated/linux/stream_set.c.clog.h
+++ b/src/generated/linux/stream_set.c.clog.h
@@ -76,6 +76,24 @@ tracepoint(CLOG_STREAM_SET_C, IndicatePeerAccepted , arg1);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for ConfiguredForDelayedFC
+// [strm][%p] Configured for delayed FC updates
+// QuicTraceLogStreamVerbose(
+                        ConfiguredForDelayedFC,
+                        Stream,
+                        "Configured for delayed FC updates");
+// arg1 = arg1 = Stream = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedFC
+#define _clog_3_ARGS_TRACE_ConfiguredForDelayedFC(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_STREAM_SET_C, ConfiguredForDelayedFC , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for MaxStreamCountUpdated
 // [conn][%p] App configured max stream count of %hu (type=%hhu).
 // QuicTraceLogConnInfo(

--- a/src/generated/linux/stream_set.c.clog.h
+++ b/src/generated/linux/stream_set.c.clog.h
@@ -76,17 +76,17 @@ tracepoint(CLOG_STREAM_SET_C, IndicatePeerAccepted , arg1);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConfiguredForDelayedFC
-// [strm][%p] Configured for delayed FC updates
+// Decoder Ring for ConfiguredForDelayedIDFC
+// [strm][%p] Configured for delayed ID FC updates
 // QuicTraceLogStreamVerbose(
-                        ConfiguredForDelayedFC,
+                        ConfiguredForDelayedIDFC,
                         Stream,
-                        "Configured for delayed FC updates");
+                        "Configured for delayed ID FC updates");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedFC
-#define _clog_3_ARGS_TRACE_ConfiguredForDelayedFC(uniqueId, arg1, encoded_arg_string)\
-tracepoint(CLOG_STREAM_SET_C, ConfiguredForDelayedFC , arg1);\
+#ifndef _clog_3_ARGS_TRACE_ConfiguredForDelayedIDFC
+#define _clog_3_ARGS_TRACE_ConfiguredForDelayedIDFC(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_STREAM_SET_C, ConfiguredForDelayedIDFC , arg1);\
 
 #endif
 

--- a/src/generated/linux/stream_set.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_set.c.clog.h.lttng.h
@@ -44,6 +44,25 @@ TRACEPOINT_EVENT(CLOG_STREAM_SET_C, IndicatePeerAccepted,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for ConfiguredForDelayedFC
+// [strm][%p] Configured for delayed FC updates
+// QuicTraceLogStreamVerbose(
+                        ConfiguredForDelayedFC,
+                        Stream,
+                        "Configured for delayed FC updates");
+// arg1 = arg1 = Stream = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_STREAM_SET_C, ConfiguredForDelayedFC,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for MaxStreamCountUpdated
 // [conn][%p] App configured max stream count of %hu (type=%hhu).
 // QuicTraceLogConnInfo(

--- a/src/generated/linux/stream_set.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_set.c.clog.h.lttng.h
@@ -44,15 +44,15 @@ TRACEPOINT_EVENT(CLOG_STREAM_SET_C, IndicatePeerAccepted,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConfiguredForDelayedFC
-// [strm][%p] Configured for delayed FC updates
+// Decoder Ring for ConfiguredForDelayedIDFC
+// [strm][%p] Configured for delayed ID FC updates
 // QuicTraceLogStreamVerbose(
-                        ConfiguredForDelayedFC,
+                        ConfiguredForDelayedIDFC,
                         Stream,
-                        "Configured for delayed FC updates");
+                        "Configured for delayed ID FC updates");
 // arg1 = arg1 = Stream = arg1
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_STREAM_SET_C, ConfiguredForDelayedFC,
+TRACEPOINT_EVENT(CLOG_STREAM_SET_C, ConfiguredForDelayedIDFC,
     TP_ARGS(
         const void *, arg1), 
     TP_FIELDS(

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -191,6 +191,8 @@ typedef enum QUIC_STREAM_OPEN_FLAGS {
     QUIC_STREAM_OPEN_FLAG_NONE              = 0x0000,
     QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL    = 0x0001,   // Indicates the stream is unidirectional.
     QUIC_STREAM_OPEN_FLAG_0_RTT             = 0x0002,   // The stream was opened via a 0-RTT packet.
+    QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES  = 0x0004,   // Indicates stream flow control limit updates for the connection
+                                                        // should be delayed to StreamClose.
 } QUIC_STREAM_OPEN_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_OPEN_FLAGS)

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -191,8 +191,8 @@ typedef enum QUIC_STREAM_OPEN_FLAGS {
     QUIC_STREAM_OPEN_FLAG_NONE              = 0x0000,
     QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL    = 0x0001,   // Indicates the stream is unidirectional.
     QUIC_STREAM_OPEN_FLAG_0_RTT             = 0x0002,   // The stream was opened via a 0-RTT packet.
-    QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES  = 0x0004,   // Indicates stream flow control limit updates for the connection
-                                                        // should be delayed to StreamClose.
+    QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES = 0x0004, // Indicates stream ID flow control limit updates for the
+                                                        // connection should be delayed to StreamClose.
 } QUIC_STREAM_OPEN_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(QUIC_STREAM_OPEN_FLAGS)

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -963,10 +963,10 @@
       ],
       "macroName": "QuicTraceLogInfo"
     },
-    "ConfiguredForDelayedFC": {
+    "ConfiguredForDelayedIDFC": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Configured for delayed FC updates",
-      "UniqueId": "ConfiguredForDelayedFC",
+      "TraceString": "[strm][%p] Configured for delayed ID FC updates",
+      "UniqueId": "ConfiguredForDelayedIDFC",
       "splitArgs": [
         {
           "DefinationEncoding": "p",
@@ -12779,9 +12779,9 @@
         "EncodingString": "[cnfg][%p] Settings %p Updated"
       },
       {
-        "UniquenessHash": "c80d64df-1584-30c7-6659-f2bba46a5fbb",
-        "TraceID": "ConfiguredForDelayedFC",
-        "EncodingString": "[strm][%p] Configured for delayed FC updates"
+        "UniquenessHash": "fd83d3d8-994b-ccc3-13b9-cf8de77990ca",
+        "TraceID": "ConfiguredForDelayedIDFC",
+        "EncodingString": "[strm][%p] Configured for delayed ID FC updates"
       },
       {
         "UniquenessHash": "905ba7f9-0427-2d53-7d13-88f2bb532bf0",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -963,6 +963,18 @@
       ],
       "macroName": "QuicTraceLogInfo"
     },
+    "ConfiguredForDelayedFC": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Configured for delayed FC updates",
+      "UniqueId": "ConfiguredForDelayedFC",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
+    },
     "ConnAppShutdown": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] App Shutdown: %llu (Remote=%hhu)",
@@ -12765,6 +12777,11 @@
         "UniquenessHash": "e104b282-92ce-2322-3af0-f59ccaabf2f1",
         "TraceID": "ConfigurationSettingsUpdated",
         "EncodingString": "[cnfg][%p] Settings %p Updated"
+      },
+      {
+        "UniquenessHash": "c80d64df-1584-30c7-6659-f2bba46a5fbb",
+        "TraceID": "ConfiguredForDelayedFC",
+        "EncodingString": "[strm][%p] Configured for delayed FC updates"
       },
       {
         "UniquenessHash": "905ba7f9-0427-2d53-7d13-88f2bb532bf0",

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -71,6 +71,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Uninitialized           : 1;    // Uninitialize started/completed. Used for Debugging.
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
+        BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
         BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -72,7 +72,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
         BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
-        BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
+        BOOLEAN DelayIdFcUpdate         : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;
 

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -70,6 +70,8 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN ShutdownComplete        : 1;    // Both directions have been shutdown and acknowledged.
         BOOLEAN Uninitialized           : 1;    // Uninitialize started/completed. Used for Debugging.
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
+
+        BOOLEAN DelayFCUpdate           : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;
 

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -751,7 +751,7 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
             BAIL_ON_NULL_CONNECTION(Connection);
             HQUIC Stream;
             auto ctx = new SpinQuicStream(*SpinQuicConnection::Get(Connection));
-            QUIC_STATUS Status = MsQuic.StreamOpen(Connection, (QUIC_STREAM_OPEN_FLAGS)GetRandom(4), SpinQuicHandleStreamEvent, ctx, &Stream);
+            QUIC_STATUS Status = MsQuic.StreamOpen(Connection, (QUIC_STREAM_OPEN_FLAGS)GetRandom(8), SpinQuicHandleStreamEvent, ctx, &Stream);
             if (QUIC_SUCCEEDED(Status)) {
                 ctx->Handle = Stream;
                 SpinQuicGetRandomParam(Stream, ThreadID);

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -430,13 +430,6 @@ QUIC_STATUS QUIC_API SpinQuicHandleConnectionEvent(HQUIC Connection, void* , QUI
         SpinQuicConnection::Get(Connection)->OnShutdownComplete();
         break;
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
-        if (GetRandom(10) == 0) {
-            return QUIC_STATUS_NOT_SUPPORTED;
-        }
-        if (GetRandom(10) == 0) {
-            MsQuic.StreamClose(Event->PEER_STREAM_STARTED.Stream);
-            return QUIC_STATUS_SUCCESS;
-        }
         if (GetRandom(2) == 0) {
             Event->PEER_STREAM_STARTED.Flags |= QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES;
         }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -430,6 +430,16 @@ QUIC_STATUS QUIC_API SpinQuicHandleConnectionEvent(HQUIC Connection, void* , QUI
         SpinQuicConnection::Get(Connection)->OnShutdownComplete();
         break;
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
+        if (GetRandom(10) == 0) {
+            return QUIC_STATUS_NOT_SUPPORTED;
+        }
+        if (GetRandom(10) == 0) {
+            MsQuic.StreamClose(Event->PEER_STREAM_STARTED.Stream);
+            return QUIC_STATUS_SUCCESS;
+        }
+        if (GetRandom(2) == 0) {
+            Event->PEER_STREAM_STARTED.Flags |= QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES;
+        }
         auto StreamCtx = new SpinQuicStream(*ctx, Event->PEER_STREAM_STARTED.Stream);
         MsQuic.SetCallbackHandler(Event->PEER_STREAM_STARTED.Stream, (void *)SpinQuicHandleStreamEvent, StreamCtx);
         ctx->AddStream(Event->PEER_STREAM_STARTED.Stream);
@@ -741,7 +751,7 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
             BAIL_ON_NULL_CONNECTION(Connection);
             HQUIC Stream;
             auto ctx = new SpinQuicStream(*SpinQuicConnection::Get(Connection));
-            QUIC_STATUS Status = MsQuic.StreamOpen(Connection, (QUIC_STREAM_OPEN_FLAGS)GetRandom(2), SpinQuicHandleStreamEvent, ctx, &Stream);
+            QUIC_STATUS Status = MsQuic.StreamOpen(Connection, (QUIC_STREAM_OPEN_FLAGS)GetRandom(4), SpinQuicHandleStreamEvent, ctx, &Stream);
             if (QUIC_SUCCEEDED(Status)) {
                 ctx->Handle = Stream;
                 SpinQuicGetRandomParam(Stream, ThreadID);

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -438,7 +438,7 @@ QUIC_STATUS QUIC_API SpinQuicHandleConnectionEvent(HQUIC Connection, void* , QUI
             return QUIC_STATUS_SUCCESS;
         }
         if (GetRandom(2) == 0) {
-            Event->PEER_STREAM_STARTED.Flags |= QUIC_STREAM_OPEN_FLAG_DELAY_FC_UPDATES;
+            Event->PEER_STREAM_STARTED.Flags |= QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES;
         }
         auto StreamCtx = new SpinQuicStream(*ctx, Event->PEER_STREAM_STARTED.Stream);
         MsQuic.SetCallbackHandler(Event->PEER_STREAM_STARTED.Stream, (void *)SpinQuicHandleStreamEvent, StreamCtx);


### PR DESCRIPTION
## Description

Sometimes apps might want to delay the stream ID FC updates to StreamClose if they intend on doing significant work between SHUTDOWN_COMPLETE and the close call.

## Testing

Updated spinquic.

## Documentation

Updated.