### PR TITLE
Change Security Hardener back to Audit Mode

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -23,21 +23,7 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969
       with:
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
-          azure.archive.ubuntu.com:80
-          crates.io:443
-          dc.services.visualstudio.com:443
-          github.com:443
-          launchpad.net:443
-          packages.microsoft.com:443
-          ppa.launchpad.net:80
-          rubygems.org:443
-          sh.rustup.rs:443
-          static.crates.io:443
-          static.rust-lang.org:443
-          www.cloudflare.com:443
+        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: Prepare Machine

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,21 +28,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            boringssl.googlesource.com:443
-            ghcr.io:443
-            github.com:443
-            pkg-containers.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
-            archive.ubuntu.com:80
-            security.ubuntu.com:80
-            packages.microsoft.com:443
-            api.nuget.org:443
-            dc.services.visualstudio.com:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -38,17 +38,7 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969
       with:
-        egress-policy: block
-        allowed-endpoints: >
-          api.nuget.org:443
-          azure.archive.ubuntu.com:80
-          dc.services.visualstudio.com:443
-          github.com:443
-          launchpad.net:443
-          objects.githubusercontent.com:443
-          packages.microsoft.com:443
-          ppa.launchpad.net:80
-          rubygems.org:443
+        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       with:


### PR DESCRIPTION
## Description

Block causes too much noise because well-known services change their endpoints too often and we don't want to have to update the block list manually.

## Testing

Existing automation

## Documentation

N/A
