### PR TITLE
Try Smaller USO Buffers

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -54,9 +54,10 @@ Abstract:
 #define MAX_URO_PAYLOAD_LENGTH              (UINT16_MAX - CXPLAT_UDP_HEADER_SIZE)
 
 //
-// The maximum single buffer size for sending coalesced payloads.
+// 60K is the largest buffer most NICs can offload without any software
+// segmentation. Current generation NICs advertise (60K < limit <= 64K).
 //
-#define CXPLAT_LARGE_SEND_BUFFER_SIZE         0xFFFF
+#define CXPLAT_LARGE_SEND_BUFFER_SIZE       0xF000
 
 //
 // The maximum number of UDP datagrams to preallocate for URO.


### PR DESCRIPTION
## Description

Try using a smaller USO buffer so that we don't have undo segmentation in TCP/IP.

## Testing

Existing perf testing

## Documentation

N/A
