### PR TITLE
Larger USO Buffers in Kernel

### DIFF
--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -63,10 +63,9 @@ typedef enum {
 #define MAX_URO_PAYLOAD_LENGTH              (UINT16_MAX - CXPLAT_UDP_HEADER_SIZE)
 
 //
-// 60K is the largest buffer most NICs can offload without any software
-// segmentation. Current generation NICs advertise (60K < limit <= 64K).
+// Use the maxiumum USO buffer size.
 //
-#define CXPLAT_LARGE_SEND_BUFFER_SIZE         0xF000
+#define CXPLAT_LARGE_SEND_BUFFER_SIZE       0xFFFF
 
 //
 // The maximum number of pages that memory allocated for our UDP payload


### PR DESCRIPTION
## Description

User mode shows better perf with 64KB. Let's try kernel.

## Testing

Existing perf tests

## Documentation

N/A
