### PR TITLE
Publish pipeline manual mode

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -56,10 +56,13 @@ parameters:
   - microsoft-fedora37-prod-yum
   - microsoft-fedora38-prod-yum
   - microsoft-rhel9.0-prod-yum
+- name: debug # debug mode will not actually upload and publish packages
+  type: boolean
+  default: false
 
 stages:
 - stage: UploadPackage_stage
-  condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+  condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - job: UploadPackage_openssl_debs
     displayName: Upload openSSL based DEB packages to repos
@@ -87,6 +90,7 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.openssldebrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl -r ${{ repo }} -n "*.deb"
+          condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
   - job: UploadPackage_openssl_rpms
@@ -115,6 +119,7 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.opensslrpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl -r ${{ repo }} -n "*.rpm"
+          condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
   - job: UploadPackage_openssl3_debs
@@ -143,6 +148,7 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.openssl3debrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3 -r ${{ repo }} -n "*.deb"
+          condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
   - job: UploadPackage_openssl3_rpms
@@ -171,5 +177,6 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.openssl3rpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3 -r ${{ repo }} -n "*.rpm"
+          condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -66,6 +66,7 @@ stages:
   jobs:
   - job: UploadPackage_openssl_debs
     displayName: Upload openSSL based DEB packages to repos
+    timeoutInMinutes: 120
     workspace:
       clean: all
     pool:
@@ -95,6 +96,7 @@ stages:
           continueOnError: true
   - job: UploadPackage_openssl_rpms
     displayName: Upload openSSL based RPM packages to repos
+    timeoutInMinutes: 120
     workspace:
       clean: all
     pool:
@@ -124,6 +126,7 @@ stages:
           continueOnError: true
   - job: UploadPackage_openssl3_debs
     displayName: Upload openSSL3 based DEB packages to repos
+    timeoutInMinutes: 120
     workspace:
       clean: all
     pool:
@@ -153,6 +156,7 @@ stages:
           continueOnError: true
   - job: UploadPackage_openssl3_rpms
     displayName: Upload openSSL3 based RPM packages to repos
+    timeoutInMinutes: 120
     workspace:
       clean: all
     pool:


### PR DESCRIPTION
## Description

Publish pipeline sometimes fails due to infra issues from PMC, ESRP and etc. Allow the pipeline to publish new releases through manually triggered runs.

## Testing

OB CI
