### PR TITLE
Fix worker event handle leak in MsQuic!RegistrationClose

### DIFF
--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -165,8 +165,8 @@ QuicWorkerUninitialize(
             CxPlatThreadWait(&Worker->Thread);
             CxPlatThreadDelete(&Worker->Thread);
         }
-        CxPlatEventUninitialize(Worker->Ready);
     }
+    CxPlatEventUninitialize(Worker->Ready);
 
     CXPLAT_TEL_ASSERT(CxPlatListIsEmpty(&Worker->Connections));
     CXPLAT_TEL_ASSERT(CxPlatListIsEmpty(&Worker->Operations));


### PR DESCRIPTION
The QUIC_WORKER Worker->Ready event handle is created unconditionally in QuicWorkerInitialize, but only closed `if (!Worker->IsExternal)` in QuicWorkerUninitialize. The handle is leaked in other cases.

This leak was detected by AppVerifier in the HTTP.SYS tests.