### PR TITLE
Fix RPS Processor Usage

### DIFF
--- a/src/generated/linux/platform_winuser.c.clog.h
+++ b/src/generated/linux/platform_winuser.c.clog.h
@@ -88,13 +88,13 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV3 , arg2, arg3, ar
                     ProcessorInfoV2,
                     "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
-                    Group,
+                    (uint16_t)Group,
                     CxPlatProcessorInfo[Proc].Index,
-                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
+                    (uint8_t)!!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
 // arg2 = arg2 = Proc = arg2
-// arg3 = arg3 = Group = arg3
+// arg3 = arg3 = (uint16_t)Group = arg3
 // arg4 = arg4 = CxPlatProcessorInfo[Proc].Index = arg4
-// arg5 = arg5 = !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
+// arg5 = arg5 = (uint8_t)!!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
 ----------------------------------------------------------*/
 #ifndef _clog_6_ARGS_TRACE_ProcessorInfoV2
 #define _clog_6_ARGS_TRACE_ProcessorInfoV2(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5)\

--- a/src/generated/linux/platform_winuser.c.clog.h
+++ b/src/generated/linux/platform_winuser.c.clog.h
@@ -58,18 +58,23 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserUnloaded );\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for WindowsUserProcessorStateV2
-// [ dll] Processors:%u, Groups:%u
+// Decoder Ring for WindowsUserProcessorStateV3
+// [ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)
 // QuicTraceLogInfo(
-        WindowsUserProcessorStateV2,
-        "[ dll] Processors:%u, Groups:%u",
-        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
-// arg2 = arg2 = MaxProcessorCount = arg2
-// arg3 = arg3 = (uint32_t)Info->Group.ActiveGroupCount = arg3
+        WindowsUserProcessorStateV3,
+        "[ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)",
+        ActiveProcessorCount,
+        MaxProcessorCount,
+        Info->Group.ActiveGroupCount,
+        Info->Group.MaximumGroupCount);
+// arg2 = arg2 = ActiveProcessorCount = arg2
+// arg3 = arg3 = MaxProcessorCount = arg3
+// arg4 = arg4 = Info->Group.ActiveGroupCount = arg4
+// arg5 = arg5 = Info->Group.MaximumGroupCount = arg5
 ----------------------------------------------------------*/
-#ifndef _clog_4_ARGS_TRACE_WindowsUserProcessorStateV2
-#define _clog_4_ARGS_TRACE_WindowsUserProcessorStateV2(uniqueId, encoded_arg_string, arg2, arg3)\
-tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV2 , arg2, arg3);\
+#ifndef _clog_6_ARGS_TRACE_WindowsUserProcessorStateV3
+#define _clog_6_ARGS_TRACE_WindowsUserProcessorStateV3(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5)\
+tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV3 , arg2, arg3, arg4, arg5);\
 
 #endif
 
@@ -77,21 +82,23 @@ tracepoint(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV2 , arg2, arg3);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ProcessorInfo
-// [ dll] Proc[%u] Group[%hu] Index[%u]
+// Decoder Ring for ProcessorInfoV2
+// [ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu
 // QuicTraceLogInfo(
-                    ProcessorInfo,
-                    "[ dll] Proc[%u] Group[%hu] Index[%u]",
+                    ProcessorInfoV2,
+                    "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
                     Group,
-                    CxPlatProcessorInfo[Proc].Index);
+                    CxPlatProcessorInfo[Proc].Index,
+                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
 // arg2 = arg2 = Proc = arg2
 // arg3 = arg3 = Group = arg3
 // arg4 = arg4 = CxPlatProcessorInfo[Proc].Index = arg4
+// arg5 = arg5 = !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
 ----------------------------------------------------------*/
-#ifndef _clog_5_ARGS_TRACE_ProcessorInfo
-#define _clog_5_ARGS_TRACE_ProcessorInfo(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
-tracepoint(CLOG_PLATFORM_WINUSER_C, ProcessorInfo , arg2, arg3, arg4);\
+#ifndef _clog_6_ARGS_TRACE_ProcessorInfoV2
+#define _clog_6_ARGS_TRACE_ProcessorInfoV2(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5)\
+tracepoint(CLOG_PLATFORM_WINUSER_C, ProcessorInfoV2 , arg2, arg3, arg4, arg5);\
 
 #endif
 

--- a/src/generated/linux/platform_winuser.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_winuser.c.clog.h.lttng.h
@@ -34,49 +34,62 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserUnloaded,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for WindowsUserProcessorStateV2
-// [ dll] Processors:%u, Groups:%u
+// Decoder Ring for WindowsUserProcessorStateV3
+// [ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)
 // QuicTraceLogInfo(
-        WindowsUserProcessorStateV2,
-        "[ dll] Processors:%u, Groups:%u",
-        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
-// arg2 = arg2 = MaxProcessorCount = arg2
-// arg3 = arg3 = (uint32_t)Info->Group.ActiveGroupCount = arg3
+        WindowsUserProcessorStateV3,
+        "[ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)",
+        ActiveProcessorCount,
+        MaxProcessorCount,
+        Info->Group.ActiveGroupCount,
+        Info->Group.MaximumGroupCount);
+// arg2 = arg2 = ActiveProcessorCount = arg2
+// arg3 = arg3 = MaxProcessorCount = arg3
+// arg4 = arg4 = Info->Group.ActiveGroupCount = arg4
+// arg5 = arg5 = Info->Group.MaximumGroupCount = arg5
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV2,
+TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV3,
     TP_ARGS(
         unsigned int, arg2,
-        unsigned int, arg3), 
+        unsigned int, arg3,
+        unsigned short, arg4,
+        unsigned short, arg5), 
     TP_FIELDS(
         ctf_integer(unsigned int, arg2, arg2)
         ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(unsigned short, arg4, arg4)
+        ctf_integer(unsigned short, arg5, arg5)
     )
 )
 
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ProcessorInfo
-// [ dll] Proc[%u] Group[%hu] Index[%u]
+// Decoder Ring for ProcessorInfoV2
+// [ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu
 // QuicTraceLogInfo(
-                    ProcessorInfo,
-                    "[ dll] Proc[%u] Group[%hu] Index[%u]",
+                    ProcessorInfoV2,
+                    "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
                     Group,
-                    CxPlatProcessorInfo[Proc].Index);
+                    CxPlatProcessorInfo[Proc].Index,
+                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
 // arg2 = arg2 = Proc = arg2
 // arg3 = arg3 = Group = arg3
 // arg4 = arg4 = CxPlatProcessorInfo[Proc].Index = arg4
+// arg5 = arg5 = !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, ProcessorInfo,
+TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, ProcessorInfoV2,
     TP_ARGS(
         unsigned int, arg2,
         unsigned short, arg3,
-        unsigned int, arg4), 
+        unsigned int, arg4,
+        unsigned char, arg5), 
     TP_FIELDS(
         ctf_integer(unsigned int, arg2, arg2)
         ctf_integer(unsigned short, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
+        ctf_integer(unsigned char, arg5, arg5)
     )
 )
 

--- a/src/generated/linux/platform_winuser.c.clog.h.lttng.h
+++ b/src/generated/linux/platform_winuser.c.clog.h.lttng.h
@@ -71,13 +71,13 @@ TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, WindowsUserProcessorStateV3,
                     ProcessorInfoV2,
                     "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
-                    Group,
+                    (uint16_t)Group,
                     CxPlatProcessorInfo[Proc].Index,
-                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
+                    (uint8_t)!!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
 // arg2 = arg2 = Proc = arg2
-// arg3 = arg3 = Group = arg3
+// arg3 = arg3 = (uint16_t)Group = arg3
 // arg4 = arg4 = CxPlatProcessorInfo[Proc].Index = arg4
-// arg5 = arg5 = !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
+// arg5 = arg5 = (uint8_t)!!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PLATFORM_WINUSER_C, ProcessorInfoV2,
     TP_ARGS(

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -1297,6 +1297,8 @@ CxPlatProcCurrentNumber(
     void
     );
 
+#define CxPlatProcIsActive(Index) TRUE // TODO
+
 //
 // Rundown Protection Interfaces.
 //

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -883,6 +883,7 @@ typedef ULONG_PTR CXPLAT_THREAD_ID;
 #define CxPlatProcMaxCount() KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS)
 #define CxPlatProcActiveCount() KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS)
 #define CxPlatProcCurrentNumber() KeGetCurrentProcessorIndex()
+#define CxPlatProcIsActive(Index) TRUE // TODO
 
 //
 // Rundown Protection Interfaces

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -1009,8 +1009,9 @@ CxPlatProcCurrentNumber(
     return CxPlatProcessorGroupInfo[ProcNumber.Group].Offset + ProcNumber.Number;
 }
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
 inline
-bool
+BOOLEAN
 CxPlatProcIsActive(
     uint32_t Index
     )

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -1009,6 +1009,16 @@ CxPlatProcCurrentNumber(
     return CxPlatProcessorGroupInfo[ProcNumber.Group].Offset + ProcNumber.Number;
 }
 
+inline
+bool
+CxPlatProcIsActive(
+    uint32_t Index
+    )
+{
+    const CXPLAT_PROCESSOR_INFO* Proc = &CxPlatProcessorInfo[Index];
+    return !!(CxPlatProcessorGroupInfo[Proc->Group].Mask & (1ULL << Proc->Index));
+}
+
 
 //
 // Create Thread Interfaces

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -8686,6 +8686,30 @@
       ],
       "macroName": "QuicTraceLogInfo"
     },
+    "ProcessorInfoV2": {
+      "ModuleProperites": {},
+      "TraceString": "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
+      "UniqueId": "ProcessorInfoV2",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
     "QueueDatagrams": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Queuing %u UDP datagrams",
@@ -11597,6 +11621,30 @@
         {
           "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogInfo"
+    },
+    "WindowsUserProcessorStateV3": {
+      "ModuleProperites": {},
+      "TraceString": "[ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)",
+      "UniqueId": "WindowsUserProcessorStateV3",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg5"
         }
       ],
       "macroName": "QuicTraceLogInfo"
@@ -15099,6 +15147,11 @@
         "EncodingString": "[ dll] Proc[%u] Group[%hu] Index[%u]"
       },
       {
+        "UniquenessHash": "3379ba23-5dc4-936c-5dd0-224fcad9d9d5",
+        "TraceID": "ProcessorInfoV2",
+        "EncodingString": "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu"
+      },
+      {
         "UniquenessHash": "18ef147d-5376-d7f2-f624-3b27af96dd05",
         "TraceID": "QueueDatagrams",
         "EncodingString": "[conn][%p] Queuing %u UDP datagrams"
@@ -16087,6 +16140,11 @@
         "UniquenessHash": "75d23316-ce7e-8980-f3f4-677d2622ee5f",
         "TraceID": "WindowsUserProcessorStateV2",
         "EncodingString": "[ dll] Processors:%u, Groups:%u"
+      },
+      {
+        "UniquenessHash": "77a73e5e-4f71-be29-4086-c7515afc8181",
+        "TraceID": "WindowsUserProcessorStateV3",
+        "EncodingString": "[ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)"
       },
       {
         "UniquenessHash": "19b21f4a-a6e8-3b9b-c4da-e303c8f108b1",

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -217,10 +217,10 @@ RpsClient::Start(
         while (!CxPlatProcIsActive(ActiveProcessorIndex)) {
             ++ActiveProcessorIndex;
         }
-        Workers[i].Processor = ActiveProcessorIndex;
+        Workers[i].Processor = (uint16_t)ActiveProcessorIndex++;
         CXPLAT_THREAD_CONFIG ThreadConfig = {
             (uint16_t)ThreadFlags,
-            (uint16_t)ActiveProcessorIndex++,
+            Workers[i].Processor,
             "RPS Worker",
             RpsWorkerThread,
             &Workers[i]

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -217,6 +217,7 @@ RpsClient::Start(
         while (!CxPlatProcIsActive(ActiveProcessorIndex)) {
             ++ActiveProcessorIndex;
         }
+        Workers[i].Processor = ActiveProcessorIndex;
         CXPLAT_THREAD_CONFIG ThreadConfig = {
             (uint16_t)ThreadFlags,
             (uint16_t)ActiveProcessorIndex++,
@@ -242,15 +243,8 @@ RpsClient::Start(
         return QUIC_STATUS_OUT_OF_MEMORY;
     }
 
-    uint32_t ActiveProcCount = CxPlatProcActiveCount();
-    if (ActiveProcCount >= 60) {
-        //
-        // If we have enough cores, leave 2 cores for OS overhead
-        //
-        ActiveProcCount -= 2;
-    }
     for (uint32_t i = 0; i < ConnectionCount; ++i) {
-        Status = CxPlatSetCurrentThreadProcessorAffinity((uint16_t)(i % ActiveProcCount));
+        Status = CxPlatSetCurrentThreadProcessorAffinity(Workers[i % WorkerCount].Processor);
         if (QUIC_FAILED(Status)) {
             WriteOutput("Setting Thread Group Failed 0x%x\n", Status);
             return Status;
@@ -269,11 +263,7 @@ RpsClient::Start(
             return Status;
         }
 
-        if (WorkerCount == 0) {
-            Workers[i % ActiveProcCount].QueueConnection(&Connections[i]);
-        } else {
-            Workers[i % WorkerCount].QueueConnection(&Connections[i]);
-        }
+        Workers[i % WorkerCount].QueueConnection(&Connections[i]);
 
         if (!UseEncryption) {
             BOOLEAN value = TRUE;

--- a/src/perf/lib/RpsClient.cpp
+++ b/src/perf/lib/RpsClient.cpp
@@ -211,11 +211,15 @@ RpsClient::Start(
     CompletionEvent = StopEvent;
 
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+    uint32_t ActiveProcessorIndex = 0;
     for (uint32_t i = 0; i < WorkerCount; ++i) {
         auto ThreadFlags = AffinitizeWorkers ? CXPLAT_THREAD_FLAG_SET_AFFINITIZE : CXPLAT_THREAD_FLAG_NONE;
+        while (!CxPlatProcIsActive(ActiveProcessorIndex)) {
+            ++ActiveProcessorIndex;
+        }
         CXPLAT_THREAD_CONFIG ThreadConfig = {
             (uint16_t)ThreadFlags,
-            (uint16_t)i,
+            (uint16_t)ActiveProcessorIndex++,
             "RPS Worker",
             RpsWorkerThread,
             &Workers[i]

--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -60,6 +60,7 @@ struct RpsWorkerContext {
     CXPLAT_THREAD Thread;
     CXPLAT_EVENT WakeEvent;
     bool ThreadStarted {false};
+    uint32_t Processor {UINT32_MAX};
     uint32_t RequestCount {0};
     RpsWorkerContext() {
         CxPlatLockInitialize(&Lock);

--- a/src/perf/lib/RpsClient.h
+++ b/src/perf/lib/RpsClient.h
@@ -60,7 +60,7 @@ struct RpsWorkerContext {
     CXPLAT_THREAD Thread;
     CXPLAT_EVENT WakeEvent;
     bool ThreadStarted {false};
-    uint32_t Processor {UINT32_MAX};
+    uint16_t Processor {UINT16_MAX};
     uint32_t RequestCount {0};
     RpsWorkerContext() {
         CxPlatLockInitialize(&Lock);

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -86,11 +86,14 @@ CxPlatProcessorInfoInit(
     SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* Info = NULL;
     uint32_t CurrentProcessorCount;
 
+    const uint32_t ActiveProcessorCount = CxPlatProcActiveCount();
     const uint32_t MaxProcessorCount = CxPlatProcMaxCount();
 
     CXPLAT_DBG_ASSERT(MaxProcessorCount > 0);
     CXPLAT_DBG_ASSERT(MaxProcessorCount <= UINT16_MAX);
-    CXPLAT_DBG_ASSERT(CxPlatProcessorInfo == NULL);
+    CXPLAT_DBG_ASSERT(ActiveProcessorCount > 0);
+    CXPLAT_DBG_ASSERT(ActiveProcessorCount <= MaxProcessorCount);
+    CXPLAT_FRE_ASSERT(CxPlatProcessorInfo == NULL);
     CxPlatProcessorInfo =
         CXPLAT_ALLOC_NONPAGED(
             MaxProcessorCount * sizeof(CXPLAT_PROCESSOR_INFO),
@@ -117,6 +120,7 @@ CxPlatProcessorInfoInit(
     CXPLAT_DBG_ASSERT(InfoLength != 0);
     CXPLAT_DBG_ASSERT(Info->Relationship == RelationGroup);
     CXPLAT_DBG_ASSERT(Info->Group.ActiveGroupCount != 0);
+    CXPLAT_DBG_ASSERT(Info->Group.ActiveGroupCount <= Info->Group.MaximumGroupCount);
     if (Info->Group.ActiveGroupCount == 0) {
         QuicTraceEvent(
             LibraryError,
@@ -127,9 +131,12 @@ CxPlatProcessorInfoInit(
     }
 
     QuicTraceLogInfo(
-        WindowsUserProcessorStateV2,
-        "[ dll] Processors:%u, Groups:%u",
-        MaxProcessorCount, (uint32_t)Info->Group.ActiveGroupCount);
+        WindowsUserProcessorStateV3,
+        "[ dll] Processors: (%u active, %u max), Groups: (%hu active, %hu max)",
+        ActiveProcessorCount,
+        MaxProcessorCount,
+        Info->Group.ActiveGroupCount,
+        Info->Group.MaximumGroupCount);
 
     CXPLAT_DBG_ASSERT(CxPlatProcessorGroupInfo == NULL);
     CxPlatProcessorGroupInfo =
@@ -160,11 +167,12 @@ CxPlatProcessorInfoInit(
                 CxPlatProcessorInfo[Proc].Group = Group;
                 CxPlatProcessorInfo[Proc].Index = (Proc - CxPlatProcessorGroupInfo[Group].Offset);
                 QuicTraceLogInfo(
-                    ProcessorInfo,
-                    "[ dll] Proc[%u] Group[%hu] Index[%u]",
+                    ProcessorInfoV2,
+                    "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
                     Group,
-                    CxPlatProcessorInfo[Proc].Index);
+                    CxPlatProcessorInfo[Proc].Index,
+                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
                 break;
             }
         }

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -172,7 +172,7 @@ CxPlatProcessorInfoInit(
                     Proc,
                     Group,
                     CxPlatProcessorInfo[Proc].Index,
-                    !!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
+                    (CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) ? 1 : 0);
                 break;
             }
         }

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -172,7 +172,7 @@ CxPlatProcessorInfoInit(
                     Proc,
                     (uint16_t)Group,
                     CxPlatProcessorInfo[Proc].Index,
-                    (CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) ? 1 : 0);
+                    (uint8_t)!!(CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)));
                 break;
             }
         }

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -170,7 +170,7 @@ CxPlatProcessorInfoInit(
                     ProcessorInfoV2,
                     "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
                     Proc,
-                    Group,
+                    (uint16_t)Group,
                     CxPlatProcessorInfo[Proc].Index,
                     (CxPlatProcessorGroupInfo[Group].Mask & (1ULL << CxPlatProcessorInfo[Proc].Index)) ? 1 : 0);
                 break;


### PR DESCRIPTION
## Description

Recent changes to how the processor index is calculated broke RPS tests on Windows. This fixes them by taking into account that a given processor index may refer to an inactive processor (since we track maximum, not active, processors). The RPS test code wants to only use active processors, so it iterates over all processors, skipping inactive ones.

## Testing

Automation

## Documentation

N/A
