### PR TITLE
Remove extra double-quotes for extraOutputFile in performance-helper.psm1

### DIFF
--- a/scripts/performance-helper.psm1
+++ b/scripts/performance-helper.psm1
@@ -545,7 +545,7 @@ function Invoke-LocalExe {
         mkdir $HistogramDir | Out-Null
     }
     $HistogramFilePath = Join-Path $HistogramDir $HistogramFileName
-    $RunArgs = """--extraOutputFile:$HistogramFilePath"" $RunArgs"
+    $RunArgs = "--extraOutputFile:$HistogramFilePath $RunArgs"
     if ($IsLinux -and $Record) {
         # `perf record -F max` generates too big data to finish within default Timeout (120s)
         $Timeout = 2000


### PR DESCRIPTION
## Description

The double-quotes are completely unnecessary. Though, the script doesn't work when the path has spaces. The extra double-quotes get escaped and will be present in the command list arguments in secnetperf, which breaks the option parsing in secnetperf.

## Testing

Perf CI