### PR TITLE
Fix ASAN GoogleTest Link Errors

### DIFF
--- a/src/core/unittest/main.cpp
+++ b/src/core/unittest/main.cpp
@@ -5,6 +5,9 @@
 
 --*/
 
+// Work around for address sanitizer build error with googletest.
+#pragma comment(linker, "/include:_annotate_string")
+
 #include "main.h"
 #ifdef QUIC_CLOG
 #include "main.cpp.clog.h"

--- a/src/platform/unittest/main.cpp
+++ b/src/platform/unittest/main.cpp
@@ -5,6 +5,9 @@
 
 --*/
 
+// Work around for address sanitizer build error with googletest.
+#pragma comment(linker, "/include:_annotate_string")
+
 #include "main.h"
 #include "msquichelper.h"
 #include "msquic.hpp"

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -5,6 +5,9 @@
 
 --*/
 
+// Work around for address sanitizer build error with googletest.
+#pragma comment(linker, "/include:_annotate_string")
+
 #include "quic_gtest.h"
 #ifdef QUIC_CLOG
 #include "quic_gtest.cpp.clog.h"


### PR DESCRIPTION
## Description

Trying to fix the build/link error:
```
error LNK2038: mismatch detected for 'annotate_string': value '0' doesn't match value '1'
```

## Testing

Automation

## Documentation

N/A
