### PR TITLE
Sign Drivers for OneBranch Testing

### DIFF
--- a/.azure/obtemplates/run-bvt.yml
+++ b/.azure/obtemplates/run-bvt.yml
@@ -46,6 +46,14 @@ jobs:
       filePath: scripts/prepare-machine.ps1
       arguments: -ForTest
 
+  - ${{ if eq(parameters.kernel, true)}}:
+    - task: PowerShell@2
+      displayName: Sign Drivers
+      inputs:
+        pwsh: true
+        filePath: scripts/sign.ps1
+        arguments: -Arch ${{ parameters.arch }} -Config ${{ parameters.config }} -Tls Schannel
+
   - task: PowerShell@2
     displayName: Run BVTs
     timeoutInMinutes: 60


### PR DESCRIPTION
## Description

Recent signing changes regressed OneBranch tests. This updates the OneBranch test pipeline to sign the drivers before installing them.

## Testing

Will need to mirror into OneBranch to test.

## Documentation

N/A
