### PR TITLE
Fix duonic installation hang

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -215,6 +215,7 @@ function Install-SigningCertificates {
         CertUtil.exe -addstore Root "$SetupPath\CoreNetSignRoot.cer"
         CertUtil.exe -addstore TrustedPublisher "$SetupPath\CoreNetSignRoot.cer"
         CertUtil.exe -addstore Root "$SetupPath\testroot-sha2.cer" # For duonic
+        Sleep -Seconds 5
     } catch {
         Write-Host "WARNING: Exception encountered while installing signing certs. Drivers may not start!"
     }


### PR DESCRIPTION
## Description

Duonic installation hangs. Add a sleep after cert installation to see if that's the issue.

## Testing

CI
