### PR TITLE
Fix skipped linux tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 concurrency:
   # Cancel any workflow currently in progress for the same PR.
   # Allow running concurrently with any other commits.
-  group: bvt-${{ github.event.pull_request.number || github.sha }}
+  group: test-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,10 @@ jobs:
       with:
         name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.systemcrypto }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
+    - name: Fix permissions for Unix
+      if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
+      run: |
+        sudo chmod -R 777 artifacts
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }}
       shell: pwsh
@@ -179,10 +183,6 @@ jobs:
       with:
         name: ${{ matrix.vec.config }}-windows-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
-    - name: Fix permissions for Unix
-      if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
-      run: |
-        sudo chmod -R 777 artifacts
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -ForTest -ForKernel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,6 +179,10 @@ jobs:
       with:
         name: ${{ matrix.vec.config }}-windows-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
+    - name: Fix permissions for Unix
+      if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
+      run: |
+        sudo chmod -R 777 artifacts
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -ForTest -ForKernel

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -189,6 +189,7 @@ $PfxPassword = ConvertTo-SecureString -String "placeholder" -Force -AsPlainText
 
 # Downloads and caches the latest version of the corenet-ci-main repo.
 function Download-CoreNet-Deps {
+    if (!$IsWindows) { return } # Windows only
     # Download and extract https://github.com/microsoft/corenet-ci.
     if ($Force) { rm -Force -Recurse $CoreNetCiPath -ErrorAction Ignore }
     if (!(Test-Path $CoreNetCiPath)) {


### PR DESCRIPTION
## Description

Linux BVT tests are skipped due to linux permission issue because the artifacts are built somewhere else.

## Testing

CI
