### PR TITLE
Fix syntax for pre-C23 standard compilers

### DIFF
--- a/src/generated/stdout/quic_trace.c
+++ b/src/generated/stdout/quic_trace.c
@@ -102,7 +102,7 @@ void clog_stdout(struct clog_param * head, const char * const format, ...)
         }
     }
 
-JustPrint:
+JustPrint: ;
     // print the log line
     va_list ap;
     va_start(ap, format);


### PR DESCRIPTION
## Description

Fix compile error for library build with stdout logging type when using older compilers without C23 standard syntax support.
