### PR TITLE
Set $ORIGIN in RUNPATH in linux binaries

### DIFF
--- a/src/core/unittest/CMakeLists.txt
+++ b/src/core/unittest/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(msquiccoretest ${SOURCES})
 target_include_directories(msquiccoretest PRIVATE ${PROJECT_SOURCE_DIR}/src/core)
 
 set_property(TARGET msquiccoretest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+set_property(TARGET msquiccoretest APPEND PROPERTY BUILD_RPATH "$ORIGIN")
 
 target_link_libraries(msquiccoretest msquic)
 

--- a/src/platform/unittest/CMakeLists.txt
+++ b/src/platform/unittest/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(msquicplatformtest ${SOURCES})
 target_include_directories(msquicplatformtest PRIVATE ${PROJECT_SOURCE_DIR}/src/core)
 
 set_property(TARGET msquicplatformtest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+set_property(TARGET msquicplatformtest APPEND PROPERTY BUILD_RPATH "$ORIGIN")
 
 target_link_libraries(msquicplatformtest msquic)
 

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(msquictest ${SOURCES})
 target_include_directories(msquictest PRIVATE ${PROJECT_SOURCE_DIR}/src/test)
 
 set_property(TARGET msquictest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")
+set_property(TARGET msquictest APPEND PROPERTY BUILD_RPATH "$ORIGIN")
 
 target_link_libraries(msquictest msquic testlib)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -15,6 +15,7 @@ function(add_quic_tool)
     target_link_libraries(${targetname} logging base_link)
 
     set_property(TARGET ${targetname} PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tools")
+    set_property(TARGET ${targetname} APPEND PROPERTY BUILD_RPATH "$ORIGIN")
 endfunction()
 
 function(quic_tool_warnings)


### PR DESCRIPTION
## Description

RUNPATH is by default set to the folder where the binary is located at build time. This makes locally reproducing issues cumbersome for Linux. Also, if the build and test runner machine have different folder structure, our tests won't run due to this issue.

## Testing

CI

