### PR TITLE
Delete msquic libs in packgaging test in case they get loaded instead of the ones in the installed package

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -77,6 +77,7 @@ jobs:
         sudo apt-get install -y lttng-tools
         sudo find -name "*.deb" -exec dpkg -i {} \;
         rm artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}/libmsquic.so*
+        ls artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}
     - name: Test
       run: |
         chmod +x artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}/msquictest

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -76,6 +76,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y lttng-tools
         sudo find -name "*.deb" -exec dpkg -i {} \;
+        rm artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}/libmsquic.so*
     - name: Test
       run: |
         chmod +x artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}/msquictest


### PR DESCRIPTION
## Description

The test is supposed to test if the installed package can be loaded into BVT test. However, the libs are also present in the same folder where the test is. Delete them to make sure libs in the package gets loaded.

## Testing

CI