### PR TITLE
Pin ubuntu docker base image hash

### DIFF
--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:c9820a44b950956a790c354700c1166a7ec648bc0d215fa438d3a339812f1d01
 
 LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 

--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508
 
 LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 


### PR DESCRIPTION
## Description

Pin the hash so the security warnings go away.

## Testing

CI