### PR TITLE
Support retrieving the initial destination CID from GetParam

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -168,7 +168,7 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_CONN_CIBIR_ID`<br> 21                 | uint8_t[]                     | Set-only  | The CIBIR well-known identifier.                                                          |
 | `QUIC_PARAM_CONN_STATISTICS_V2`<br> 22            | QUIC_STATISTICS_V2            | Get-only  | Connection-level statistics, version 2.                                                   |
 | `QUIC_PARAM_CONN_STATISTICS_V2_PLAT`<br> 23       | QUIC_STATISTICS_V2            | Get-only  | Connection-level statistics with platform-specific time format, version 2.                |
-
+| `QUIC_PARAM_CONN_ORIG_DEST_CID` <br> 24           | uint8_t[]                     | Get-only  | CID information about the original client that made the connection to the server.         |
 ### QUIC_PARAM_CONN_STATISTICS_V2
 
 Querying the `QUIC_STATISTICS_V2` struct via `QUIC_PARAM_CONN_STATISTICS_V2` or `QUIC_PARAM_CONN_STATISTICS_V2_PLAT` should be aware of possible changes in the size of the struct, depending on the version of MsQuic the app using at runtime, not just what it was compiled against.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -168,7 +168,8 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_CONN_CIBIR_ID`<br> 21                 | uint8_t[]                     | Set-only  | The CIBIR well-known identifier.                                                          |
 | `QUIC_PARAM_CONN_STATISTICS_V2`<br> 22            | QUIC_STATISTICS_V2            | Get-only  | Connection-level statistics, version 2.                                                   |
 | `QUIC_PARAM_CONN_STATISTICS_V2_PLAT`<br> 23       | QUIC_STATISTICS_V2            | Get-only  | Connection-level statistics with platform-specific time format, version 2.                |
-| `QUIC_PARAM_CONN_ORIG_DEST_CID` <br> 24           | uint8_t[]                     | Get-only  | CID information about the original client that made the connection to the server.         |
+| `QUIC_PARAM_CONN_ORIG_DEST_CID` <br> 24           | uint8_t[]                     | Get-only  | The original destination connection ID used by the client to connect to the server.       |
+
 ### QUIC_PARAM_CONN_STATISTICS_V2
 
 Querying the `QUIC_STATISTICS_V2` struct via `QUIC_PARAM_CONN_STATISTICS_V2` or `QUIC_PARAM_CONN_STATISTICS_V2_PLAT` should be aware of possible changes in the size of the struct, depending on the version of MsQuic the app using at runtime, not just what it was compiled against.

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6821,8 +6821,8 @@ QuicConnParamGet(
 
     switch (Param) {
     
-    case QUICK_PARAM_CONN_ORIG_DEST_CID:
-        if (Connection == NULL) {
+    case QUIC_PARAM_CONN_ORIG_DEST_CID:
+        if (Connection == NULL || Connection->OrigDestCID == NULL) {
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6820,6 +6820,30 @@ QuicConnParamGet(
     uint8_t Type;
 
     switch (Param) {
+    
+    case QUICK_PARAM_CONN_ORIG_DEST_CID:
+        if (Connection == NULL) {
+            Status = QUIC_STATUS_INVALID_STATE;
+            break;
+        }
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+        if (*BufferLength < Connection->OrigDestCID->Length) {
+            // Tell app it needs to pass in a bigger buffer.
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            // Let app know this is the size buffer it needs.
+            *BufferLength = Connection->OrigDestCID->Length;
+            break;
+        }
+        CxPlatCopyMemory(
+            Connection->OrigDestCID->Data,
+            Buffer,
+            Connection->OrigDestCID->Length);
+        // Tell app how much buffer we copied.
+        *BufferLength = Connection->OrigDestCID->Length;
+        break;
 
     case QUIC_PARAM_CONN_QUIC_VERSION:
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7185,8 +7185,8 @@ QuicConnParamGet(
             break;
         }
         CxPlatCopyMemory(
-            Connection->OrigDestCID->Data,
             Buffer,
+            Connection->OrigDestCID->Data,
             Connection->OrigDestCID->Length);
         //
         // Tell app how much buffer we copied.

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6843,6 +6843,7 @@ QuicConnParamGet(
             Connection->OrigDestCID->Length);
         // Tell app how much buffer we copied.
         *BufferLength = Connection->OrigDestCID->Length;
+        Status = QUIC_STATUS_SUCCESS;
         break;
 
     case QUIC_PARAM_CONN_QUIC_VERSION:

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6822,7 +6822,7 @@ QuicConnParamGet(
     switch (Param) {
     
     case QUIC_PARAM_CONN_ORIG_DEST_CID:
-        if (Connection == NULL || Connection->OrigDestCID == NULL) {
+        if (Connection->OrigDestCID == NULL) {
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6820,31 +6820,6 @@ QuicConnParamGet(
     uint8_t Type;
 
     switch (Param) {
-    
-    case QUIC_PARAM_CONN_ORIG_DEST_CID:
-        if (Connection->OrigDestCID == NULL) {
-            Status = QUIC_STATUS_INVALID_STATE;
-            break;
-        }
-        if (Buffer == NULL) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
-        if (*BufferLength < Connection->OrigDestCID->Length) {
-            // Tell app it needs to pass in a bigger buffer.
-            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
-            // Let app know this is the size buffer it needs.
-            *BufferLength = Connection->OrigDestCID->Length;
-            break;
-        }
-        CxPlatCopyMemory(
-            Connection->OrigDestCID->Data,
-            Buffer,
-            Connection->OrigDestCID->Length);
-        // Tell app how much buffer we copied.
-        *BufferLength = Connection->OrigDestCID->Length;
-        Status = QUIC_STATUS_SUCCESS;
-        break;
 
     case QUIC_PARAM_CONN_QUIC_VERSION:
 
@@ -7194,6 +7169,31 @@ QuicConnParamGet(
                 (QUIC_STATISTICS_V2*)Buffer);
         break;
     }
+
+    case QUIC_PARAM_CONN_ORIG_DEST_CID:
+        if (Connection->OrigDestCID == NULL) {
+            Status = QUIC_STATUS_INVALID_STATE;
+            break;
+        }
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+        if (*BufferLength < Connection->OrigDestCID->Length) {
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            *BufferLength = Connection->OrigDestCID->Length;
+            break;
+        }
+        CxPlatCopyMemory(
+            Connection->OrigDestCID->Data,
+            Buffer,
+            Connection->OrigDestCID->Length);
+        //
+        // Tell app how much buffer we copied.
+        //
+        *BufferLength = Connection->OrigDestCID->Length;
+        Status = QUIC_STATUS_SUCCESS;
+        break;
 
     default:
         Status = QUIC_STATUS_INVALID_PARAMETER;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7175,13 +7175,13 @@ QuicConnParamGet(
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }
-        if (Buffer == NULL) {
-            Status = QUIC_STATUS_INVALID_PARAMETER;
-            break;
-        }
         if (*BufferLength < Connection->OrigDestCID->Length) {
             Status = QUIC_STATUS_BUFFER_TOO_SMALL;
             *BufferLength = Connection->OrigDestCID->Length;
+            break;
+        }
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
             break;
         }
         CxPlatCopyMemory(

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -3110,6 +3110,9 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_PARAM_CONN_STATISTICS_V2_PLAT 0x05000017")]
         internal const uint QUIC_PARAM_CONN_STATISTICS_V2_PLAT = 0x05000017;
 
+        [NativeTypeName("#define QUIC_PARAM_CONN_ORIG_DEST_CID 0x05000018")]
+        internal const uint QUIC_PARAM_CONN_ORIG_DEST_CID = 0x05000018;
+
         [NativeTypeName("#define QUIC_PARAM_TLS_HANDSHAKE_INFO 0x06000000")]
         internal const uint QUIC_PARAM_TLS_HANDSHAKE_INFO = 0x06000000;
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -889,7 +889,7 @@ typedef struct QUIC_SCHANNEL_CREDENTIAL_ATTRIBUTE_W {
 #endif
 #define QUIC_PARAM_CONN_STATISTICS_V2                   0x05000016  // QUIC_STATISTICS_V2
 #define QUIC_PARAM_CONN_STATISTICS_V2_PLAT              0x05000017  // QUIC_STATISTICS_V2
-#define QUICK_PARAM_CONN_ORIG_DEST_CID                  0x05000018  // uint8_t[]
+#define QUIC_PARAM_CONN_ORIG_DEST_CID                   0x05000018  // uint8_t[]
 
 //
 // Parameters for TLS.

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -889,6 +889,7 @@ typedef struct QUIC_SCHANNEL_CREDENTIAL_ATTRIBUTE_W {
 #endif
 #define QUIC_PARAM_CONN_STATISTICS_V2                   0x05000016  // QUIC_STATISTICS_V2
 #define QUIC_PARAM_CONN_STATISTICS_V2_PLAT              0x05000017  // QUIC_STATISTICS_V2
+#define QUICK_PARAM_CONN_ORIG_DEST_CID                  0x05000018  // uint8_t[]
 
 //
 // Parameters for TLS.

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4237,12 +4237,11 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
         TEST_QUIC_SUCCEEDED(
-        MsQuic->ConnectionStart(
-            Connection.Handle,
-            ClientConfiguration,
-            QUIC_ADDRESS_FAMILY_INET,
-            "localhost",
-            4433));
+          Connection.Start(
+              ClientConfiguration,
+              QUIC_ADDRESS_FAMILY_INET,
+              "localhost",
+              4433));
         MsQuic->ConnectionSetConfiguration(Connection.Handle, ClientConfiguration);
         //
         // 8 bytes is the expected minimum size of the CID.
@@ -4265,12 +4264,11 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
         TEST_QUIC_SUCCEEDED(
-        MsQuic->ConnectionStart(
-            Connection.Handle,
-            ClientConfiguration,
-            QUIC_ADDRESS_FAMILY_INET,
-            "localhost",
-            4433));
+          Connection.Start(
+              ClientConfiguration,
+              QUIC_ADDRESS_FAMILY_INET,
+              "localhost",
+              4433));
         uint32_t SizeOfBuffer = 8;
         TestScopeLogger LogScope1("GetParam null buffer check");
         TEST_QUIC_STATUS(
@@ -4286,12 +4284,11 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
         TEST_QUIC_SUCCEEDED(
-        MsQuic->ConnectionStart(
-            Connection.Handle,
-            ClientConfiguration,
-            QUIC_ADDRESS_FAMILY_INET,
-            "localhost",
-            4433));
+          Connection.Start(
+              ClientConfiguration,
+              QUIC_ADDRESS_FAMILY_INET,
+              "localhost",
+              4433));
         uint32_t SizeOfBuffer = 1;
         TestScopeLogger LogScope1("GetParam buffer too small check");
         uint8_t Buffer[1];
@@ -4308,14 +4305,13 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
         TEST_QUIC_SUCCEEDED(
-        MsQuic->ConnectionStart(
-            Connection.Handle,
-            ClientConfiguration,
-            QUIC_ADDRESS_FAMILY_INET,
-            "localhost",
-            4433));
+          Connection.Start(
+              ClientConfiguration,
+              QUIC_ADDRESS_FAMILY_INET,
+              "localhost",
+              4433));
         uint32_t SizeOfBuffer = 100;
-        uint8_t Buffer[100];
+        uint8_t Buffer[100] = {0};
         uint8_t ZeroBuffer[100] = {0}; 
         TestScopeLogger LogScope1("GetParam size of buffer bigger than needed");
         TEST_QUIC_STATUS(

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4328,6 +4328,35 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
         //
         TEST_TRUE(SizeOfBuffer < 100);
     }
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        TEST_QUIC_SUCCEEDED(
+          Connection.Start(
+              ClientConfiguration,
+              QUIC_ADDRESS_FAMILY_INET,
+              "localhost",
+              4433));
+        uint32_t SizeOfBuffer = 0;
+        TestScopeLogger LogScope1("GetParam check OrigDestCID size with nullptr");
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_BUFFER_TOO_SMALL, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                nullptr
+            )
+        )
+        TEST_TRUE(SizeOfBuffer >= 8);
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_INVALID_PARAMETER, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                nullptr
+            )
+        )
+    }
 }
 
 void QuicTestConnectionParam()

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4228,7 +4228,7 @@ void QuicTest_QUIC_PARAM_CONN_STATISTICS_V2_PLAT(MsQuicRegistration& Registratio
 }
 
 
-void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
+void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, MsQuicConfiguration& ClientConfiguration) {
     //
     // This is the unit test for checking to see if a server has the correct original dest CID.
     //
@@ -4236,8 +4236,6 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-        MsQuicAlpn Alpn("MsQuicTest");
-        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
         TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Connection.Handle,
@@ -4263,8 +4261,6 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-        MsQuicAlpn Alpn("MsQuicTest");
-        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
         TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Connection.Handle,
@@ -4286,8 +4282,6 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-        MsQuicAlpn Alpn("MsQuicTest");
-        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
         TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Connection.Handle,
@@ -4310,8 +4304,6 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-        MsQuicAlpn Alpn("MsQuicTest");
-        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
         TEST_QUIC_SUCCEEDED(
         MsQuic->ConnectionStart(
             Connection.Handle,
@@ -4369,7 +4361,7 @@ void QuicTestConnectionParam()
     QuicTest_QUIC_PARAM_CONN_CIBIR_ID(Registration, ClientConfiguration);
     QuicTest_QUIC_PARAM_CONN_STATISTICS_V2(Registration);
     QuicTest_QUIC_PARAM_CONN_STATISTICS_V2_PLAT(Registration);
-    QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(Registration);
+    QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(Registration, ClientConfiguration);
 }
 
 //

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4245,8 +4245,11 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
             QUIC_ADDRESS_FAMILY_INET,
             "localhost",
             4433));
+        //
+        // 8 bytes is the expected minimum size of the CID.
+        //
         uint32_t SizeOfBuffer = 8;
-        uint8_t Buffer[8]; // 8 bytes is the expected minimum size of the CID.
+        uint8_t Buffer[8]; 
         TestScopeLogger LogScope1("GetParam test success case");
         TEST_QUIC_STATUS(
             QUIC_STATUS_SUCCESS, 
@@ -4328,7 +4331,7 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
             )
         )
         // 
-        // There is no way the CID written should be 100 bytes.
+        // There is no way the CID written should be 100 bytes according to the RFC.
         //
         TEST_TRUE(SizeOfBuffer < 100);
     }

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4243,11 +4243,13 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
             QUIC_ADDRESS_FAMILY_INET,
             "localhost",
             4433));
+        MsQuic->ConnectionSetConfiguration(Connection.Handle, ClientConfiguration);
         //
         // 8 bytes is the expected minimum size of the CID.
         //
         uint32_t SizeOfBuffer = 8;
-        uint8_t Buffer[8]; 
+        uint8_t Buffer[8] = {0};
+        uint8_t ZeroBuffer[8] = {0}; 
         TestScopeLogger LogScope1("GetParam test success case");
         TEST_QUIC_STATUS(
             QUIC_STATUS_SUCCESS, 
@@ -4257,6 +4259,7 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
                 Buffer
             )
         )
+        TEST_NOT_EQUAL(memcmp(Buffer, ZeroBuffer, sizeof(Buffer)), 0);
     }
     {
         MsQuicConnection Connection(Registration);
@@ -4313,6 +4316,7 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
             4433));
         uint32_t SizeOfBuffer = 100;
         uint8_t Buffer[100];
+        uint8_t ZeroBuffer[100] = {0}; 
         TestScopeLogger LogScope1("GetParam size of buffer bigger than needed");
         TEST_QUIC_STATUS(
             QUIC_STATUS_SUCCESS, 
@@ -4322,6 +4326,7 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration, Ms
                 Buffer
             )
         )
+        TEST_NOT_EQUAL(memcmp(Buffer, ZeroBuffer, sizeof(Buffer)), 0);
         // 
         // There is no way the CID written should be 100 bytes according to the RFC.
         //

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4229,26 +4229,46 @@ void QuicTest_QUIC_PARAM_CONN_STATISTICS_V2_PLAT(MsQuicRegistration& Registratio
 
 
 void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
+    //
     // This is the unit test for checking to see if a server has the correct original dest CID.
+    //
     TestScopeLogger LogScope0("QUIC_PARAM_CONN_ORIG_DEST_CID");
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-        uint32_t SizeOfBuffer = 8; // 8 bytes is the expected minimum size of the CID.
+        MsQuicAlpn Alpn("MsQuicTest");
+        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
+        TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionStart(
+            Connection.Handle,
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_INET,
+            "localhost",
+            4433));
+        uint32_t SizeOfBuffer = 8;
+        uint8_t Buffer[8]; // 8 bytes is the expected minimum size of the CID.
         TestScopeLogger LogScope1("GetParam test success case");
-        QUIC_BUFFER buffer = {SizeOfBuffer, new uint8_t[SizeOfBuffer]};
         TEST_QUIC_STATUS(
             QUIC_STATUS_SUCCESS, 
             Connection.GetParam(
                 QUIC_PARAM_CONN_ORIG_DEST_CID,
                 &SizeOfBuffer, 
-                &buffer
+                Buffer
             )
         )
     }
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        MsQuicAlpn Alpn("MsQuicTest");
+        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
+        TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionStart(
+            Connection.Handle,
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_INET,
+            "localhost",
+            4433));
         uint32_t SizeOfBuffer = 8;
         TestScopeLogger LogScope1("GetParam null buffer check");
         TEST_QUIC_STATUS(
@@ -4263,17 +4283,54 @@ void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
     {
         MsQuicConnection Connection(Registration);
         TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        MsQuicAlpn Alpn("MsQuicTest");
+        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
+        TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionStart(
+            Connection.Handle,
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_INET,
+            "localhost",
+            4433));
         uint32_t SizeOfBuffer = 1;
         TestScopeLogger LogScope1("GetParam buffer too small check");
-        QUIC_BUFFER buffer = {SizeOfBuffer, new uint8_t[SizeOfBuffer]};
+        uint8_t Buffer[1];
         TEST_QUIC_STATUS(
             QUIC_STATUS_BUFFER_TOO_SMALL, 
             Connection.GetParam(
                 QUIC_PARAM_CONN_ORIG_DEST_CID,
                 &SizeOfBuffer, 
-                &buffer
+                Buffer
             )
         )
+    }
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        MsQuicAlpn Alpn("MsQuicTest");
+        MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
+        TEST_QUIC_SUCCEEDED(
+        MsQuic->ConnectionStart(
+            Connection.Handle,
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_INET,
+            "localhost",
+            4433));
+        uint32_t SizeOfBuffer = 100;
+        uint8_t Buffer[100];
+        TestScopeLogger LogScope1("GetParam size of buffer bigger than needed");
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_SUCCESS, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                Buffer
+            )
+        )
+        // 
+        // There is no way the CID written should be 100 bytes.
+        //
+        TEST_TRUE(SizeOfBuffer < 100);
     }
 }
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4227,6 +4227,56 @@ void QuicTest_QUIC_PARAM_CONN_STATISTICS_V2_PLAT(MsQuicRegistration& Registratio
     }
 }
 
+
+void QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(MsQuicRegistration& Registration) {
+    // This is the unit test for checking to see if a server has the correct original dest CID.
+    TestScopeLogger LogScope0("QUIC_PARAM_CONN_ORIG_DEST_CID");
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        uint32_t SizeOfBuffer = 8; // 8 bytes is the expected minimum size of the CID.
+        TestScopeLogger LogScope1("GetParam test success case");
+        QUIC_BUFFER buffer = {SizeOfBuffer, new uint8_t[SizeOfBuffer]};
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_SUCCESS, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                &buffer
+            )
+        )
+    }
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        uint32_t SizeOfBuffer = 8;
+        TestScopeLogger LogScope1("GetParam null buffer check");
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_INVALID_PARAMETER, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                nullptr
+            )
+        )
+    }
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        uint32_t SizeOfBuffer = 1;
+        TestScopeLogger LogScope1("GetParam buffer too small check");
+        QUIC_BUFFER buffer = {SizeOfBuffer, new uint8_t[SizeOfBuffer]};
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_BUFFER_TOO_SMALL, 
+            Connection.GetParam(
+                QUIC_PARAM_CONN_ORIG_DEST_CID,
+                &SizeOfBuffer, 
+                &buffer
+            )
+        )
+    }
+}
+
 void QuicTestConnectionParam()
 {
     MsQuicAlpn Alpn("MsQuicTest");
@@ -4259,6 +4309,7 @@ void QuicTestConnectionParam()
     QuicTest_QUIC_PARAM_CONN_CIBIR_ID(Registration, ClientConfiguration);
     QuicTest_QUIC_PARAM_CONN_STATISTICS_V2(Registration);
     QuicTest_QUIC_PARAM_CONN_STATISTICS_V2_PLAT(Registration);
+    QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(Registration);
 }
 
 //


### PR DESCRIPTION
## Description

This PR fixes #3613 that requests a new feature which allows clients and servers to get the original destination CID of the client that initialized the connection. 

## Testing

A new test was added that checks the various fail conditions and edge cases.

## Documentation

Yes, a new GetParameter was added.