### PR TITLE
Minor fixes for Github workflows

### DIFF
--- a/.github/workflows/build-reuse-darwin-framework.yml
+++ b/.github/workflows/build-reuse-darwin-framework.yml
@@ -48,8 +48,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Download Build Artifacts (x64)
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:
@@ -84,8 +82,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Download Build Artifacts (x64)
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:
@@ -107,8 +103,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Download Build Artifacts (iOS x64)
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -82,8 +82,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Set ownership
       if: inputs.plat == 'linux' && contains(inputs.arch, 'arm')
       run: |

--- a/.github/workflows/build-reuse-win.yml
+++ b/.github/workflows/build-reuse-win.yml
@@ -71,8 +71,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Install Perl
       uses: shogo82148/actions-setup-perl@04a9a397f834661fa6faf5aa6d16d14536249d2a
       with:

--- a/.github/workflows/build-reuse-winkernel.yml
+++ b/.github/workflows/build-reuse-winkernel.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -ForBuild -ForKernel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,8 +208,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Download Build Artifacts
       uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
       with:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -79,8 +79,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -ForTest

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -41,8 +41,6 @@ jobs:
         egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.tls }} -DisableTest
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,8 @@ jobs:
         ]
     runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WSPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WSPrerelease'']') || matrix.vec.os }}
     steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Download Build Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'windows'
@@ -251,8 +250,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      with:
-        fetch-depth: 0
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'windows'
       with:

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -153,7 +153,13 @@ if ($ForTest) {
     # enabled for any possible test.
     $InstallTestCertificates = $true
     $InstallClog2Text = $true
-    $InstallSigningCertificates = $true; # For kernel drivers
+
+    # Since installing signing certs also checks whether test signing is enabled, which most
+    # likely will fail on a devbox, do it only when we need to test kernel drivers so that
+    # local testing setup won't be blocked by test signing not enabled.
+    if ($ForKernel) {
+        $InstallSigningCertificates = $true;
+    }
 
     #$InstallCodeCoverage = $true # Ideally we'd enable this by default, but it
                                   # hangs sometimes, so we only want to install


### PR DESCRIPTION
## Description

1. Skip installing signing certs if `ForTest` is not used with `ForKernel` in prepare-machine.ps1.
2. Only fetch the number of commits in checkout action required by the workflow.

## Testing

CI
