### PR TITLE
Dynamically load/unload xdp dll

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -55,8 +55,7 @@ if ("${CX_PLATFORM}" STREQUAL "windows" AND QUIC_USE_XDP)
         platform
         PUBLIC
         inc
-        wbemuuid
-        ${PROJECT_SOURCE_DIR}/artifacts/xdp/lib/xdpapi.lib)
+        wbemuuid)
 else()
     target_link_libraries(platform PUBLIC inc)
 endif()

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1018,8 +1018,7 @@ CxPlatDpRawInitialize(
     const uint16_t* ProcessorList;
 
     CxPlatListInitializeHead(&Xdp->Interfaces);
-    XDP_LOAD_API_CONTEXT XdpApiLoadContext;
-    if (QUIC_FAILED(XdpLoadApi(XDP_VERSION_PRERELEASE, &Xdp->, &Xdp->XdpApi))) {
+    if (QUIC_FAILED(XdpLoadApi(XDP_VERSION_PRERELEASE, &Xdp->XdpApiLoadContext, &Xdp->XdpApi))) {
         Status = QUIC_STATUS_NOT_SUPPORTED;
         goto Error;
     }
@@ -1233,7 +1232,7 @@ Error:
         }
 
         if (Xdp->XdpApi) {
-            XdpUnloadApi(&Xdp->XdpApiLoadContext, Xdp->XdpApi);
+            XdpUnloadApi(Xdp->XdpApiLoadContext, Xdp->XdpApi);
         }
     }
 
@@ -1261,7 +1260,7 @@ CxPlatDpRawRelease(
             CxPlatDpRawInterfaceUninitialize(Interface);
             CxPlatFree(Interface, IF_TAG);
         }
-        XdpCloseApi(&Xdp->XdpApiLoadContext, Xdp->XdpApi);
+        XdpUnloadApi(Xdp->XdpApiLoadContext, Xdp->XdpApi);
         CxPlatDataPathUninitializeComplete((CXPLAT_DATAPATH*)Xdp);
     }
 }

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -38,6 +38,7 @@ typedef struct XDP_DATAPATH {
     BOOLEAN TxAlwaysPoke;
     BOOLEAN SkipXsum;
     BOOLEAN Running;        // Signal to stop workers.
+    XDP_LOAD_API_CONTEXT XdpApiLoadContext;
     const XDP_API_TABLE *XdpApi;
 
     XDP_WORKER Workers[0];
@@ -1017,7 +1018,8 @@ CxPlatDpRawInitialize(
     const uint16_t* ProcessorList;
 
     CxPlatListInitializeHead(&Xdp->Interfaces);
-    if (QUIC_FAILED(XdpOpenApi(XDP_VERSION_PRERELEASE, &Xdp->XdpApi))) {
+    XDP_LOAD_API_CONTEXT XdpApiLoadContext;
+    if (QUIC_FAILED(XdpLoadApi(XDP_VERSION_PRERELEASE, &Xdp->, &Xdp->XdpApi))) {
         Status = QUIC_STATUS_NOT_SUPPORTED;
         goto Error;
     }
@@ -1231,7 +1233,7 @@ Error:
         }
 
         if (Xdp->XdpApi) {
-            XdpCloseApi(Xdp->XdpApi);
+            XdpUnloadApi(&Xdp->XdpApiLoadContext, Xdp->XdpApi);
         }
     }
 
@@ -1259,7 +1261,7 @@ CxPlatDpRawRelease(
             CxPlatDpRawInterfaceUninitialize(Interface);
             CxPlatFree(Interface, IF_TAG);
         }
-        XdpCloseApi(Xdp->XdpApi);
+        XdpCloseApi(&Xdp->XdpApiLoadContext, Xdp->XdpApi);
         CxPlatDataPathUninitializeComplete((CXPLAT_DATAPATH*)Xdp);
     }
 }


### PR DESCRIPTION
## Description

Use `XdpLoadApi` which uses run-time linking instead of `XdpOpenApi` which uses load-time linking.

## Testing

CI/CD

## Documentation

No.
