### PR TITLE
Use UDP Length for XDP RX

### DIFF
--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -128,7 +128,6 @@ CxPlatDpRawParseUdp(
         return;
     }
 
-    Length -= sizeof(UDP_HEADER);
     Packet->Reserved = L4_TYPE_UDP;
 
     Packet->Route->RemoteAddress.Ipv4.sin_port = Udp->SourcePort;

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -118,6 +118,16 @@ CxPlatDpRawParseUdp(
         return;
     }
 
+    if (Length < QuicNetByteSwapShort(Udp->Length)) {
+        QuicTraceEvent(
+            DatapathErrorStatus,
+            "[data][%p] ERROR, %u, %s.",
+            Datapath,
+            Length,
+            "UDP Length larger than IP length");
+        return;
+    }
+
     Length -= sizeof(UDP_HEADER);
     Packet->Reserved = L4_TYPE_UDP;
 
@@ -125,7 +135,7 @@ CxPlatDpRawParseUdp(
     Packet->Route->LocalAddress.Ipv4.sin_port = Udp->DestinationPort;
 
     Packet->Buffer = (uint8_t*)Udp->Data;
-    Packet->BufferLength = Length;
+    Packet->BufferLength = QuicNetByteSwapShort(Udp->Length) - sizeof(UDP_HEADER);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)


### PR DESCRIPTION
## Description

Uses the UDP length field instead of the IP length for receiving the UDP payload. Fixes #3776.

## Testing

CI

## Documentation

N/A
