### PR TITLE
Add a name to unnamed struct QUIC_HANDLE

### DIFF
--- a/src/core/configuration.h
+++ b/src/core/configuration.h
@@ -10,7 +10,7 @@
 //
 typedef struct QUIC_CONFIGURATION {
 
-    struct QUIC_HANDLE;
+    struct QUIC_HANDLE Self;
 
     //
     // Parent registration.

--- a/src/core/configuration.h
+++ b/src/core/configuration.h
@@ -10,7 +10,11 @@
 //
 typedef struct QUIC_CONFIGURATION {
 
-    struct QUIC_HANDLE Self;
+#ifdef __cplusplus
+    struct QUIC_HANDLE _;
+#else
+    struct QUIC_HANDLE;
+#endif
 
     //
     // Parent registration.

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -312,7 +312,11 @@ typedef struct QUIC_CONN_STATS {
 //
 typedef struct QUIC_CONNECTION {
 
-    struct QUIC_HANDLE Self;
+#ifdef __cplusplus
+    struct QUIC_HANDLE _;
+#else
+    struct QUIC_HANDLE;
+#endif
 
     //
     // Link into the registrations's list of connections.

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -312,11 +312,7 @@ typedef struct QUIC_CONN_STATS {
 //
 typedef struct QUIC_CONNECTION {
 
-#ifdef __cplusplus
-    struct QUIC_HANDLE _;
-#else
-    struct QUIC_HANDLE;
-#endif
+    struct QUIC_HANDLE Self;
 
     //
     // Link into the registrations's list of connections.

--- a/src/core/listener.h
+++ b/src/core/listener.h
@@ -10,7 +10,7 @@
 //
 typedef struct QUIC_LISTENER {
 
-    struct QUIC_HANDLE;
+    struct QUIC_HANDLE Self;
 
     //
     // Indicates the listener is listening on a wildcard address (v4/v6/both).

--- a/src/core/listener.h
+++ b/src/core/listener.h
@@ -10,7 +10,11 @@
 //
 typedef struct QUIC_LISTENER {
 
-    struct QUIC_HANDLE Self;
+#ifdef __cplusplus
+    struct QUIC_HANDLE _;
+#else
+    struct QUIC_HANDLE;
+#endif
 
     //
     // Indicates the listener is listening on a wildcard address (v4/v6/both).

--- a/src/core/registration.h
+++ b/src/core/registration.h
@@ -26,7 +26,7 @@ typedef enum QUIC_CONNECTION_ACCEPT_RESULT {
 //
 typedef struct QUIC_REGISTRATION {
 
-    struct QUIC_HANDLE;
+    struct QUIC_HANDLE Self;
 
 #ifdef CxPlatVerifierEnabledByAddr
     //

--- a/src/core/registration.h
+++ b/src/core/registration.h
@@ -26,7 +26,11 @@ typedef enum QUIC_CONNECTION_ACCEPT_RESULT {
 //
 typedef struct QUIC_REGISTRATION {
 
-    struct QUIC_HANDLE Self;
+#ifdef __cplusplus
+    struct QUIC_HANDLE _;
+#else
+    struct QUIC_HANDLE;
+#endif
 
 #ifdef CxPlatVerifierEnabledByAddr
     //

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -198,7 +198,11 @@ typedef enum QUIC_STREAM_REF {
 //
 typedef struct QUIC_STREAM {
 
-    struct QUIC_HANDLE Self;
+#ifdef __cplusplus
+    struct QUIC_HANDLE _;
+#else
+    struct QUIC_HANDLE;
+#endif
 
     //
     // Number of references to the handle.

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -198,7 +198,7 @@ typedef enum QUIC_STREAM_REF {
 //
 typedef struct QUIC_STREAM {
 
-    struct QUIC_HANDLE;
+    struct QUIC_HANDLE Self;
 
     //
     // Number of references to the handle.


### PR DESCRIPTION
## Description

Add a name to unnamed struct QUIC_HANDLE to improve compatibility with C++. #3785 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
