### PR TITLE
Update OpenSSL to v3.1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 [submodule "submodules/openssl3"]
 	path = submodules/openssl3
 	url = https://github.com/quictls/openssl.git
-	branch = openssl-3.1.0+quic
+	branch = openssl-3.1.2+quic
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git


### PR DESCRIPTION
## Description

Consumes the latest OpenSSL v3 release. Notes: https://www.openssl.org/news/openssl-3.1-notes.html

## Testing

Automation

## Documentation

N/A