### PR TITLE
Add Debian 12 package & fix Fedora 37 package

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -52,6 +52,7 @@ parameters:
   - microsoft-ubuntu-jammy-prod-apt
   - microsoft-ubuntu-kinetic-prod-apt
   - microsoft-ubuntu-lunar-prod-apt
+  - microsoft-debian-bookworm-prod-apt
 - name: openssl3rpmrepos
   type: object
   default:

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -32,6 +32,7 @@ parameters:
   - microsoft-fedora32-prod-yum
   - microsoft-fedora33-prod-yum
   - microsoft-fedora34-prod-yum
+  - microsoft-fedora37-prod-yum
   - microsoft-rhel7.3-prod-yum
   - microsoft-rhel8.0-prod-yum
   - microsoft-rhel8.1-prod-yum
@@ -57,7 +58,6 @@ parameters:
   type: object
   default:
   - microsoft-fedora36-prod-yum
-  - microsoft-fedora37-prod-yum
   - microsoft-fedora38-prod-yum
   - microsoft-rhel9.0-prod-yum
 - name: debug # debug mode will not actually upload and publish packages


### PR DESCRIPTION
## Description

Adds Debian 12 (bookworm) to the list of distros to publish to. Debian 12 was released on [June 10](https://www.debian.org/releases/bookworm/). The distro already exists on [packages.microsoft.com](https://packages.microsoft.com/debian/12/prod/). LMK if I've missed something @nibanks @csujedihy

The second change is an attempt to fix Fedora 37 usecase, which has strange problems with OpenSSL 3 package (https://github.com/microsoft/msquic/issues/3640#issuecomment-1579439966). However, the distro has a compat OpenSSL 1.1 package, so I propose to fallback to that, given that the distro will be supported only until [2023-11-14](https://fedorapeople.org/groups/schedule/f-39/f-39-key-tasks.html).

## Testing

I've verified that Ubuntu 22.04 package (OpenSSL 3) works on Debian 12, and that CentOS 8 package (OpenSSL 1.1) works on Fedora 37 ([verification script](https://github.com/CarnaViire/QuicDockerTest/blob/main/quic-docker.ps1)). I don't have access to verify actual publish scripts.

## Documentation

N/A

cc @wfurt @ManickaP
