### PR TITLE
Fix QEO RX Packet Encrypted Logic

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3945,7 +3945,7 @@ QuicConnRecvHeader(
         } else {
             Packet->KeyType = QuicPacketTypeToKeyTypeV1(Packet->LH->Type);
         }
-        Packet->Encrypted = !Connection->Paths[0].EncryptionOffloading;
+        Packet->Encrypted = TRUE;
 
     } else {
 
@@ -3955,7 +3955,9 @@ QuicConnRecvHeader(
         }
 
         Packet->KeyType = QUIC_PACKET_KEY_1_RTT;
-        Packet->Encrypted = !Connection->State.Disable1RttEncrytion;
+        Packet->Encrypted =
+            !Connection->State.Disable1RttEncrytion &&
+            !Connection->Paths[0].EncryptionOffloading;
     }
 
     if (Packet->Encrypted &&


### PR DESCRIPTION
## Description

Logic wasn't correct for determining when a short header packet wasn't actually encrypted.

## Testing

Will do manual testing.

## Documentation

N/A
