### PR TITLE
Fix OneBranch Kernel Tests

### DIFF
--- a/.azure/obtemplates/run-bvt.yml
+++ b/.azure/obtemplates/run-bvt.yml
@@ -23,7 +23,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
-      arguments: -ForTest
+      arguments: -ForTest -ForKernel
   - template: ./download-artifacts.yml
     parameters:
       platform: winkernel


### PR DESCRIPTION
## Description

Fixes the kernel OneBranch tests by making sure to prepare machine for kernel mode, which includes downloading signing certs.

## Testing

Automation

## Documentation

N/A
