### PR TITLE
fix kernel build warning

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -18,7 +18,7 @@ Abstract:
 
 #if defined(_KERNEL_MODE)
 bool UseQTIP = false;
-#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -16,7 +16,9 @@ Abstract:
 
 #pragma warning(disable:6387)  // '_Param_(1)' could be '0':  this does not adhere to the specification for the function
 
-#if defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#if defined(_KERNEL_MODE)
+bool UseQTIP = false;
+#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -17,7 +17,7 @@ Abstract:
 #pragma warning(disable:6387)  // '_Param_(1)' could be '0':  this does not adhere to the specification for the function
 
 #if defined(_KERNEL_MODE)
-bool UseQTIP = false;
+static bool UseQTIP = false;
 #elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -16,7 +16,7 @@ Abstract:
 
 #if defined(_KERNEL_MODE)
 bool UseQTIP = false;
-#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -15,7 +15,7 @@ Abstract:
 #endif
 
 #if defined(_KERNEL_MODE)
-bool UseQTIP = false;
+static bool UseQTIP = false;
 #elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -14,7 +14,9 @@ Abstract:
 #include "DataTest.cpp.clog.h"
 #endif
 
-#if defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#if defined(_KERNEL_MODE)
+bool UseQTIP = false;
+#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -16,7 +16,7 @@ Abstract:
 
 #if defined(_KERNEL_MODE)
 bool UseQTIP = false;
-#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -15,7 +15,7 @@ Abstract:
 #endif
 
 #if defined(_KERNEL_MODE)
-bool UseQTIP = false;
+static bool UseQTIP = false;
 #elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif

--- a/src/test/lib/MtuTest.cpp
+++ b/src/test/lib/MtuTest.cpp
@@ -14,7 +14,9 @@ Abstract:
 #include "MtuTest.cpp.clog.h"
 #endif
 
-#if defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+#if defined(_KERNEL_MODE)
+bool UseQTIP = false;
+#elf defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
 extern bool UseQTIP;
 #endif
 

--- a/src/test/lib/precomp.h
+++ b/src/test/lib/precomp.h
@@ -35,11 +35,6 @@
 #define WIN_ASSERT CXPLAT_FRE_ASSERT
 #endif
 #include "karray.h"
-
-#ifndef GLOBAL_FOR_KERNEL
-#define GLOBAL_FOR_KERNEL
-bool UseQTIP = false;
-#endif
 #endif
 
 #include "TestHelpers.h"


### PR DESCRIPTION
## Description
Kernel build has build warning by trying to define `UseQTIP` multiple times.

## Testing
build matter

## Documentation
N/A

