### PR TITLE
Configure Codecov to reduce noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      target: 80%
+      threshold: 2%


### PR DESCRIPTION
## Description

Add a config file for codecov so that the workflow won't just fail for every PR when code coverage moves a little bit due to stress test.

Feel free to push a change to modify the threshold and target.

Currently, for the whole project, it compares with the parent commit and fails if the coverage is down more than 2% (threshold).

For the diff in a PR/commit, I currently set the target to 80% with a 2% threshold.

## Testing

CI
