### PR TITLE
Only do Official Releases in OneBranch

### DIFF
--- a/.azure/obtemplates/build-linux.yml
+++ b/.azure/obtemplates/build-linux.yml
@@ -32,7 +32,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI -UseSystemOpenSSLCrypto -OneBranch
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI -UseSystemOpenSSLCrypto -OneBranch -OfficialRelease
   - task: PowerShell@2
     displayName: arm64
     ${{ if eq(parameters.tls, 'openssl') }}:
@@ -42,7 +42,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm64 -CI -UseSystemOpenSSLCrypto -OneBranch
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm64 -CI -UseSystemOpenSSLCrypto -OneBranch -OfficialRelease
   - task: PowerShell@2
     displayName: arm
     ${{ if eq(parameters.tls, 'openssl') }}:
@@ -52,4 +52,4 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm -CI -UseSystemOpenSSLCrypto -OneBranch
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm -CI -UseSystemOpenSSLCrypto -OneBranch -OfficialRelease

--- a/.azure/obtemplates/build-winuser-xdp.yml
+++ b/.azure/obtemplates/build-winuser-xdp.yml
@@ -26,7 +26,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI -UseXdp -ExtraArtifactDir xdp
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI -UseXdp -ExtraArtifactDir xdp -OfficialRelease
   - task: onebranch.pipeline.signing@1
     target: windows_build_container2
     inputs:

--- a/.azure/obtemplates/build-winuser.yml
+++ b/.azure/obtemplates/build-winuser.yml
@@ -19,7 +19,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x64 -CI -OfficialRelease
   - task: PowerShell@2
     displayName: x86
     condition: ne('${{ parameters.platform }}', 'gamecore_console')
@@ -27,7 +27,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x86 -CI
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch x86 -CI -OfficialRelease
   - task: PowerShell@2
     displayName: ARM
     condition: ne('${{ parameters.platform }}', 'gamecore_console')
@@ -35,7 +35,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm -CI
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm -CI -OfficialRelease
   - task: PowerShell@2
     displayName: ARM64
     condition: and(ne('${{ parameters.platform }}', 'gamecore_console'), ne('${{ parameters.tls }}', 'openssl'))
@@ -43,7 +43,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
-      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm64 -CI
+      arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm64 -CI -OfficialRelease
   - task: PowerShell@2
     displayName: Write Versions
     target: windows_build_container2

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -277,6 +277,7 @@ if (!$OfficialRelease) {
         # Thanks to https://stackoverflow.com/questions/3404936/show-which-git-tag-you-are-on
         # for this magic git command!
         $Output = git describe --exact-match --tags $(git log -n1 --pretty='%h')
+        Write-Host "Git tag output: $Output"
         if (!$Output.Contains("fatal: no tag exactly matches")) {
             Write-Host "Configuring OfficialRelease for tag build"
             $OfficialRelease = $true

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -271,13 +271,15 @@ if ($Platform -eq "ios" -and !$Static) {
     Write-Host "iOS can only be built as static"
 }
 
-if (!$OfficialRelease) {
+if ($OfficialRelease) {
+    # We only actually try to do official release if there is a matching git tag.
+    # Clear the flag and then only set it if we find a tag.
+    $OfficialRelease = $false
     try {
         $env:GIT_REDIRECT_STDERR = '2>&1'
         # Thanks to https://stackoverflow.com/questions/3404936/show-which-git-tag-you-are-on
         # for this magic git command!
         $Output = git describe --exact-match --tags $(git log -n1 --pretty='%h')
-        Write-Host "Git tag output: $Output"
         if (!$Output.Contains("fatal: no tag exactly matches")) {
             Write-Host "Configuring OfficialRelease for tag build"
             $OfficialRelease = $true


### PR DESCRIPTION
## Description

With a recent change to fetch depth, our logic to determine if we're doing an official break, based on reading tags, broke (they aren't present any more). Rework things so we don't care for the public CI.

BTW, the break above was causing all prerelease tests to get disabled on Windows. Fixing that is the primary motivation here.

## Testing

Automation

## Documentation

N/A
