### PR TITLE
Fix Debug Builds on Windows User Mode

### DIFF
--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -69,6 +69,7 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 } QUIC_TEST_DATAPATH_HOOKS;
 
 #if DEBUG
+#pragma message("Enabling datapath hooks")
 //
 // Datapath hooks are currently only enabled on debug builds for functional
 // testing helpers.
@@ -92,6 +93,8 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 // negotiation transport parameter.
 //
 #define QUIC_TEST_DISABLE_VNE_TP_GENERATION 1
+#else
+#pragma message("Not enabling datapath hooks")
 #endif
 
 typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -69,7 +69,6 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 } QUIC_TEST_DATAPATH_HOOKS;
 
 #if DEBUG
-#pragma message("Enabling datapath hooks")
 //
 // Datapath hooks are currently only enabled on debug builds for functional
 // testing helpers.
@@ -93,8 +92,6 @@ typedef struct QUIC_TEST_DATAPATH_HOOKS {
 // negotiation transport parameter.
 //
 #define QUIC_TEST_DISABLE_VNE_TP_GENERATION 1
-#else
-#pragma message("Not enabling datapath hooks")
 #endif
 
 typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -57,6 +57,7 @@ extern "C" {
 #endif
 
 #if defined(DEBUG) || defined(_DEBUG)
+#pragma message("Debug build enabled")
 #define DBG 1
 #define DEBUG 1
 #endif

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -56,7 +56,7 @@ Environment:
 extern "C" {
 #endif
 
-#if defined(DEBUG) || defined(_DEBUG)
+#ifndef NDEBUG
 #pragma message("Debug build enabled")
 #define DBG 1
 #define DEBUG 1

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -57,7 +57,6 @@ extern "C" {
 #endif
 
 #ifndef NDEBUG
-#pragma message("Debug build enabled")
 #define DBG 1
 #define DEBUG 1
 #endif

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -10,6 +10,12 @@
 #include "quic_gtest.cpp.clog.h"
 #endif
 
+#ifdef QUIC_TEST_DATAPATH_HOOKS_ENABLED
+#pragma message("Datapath hooks enabled!")
+#else
+#pragma message("No datapath hooks enabled!")
+#endif
+
 bool TestingKernelMode = false;
 bool PrivateTestLibrary = false;
 bool UseDuoNic = false;

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -10,6 +10,14 @@
 #include "quic_gtest.cpp.clog.h"
 #endif
 
+#ifdef QUIC_TEST_DATAPATH_HOOKS_ENABLED
+#pragma message("Test compiled with datapath hooks enabled")
+#endif
+
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#pragma message("Test compiled with preview features enabled")
+#endif
+
 bool TestingKernelMode = false;
 bool PrivateTestLibrary = false;
 bool UseDuoNic = false;

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -10,12 +10,6 @@
 #include "quic_gtest.cpp.clog.h"
 #endif
 
-#ifdef QUIC_TEST_DATAPATH_HOOKS_ENABLED
-#pragma message("Datapath hooks enabled!")
-#else
-#pragma message("No datapath hooks enabled!")
-#endif
-
 bool TestingKernelMode = false;
 bool PrivateTestLibrary = false;
 bool UseDuoNic = false;


### PR DESCRIPTION
## Description

For some reason the previous logic for setting the `DEBUG` flag didn't work for Windows user mode always (i.e. not in CI, but it did locally). Updates the logic to hopefully work consistently now.

## Testing

Automation

## Documentation

N/A
