### PR TITLE
Refactor the RX Datapath Object Abstraction Model

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -921,11 +921,11 @@ QuicBindingProcessStatelessOperation(
         PacketLength >>= 5; // Only drop 5 of the 8 bits of randomness.
         PacketLength += QUIC_RECOMMENDED_STATELESS_RESET_PACKET_LENGTH;
 
-        if (PacketLength >= RecvPacket->BufferLength) {
+        if (PacketLength >= RecvPacket->AvailBufferLength) {
             //
             // Can't go over the recieve packet's length.
             //
-            PacketLength = (uint8_t)RecvPacket->BufferLength - 1;
+            PacketLength = (uint8_t)RecvPacket->AvailBufferLength - 1;
         }
 
         if (PacketLength < QUIC_MIN_STATELESS_RESET_PACKET_LENGTH) {
@@ -1148,8 +1148,8 @@ QuicBindingPreprocessDatagram(
 {
     QUIC_RX_PACKET* Packet = GetQuicRxPacket(Datagram);
     CxPlatZeroMemory(&Packet->PacketNumber, sizeof(QUIC_RX_PACKET) - sizeof(uint64_t));
-    Packet->Buffer = Datagram->Buffer;
-    Packet->BufferLength = Datagram->BufferLength;
+    Packet->AvailBuffer = Datagram->Buffer;
+    Packet->AvailBufferLength = Datagram->BufferLength;
 
     *ReleaseDatagram = TRUE;
 
@@ -1656,8 +1656,8 @@ QuicBindingReceive(
         CxPlatZeroMemory(Packet, sizeof(QUIC_RX_PACKET));
         Packet->PacketId =
             PartitionShifted | InterlockedIncrement64((int64_t*)&QuicLibraryGetPerProc()->ReceivePacketId);
-        Packet->Buffer = Datagram->Buffer;
-        Packet->BufferLength = Datagram->BufferLength;
+        Packet->AvailBuffer = Datagram->Buffer;
+        Packet->AvailBufferLength = Datagram->BufferLength;
 
         CXPLAT_DBG_ASSERT(Packet->PacketId != 0);
         QuicTraceEvent(

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1653,11 +1653,19 @@ QuicBindingReceive(
         Datagram->Next = NULL;
 
         QUIC_RX_PACKET* Packet = GetQuicRxPacket(Datagram);
-        CxPlatZeroMemory(Packet, sizeof(QUIC_RX_PACKET));
         Packet->PacketId =
             PartitionShifted | InterlockedIncrement64((int64_t*)&QuicLibraryGetPerProc()->ReceivePacketId);
+        Packet->PacketNumber = 0;
         Packet->AvailBuffer = Datagram->Buffer;
+        Packet->DestCid = NULL;
+        Packet->SourceCid = NULL;
         Packet->AvailBufferLength = Datagram->BufferLength;
+        Packet->HeaderLength = 0;
+        Packet->PayloadLength = 0;
+        Packet->DestCidLen = 0;
+        Packet->SourceCidLen = 0;
+        Packet->KeyType = QUIC_PACKET_KEY_INITIAL;
+        Packet->Flags = 0;
 
         CXPLAT_DBG_ASSERT(Packet->PacketId != 0);
         QuicTraceEvent(

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -676,7 +676,7 @@ QuicBindingCreateStatelessOperation(
     }
 
     if (Binding->StatelessOperCount >= (uint32_t)MsQuicLib.Settings.MaxBindingStatelessOperations) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "Max binding operations reached");
         goto Exit;
     }
@@ -694,7 +694,7 @@ QuicBindingCreateStatelessOperation(
             CXPLAT_CONTAINING_RECORD(TableEntry, QUIC_STATELESS_CONTEXT, TableEntry);
 
         if (QuicAddrCompare(&ExistingCtx->RemoteAddress, RemoteAddress)) {
-            QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+            QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
                 "Already in stateless oper table");
             goto Exit;
         }
@@ -710,7 +710,7 @@ QuicBindingCreateStatelessOperation(
     StatelessCtx =
         (QUIC_STATELESS_CONTEXT*)CxPlatPoolAlloc(&Worker->StatelessContextPool);
     if (StatelessCtx == NULL) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "Alloc failure for stateless oper ctx");
         goto Exit;
     }
@@ -753,14 +753,14 @@ QuicBindingQueueStatelessOperation(
     )
 {
     if (MsQuicLib.StatelessRegistration == NULL) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "NULL stateless registration");
         return FALSE;
     }
 
     QUIC_WORKER* Worker = QuicLibraryGetWorker(Datagram);
     if (QuicWorkerIsOverloaded(Worker)) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "Stateless worker overloaded (stateless oper)");
         return FALSE;
     }
@@ -780,7 +780,7 @@ QuicBindingQueueStatelessOperation(
             sizeof(QUIC_OPERATION));
         QuicPacketLogDrop(
             Binding,
-            CxPlatDataPathRecvDataToRecvPacket(Datagram),
+            GetQuicRxPacket(Datagram),
             "Alloc failure for stateless operation");
         QuicBindingReleaseStatelessOperation(Context, FALSE);
         return FALSE;
@@ -801,8 +801,7 @@ QuicBindingProcessStatelessOperation(
 {
     QUIC_BINDING* Binding = StatelessCtx->Binding;
     CXPLAT_RECV_DATA* RecvDatagram = StatelessCtx->Datagram;
-    CXPLAT_RECV_PACKET* RecvPacket =
-        CxPlatDataPathRecvDataToRecvPacket(RecvDatagram);
+    QUIC_RX_PACKET* RecvPacket = GetQuicRxPacket(RecvDatagram);
     QUIC_BUFFER* SendDatagram = NULL;
 
     CXPLAT_DBG_ASSERT(RecvPacket->ValidatedHeaderInv);
@@ -893,7 +892,7 @@ QuicBindingProcessStatelessOperation(
             SupportedVersions,
             SupportedVersionsLength * sizeof(uint32_t));
 
-        CXPLAT_RECV_PACKET* Packet = CxPlatDataPathRecvDataToRecvPacket(RecvDatagram);
+        QUIC_RX_PACKET* Packet = GetQuicRxPacket(RecvDatagram);
         Packet->ReleaseDeferred = FALSE;
 
         QuicTraceLogVerbose(
@@ -1118,7 +1117,7 @@ QuicBindingQueueStatelessReset(
     CXPLAT_DBG_ASSERT(!((QUIC_SHORT_HEADER_V1*)Datagram->Buffer)->IsLongHeader);
 
     if (Datagram->BufferLength <= QUIC_MIN_STATELESS_RESET_PACKET_LENGTH) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "Packet too short for stateless reset");
         return FALSE;
     }
@@ -1129,7 +1128,7 @@ QuicBindingQueueStatelessReset(
         // a connection ID. Without a connection ID, a stateless reset token
         // cannot be generated.
         //
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "No stateless reset on exclusive binding");
         return FALSE;
     }
@@ -1147,8 +1146,8 @@ QuicBindingPreprocessDatagram(
     _Out_ BOOLEAN* ReleaseDatagram
     )
 {
-    CXPLAT_RECV_PACKET* Packet = CxPlatDataPathRecvDataToRecvPacket(Datagram);
-    CxPlatZeroMemory(&Packet->PacketNumber, sizeof(CXPLAT_RECV_PACKET) - sizeof(uint64_t));
+    QUIC_RX_PACKET* Packet = GetQuicRxPacket(Datagram);
+    CxPlatZeroMemory(&Packet->PacketNumber, sizeof(QUIC_RX_PACKET) - sizeof(uint64_t));
     Packet->Buffer = Datagram->Buffer;
     Packet->BufferLength = Datagram->BufferLength;
 
@@ -1219,7 +1218,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicBindingShouldRetryConnection(
     _In_ const QUIC_BINDING* const Binding,
-    _In_ CXPLAT_RECV_PACKET* Packet,
+    _In_ QUIC_RX_PACKET* Packet,
     _In_ uint16_t TokenLength,
     _In_reads_(TokenLength)
         const uint8_t* Token,
@@ -1269,7 +1268,7 @@ QuicBindingCreateConnection(
     // QuicLookupAddRemoteHash.
     //
 
-    CXPLAT_RECV_PACKET* Packet = CxPlatDataPathRecvDataToRecvPacket(Datagram);
+    QUIC_RX_PACKET* Packet = GetQuicRxPacket(Datagram);
 
     //
     // Pick a stateless worker to process the client hello and if successful,
@@ -1312,7 +1311,7 @@ QuicBindingCreateConnection(
     //
 
     if (!QuicLibraryTryAddRefBinding(Binding)) {
-        QuicPacketLogDrop(Binding, CxPlatDataPathRecvDataToRecvPacket(Datagram),
+        QuicPacketLogDrop(Binding, GetQuicRxPacket(Datagram),
             "Clean up in progress");
         goto Exit;
     }
@@ -1414,7 +1413,7 @@ QuicBindingDropBlockedSourcePorts(
         if (BlockedPorts[i] == SourcePort) {
             QuicPacketLogDrop(
                 Binding,
-                CxPlatDataPathRecvDataToRecvPacket(Datagram),
+                GetQuicRxPacket(Datagram),
                 "Blocked source port");
             return TRUE;
         }
@@ -1438,8 +1437,7 @@ QuicBindingDeliverDatagrams(
     _In_ uint32_t DatagramChainByteLength
     )
 {
-    CXPLAT_RECV_PACKET* Packet =
-            CxPlatDataPathRecvDataToRecvPacket(DatagramChain);
+    QUIC_RX_PACKET* Packet = GetQuicRxPacket(DatagramChain);
     CXPLAT_DBG_ASSERT(Packet->ValidatedHeaderInv);
 
     //
@@ -1654,9 +1652,8 @@ QuicBindingReceive(
         DatagramChain = Datagram->Next;
         Datagram->Next = NULL;
 
-        CXPLAT_RECV_PACKET* Packet =
-            CxPlatDataPathRecvDataToRecvPacket(Datagram);
-        CxPlatZeroMemory(Packet, sizeof(CXPLAT_RECV_PACKET));
+        QUIC_RX_PACKET* Packet = GetQuicRxPacket(Datagram);
+        CxPlatZeroMemory(Packet, sizeof(QUIC_RX_PACKET));
         Packet->PacketId =
             PartitionShifted | InterlockedIncrement64((int64_t*)&QuicLibraryGetPerProc()->ReceivePacketId);
         Packet->Buffer = Datagram->Buffer;
@@ -1708,8 +1705,7 @@ QuicBindingReceive(
         // the same connection and this chain-splitting step is skipped.)
         //
         if (!Binding->Exclusive && SubChain != NULL) {
-            CXPLAT_RECV_PACKET* SubChainPacket =
-                CxPlatDataPathRecvDataToRecvPacket(SubChain);
+            QUIC_RX_PACKET* SubChainPacket = GetQuicRxPacket(SubChain);
             if ((Packet->DestCidLen != SubChainPacket->DestCidLen ||
                  memcmp(Packet->DestCid, SubChainPacket->DestCid, Packet->DestCidLen) != 0)) {
                 if (!QuicBindingDeliverDatagrams(Binding, SubChain, SubChainLength, SubChainBytes)) {

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -28,7 +28,7 @@ typedef struct QUIC_TOKEN_CONTENTS {
 //
 // The per recv buffer context type.
 //
-typedef struct CXPLAT_RECV_PACKET {
+typedef struct QUIC_RX_PACKET {
 
     //
     // The unique identifier for the packet.
@@ -152,7 +152,12 @@ typedef struct CXPLAT_RECV_PACKET {
     //
     BOOLEAN HasNonProbingFrame : 1;
 
-} CXPLAT_RECV_PACKET;
+} QUIC_RX_PACKET;
+
+#define GetRecvData(Packet) \
+    CXPLAT_CONTAINING_RECORD(Packet, CXPLAT_RECV_DATA, ClientData)
+#define GetQuicRxPacket(RecvData) \
+    ((QUIC_RX_PACKET*)&(RecvData)->ClientData)
 
 typedef enum QUIC_BINDING_LOOKUP_TYPE {
 
@@ -455,7 +460,7 @@ inline
 _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicRetryTokenDecrypt(
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _In_reads_(sizeof(QUIC_TOKEN_CONTENTS))
         const uint8_t* TokenBuffer,
     _Out_ QUIC_TOKEN_CONTENTS* Token

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -30,6 +30,12 @@ typedef struct QUIC_TOKEN_CONTENTS {
 //
 typedef struct QUIC_RX_PACKET {
 
+#ifdef __cplusplus
+    struct CXPLAT_RECV_DATA _;
+#else
+    struct CXPLAT_RECV_DATA;
+#endif
+
     //
     // The unique identifier for the packet.
     //
@@ -44,8 +50,8 @@ typedef struct QUIC_RX_PACKET {
     // The current packet buffer.
     //
     union {
-        _Field_size_(BufferLength)
-        const uint8_t* Buffer;
+        _Field_size_(AvailBufferLength)
+        const uint8_t* AvailBuffer;
         const struct QUIC_HEADER_INVARIANT* Invariant;
         const struct QUIC_VERSION_NEGOTIATION_PACKET* VerNeg;
         const struct QUIC_LONG_HEADER_V1* LH;
@@ -64,9 +70,9 @@ typedef struct QUIC_RX_PACKET {
     const uint8_t* SourceCid;
 
     //
-    // Length of the Buffer array.
+    // Length of the AvailBuffer array.
     //
-    uint16_t BufferLength;
+    uint16_t AvailBufferLength;
 
     //
     // Length of the current packet header.
@@ -154,10 +160,7 @@ typedef struct QUIC_RX_PACKET {
 
 } QUIC_RX_PACKET;
 
-#define GetRecvData(Packet) \
-    CXPLAT_CONTAINING_RECORD(Packet, CXPLAT_RECV_DATA, ClientData)
-#define GetQuicRxPacket(RecvData) \
-    ((QUIC_RX_PACKET*)&(RecvData)->ClientData)
+#define GetQuicRxPacket(RecvData) ((QUIC_RX_PACKET*)RecvData)
 
 typedef enum QUIC_BINDING_LOOKUP_TYPE {
 

--- a/src/core/binding.h
+++ b/src/core/binding.h
@@ -95,6 +95,9 @@ typedef struct QUIC_RX_PACKET {
     //
     QUIC_PACKET_KEY_TYPE KeyType;
 
+    union {
+    uint32_t Flags;
+    struct {
     //
     // Flag indicating we have found the connection the packet belongs to.
     //
@@ -157,6 +160,8 @@ typedef struct QUIC_RX_PACKET {
     // Flag indicating the packet contained a non-probing frame.
     //
     BOOLEAN HasNonProbingFrame : 1;
+    };
+    };
 
 } QUIC_RX_PACKET;
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3457,7 +3457,7 @@ QuicConnRecvVerNeg(
         sizeof(uint8_t) +                                         // SourceCidLength field size
         Packet->VerNeg->DestCid[Packet->VerNeg->DestCidLength]);  // SourceCidLength
     uint16_t ServerVersionListLength =
-        (Packet->BufferLength - (uint16_t)((uint8_t*)ServerVersionList - Packet->Buffer)) / sizeof(uint32_t);
+        (Packet->AvailBufferLength - (uint16_t)((uint8_t*)ServerVersionList - Packet->AvailBuffer)) / sizeof(uint32_t);
 
     //
     // Go through the list and make sure it doesn't include our originally
@@ -3570,7 +3570,7 @@ QuicConnRecvRetry(
     // Decode and validate the Retry packet.
     //
 
-    if (Packet->BufferLength - Packet->HeaderLength <= QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1) {
+    if (Packet->AvailBufferLength - Packet->HeaderLength <= QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1) {
         QuicPacketLogDrop(Connection, Packet, "No room for Retry Token");
         return;
     }
@@ -3588,16 +3588,16 @@ QuicConnRecvRetry(
     }
     CXPLAT_FRE_ASSERT(VersionInfo != NULL);
 
-    const uint8_t* Token = (Packet->Buffer + Packet->HeaderLength);
-    uint16_t TokenLength = Packet->BufferLength - (Packet->HeaderLength + QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1);
+    const uint8_t* Token = (Packet->AvailBuffer + Packet->HeaderLength);
+    uint16_t TokenLength = Packet->AvailBufferLength - (Packet->HeaderLength + QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1);
 
     QuicPacketLogHeader(
         Connection,
         TRUE,
         0,
         0,
-        Packet->BufferLength,
-        Packet->Buffer,
+        Packet->AvailBufferLength,
+        Packet->AvailBuffer,
         0);
 
     CXPLAT_DBG_ASSERT(!CxPlatListIsEmpty(&Connection->DestCids));
@@ -3614,8 +3614,8 @@ QuicConnRecvRetry(
             VersionInfo,
             DestCid->CID.Length,
             DestCid->CID.Data,
-            Packet->BufferLength - QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1,
-            Packet->Buffer,
+            Packet->AvailBufferLength - QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1,
+            Packet->AvailBuffer,
             CalculatedIntegrityValue))) {
         QuicPacketLogDrop(Connection, Packet, "Failed to generate integrity field");
         return;
@@ -3623,7 +3623,7 @@ QuicConnRecvRetry(
 
     if (memcmp(
             CalculatedIntegrityValue,
-            Packet->Buffer + (Packet->BufferLength - QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1),
+            Packet->AvailBuffer + (Packet->AvailBufferLength - QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1),
             QUIC_RETRY_INTEGRITY_TAG_LENGTH_V1) != 0) {
         QuicPacketLogDrop(Connection, Packet, "Invalid integrity field");
         return;
@@ -3753,7 +3753,7 @@ QuicConnGetKeyOrDeferDatagram(
                 while (*Tail != NULL) {
                     Tail = &((*Tail)->Next);
                 }
-                *Tail = GetRecvData(Packet);
+                *Tail = (CXPLAT_RECV_DATA*)Packet;
                 (*Tail)->Next = NULL;
             }
         }
@@ -4008,7 +4008,7 @@ QuicConnRecvHeader(
     //
     CxPlatCopyMemory(
         Cipher,
-        Packet->Buffer + Packet->HeaderLength + 4,
+        Packet->AvailBuffer + Packet->HeaderLength + 4,
         CXPLAT_HP_SAMPLE_LENGTH);
 
     return TRUE;
@@ -4029,9 +4029,9 @@ QuicConnRecvPrepareDecrypt(
 {
     CXPLAT_DBG_ASSERT(Packet->ValidatedHeaderInv);
     CXPLAT_DBG_ASSERT(Packet->ValidatedHeaderVer);
-    CXPLAT_DBG_ASSERT(Packet->HeaderLength <= Packet->BufferLength);
-    CXPLAT_DBG_ASSERT(Packet->PayloadLength <= Packet->BufferLength);
-    CXPLAT_DBG_ASSERT(Packet->HeaderLength + Packet->PayloadLength <= Packet->BufferLength);
+    CXPLAT_DBG_ASSERT(Packet->HeaderLength <= Packet->AvailBufferLength);
+    CXPLAT_DBG_ASSERT(Packet->PayloadLength <= Packet->AvailBufferLength);
+    CXPLAT_DBG_ASSERT(Packet->HeaderLength + Packet->PayloadLength <= Packet->AvailBufferLength);
 
     //
     // Packet->HeaderLength currently points to the start of the encrypted
@@ -4044,21 +4044,21 @@ QuicConnRecvPrepareDecrypt(
     //
     uint8_t CompressedPacketNumberLength = 0;
     if (Packet->IsShortHeader) {
-        ((uint8_t*)Packet->Buffer)[0] ^= HpMask[0] & 0x1f; // Only the first 5 bits
+        ((uint8_t*)Packet->AvailBuffer)[0] ^= HpMask[0] & 0x1f; // Only the first 5 bits
         CompressedPacketNumberLength = Packet->SH->PnLength + 1;
     } else {
-        ((uint8_t*)Packet->Buffer)[0] ^= HpMask[0] & 0x0f; // Only the first 4 bits
+        ((uint8_t*)Packet->AvailBuffer)[0] ^= HpMask[0] & 0x0f; // Only the first 4 bits
         CompressedPacketNumberLength = Packet->LH->PnLength + 1;
     }
 
     CXPLAT_DBG_ASSERT(CompressedPacketNumberLength >= 1 && CompressedPacketNumberLength <= 4);
-    CXPLAT_DBG_ASSERT(Packet->HeaderLength + CompressedPacketNumberLength <= Packet->BufferLength);
+    CXPLAT_DBG_ASSERT(Packet->HeaderLength + CompressedPacketNumberLength <= Packet->AvailBufferLength);
 
     //
     // Decrypt the packet number now that we have the length.
     //
     for (uint8_t i = 0; i < CompressedPacketNumberLength; i++) {
-        ((uint8_t*)Packet->Buffer)[Packet->HeaderLength + i] ^= HpMask[1 + i];
+        ((uint8_t*)Packet->AvailBuffer)[Packet->HeaderLength + i] ^= HpMask[1 + i];
     }
 
     //
@@ -4070,7 +4070,7 @@ QuicConnRecvPrepareDecrypt(
     uint64_t CompressedPacketNumber = 0;
     QuicPktNumDecode(
         CompressedPacketNumberLength,
-        Packet->Buffer + Packet->HeaderLength,
+        Packet->AvailBuffer + Packet->HeaderLength,
         &CompressedPacketNumber);
 
     Packet->HeaderLength += CompressedPacketNumberLength;
@@ -4160,9 +4160,9 @@ QuicConnRecvDecryptAndAuthenticate(
     _In_ QUIC_RX_PACKET* Packet
     )
 {
-    CXPLAT_DBG_ASSERT(Packet->BufferLength >= Packet->HeaderLength + Packet->PayloadLength);
+    CXPLAT_DBG_ASSERT(Packet->AvailBufferLength >= Packet->HeaderLength + Packet->PayloadLength);
 
-    const uint8_t* Payload = Packet->Buffer + Packet->HeaderLength;
+    const uint8_t* Payload = Packet->AvailBuffer + Packet->HeaderLength;
 
     //
     // We need to copy the end of the packet before trying decryption, as a
@@ -4201,7 +4201,7 @@ QuicConnRecvDecryptAndAuthenticate(
                 Connection->Crypto.TlsState.ReadKeys[Packet->KeyType]->PacketKey,
                 Iv,
                 Packet->HeaderLength,   // HeaderLength
-                Packet->Buffer,         // Header
+                Packet->AvailBuffer,    // Header
                 Packet->PayloadLength,  // BufferLength
                 (uint8_t*)Payload))) {  // Buffer
 
@@ -4252,7 +4252,7 @@ QuicConnRecvDecryptAndAuthenticate(
                     Connection->State.ShareBinding ? MsQuicLib.CidTotalLength : 0,
                     Packet->PacketNumber,
                     Packet->HeaderLength,
-                    Packet->Buffer,
+                    Packet->AvailBuffer,
                     Connection->Stats.QuicVersion);
             }
             Connection->Stats.Recv.DecryptionFailures++;
@@ -4314,8 +4314,8 @@ QuicConnRecvDecryptAndAuthenticate(
                 TRUE,
                 Connection->State.ShareBinding ? MsQuicLib.CidTotalLength : 0,
                 Packet->PacketNumber,
-                Packet->BufferLength,
-                Packet->Buffer,
+                Packet->AvailBufferLength,
+                Packet->AvailBuffer,
                 Connection->Stats.QuicVersion);
         }
         QuicPacketLogDrop(Connection, Packet, "Duplicate packet number");
@@ -4334,14 +4334,14 @@ QuicConnRecvDecryptAndAuthenticate(
             Connection->State.ShareBinding ? MsQuicLib.CidTotalLength : 0,
             Packet->PacketNumber,
             Packet->HeaderLength + Packet->PayloadLength,
-            Packet->Buffer,
+            Packet->AvailBuffer,
             Connection->Stats.QuicVersion);
         QuicFrameLogAll(
             Connection,
             TRUE,
             Packet->PacketNumber,
             Packet->HeaderLength + Packet->PayloadLength,
-            Packet->Buffer,
+            Packet->AvailBuffer,
             Packet->HeaderLength);
     }
 
@@ -4442,7 +4442,7 @@ QuicConnRecvFrames(
     BOOLEAN UpdatedFlowControl = FALSE;
     QUIC_ENCRYPT_LEVEL EncryptLevel = QuicKeyTypeToEncryptLevel(Packet->KeyType);
     BOOLEAN Closed = Connection->State.ClosedLocally || Connection->State.ClosedRemotely;
-    const uint8_t* Payload = Packet->Buffer + Packet->HeaderLength;
+    const uint8_t* Payload = Packet->AvailBuffer + Packet->HeaderLength;
     uint16_t PayloadLength = Packet->PayloadLength;
     uint64_t RecvTime = CxPlatTimeUs64();
 
@@ -4613,7 +4613,7 @@ QuicConnRecvFrames(
                     if (QuicBindingQueueStatelessOperation(
                             Connection->Paths[0].Binding,
                             QUIC_OPER_TYPE_VERSION_NEGOTIATION,
-                            GetRecvData(Packet))) {
+                            (CXPLAT_RECV_DATA*)Packet)) {
                         Packet->ReleaseDeferred = TRUE;
                     }
                     QuicConnCloseLocally(
@@ -5662,8 +5662,8 @@ QuicConnRecvDatagrams(
                 // payload length if the long header hasn't already been
                 // validated (which indicates the actual length);
                 //
-                Packet->BufferLength =
-                    Datagram->BufferLength - (uint16_t)(Packet->Buffer - Datagram->Buffer);
+                Packet->AvailBufferLength =
+                    Datagram->BufferLength - (uint16_t)(Packet->AvailBuffer - Datagram->Buffer);
             }
 
             if (Connection->Crypto.CertValidationPending ||
@@ -5725,7 +5725,7 @@ QuicConnRecvDatagrams(
 
         NextPacket:
 
-            Packet->Buffer += Packet->BufferLength;
+            Packet->AvailBuffer += Packet->AvailBufferLength;
 
             Packet->ValidatedHeaderInv = FALSE;
             Packet->ValidatedHeaderVer = FALSE;
@@ -5737,7 +5737,7 @@ QuicConnRecvDatagrams(
             Packet->NewLargestPacketNumber = FALSE;
             Packet->HasNonProbingFrame = FALSE;
 
-        } while (Packet->Buffer - Datagram->Buffer < Datagram->BufferLength);
+        } while (Packet->AvailBuffer - Datagram->Buffer < Datagram->BufferLength);
 
     Drop:
 

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -538,7 +538,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicDatagramProcessFrame(
     _In_ QUIC_DATAGRAM* Datagram,
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _In_ QUIC_FRAME_TYPE FrameType,
     _In_ uint16_t BufferLength,
     _In_reads_bytes_(BufferLength)

--- a/src/core/datagram.h
+++ b/src/core/datagram.h
@@ -96,7 +96,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicDatagramProcessFrame(
     _In_ QUIC_DATAGRAM* Datagram,
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _In_ QUIC_FRAME_TYPE FrameType,
     _In_ uint16_t BufferLength,
     _In_reads_bytes_(BufferLength)

--- a/src/core/inline.c
+++ b/src/core/inline.c
@@ -714,7 +714,7 @@ QuicStreamRecvGetState(
 
 BOOLEAN
 QuicRetryTokenDecrypt(
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _In_reads_(sizeof(QUIC_TOKEN_CONTENTS))
         const uint8_t* TokenBuffer,
     _Out_ QUIC_TOKEN_CONTENTS* Token

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -677,7 +677,7 @@ QuicLibraryLazyInitialize(
 
     Status =
         CxPlatDataPathInitialize(
-            sizeof(CXPLAT_RECV_PACKET),
+            sizeof(QUIC_RX_PACKET),
             &DatapathCallbacks,
             NULL,                   // TcpCallbacks
             MsQuicLib.ExecutionConfig,

--- a/src/core/packet.c
+++ b/src/core/packet.c
@@ -114,8 +114,8 @@ QuicPacketValidateInvariant(
     //
     // Ignore empty or too short packets.
     //
-    if (Packet->BufferLength == 0 ||
-        Packet->BufferLength < QuicMinPacketLengths[Packet->Invariant->IsLongHeader]) {
+    if (Packet->AvailBufferLength == 0 ||
+        Packet->AvailBufferLength < QuicMinPacketLengths[Packet->Invariant->IsLongHeader]) {
         QuicPacketLogDrop(Owner, Packet, "Too small for Packet->Invariant");
         return FALSE;
     }
@@ -125,7 +125,7 @@ QuicPacketValidateInvariant(
         Packet->IsShortHeader = FALSE;
 
         DestCidLen = Packet->Invariant->LONG_HDR.DestCidLength;
-        if (Packet->BufferLength < MIN_INV_LONG_HDR_LENGTH + DestCidLen) {
+        if (Packet->AvailBufferLength < MIN_INV_LONG_HDR_LENGTH + DestCidLen) {
             QuicPacketLogDrop(Owner, Packet, "LH no room for DestCid");
             return FALSE;
         }
@@ -134,7 +134,7 @@ QuicPacketValidateInvariant(
 
         SourceCidLen = *(DestCid + DestCidLen);
         Packet->HeaderLength = MIN_INV_LONG_HDR_LENGTH + DestCidLen + SourceCidLen;
-        if (Packet->BufferLength < Packet->HeaderLength) {
+        if (Packet->AvailBufferLength < Packet->HeaderLength) {
             QuicPacketLogDrop(Owner, Packet, "LH no room for SourceCid");
             return FALSE;
         }
@@ -151,7 +151,7 @@ QuicPacketValidateInvariant(
         //
         Packet->HeaderLength = sizeof(uint8_t) + DestCidLen;
 
-        if (Packet->BufferLength < Packet->HeaderLength) {
+        if (Packet->AvailBufferLength < Packet->HeaderLength) {
             QuicPacketLogDrop(Owner, Packet, "SH no room for DestCid");
             return FALSE;
         }
@@ -220,7 +220,7 @@ QuicPacketValidateLongHeaderV1(
     // to check that portion of the header again.
     //
     CXPLAT_DBG_ASSERT(Packet->ValidatedHeaderInv);
-    CXPLAT_DBG_ASSERT(Packet->BufferLength >= Packet->HeaderLength);
+    CXPLAT_DBG_ASSERT(Packet->AvailBufferLength >= Packet->HeaderLength);
     CXPLAT_DBG_ASSERT(
         (Packet->LH->Version != QUIC_VERSION_2 && Packet->LH->Type != QUIC_RETRY_V1) ||
         (Packet->LH->Version == QUIC_VERSION_2 && Packet->LH->Type != QUIC_RETRY_V2)); // Retry uses a different code path.
@@ -258,30 +258,30 @@ QuicPacketValidateLongHeaderV1(
 
     if ((Packet->LH->Version != QUIC_VERSION_2 && Packet->LH->Type == QUIC_INITIAL_V1) ||
         (Packet->LH->Version == QUIC_VERSION_2 && Packet->LH->Type == QUIC_INITIAL_V2)) {
-        if (IsServer && Packet->BufferLength < QUIC_MIN_INITIAL_PACKET_LENGTH) {
+        if (IsServer && Packet->AvailBufferLength < QUIC_MIN_INITIAL_PACKET_LENGTH) {
             //
             // All client initial packets need to be padded to a minimum length.
             //
-            QuicPacketLogDropWithValue(Owner, Packet, "Client Long header Initial packet too short", Packet->BufferLength);
+            QuicPacketLogDropWithValue(Owner, Packet, "Client Long header Initial packet too short", Packet->AvailBufferLength);
             return FALSE;
         }
 
         QUIC_VAR_INT TokenLengthVarInt;
         if (!QuicVarIntDecode(
-                Packet->BufferLength,
-                Packet->Buffer,
+                Packet->AvailBufferLength,
+                Packet->AvailBuffer,
                 &Offset,
                 &TokenLengthVarInt)) {
             QuicPacketLogDrop(Owner, Packet, "Long header has invalid token length");
             return FALSE;
         }
 
-        if ((uint64_t)Packet->BufferLength < Offset + TokenLengthVarInt) {
+        if ((uint64_t)Packet->AvailBufferLength < Offset + TokenLengthVarInt) {
             QuicPacketLogDropWithValue(Owner, Packet, "Long header has token length larger than buffer length", TokenLengthVarInt);
             return FALSE;
         }
 
-        *Token = Packet->Buffer + Offset;
+        *Token = Packet->AvailBuffer + Offset;
         *TokenLength = (uint16_t)TokenLengthVarInt;
 
         Offset += (uint16_t)TokenLengthVarInt;
@@ -294,22 +294,22 @@ QuicPacketValidateLongHeaderV1(
 
     QUIC_VAR_INT LengthVarInt;
     if (!QuicVarIntDecode(
-            Packet->BufferLength,
-            Packet->Buffer,
+            Packet->AvailBufferLength,
+            Packet->AvailBuffer,
             &Offset,
             &LengthVarInt)) {
         QuicPacketLogDrop(Owner, Packet, "Long header has invalid payload length");
         return FALSE;
     }
 
-    if ((uint64_t)Packet->BufferLength < Offset + LengthVarInt) {
+    if ((uint64_t)Packet->AvailBufferLength < Offset + LengthVarInt) {
         QuicPacketLogDropWithValue(Owner, Packet, "Long header has length larger than buffer length", LengthVarInt);
         return FALSE;
     }
 
-    if (Packet->BufferLength < Offset + sizeof(uint32_t)) {
+    if (Packet->AvailBufferLength < Offset + sizeof(uint32_t)) {
         QuicPacketLogDropWithValue(Owner, Packet, "Long Header doesn't have enough room for packet number",
-            Packet->BufferLength);
+            Packet->AvailBufferLength);
         return FALSE;
     }
 
@@ -321,7 +321,7 @@ QuicPacketValidateLongHeaderV1(
     //
     Packet->HeaderLength = Offset;
     Packet->PayloadLength = (uint16_t)LengthVarInt;
-    Packet->BufferLength = Packet->HeaderLength + Packet->PayloadLength;
+    Packet->AvailBufferLength = Packet->HeaderLength + Packet->PayloadLength;
     Packet->ValidatedHeaderVer = TRUE;
 
     return TRUE;
@@ -502,12 +502,12 @@ QuicPacketDecodeRetryTokenV1(
 
     QUIC_VAR_INT TokenLengthVarInt = 0;
     BOOLEAN Success = QuicVarIntDecode(
-        Packet->BufferLength, Packet->Buffer, &Offset, &TokenLengthVarInt);
+        Packet->AvailBufferLength, Packet->AvailBuffer, &Offset, &TokenLengthVarInt);
     CXPLAT_DBG_ASSERT(Success); // Was previously validated.
     UNREFERENCED_PARAMETER(Success);
 
-    CXPLAT_DBG_ASSERT(Offset + TokenLengthVarInt <= Packet->BufferLength); // Was previously validated.
-    *Token = Packet->Buffer + Offset;
+    CXPLAT_DBG_ASSERT(Offset + TokenLengthVarInt <= Packet->AvailBufferLength); // Was previously validated.
+    *Token = Packet->AvailBuffer + Offset;
     *TokenLength = (uint16_t)TokenLengthVarInt;
 }
 
@@ -550,8 +550,7 @@ QuicPacketValidateInitialToken(
         return FALSE;
     }
 
-    const CXPLAT_RECV_DATA* Datagram = GetRecvData(Packet);
-    if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Datagram->Route->RemoteAddress)) {
+    if (!QuicAddrCompare(&Token.Encrypted.RemoteAddress, &Packet->Route->RemoteAddress)) {
         QuicPacketLogDrop(Owner, Packet, "Retry Token Addr Mismatch");
         *DropPacket = TRUE;
         return FALSE;
@@ -575,7 +574,7 @@ QuicPacketValidateShortHeaderV1(
     // specific header isn't any larger than the Packet->Invariant.
     //
     CXPLAT_DBG_ASSERT(Packet->ValidatedHeaderInv);
-    CXPLAT_DBG_ASSERT(Packet->BufferLength >= Packet->HeaderLength);
+    CXPLAT_DBG_ASSERT(Packet->AvailBufferLength >= Packet->HeaderLength);
 
     //
     // Check the Fixed bit to ensure it is set to 1, unless we ignore it.
@@ -596,7 +595,7 @@ QuicPacketValidateShortHeaderV1(
     // For the time being, set header length to the start of the packet
     // number and payload length to everything after that.
     //
-    Packet->PayloadLength = Packet->BufferLength - Packet->HeaderLength;
+    Packet->PayloadLength = Packet->AvailBufferLength - Packet->HeaderLength;
     Packet->ValidatedHeaderVer = TRUE;
 
     return TRUE;
@@ -810,15 +809,14 @@ QuicPacketLogDrop(
     _In_z_ const char* Reason
     )
 {
-    const CXPLAT_RECV_DATA* Datagram = GetRecvData(Packet); // cppcheck-suppress unreadVariable; NOLINT
     if (Packet->AssignedToConnection) {
         InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
     } else {
         InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
@@ -826,8 +824,8 @@ QuicPacketLogDrop(
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
     }
     QuicPerfCounterIncrement(QUIC_PERF_COUNTER_PKTS_DROPPED);
@@ -842,7 +840,6 @@ QuicPacketLogDropWithValue(
     _In_ uint64_t Value
     )
 {
-    const CXPLAT_RECV_DATA* Datagram = GetRecvData(Packet); // cppcheck-suppress unreadVariable; NOLINT
     if (Packet->AssignedToConnection) {
         InterlockedIncrement64((int64_t*)&((QUIC_CONNECTION*)Owner)->Stats.Recv.DroppedPackets);
         QuicTraceEvent(
@@ -850,8 +847,8 @@ QuicPacketLogDropWithValue(
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
     } else {
         InterlockedIncrement64((int64_t*)&((QUIC_BINDING*)Owner)->Stats.Recv.DroppedPackets);
@@ -860,8 +857,8 @@ QuicPacketLogDropWithValue(
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
     }
     QuicPerfCounterIncrement(QUIC_PERF_COUNTER_PKTS_DROPPED);

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -97,7 +97,7 @@ _Success_(return != FALSE)
 BOOLEAN
 QuicPacketValidateInvariant(
     _In_ const void* Owner, // Binding or Connection depending on state
-    _Inout_ CXPLAT_RECV_PACKET* Packet,
+    _Inout_ QUIC_RX_PACKET* Packet,
     _In_ BOOLEAN IsBindingShared
     );
 
@@ -287,7 +287,7 @@ BOOLEAN
 QuicPacketValidateLongHeaderV1(
     _In_ const void* Owner, // Binding or Connection depending on state
     _In_ BOOLEAN IsServer,
-    _Inout_ CXPLAT_RECV_PACKET* Packet,
+    _Inout_ QUIC_RX_PACKET* Packet,
     _Outptr_result_buffer_maybenull_(*TokenLength)
         const uint8_t** Token,
     _Out_ uint16_t* TokenLength,
@@ -301,7 +301,7 @@ QuicPacketValidateLongHeaderV1(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPacketDecodeRetryTokenV1(
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _Outptr_result_buffer_maybenull_(*TokenLength)
         const uint8_t** Token,
     _Out_ uint16_t* TokenLength
@@ -311,7 +311,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 QuicPacketValidateInitialToken(
     _In_ const void* const Owner,
-    _In_ const CXPLAT_RECV_PACKET* const Packet,
+    _In_ const QUIC_RX_PACKET* const Packet,
     _In_range_(>, 0) uint16_t TokenLength,
     _In_reads_(TokenLength)
         const uint8_t* TokenBuffer,
@@ -323,7 +323,7 @@ _Success_(return != FALSE)
 BOOLEAN
 QuicPacketValidateShortHeaderV1(
     _In_ const void* Owner, // Binding or Connection depending on state
-    _Inout_ CXPLAT_RECV_PACKET* Packet,
+    _Inout_ QUIC_RX_PACKET* Packet,
     _In_ BOOLEAN IgnoreFixedBit
     );
 
@@ -626,7 +626,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPacketLogDrop(
     _In_ const void* Owner, // Binding or Connection depending on state
-    _In_ const CXPLAT_RECV_PACKET* Packet,
+    _In_ const QUIC_RX_PACKET* Packet,
     _In_z_ const char* Reason
     );
 
@@ -634,7 +634,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicPacketLogDropWithValue(
     _In_ const void* Owner, // Binding or Connection depending on state
-    _In_ const CXPLAT_RECV_PACKET* Packet,
+    _In_ const QUIC_RX_PACKET* Packet,
     _In_z_ const char* Reason,
     _In_ uint64_t Value
     );

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -953,7 +953,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicStreamRecv(
     _In_ QUIC_STREAM* Stream,
-    _In_ CXPLAT_RECV_PACKET* Packet,
+    _In_ QUIC_RX_PACKET* Packet,
     _In_ QUIC_FRAME_TYPE FrameType,
     _In_ uint16_t BufferLength,
     _In_reads_bytes_(BufferLength)

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -505,7 +505,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicStreamRecv(
     _In_ QUIC_STREAM* Stream,
-    _In_ CXPLAT_RECV_PACKET* Packet,
+    _In_ QUIC_RX_PACKET* Packet,
     _In_ QUIC_FRAME_TYPE FrameType,
     _In_ uint16_t BufferLength,
     _In_reads_bytes_(BufferLength)

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -313,9 +313,8 @@ QuicWorkerQueueOperation(
 
     if (Operation != NULL) {
         const QUIC_BINDING* Binding = Operation->STATELESS.Context->Binding;
-        const CXPLAT_RECV_PACKET* Packet =
-            CxPlatDataPathRecvDataToRecvPacket(
-                Operation->STATELESS.Context->Datagram);
+        const QUIC_RX_PACKET* Packet =
+            GetQuicRxPacket(Operation->STATELESS.Context->Datagram);
         QuicPacketLogDrop(Binding, Packet, "Worker operation limit reached");
         QuicOperationFree(Worker, Operation);
     } else if (WakeWorkerThread) {

--- a/src/generated/linux/datapath_winkernel.c.clog.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h
@@ -306,17 +306,17 @@ tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathFragmented , arg2);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for DatapathDropAllocRecvContextFailure
+// Decoder Ring for DatapathDropAllocIoBlockFailure
 // [%p] Couldn't allocate receive context.
 // QuicTraceLogWarning(
-                        DatapathDropAllocRecvContextFailure,
+                        DatapathDropAllocIoBlockFailure,
                         "[%p] Couldn't allocate receive context.",
                         Binding);
 // arg2 = arg2 = Binding = arg2
 ----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_DatapathDropAllocRecvContextFailure
-#define _clog_3_ARGS_TRACE_DatapathDropAllocRecvContextFailure(uniqueId, encoded_arg_string, arg2)\
-tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocRecvContextFailure , arg2);\
+#ifndef _clog_3_ARGS_TRACE_DatapathDropAllocIoBlockFailure
+#define _clog_3_ARGS_TRACE_DatapathDropAllocIoBlockFailure(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocIoBlockFailure , arg2);\
 
 #endif
 

--- a/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
@@ -291,15 +291,15 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathFragmented,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for DatapathDropAllocRecvContextFailure
+// Decoder Ring for DatapathDropAllocIoBlockFailure
 // [%p] Couldn't allocate receive context.
 // QuicTraceLogWarning(
-                        DatapathDropAllocRecvContextFailure,
+                        DatapathDropAllocIoBlockFailure,
                         "[%p] Couldn't allocate receive context.",
                         Binding);
 // arg2 = arg2 = Binding = arg2
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocRecvContextFailure,
+TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocIoBlockFailure,
     TP_ARGS(
         const void *, arg2), 
     TP_FIELDS(

--- a/src/generated/linux/packet.c.clog.h
+++ b/src/generated/linux/packet.c.clog.h
@@ -254,12 +254,12 @@ tracepoint(CLOG_PACKET_C, AllocFailure , arg2, arg3);\
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg4
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg4
 // arg5 = arg5 = Reason = arg5
 ----------------------------------------------------------*/
 #ifndef _clog_8_ARGS_TRACE_ConnDropPacket
@@ -278,12 +278,12 @@ tracepoint(CLOG_PACKET_C, ConnDropPacket , arg2, arg3_len, arg3, arg4_len, arg4,
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg4
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg4
 // arg5 = arg5 = Reason = arg5
 ----------------------------------------------------------*/
 #ifndef _clog_8_ARGS_TRACE_BindingDropPacket
@@ -303,13 +303,13 @@ tracepoint(CLOG_PACKET_C, BindingDropPacket , arg2, arg3_len, arg3, arg4_len, ar
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
 // arg3 = arg3 = Value = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg4
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg5
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg4
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg5
 // arg6 = arg6 = Reason = arg6
 ----------------------------------------------------------*/
 #ifndef _clog_9_ARGS_TRACE_ConnDropPacketEx
@@ -329,13 +329,13 @@ tracepoint(CLOG_PACKET_C, ConnDropPacketEx , arg2, arg3, arg4_len, arg4, arg5_le
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
 // arg3 = arg3 = Value = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg4
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg5
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg4
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg5
 // arg6 = arg6 = Reason = arg6
 ----------------------------------------------------------*/
 #ifndef _clog_9_ARGS_TRACE_BindingDropPacketEx

--- a/src/generated/linux/packet.c.clog.h.lttng.h
+++ b/src/generated/linux/packet.c.clog.h.lttng.h
@@ -312,12 +312,12 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, AllocFailure,
             ConnDropPacket,
             "[conn][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg4
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg4
 // arg5 = arg5 = Reason = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacket,
@@ -347,12 +347,12 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacket,
             BindingDropPacket,
             "[bind][%p] DROP packet Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg4
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg3
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg4
 // arg5 = arg5 = Reason = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacket,
@@ -383,13 +383,13 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacket,
             "[conn][%p] DROP packet Value=%llu Dst=%!ADDR! Src=%!ADDR! Reason=%s.",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
 // arg3 = arg3 = Value = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg4
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg5
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg4
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg5
 // arg6 = arg6 = Reason = arg6
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacketEx,
@@ -422,13 +422,13 @@ TRACEPOINT_EVENT(CLOG_PACKET_C, ConnDropPacketEx,
             "[bind][%p] DROP packet %llu. Dst=%!ADDR! Src=%!ADDR! Reason=%s",
             Owner,
             Value,
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress),
-            CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress),
+            CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress),
             Reason);
 // arg2 = arg2 = Owner = arg2
 // arg3 = arg3 = Value = arg3
-// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->LocalAddress), &Datagram->Route->LocalAddress) = arg4
-// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Datagram->Route->RemoteAddress), &Datagram->Route->RemoteAddress) = arg5
+// arg4 = arg4 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->LocalAddress), &Packet->Route->LocalAddress) = arg4
+// arg5 = arg5 = CASTED_CLOG_BYTEARRAY(sizeof(Packet->Route->RemoteAddress), &Packet->Route->RemoteAddress) = arg5
 // arg6 = arg6 = Reason = arg6
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PACKET_C, BindingDropPacketEx,

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -231,7 +231,7 @@ typedef struct CXPLAT_RECV_DATA {
     // Variable length data of size `ClientRecvContextLength` passed into
     // CxPlatDataPathInitialize.
     //
-    uint8_t ClientData[0];
+    __attribute__((aligned(16))) uint8_t ClientData[0];
 
 } CXPLAT_RECV_DATA;
 

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -132,11 +132,6 @@ typedef struct CXPLAT_DATAPATH CXPLAT_DATAPATH;
 typedef struct CXPLAT_SOCKET CXPLAT_SOCKET;
 
 //
-// Can be defined to whatever the client needs.
-//
-typedef struct CXPLAT_RECV_PACKET CXPLAT_RECV_PACKET;
-
-//
 // Structure that maintains the 'per send' context.
 //
 typedef struct CXPLAT_SEND_DATA CXPLAT_SEND_DATA;
@@ -232,7 +227,16 @@ typedef struct CXPLAT_RECV_DATA {
     uint16_t Reserved : 6;
     uint16_t ReservedEx : 8;
 
+    //
+    // Variable length data of size `ClientRecvContextLength` passed into
+    // CxPlatDataPathInitialize.
+    //
+    uint8_t ClientData[0];
+
 } CXPLAT_RECV_DATA;
+
+#define CxPlatRecvDataSize(ClientRecvContextLength) \
+    (sizeof(CXPLAT_RECV_DATA) + (ClientRecvContextLength))
 
 //
 // QUIC Encryption Offload (QEO) interfaces
@@ -275,22 +279,6 @@ typedef struct CXPLAT_QEO_CONNECTION {
     uint8_t HeaderKey[32];    // Length determined by CipherType
     uint8_t PayloadIv[12];
 } CXPLAT_QEO_CONNECTION;
-
-//
-// Gets the corresponding receive data from its context pointer.
-//
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const RecvPacket
-    );
-
-//
-// Gets the corresponding client context from its receive data pointer.
-//
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const RecvData
-    );
 
 //
 // Function pointer type for datapath TCP accept callbacks.

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -235,9 +235,6 @@ typedef struct CXPLAT_RECV_DATA {
 
 } CXPLAT_RECV_DATA;
 
-#define CxPlatRecvDataSize(ClientRecvContextLength) \
-    (sizeof(CXPLAT_RECV_DATA) + (ClientRecvContextLength))
-
 //
 // QUIC Encryption Offload (QEO) interfaces
 //

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -228,10 +228,9 @@ typedef struct CXPLAT_RECV_DATA {
     uint16_t ReservedEx : 8;
 
     //
-    // Variable length data of size `ClientRecvContextLength` passed into
-    // CxPlatDataPathInitialize.
+    // Variable length data (of size `ClientRecvContextLength` passed into
+    // CxPlatDataPathInitialize) directly follows.
     //
-    __attribute__((aligned(16))) uint8_t ClientData[0];
 
 } CXPLAT_RECV_DATA;
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2487,6 +2487,18 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "DatapathDropAllocIoBlockFailure": {
+      "ModuleProperites": {},
+      "TraceString": "[%p] Couldn't allocate receive context.",
+      "UniqueId": "DatapathDropAllocIoBlockFailure",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogWarning"
+    },
     "DatapathDropAllocRecvBufferFailure": {
       "ModuleProperites": {},
       "TraceString": "[%p] Couldn't allocate receive buffers.",
@@ -13403,6 +13415,11 @@
         "UniquenessHash": "f5328bae-6bcb-72fc-a6fd-89b44261a85b",
         "TraceID": "DatapathDestroyed",
         "EncodingString": "[data][%p] Destroyed"
+      },
+      {
+        "UniquenessHash": "1705c557-a3f1-30bf-f2d6-d31f7a2995cc",
+        "TraceID": "DatapathDropAllocIoBlockFailure",
+        "EncodingString": "[%p] Couldn't allocate receive context."
       },
       {
         "UniquenessHash": "977ca100-03bb-010a-09ab-0a04d33a7dfd",

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -43,18 +43,11 @@ CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Buffer) == sizeof(void*)
 const uint16_t CXPLAT_MAX_IO_BATCH_SIZE =
     (CXPLAT_LARGE_IO_BUFFER_SIZE / (CXPLAT_MAX_MTU - CXPLAT_MIN_IPV6_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE));
 
-typedef struct CXPLAT_RECV_SUBBLOCK {
-
-    struct CXPLAT_RECV_BLOCK* RecvBlock;
-    CXPLAT_RECV_DATA RecvData;
-    // CXPLAT_RECV_PACKET RecvPacket;
-
-} CXPLAT_RECV_SUBBLOCK;
-
 //
-// A receive block to receive a UDP packet over the sockets.
+// Contains all the info for a single RX IO operation. Multiple RX packets may
+// come from a single IO operation.
 //
-typedef struct CXPLAT_RECV_BLOCK {
+typedef struct DATAPATH_RX_IO_BLOCK {
     //
     // The pool owning this recv block.
     //
@@ -71,17 +64,30 @@ typedef struct CXPLAT_RECV_BLOCK {
     long RefCount;
 
     //
-    // An array of sub-blocks to represent the datagram and metadata returned to
+    // An array of packets to represent the datagram and metadata returned to
     // the app.
     //
-    //CXPLAT_RECV_SUBBLOCK SubBlocks[0];
+    //DATAPATH_RX_PACKET Packets[0];
 
     //
     // Buffer that actually stores the UDP payload.
     //
     //uint8_t Buffer[]; // CXPLAT_SMALL_IO_BUFFER_SIZE or CXPLAT_LARGE_IO_BUFFER_SIZE
 
-} CXPLAT_RECV_BLOCK;
+} DATAPATH_RX_IO_BLOCK;
+
+typedef struct DATAPATH_RX_PACKET {
+    //
+    // The IO block that owns the packet.
+    //
+    DATAPATH_RX_IO_BLOCK* IoBlock;
+
+    //
+    // Publicly visible receive data.
+    //
+    CXPLAT_RECV_DATA Data;
+
+} DATAPATH_RX_PACKET;
 
 //
 // Send context.
@@ -408,20 +414,20 @@ typedef struct CXPLAT_DATAPATH {
     uint32_t SendIoVecCount;
 
     //
-    // The length of the CXPLAT_RECV_DATA and CXPLAT_RECV_PACKET part of the
-    // CXPLAT_RECV_BLOCK.
+    // The length of the CXPLAT_RECV_DATA and client data part of the
+    // DATAPATH_RX_IO_BLOCK.
     //
     uint32_t RecvBlockStride;
 
     //
-    // The offset of the raw buffer in the CXPLAT_RECV_BLOCK.
+    // The offset of the raw buffer in the DATAPATH_RX_IO_BLOCK.
     //
     uint32_t RecvBlockBufferOffset;
 
     //
-    // The total length of the CXPLAT_RECV_BLOCK. Calculated based on the
+    // The total length of the DATAPATH_RX_IO_BLOCK. Calculated based on the
     // support level for GRO. No GRO only uses a single CXPLAT_RECV_DATA and
-    // CXPLAT_RECV_PACKET, while GRO allows for multiple.
+    // client data, while GRO allows for multiple.
     //
     uint32_t RecvBlockSize;
 
@@ -452,7 +458,7 @@ typedef struct CXPLAT_DATAPATH {
 void
 CxPlatDataPathCalculateFeatureSupport(
     _Inout_ CXPLAT_DATAPATH* Datapath,
-    _In_ uint32_t ClientRecvContextLength
+    _In_ uint32_t ClientRecvDataLength
     )
 {
 #ifdef UDP_SEGMENT
@@ -563,16 +569,16 @@ Error:
     }
 
     Datapath->RecvBlockStride =
-        sizeof(CXPLAT_RECV_SUBBLOCK) + ClientRecvContextLength;
+        sizeof(DATAPATH_RX_PACKET) + ClientRecvDataLength;
     if (Datapath->Features & CXPLAT_DATAPATH_FEATURE_RECV_COALESCING) {
         Datapath->RecvBlockBufferOffset =
-            sizeof(CXPLAT_RECV_BLOCK) +
+            sizeof(DATAPATH_RX_IO_BLOCK) +
             CXPLAT_MAX_IO_BATCH_SIZE * Datapath->RecvBlockStride;
         Datapath->RecvBlockSize =
             Datapath->RecvBlockBufferOffset + CXPLAT_LARGE_IO_BUFFER_SIZE;
     } else {
         Datapath->RecvBlockBufferOffset =
-            sizeof(CXPLAT_RECV_BLOCK) + Datapath->RecvBlockStride;
+            sizeof(DATAPATH_RX_IO_BLOCK) + Datapath->RecvBlockStride;
         Datapath->RecvBlockSize =
             Datapath->RecvBlockBufferOffset + CXPLAT_SMALL_IO_BUFFER_SIZE;
     }
@@ -596,7 +602,7 @@ CxPlatProcessorContextInitialize(
 
 QUIC_STATUS
 CxPlatDataPathInitialize(
-    _In_ uint32_t ClientRecvContextLength,
+    _In_ uint32_t ClientRecvDataLength,
     _In_opt_ const CXPLAT_UDP_DATAPATH_CALLBACKS* UdpCallbacks,
     _In_opt_ const CXPLAT_TCP_DATAPATH_CALLBACKS* TcpCallbacks,
     _In_opt_ QUIC_EXECUTION_CONFIG* Config,
@@ -641,16 +647,14 @@ CxPlatDataPathInitialize(
     Datapath->PartitionCount = PartitionCount;
     Datapath->Features = CXPLAT_DATAPATH_FEATURE_LOCAL_PORT_SHARING;
     CxPlatRefInitializeEx(&Datapath->RefCount, Datapath->PartitionCount);
-    CxPlatDataPathCalculateFeatureSupport(Datapath, ClientRecvContextLength);
+    CxPlatDataPathCalculateFeatureSupport(Datapath, ClientRecvDataLength);
 
     //
     // Initialize the per processor contexts.
     //
     for (uint32_t i = 0; i < Datapath->PartitionCount; i++) {
         CxPlatProcessorContextInitialize(
-            Datapath,
-            i,
-            &Datapath->Partitions[i]);
+            Datapath, i, &Datapath->Partitions[i]);
     }
 
     CXPLAT_FRE_ASSERT(CxPlatRundownAcquire(&CxPlatWorkerRundown));
@@ -1684,22 +1688,6 @@ CxPlatSocketGetRemoteAddress(
 // Receive Path
 //
 
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Packet
-    )
-{
-    return (CXPLAT_RECV_DATA*)((char *)Packet - sizeof(CXPLAT_RECV_DATA));
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const RecvData
-    )
-{
-    return (CXPLAT_RECV_PACKET*)(RecvData + 1);
-}
-
 void
 CxPlatSocketHandleErrors(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketContext
@@ -1749,7 +1737,7 @@ CxPlatSocketHandleErrors(
 void
 CxPlatSocketContextRecvComplete(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketContext,
-    _Inout_ CXPLAT_RECV_BLOCK** RecvBlocks,
+    _Inout_ DATAPATH_RX_IO_BLOCK** IoBlocks,
     _In_ struct mmsghdr* RecvMsgHdr,
     _In_ int MessagesReceived
     )
@@ -1760,17 +1748,17 @@ CxPlatSocketContextRecvComplete(
     CXPLAT_RECV_DATA* DatagramHead = NULL;
     CXPLAT_RECV_DATA** DatagramTail = &DatagramHead;
     for (int CurrentMessage = 0; CurrentMessage < MessagesReceived; CurrentMessage++) {
-        CXPLAT_RECV_BLOCK* RecvBlock = RecvBlocks[CurrentMessage];
-        RecvBlocks[CurrentMessage] = NULL;
+        DATAPATH_RX_IO_BLOCK* IoBlock = IoBlocks[CurrentMessage];
+        IoBlocks[CurrentMessage] = NULL;
         BytesTransferred += RecvMsgHdr[CurrentMessage].msg_len;
 
         uint8_t TOS = 0;
         uint16_t SegmentLength = 0;
         BOOLEAN FoundLocalAddr = FALSE, FoundTOS = FALSE;
-        QUIC_ADDR* LocalAddr = &RecvBlock->Route.LocalAddress;
-        QUIC_ADDR* RemoteAddr = &RecvBlock->Route.RemoteAddress;
+        QUIC_ADDR* LocalAddr = &IoBlock->Route.LocalAddress;
+        QUIC_ADDR* RemoteAddr = &IoBlock->Route.RemoteAddress;
         CxPlatConvertFromMappedV6(RemoteAddr, RemoteAddr);
-        RecvBlock->Route.Queue = SocketContext;
+        IoBlock->Route.Queue = SocketContext;
 
         //
         // Process the ancillary control messages to get the local address,
@@ -1830,23 +1818,23 @@ CxPlatSocketContextRecvComplete(
             SegmentLength = RecvMsgHdr[CurrentMessage].msg_len;
         }
 
-        CXPLAT_RECV_SUBBLOCK* SubBlock = (CXPLAT_RECV_SUBBLOCK*)(RecvBlock + 1);
+        DATAPATH_RX_PACKET* Datagram = (DATAPATH_RX_PACKET*)(IoBlock + 1);
         uint8_t* RecvBuffer =
-            (uint8_t*)RecvBlock + SocketContext->DatapathPartition->Datapath->RecvBlockBufferOffset;
-        RecvBlock->RefCount = 0;
+            (uint8_t*)IoBlock + SocketContext->DatapathPartition->Datapath->RecvBlockBufferOffset;
+        IoBlock->RefCount = 0;
 
         //
         // Build up the chain of receive packets to indicate up to the app.
         //
         uint32_t Offset = 0;
         while (Offset < RecvMsgHdr[CurrentMessage].msg_len &&
-               RecvBlock->RefCount < CXPLAT_MAX_IO_BATCH_SIZE) {
-            RecvBlock->RefCount++;
-            SubBlock->RecvBlock = RecvBlock;
+               IoBlock->RefCount < CXPLAT_MAX_IO_BATCH_SIZE) {
+            IoBlock->RefCount++;
+            Datagram->IoBlock = IoBlock;
 
-            CXPLAT_RECV_DATA* RecvData = &SubBlock->RecvData;
+            CXPLAT_RECV_DATA* RecvData = &Datagram->RecvData;
             RecvData->Next = NULL;
-            RecvData->Route = &RecvBlock->Route;
+            RecvData->Route = &IoBlock->Route;
             RecvData->Buffer = RecvBuffer + Offset;
             if (RecvMsgHdr[CurrentMessage].msg_len - Offset < SegmentLength) {
                 RecvData->BufferLength = (uint16_t)(RecvMsgHdr[CurrentMessage].msg_len - Offset);
@@ -1863,8 +1851,8 @@ CxPlatSocketContextRecvComplete(
             DatagramTail = &RecvData->Next;
 
             Offset += RecvData->BufferLength;
-            SubBlock = (CXPLAT_RECV_SUBBLOCK*)
-                ((char*)SubBlock + SocketContext->DatapathPartition->Datapath->RecvBlockStride);
+            Datagram = (DATAPATH_RX_PACKET*)
+                ((char*)Datagram + SocketContext->DatapathPartition->Datapath->RecvBlockStride);
         }
     }
 
@@ -1896,7 +1884,7 @@ CxPlatSocketReceiveCoalesced(
     )
 {
     CXPLAT_DATAPATH_PARTITION* DatapathPartition = SocketContext->DatapathPartition;
-    CXPLAT_RECV_BLOCK* RecvBlock = NULL;
+    DATAPATH_RX_IO_BLOCK* IoBlock = NULL;
     struct mmsghdr RecvMsgHdr;
     CXPLAT_RECV_MSG_CONTROL_BUFFER RecvMsgControl;
     struct iovec RecvIov;
@@ -1904,29 +1892,29 @@ CxPlatSocketReceiveCoalesced(
     do {
         uint32_t RetryCount = 0;
         do {
-            RecvBlock = CxPlatPoolAlloc(&DatapathPartition->RecvBlockPool);
-        } while (RecvBlock == NULL && ++RetryCount < 10);
-        if (RecvBlock == NULL) {
+            IoBlock = CxPlatPoolAlloc(&DatapathPartition->RecvBlockPool);
+        } while (IoBlock == NULL && ++RetryCount < 10);
+        if (IoBlock == NULL) {
             QuicTraceEvent(
                 AllocFailure,
                 "Allocation of '%s' failed. (%llu bytes)",
-                "CXPLAT_RECV_BLOCK",
+                "DATAPATH_RX_IO_BLOCK",
                 0);
             goto Exit;
         }
 
-        RecvBlock->OwningPool = &DatapathPartition->RecvBlockPool;
-        RecvBlock->Route.State = RouteResolved;
+        IoBlock->OwningPool = &DatapathPartition->RecvBlockPool;
+        IoBlock->Route.State = RouteResolved;
 
         struct msghdr* MsgHdr = &RecvMsgHdr.msg_hdr;
-        MsgHdr->msg_name = &RecvBlock->Route.RemoteAddress;
-        MsgHdr->msg_namelen = sizeof(RecvBlock->Route.RemoteAddress);
+        MsgHdr->msg_name = &IoBlock->Route.RemoteAddress;
+        MsgHdr->msg_namelen = sizeof(IoBlock->Route.RemoteAddress);
         MsgHdr->msg_iov = &RecvIov;
         MsgHdr->msg_iovlen = 1;
         MsgHdr->msg_control = &RecvMsgControl.Data;
         MsgHdr->msg_controllen = sizeof(RecvMsgControl.Data);
         MsgHdr->msg_flags = 0;
-        RecvIov.iov_base = (char*)RecvBlock + DatapathPartition->Datapath->RecvBlockBufferOffset;
+        RecvIov.iov_base = (char*)IoBlock + DatapathPartition->Datapath->RecvBlockBufferOffset;
         RecvIov.iov_len = CXPLAT_LARGE_IO_BUFFER_SIZE;
 
         int Ret =
@@ -1949,14 +1937,14 @@ CxPlatSocketReceiveCoalesced(
         }
 
         CXPLAT_DBG_ASSERT(Ret == 1);
-        CxPlatSocketContextRecvComplete(SocketContext, &RecvBlock, &RecvMsgHdr, Ret);
+        CxPlatSocketContextRecvComplete(SocketContext, &IoBlock, &RecvMsgHdr, Ret);
 
     } while (TRUE);
 
 Exit:
 
-    if (RecvBlock) {
-        CxPlatPoolFree(&DatapathPartition->RecvBlockPool, RecvBlock);
+    if (IoBlock) {
+        CxPlatPoolFree(&DatapathPartition->RecvBlockPool, IoBlock);
     }
 }
 
@@ -1966,42 +1954,42 @@ CxPlatSocketReceiveMessages(
     )
 {
     CXPLAT_DATAPATH_PARTITION* DatapathPartition = SocketContext->DatapathPartition;
-    CXPLAT_RECV_BLOCK* RecvBlocks[CXPLAT_MAX_IO_BATCH_SIZE];
+    DATAPATH_RX_IO_BLOCK* IoBlocks[CXPLAT_MAX_IO_BATCH_SIZE];
     struct mmsghdr RecvMsgHdr[CXPLAT_MAX_IO_BATCH_SIZE];
     CXPLAT_RECV_MSG_CONTROL_BUFFER RecvMsgControl[CXPLAT_MAX_IO_BATCH_SIZE];
     struct iovec RecvIov[CXPLAT_MAX_IO_BATCH_SIZE];
-    CxPlatZeroMemory(RecvBlocks, sizeof(RecvBlocks));
+    CxPlatZeroMemory(IoBlocks, sizeof(IoBlocks));
 
     do {
         uint32_t RetryCount = 0;
-        for (uint32_t i = 0; i < CXPLAT_MAX_IO_BATCH_SIZE && RecvBlocks[i] == NULL; ++i) {
+        for (uint32_t i = 0; i < CXPLAT_MAX_IO_BATCH_SIZE && IoBlocks[i] == NULL; ++i) {
 
-            CXPLAT_RECV_BLOCK* RecvBlock;
+            DATAPATH_RX_IO_BLOCK* IoBlock;
             do {
-                RecvBlock = CxPlatPoolAlloc(&DatapathPartition->RecvBlockPool);
-            } while (RecvBlock == NULL && ++RetryCount < 10);
-            if (RecvBlock == NULL) {
+                IoBlock = CxPlatPoolAlloc(&DatapathPartition->RecvBlockPool);
+            } while (IoBlock == NULL && ++RetryCount < 10);
+            if (IoBlock == NULL) {
                 QuicTraceEvent(
                     AllocFailure,
                     "Allocation of '%s' failed. (%llu bytes)",
-                    "CXPLAT_RECV_BLOCK",
+                    "DATAPATH_RX_IO_BLOCK",
                     0);
                 goto Exit;
             }
 
-            RecvBlocks[i] = RecvBlock;
-            RecvBlock->OwningPool = &DatapathPartition->RecvBlockPool;
-            RecvBlock->Route.State = RouteResolved;
+            IoBlocks[i] = IoBlock;
+            IoBlock->OwningPool = &DatapathPartition->RecvBlockPool;
+            IoBlock->Route.State = RouteResolved;
 
             struct msghdr* MsgHdr = &RecvMsgHdr[i].msg_hdr;
-            MsgHdr->msg_name = &RecvBlock->Route.RemoteAddress;
-            MsgHdr->msg_namelen = sizeof(RecvBlock->Route.RemoteAddress);
+            MsgHdr->msg_name = &IoBlock->Route.RemoteAddress;
+            MsgHdr->msg_namelen = sizeof(IoBlock->Route.RemoteAddress);
             MsgHdr->msg_iov = &RecvIov[i];
             MsgHdr->msg_iovlen = 1;
             MsgHdr->msg_control = &RecvMsgControl[i].Data;
             MsgHdr->msg_controllen = sizeof(RecvMsgControl[i].Data);
             MsgHdr->msg_flags = 0;
-            RecvIov[i].iov_base = (char*)RecvBlock + DatapathPartition->Datapath->RecvBlockBufferOffset;
+            RecvIov[i].iov_base = (char*)IoBlock + DatapathPartition->Datapath->RecvBlockBufferOffset;
             RecvIov[i].iov_len = CXPLAT_SMALL_IO_BUFFER_SIZE;
         }
 
@@ -2025,15 +2013,15 @@ CxPlatSocketReceiveMessages(
         }
 
         CXPLAT_DBG_ASSERT(Ret <= CXPLAT_MAX_IO_BATCH_SIZE);
-        CxPlatSocketContextRecvComplete(SocketContext, RecvBlocks, RecvMsgHdr, Ret);
+        CxPlatSocketContextRecvComplete(SocketContext, IoBlocks, RecvMsgHdr, Ret);
 
     } while (TRUE);
 
 Exit:
 
     for (uint32_t i = 0; i < CXPLAT_MAX_IO_BATCH_SIZE; ++i) {
-        if (RecvBlocks[i]) {
-            CxPlatPoolFree(&DatapathPartition->RecvBlockPool, RecvBlocks[i]);
+        if (IoBlocks[i]) {
+            CxPlatPoolFree(&DatapathPartition->RecvBlockPool, IoBlocks[i]);
         }
     }
 }
@@ -2058,10 +2046,10 @@ CxPlatRecvDataReturn(
     CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = RecvDataChain) != NULL) {
         RecvDataChain = RecvDataChain->Next;
-        CXPLAT_RECV_SUBBLOCK* SubBlock =
-            CXPLAT_CONTAINING_RECORD(Datagram, CXPLAT_RECV_SUBBLOCK, RecvData);
-        if (InterlockedDecrement(&SubBlock->RecvBlock->RefCount) == 0) {
-            CxPlatPoolFree(SubBlock->RecvBlock->OwningPool, SubBlock->RecvBlock);
+        DATAPATH_RX_PACKET* Datagram =
+            CXPLAT_CONTAINING_RECORD(Datagram, DATAPATH_RX_PACKET, Data);
+        if (InterlockedDecrement(&Datagram->IoBlock->RefCount) == 0) {
+            CxPlatPoolFree(Datagram->IoBlock->OwningPool, Datagram->IoBlock);
         }
     }
 }

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1832,7 +1832,7 @@ CxPlatSocketContextRecvComplete(
             IoBlock->RefCount++;
             Datagram->IoBlock = IoBlock;
 
-            CXPLAT_RECV_DATA* RecvData = &Datagram->RecvData;
+            CXPLAT_RECV_DATA* RecvData = &Datagram->Data;
             RecvData->Next = NULL;
             RecvData->Route = &IoBlock->Route;
             RecvData->Buffer = RecvBuffer + Offset;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2046,10 +2046,10 @@ CxPlatRecvDataReturn(
     CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = RecvDataChain) != NULL) {
         RecvDataChain = RecvDataChain->Next;
-        DATAPATH_RX_PACKET* Datagram =
+        DATAPATH_RX_PACKET* Packet =
             CXPLAT_CONTAINING_RECORD(Datagram, DATAPATH_RX_PACKET, Data);
-        if (InterlockedDecrement(&Datagram->IoBlock->RefCount) == 0) {
-            CxPlatPoolFree(Datagram->IoBlock->OwningPool, Datagram->IoBlock);
+        if (InterlockedDecrement(&Packet->IoBlock->RefCount) == 0) {
+            CxPlatPoolFree(Packet->IoBlock->OwningPool, Packet->IoBlock);
         }
     }
 }

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -53,18 +53,13 @@ CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Buffer) == sizeof(void*)
 #define CXPLAT_LARGE_SEND_BUFFER_SIZE         0xFFFF
 
 //
-// A receive block to receive a UDP packet over the sockets.
+// Contains all the info for a single RX IO operation.
 //
-typedef struct CXPLAT_DATAPATH_RECV_BLOCK {
+typedef struct DATAPATH_RX_IO_BLOCK {
     //
     // The pool owning this recv block.
     //
     CXPLAT_POOL* OwningPool;
-
-    //
-    // The recv buffer used by MsQuic.
-    //
-    CXPLAT_RECV_DATA RecvPacket;
 
     //
     // Represents the network route.
@@ -77,11 +72,11 @@ typedef struct CXPLAT_DATAPATH_RECV_BLOCK {
     uint8_t Buffer[MAX_UDP_PAYLOAD_LENGTH];
 
     //
-    // This follows the recv block.
+    // Publicly visible receive data.
     //
-    // CXPLAT_RECV_PACKET RecvContext;
+    CXPLAT_RECV_DATA RecvPacket;
 
-} CXPLAT_DATAPATH_RECV_BLOCK;
+} DATAPATH_RX_IO_BLOCK;
 
 //
 // Send context.
@@ -207,7 +202,7 @@ typedef struct QUIC_CACHEALIGN CXPLAT_SOCKET_CONTEXT {
     //
     // The receive block currently being used for receives on this socket.
     //
-    CXPLAT_DATAPATH_RECV_BLOCK* CurrentRecvBlock;
+    DATAPATH_RX_IO_BLOCK* CurrentRecvBlock;
 
     //
     // The head of list containg all pending sends on this socket.
@@ -403,12 +398,12 @@ void
 CxPlatProcessorContextInitialize(
     _In_ CXPLAT_DATAPATH* Datapath,
     _In_ uint16_t PartitionIndex,
-    _In_ uint32_t ClientRecvContextLength,
+    _In_ uint32_t ClientRecvDataLength,
     _Out_ CXPLAT_DATAPATH_PARTITION* DatapathPartition
     )
 {
     const uint32_t RecvPacketLength =
-        sizeof(CXPLAT_DATAPATH_RECV_BLOCK) + ClientRecvContextLength;
+        sizeof(DATAPATH_RX_IO_BLOCK) + ClientRecvDataLength;
 
     CXPLAT_DBG_ASSERT(Datapath != NULL);
     DatapathPartition->Datapath = Datapath;
@@ -440,7 +435,7 @@ CxPlatProcessorContextInitialize(
 
 QUIC_STATUS
 CxPlatDataPathInitialize(
-    _In_ uint32_t ClientRecvContextLength,
+    _In_ uint32_t ClientRecvDataLength,
     _In_opt_ const CXPLAT_UDP_DATAPATH_CALLBACKS* UdpCallbacks,
     _In_opt_ const CXPLAT_TCP_DATAPATH_CALLBACKS* TcpCallbacks,
     _In_opt_ QUIC_EXECUTION_CONFIG* Config,
@@ -492,7 +487,7 @@ CxPlatDataPathInitialize(
         CxPlatProcessorContextInitialize(
             Datapath,
             i,
-            ClientRecvContextLength,
+            ClientRecvDataLength,
             &Datapath->Partitions[i]);
     }
 
@@ -583,27 +578,27 @@ CxPlatDataPathIsPaddingPreferred(
     return !!(Datapath->Features & CXPLAT_DATAPATH_FEATURE_SEND_SEGMENTATION);
 }
 
-CXPLAT_DATAPATH_RECV_BLOCK*
-CxPlatDataPathAllocRecvBlock(
+DATAPATH_RX_IO_BLOCK*
+CxPlatDataPathAllocRxIoBlock(
     _In_ CXPLAT_DATAPATH_PARTITION* DatapathPartition
     )
 {
-    CXPLAT_DATAPATH_RECV_BLOCK* RecvBlock =
+    DATAPATH_RX_IO_BLOCK* IoBlock =
         CxPlatPoolAlloc(&DatapathPartition->RecvBlockPool);
-    if (RecvBlock == NULL) {
+    if (IoBlock == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
-            "CXPLAT_DATAPATH_RECV_BLOCK",
+            "DATAPATH_RX_IO_BLOCK",
             0);
     } else {
-        CxPlatZeroMemory(RecvBlock, sizeof(*RecvBlock));
-        RecvBlock->Route.State = RouteResolved;
-        RecvBlock->OwningPool = &DatapathPartition->RecvBlockPool;
-        RecvBlock->RecvPacket.Buffer = RecvBlock->Buffer;
-        RecvBlock->RecvPacket.Allocated = TRUE;
+        CxPlatZeroMemory(IoBlock, sizeof(*IoBlock));
+        IoBlock->Route.State = RouteResolved;
+        IoBlock->OwningPool = &DatapathPartition->RecvBlockPool;
+        IoBlock->RecvPacket.Buffer = IoBlock->Buffer;
+        IoBlock->RecvPacket.Allocated = TRUE;
     }
-    return RecvBlock;
+    return IoBlock;
 }
 
 void
@@ -1168,12 +1163,12 @@ CxPlatSocketContextPrepareReceive(
 {
     if (SocketContext->CurrentRecvBlock == NULL) {
         SocketContext->CurrentRecvBlock =
-            CxPlatDataPathAllocRecvBlock(SocketContext->DatapathPartition);
+            CxPlatDataPathAllocRxIoBlock(SocketContext->DatapathPartition);
         if (SocketContext->CurrentRecvBlock == NULL) {
             QuicTraceEvent(
                 AllocFailure,
                 "Allocation of '%s' failed. (%llu bytes)",
-                "CXPLAT_DATAPATH_RECV_BLOCK",
+                "DATAPATH_RX_IO_BLOCK",
                 0);
             return QUIC_STATUS_OUT_OF_MEMORY;
         }
@@ -1725,29 +1720,6 @@ CxPlatSocketGetRemoteAddress(
     *Address = Socket->RemoteAddress;
 }
 
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Packet
-    )
-{
-    CXPLAT_DATAPATH_RECV_BLOCK* RecvBlock =
-        (CXPLAT_DATAPATH_RECV_BLOCK*)
-            ((char *)Packet - sizeof(CXPLAT_DATAPATH_RECV_BLOCK));
-
-    return &RecvBlock->RecvPacket;
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const RecvData
-    )
-{
-    CXPLAT_DATAPATH_RECV_BLOCK* RecvBlock =
-        CXPLAT_CONTAINING_RECORD(RecvData, CXPLAT_DATAPATH_RECV_BLOCK, RecvPacket);
-
-    return (CXPLAT_RECV_PACKET*)(RecvBlock + 1);
-}
-
 void
 CxPlatRecvDataReturn(
     _In_opt_ CXPLAT_RECV_DATA* RecvDataChain
@@ -1756,9 +1728,9 @@ CxPlatRecvDataReturn(
     CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = RecvDataChain) != NULL) {
         RecvDataChain = RecvDataChain->Next;
-        CXPLAT_DATAPATH_RECV_BLOCK* RecvBlock =
-            CXPLAT_CONTAINING_RECORD(Datagram, CXPLAT_DATAPATH_RECV_BLOCK, RecvPacket);
-        CxPlatPoolFree(RecvBlock->OwningPool, RecvBlock);
+        DATAPATH_RX_IO_BLOCK* IoBlock =
+            CXPLAT_CONTAINING_RECORD(Datagram, DATAPATH_RX_IO_BLOCK, RecvPacket);
+        CxPlatPoolFree(IoBlock->OwningPool, IoBlock);
     }
 }
 

--- a/src/platform/datapath_raw_dpdk.c
+++ b/src/platform/datapath_raw_dpdk.c
@@ -83,22 +83,6 @@ CXPLAT_STATIC_ASSERT(
 CXPLAT_THREAD_CALLBACK(CxPlatDpdkMainThread, Context);
 static int CxPlatDpdkWorkerThread(_In_ void* Context);
 
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Context
-    )
-{
-    return (CXPLAT_RECV_DATA*)(((uint8_t*)Context) - sizeof(DPDK_RX_PACKET));
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const Datagram
-    )
-{
-    return (CXPLAT_RECV_PACKET*)(((uint8_t*)Datagram) + sizeof(DPDK_RX_PACKET));
-}
-
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 CxPlatDpdkReadConfig(

--- a/src/platform/datapath_raw_xdp_linux.c
+++ b/src/platform/datapath_raw_xdp_linux.c
@@ -84,9 +84,9 @@ typedef struct XDP_QUEUE {
 
 // -> CxPlat
 typedef struct __attribute__((aligned(64))) XDP_RX_PACKET {
-    CXPLAT_RECV_DATA;
-    CXPLAT_ROUTE RouteStorage;
     XDP_QUEUE* Queue;
+    CXPLAT_ROUTE RouteStorage;
+    CXPLAT_RECV_DATA RecvData;
     // Followed by:
     // uint8_t ClientContext[...];
     // uint8_t FrameBuffer[MAX_ETH_FRAME_SIZE];
@@ -98,23 +98,6 @@ typedef struct __attribute__((aligned(64))) XDP_TX_PACKET {
     CXPLAT_LIST_ENTRY Link;
     uint8_t FrameBuffer[MAX_ETH_FRAME_SIZE];
 } XDP_TX_PACKET;
-
-
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Context
-    )
-{
-    return (CXPLAT_RECV_DATA*)(((uint8_t*)Context) - sizeof(XDP_RX_PACKET));
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const Datagram
-    )
-{
-    return (CXPLAT_RECV_PACKET*)(((uint8_t*)Datagram) + sizeof(XDP_RX_PACKET));
-}
 
 QUIC_STATUS
 CxPlatGetInterfaceRssQueueCount(

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -91,6 +91,7 @@ typedef struct XDP_QUEUE {
 } XDP_QUEUE;
 
 typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) XDP_RX_PACKET {
+    // N.B. This struct is also put in a SLIST, so it must be aligned.
     XDP_QUEUE* Queue;
     CXPLAT_ROUTE RouteStorage;
     CXPLAT_RECV_DATA RecvData;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -109,7 +109,7 @@ typedef struct CXPLAT_DATAPATH_PROC_CONTEXT CXPLAT_DATAPATH_PROC_CONTEXT;
 //
 // Internal receive allocation context.
 //
-typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
+typedef struct DATAPATH_RX_IO_BLOCK {
 
     //
     // The per proc context for this receive context.
@@ -138,7 +138,20 @@ typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
     uint8_t DatagramPoolIndex   : 1;
     uint8_t BufferPoolIndex     : 1;
     uint8_t IsCopiedBuffer      : 1;
-} CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT;
+} DATAPATH_RX_IO_BLOCK;
+
+typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) DATAPATH_RX_PACKET {
+    //
+    // The IO block that owns the packet.
+    //
+    DATAPATH_RX_IO_BLOCK* IoBlock;
+
+    //
+    // Publicly visible receive data.
+    //
+    CXPLAT_RECV_DATA Data;
+
+} DATAPATH_RX_PACKET;
 
 BOOLEAN
 CxPlatMdlMapChain(
@@ -158,19 +171,6 @@ CxPlatMdlMapChain(
     } while ((Mdl = Mdl->Next) != NULL);
     return TRUE;
 }
-
-//
-// Internal receive buffer context.
-//
-typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT {
-
-    //
-    // The internal receive context owning the data indication and allocation
-    // chain.
-    //
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext;
-
-} CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT;
 
 typedef struct CXPLAT_DATAPATH_SEND_BUFFER {
 
@@ -405,7 +405,7 @@ typedef struct CXPLAT_DATAPATH {
     //
     // The size of the buffer to allocate for client's receive context structure.
     //
-    uint32_t ClientRecvContextLength;
+    uint32_t ClientRecvDataLength;
 
     //
     // The size of each receive datagram array element, including client context,
@@ -445,37 +445,6 @@ CxPlatSendBufferPoolAlloc(
         Size, \
         Tag, \
         0)
-
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Context
-    )
-{
-    return (CXPLAT_RECV_DATA*)
-        (((PUCHAR)Context) -
-            sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) -
-            sizeof(CXPLAT_RECV_DATA));
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const Datagram
-    )
-{
-    return (CXPLAT_RECV_PACKET*)
-        (((PUCHAR)Datagram) +
-            sizeof(CXPLAT_RECV_DATA) +
-            sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT));
-}
-
-CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*
-CxPlatDataPathDatagramToInternalDatagramContext(
-    _In_ CXPLAT_RECV_DATA* Datagram
-    )
-{
-    return (CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*)
-        (((PUCHAR)Datagram) + sizeof(CXPLAT_RECV_DATA));
-}
 
 IO_COMPLETION_ROUTINE CxPlatDataPathIoCompletion;
 
@@ -821,7 +790,7 @@ Error:
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 CxPlatDataPathInitialize(
-    _In_ uint32_t ClientRecvContextLength,
+    _In_ uint32_t ClientRecvDataLength,
     _In_opt_ const CXPLAT_UDP_DATAPATH_CALLBACKS* UdpCallbacks,
     _In_opt_ const CXPLAT_TCP_DATAPATH_CALLBACKS* TcpCallbacks,
     _In_opt_ QUIC_EXECUTION_CONFIG* Config,
@@ -875,21 +844,20 @@ CxPlatDataPathInitialize(
     if (UdpCallbacks) {
         Datapath->UdpHandlers = *UdpCallbacks;
     }
-    Datapath->ClientRecvContextLength = ClientRecvContextLength;
+    Datapath->ClientRecvDataLength = ClientRecvDataLength;
     Datapath->ProcCount = (uint32_t)CxPlatProcMaxCount();
     Datapath->WskDispatch.WskReceiveFromEvent = CxPlatDataPathSocketReceive;
     Datapath->DatagramStride =
         ALIGN_UP(
-            sizeof(CXPLAT_RECV_DATA) +
-            sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT) +
-            ClientRecvContextLength,
+            sizeof(DATAPATH_RX_PACKET) +
+            ClientRecvDataLength,
             PVOID);
 
     uint32_t RecvDatagramLength =
-        sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT) +
+        sizeof(DATAPATH_RX_IO_BLOCK) +
         Datapath->DatagramStride;
     uint32_t UroDatagramLength =
-        sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT) +
+        sizeof(DATAPATH_RX_IO_BLOCK) +
         URO_MAX_DATAGRAMS_PER_INDICATION * Datapath->DatagramStride;
 
     for (uint32_t i = 0; i < Datapath->ProcCount; i++) {
@@ -2106,8 +2074,8 @@ CxPlatSocketGetRemoteAddress(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT*
-CxPlatSocketAllocRecvContext(
+DATAPATH_RX_IO_BLOCK*
+CxPlatSocketAllocRxIoBlock(
     _In_ CXPLAT_DATAPATH* Datapath,
     _In_ UINT16 ProcIndex,
     _In_ BOOLEAN IsUro
@@ -2117,42 +2085,42 @@ CxPlatSocketAllocRecvContext(
     CXPLAT_DBG_ASSERT(ProcIndex < Datapath->ProcCount);
     CXPLAT_POOL* Pool = &Datapath->ProcContexts[ProcIndex].RecvDatagramPools[IsUro];
 
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* InternalContext = CxPlatPoolAlloc(Pool);
+    DATAPATH_RX_IO_BLOCK* IoBlock = CxPlatPoolAlloc(Pool);
 
-    if (InternalContext != NULL) {
-        InternalContext->Route.State = RouteResolved;
-        InternalContext->DatagramPoolIndex = IsUro;
-        InternalContext->ProcContext = &Datapath->ProcContexts[ProcIndex];
-        InternalContext->DataBufferStart = NULL;
+    if (IoBlock != NULL) {
+        IoBlock->Route.State = RouteResolved;
+        IoBlock->DatagramPoolIndex = IsUro;
+        IoBlock->ProcContext = &Datapath->ProcContexts[ProcIndex];
+        IoBlock->DataBufferStart = NULL;
     }
 
-    return InternalContext;
+    return IoBlock;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Must_inspect_result_
 PWSK_DATAGRAM_INDICATION
-CxPlatDataPathFreeRecvContext(
-    _In_ __drv_freesMem(Context) CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* Context
+CxPlatDataPathFreeRxIoBlock(
+    _In_ __drv_freesMem(Context) DATAPATH_RX_IO_BLOCK* IoBlock
     )
 {
     PWSK_DATAGRAM_INDICATION DataIndication = NULL;
-    if (Context->DataBufferStart != NULL) {
-        if (Context->IsCopiedBuffer) {
+    if (IoBlock->DataBufferStart != NULL) {
+        if (IoBlock->IsCopiedBuffer) {
             CxPlatPoolFree(
-                &Context->ProcContext->RecvBufferPools[Context->BufferPoolIndex],
-                Context->DataBufferStart);
+                &IoBlock->ProcContext->RecvBufferPools[IoBlock->BufferPoolIndex],
+                IoBlock->DataBufferStart);
         } else {
-            DataIndication = Context->DataIndication;
+            DataIndication = IoBlock->DataIndication;
             InterlockedAdd64(
-                &Context->ProcContext->OutstandingPendingBytes,
-                -Context->DataIndicationSize);
+                &IoBlock->ProcContext->OutstandingPendingBytes,
+                -IoBlock->DataIndicationSize);
         }
     }
 
     CxPlatPoolFree(
-        &Context->ProcContext->RecvDatagramPools[Context->DatagramPoolIndex],
-        Context);
+        &IoBlock->ProcContext->RecvDatagramPools[IoBlock->DatagramPoolIndex],
+        IoBlock);
     return DataIndication;
 }
 
@@ -2199,8 +2167,7 @@ CxPlatDataPathSocketReceive(
         DataIndicationHead = DataIndicationHead->Next;
         DataIndication->Next = NULL;
 
-        CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext = NULL;
-        CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalDatagramContext;
+        DATAPATH_RX_IO_BLOCK* IoBlock = NULL;
         CXPLAT_RECV_DATA* Datagram = NULL;
 
         if (DataIndication->Buffer.Mdl == NULL ||
@@ -2380,54 +2347,54 @@ CxPlatDataPathSocketReceive(
                 goto Drop;
             }
 
-            if (RecvContext == NULL) {
-                RecvContext =
-                    CxPlatSocketAllocRecvContext(
+            if (IoBlock == NULL) {
+                IoBlock =
+                    CxPlatSocketAllocRxIoBlock(
                         Binding->Datapath,
                         (UINT16)(CurProcNumber % Binding->Datapath->ProcCount),
                         IsCoalesced);
-                if (RecvContext == NULL) {
+                if (IoBlock == NULL) {
                     QuicTraceLogWarning(
-                        DatapathDropAllocRecvContextFailure,
+                        DatapathDropAllocIoBlockFailure,
                         "[%p] Couldn't allocate receive context.",
                         Binding);
                     goto Drop;
                 }
 
-                if (RecvContext->ProcContext->OutstandingPendingBytes >= PENDING_BUFFER_LIMIT) {
+                if (IoBlock->ProcContext->OutstandingPendingBytes >= PENDING_BUFFER_LIMIT) {
                     //
                     // Perform a copy
                     //
-                    RecvContext->IsCopiedBuffer = TRUE;
-                    RecvContext->BufferPoolIndex = DataLength > 4096 ? 1 : 0;
-                    RecvContext->DataBufferStart =
+                    IoBlock->IsCopiedBuffer = TRUE;
+                    IoBlock->BufferPoolIndex = DataLength > 4096 ? 1 : 0;
+                    IoBlock->DataBufferStart =
                         (uint8_t*)CxPlatPoolAlloc(
-                            &RecvContext->ProcContext->RecvBufferPools[RecvContext->BufferPoolIndex]);
-                    if (RecvContext->DataBufferStart == NULL) {
+                            &IoBlock->ProcContext->RecvBufferPools[IoBlock->BufferPoolIndex]);
+                    if (IoBlock->DataBufferStart == NULL) {
                         QuicTraceLogWarning(
                             DatapathDropAllocRecvBufferFailure,
                             "[%p] Couldn't allocate receive buffers.",
                             Binding);
                         goto Drop;
                     }
-                    CurrentCopiedBuffer = RecvContext->DataBufferStart;
+                    CurrentCopiedBuffer = IoBlock->DataBufferStart;
                 } else {
-                    RecvContext->IsCopiedBuffer = FALSE;
-                    RecvContext->DataIndication = DataIndication;
+                    IoBlock->IsCopiedBuffer = FALSE;
+                    IoBlock->DataIndication = DataIndication;
                     CXPLAT_DBG_ASSERT(DataIndication->Next == NULL);
-                    RecvContext->DataIndicationSize = (int32_t)DataLength;
+                    IoBlock->DataIndicationSize = (int32_t)DataLength;
                     InterlockedAdd64(
-                        &RecvContext->ProcContext->OutstandingPendingBytes,
-                        RecvContext->DataIndicationSize);
+                        &IoBlock->ProcContext->OutstandingPendingBytes,
+                        IoBlock->DataIndicationSize);
                 }
 
-                RecvContext->Binding = Binding;
-                RecvContext->ReferenceCount = 0;
-                RecvContext->Route.Queue =
+                IoBlock->Binding = Binding;
+                IoBlock->ReferenceCount = 0;
+                IoBlock->Route.Queue =
                     &Binding->Datapath->ProcContexts[CurProcNumber % Binding->Datapath->ProcCount];
-                RecvContext->Route.LocalAddress = LocalAddr;
-                RecvContext->Route.RemoteAddress = RemoteAddr;
-                Datagram = (CXPLAT_RECV_DATA*)(RecvContext + 1);
+                IoBlock->Route.LocalAddress = LocalAddr;
+                IoBlock->Route.RemoteAddress = RemoteAddr;
+                Datagram = (CXPLAT_RECV_DATA*)(IoBlock + 1);
             }
 
             CXPLAT_DBG_ASSERT(Datagram != NULL);
@@ -2436,12 +2403,10 @@ CxPlatDataPathSocketReceive(
             Datagram->TypeOfService = (uint8_t)ECN;
             Datagram->Allocated = TRUE;
             Datagram->QueuedOnConnection = FALSE;
+            CXPLAT_CONTAINING_RECORD(
+                Datagram, DATAPATH_RX_PACKET, Data)->IoBlock = IoBlock;
 
-            InternalDatagramContext =
-                CxPlatDataPathDatagramToInternalDatagramContext(Datagram);
-            InternalDatagramContext->RecvContext = RecvContext;
-
-            if (RecvContext->IsCopiedBuffer) {
+            if (IoBlock->IsCopiedBuffer) {
                 Datagram->Buffer = CurrentCopiedBuffer;
                 CxPlatCopyMemory(Datagram->Buffer, (uint8_t*)Mdl->MappedSystemVa + MdlOffset, MessageLength);
                 CurrentCopiedBuffer += MessageLength;
@@ -2450,14 +2415,14 @@ CxPlatDataPathSocketReceive(
             }
 
             Datagram->BufferLength = MessageLength;
-            Datagram->Route = &RecvContext->Route;
+            Datagram->Route = &IoBlock->Route;
 
             //
             // Add the datagram to the end of the current chain.
             //
             *DatagramChainTail = Datagram;
             DatagramChainTail = &Datagram->Next;
-            if (++RecvContext->ReferenceCount == URO_MAX_DATAGRAMS_PER_INDICATION) {
+            if (++IoBlock->ReferenceCount == URO_MAX_DATAGRAMS_PER_INDICATION) {
                 QuicTraceLogWarning(
                     DatapathUroExceeded,
                     "[%p] Exceeded URO preallocation capacity.",
@@ -2484,7 +2449,7 @@ CxPlatDataPathSocketReceive(
 
     Drop:
 
-        if (RecvContext != NULL && RecvContext->ReferenceCount == 0) {
+        if (IoBlock != NULL && IoBlock->ReferenceCount == 0) {
             //
             // No receive buffers were generated, so clean up now and return the
             // indication back to WSK. If the reference count is nonzero, then
@@ -2492,13 +2457,13 @@ CxPlatDataPathSocketReceive(
             // returned the buffers.
             //
             PWSK_DATAGRAM_INDICATION FreeIndic =
-                CxPlatDataPathFreeRecvContext(RecvContext);
+                CxPlatDataPathFreeRxIoBlock(IoBlock);
             CXPLAT_DBG_ASSERT(FreeIndic == DataIndication);
             UNREFERENCED_PARAMETER(FreeIndic);
-            RecvContext = NULL;
+            IoBlock = NULL;
         }
 
-        if (RecvContext == NULL || RecvContext->IsCopiedBuffer) {
+        if (IoBlock == NULL || IoBlock->IsCopiedBuffer) {
             *ReleaseChainTail = DataIndication;
             ReleaseChainTail = &DataIndication->Next;
         }
@@ -2545,7 +2510,7 @@ CxPlatRecvDataReturn(
     PWSK_DATAGRAM_INDICATION* DataIndicationTail = &DataIndications;
 
     LONG BatchedBufferCount = 0;
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* BatchedInternalContext = NULL;
+    DATAPATH_RX_IO_BLOCK* BatchedIoBlock = NULL;
 
     CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = RecvDataChain) != NULL) {
@@ -2554,28 +2519,24 @@ CxPlatRecvDataReturn(
         CXPLAT_DBG_ASSERT(!Datagram->QueuedOnConnection);
         RecvDataChain = RecvDataChain->Next;
 
-        CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalBufferContext =
-            CxPlatDataPathDatagramToInternalDatagramContext(Datagram);
-        CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* InternalContext =
-            InternalBufferContext->RecvContext;
+        DATAPATH_RX_IO_BLOCK* IoBlock =
+            CXPLAT_CONTAINING_RECORD(Datagram, DATAPATH_RX_PACKET, Data)->IoBlock;
 
-        CXPLAT_DBG_ASSERT(Binding == NULL || Binding == InternalContext->Binding);
-        Binding = InternalContext->Binding;
+        CXPLAT_DBG_ASSERT(Binding == NULL || Binding == IoBlock->Binding);
+        Binding = IoBlock->Binding;
         Datagram->Allocated = FALSE;
 
-        if (BatchedInternalContext == InternalContext) {
+        if (BatchedIoBlock == IoBlock) {
             BatchedBufferCount++;
         } else {
-            if (BatchedInternalContext != NULL &&
+            if (BatchedIoBlock != NULL &&
                 InterlockedAdd(
-                    (PLONG)&BatchedInternalContext->ReferenceCount,
+                    (PLONG)&BatchedIoBlock->ReferenceCount,
                     -BatchedBufferCount) == 0) {
                 //
                 // Clean up the data indication.
                 //
-                DataIndication =
-                    CxPlatDataPathFreeRecvContext(BatchedInternalContext);
-
+                DataIndication = CxPlatDataPathFreeRxIoBlock(BatchedIoBlock);
                 if (DataIndication != NULL) {
                     CXPLAT_DBG_ASSERT(DataIndication->Next == NULL);
                     *DataIndicationTail = DataIndication;
@@ -2583,21 +2544,19 @@ CxPlatRecvDataReturn(
                 }
             }
 
-            BatchedInternalContext = InternalContext;
+            BatchedIoBlock = IoBlock;
             BatchedBufferCount = 1;
         }
     }
 
-    if (BatchedInternalContext != NULL &&
+    if (BatchedIoBlock != NULL &&
         InterlockedAdd(
-            (PLONG)&BatchedInternalContext->ReferenceCount,
+            (PLONG)&BatchedIoBlock->ReferenceCount,
             -BatchedBufferCount) == 0) {
         //
         // Clean up the data indication.
         //
-        DataIndication =
-            CxPlatDataPathFreeRecvContext(BatchedInternalContext);
-
+        DataIndication = CxPlatDataPathFreeRxIoBlock(BatchedIoBlock);
         if (DataIndication != NULL) {
             CXPLAT_DBG_ASSERT(DataIndication->Next == NULL);
             *DataIndicationTail = DataIndication;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -140,9 +140,10 @@ typedef struct DATAPATH_IO_SQE {
 } DATAPATH_IO_SQE;
 
 //
-// Internal receive context.
+// Contains all the info for a single RX IO operation. Multiple RX packets may
+// come from a single IO operation.
 //
-typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
+typedef struct DATAPATH_RX_IO_BLOCK {
     //
     // The owning datagram pool.
     //
@@ -189,19 +190,20 @@ typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT {
         WSA_CMSG_SPACE(sizeof(INT))             // IP_ECN
         ];
 
-} CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT;
+} DATAPATH_RX_IO_BLOCK;
 
-//
-// Internal receive context.
-//
-typedef struct CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT {
+typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) DATAPATH_RX_PACKET {
+    //
+    // The IO block that owns the packet.
+    //
+    DATAPATH_RX_IO_BLOCK* IoBlock;
 
     //
-    // The owning allocation.
+    // Publicly visible receive data.
     //
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext;
+    CXPLAT_RECV_DATA Data;
 
-} CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT;
+} DATAPATH_RX_PACKET;
 
 //
 // Header prefixed to each RIO send buffer.
@@ -659,11 +661,6 @@ typedef struct CXPLAT_DATAPATH {
 
 } CXPLAT_DATAPATH;
 
-typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) SOCK_RX_PACKET {
-    CXPLAT_RECV_DATA;
-    CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT Context;
-} SOCK_RX_PACKET;
-
 #ifdef DEBUG
 #ifndef AllocOffset
 #define AllocOffset (sizeof(void*) * 2)
@@ -789,33 +786,6 @@ CxPlatStopInlineDatapathIo(
     CxPlatStopDatapathIo(Sqe);
 }
 
-CXPLAT_RECV_DATA*
-CxPlatDataPathRecvPacketToRecvData(
-    _In_ const CXPLAT_RECV_PACKET* const Context
-    )
-{
-    return (CXPLAT_RECV_DATA*)
-        (((PUCHAR)Context) - sizeof(SOCK_RX_PACKET));
-}
-
-CXPLAT_RECV_PACKET*
-CxPlatDataPathRecvDataToRecvPacket(
-    _In_ const CXPLAT_RECV_DATA* const Datagram
-    )
-{
-    return (CXPLAT_RECV_PACKET*)
-        (((PUCHAR)Datagram) + sizeof(SOCK_RX_PACKET));
-}
-
-CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*
-CxPlatDataPathDatagramToInternalDatagramContext(
-    _In_ CXPLAT_RECV_DATA* Datagram
-    )
-{
-    return (CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT*)
-        (((PUCHAR)Datagram) + sizeof(CXPLAT_RECV_DATA));
-}
-
 void
 CxPlatDataPathStartReceiveAsync(
     _In_ CXPLAT_SOCKET_PROC* SocketProc
@@ -895,14 +865,14 @@ CxPlatSendDataComplete(
 BOOLEAN
 CxPlatDataPathRecvComplete(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext,
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock,
     _In_ ULONG IoResult,
     _In_ uint16_t BytesTransferred
     );
 
 void
-CxPlatFreeRecvContext(
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext
+CxPlatFreeRxIoBlock(
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock
     );
 
 void
@@ -1152,7 +1122,7 @@ typedef LONG (WINAPI *FuncRtlGetVersion)(RTL_OSVERSIONINFOW *);
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 CxPlatDataPathInitialize(
-    _In_ uint32_t ClientRecvContextLength,
+    _In_ uint32_t ClientRecvDataLength,
     _In_opt_ const CXPLAT_UDP_DATAPATH_CALLBACKS* UdpCallbacks,
     _In_opt_ const CXPLAT_TCP_DATAPATH_CALLBACKS* TcpCallbacks,
     _In_opt_ QUIC_EXECUTION_CONFIG* Config,
@@ -1281,11 +1251,11 @@ CxPlatDataPathInitialize(
 
     Datapath->DatagramStride =
         ALIGN_UP(
-            sizeof(SOCK_RX_PACKET) +
-            ClientRecvContextLength,
+            sizeof(DATAPATH_RX_PACKET) +
+            ClientRecvDataLength,
             PVOID);
     Datapath->RecvPayloadOffset =
-        sizeof(CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT) +
+        sizeof(DATAPATH_RX_IO_BLOCK) +
         MessageCount * Datapath->DatagramStride;
 
     const uint32_t RecvDatagramLength =
@@ -3158,19 +3128,19 @@ RioRecvBufferAllocate(
         CXPLAT_CONTAINING_RECORD(Pool, CXPLAT_DATAPATH_PARTITION, RioRecvPool);
     CXPLAT_DATAPATH* Datapath = DatapathProc->Datapath;
 
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext = CxPlatLargeAlloc(Size, Tag);
+    DATAPATH_RX_IO_BLOCK* IoBlock = CxPlatLargeAlloc(Size, Tag);
 
-    if (RecvContext != NULL) {
-        RecvContext->RioBufferId =
-            Datapath->RioDispatch.RIORegisterBuffer((char*)RecvContext, Size);
+    if (IoBlock != NULL) {
+        IoBlock->RioBufferId =
+            Datapath->RioDispatch.RIORegisterBuffer((char*)IoBlock, Size);
 
-        if (RecvContext->RioBufferId == RIO_INVALID_BUFFERID) {
-            CxPlatLargeFree(RecvContext, Tag);
-            RecvContext = NULL;
+        if (IoBlock->RioBufferId == RIO_INVALID_BUFFERID) {
+            CxPlatLargeFree(IoBlock, Tag);
+            IoBlock = NULL;
         }
     }
 
-    return RecvContext;
+    return IoBlock;
 }
 
 void
@@ -3180,23 +3150,23 @@ RioRecvBufferFree(
     _Inout_ CXPLAT_POOL* Pool
     )
 {
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext = Entry;
+    DATAPATH_RX_IO_BLOCK* IoBlock = Entry;
     CXPLAT_DATAPATH_PARTITION* DatapathProc =
         CXPLAT_CONTAINING_RECORD(Pool, CXPLAT_DATAPATH_PARTITION, RioRecvPool);
     CXPLAT_DATAPATH* Datapath = DatapathProc->Datapath;
 
-    CXPLAT_DBG_ASSERT(RecvContext->RioBufferId != RIO_INVALID_BUFFERID);
-    Datapath->RioDispatch.RIODeregisterBuffer(RecvContext->RioBufferId);
-    CxPlatLargeFree(RecvContext, Tag);
+    CXPLAT_DBG_ASSERT(IoBlock->RioBufferId != RIO_INVALID_BUFFERID);
+    Datapath->RioDispatch.RIODeregisterBuffer(IoBlock->RioBufferId);
+    CxPlatLargeFree(IoBlock, Tag);
 }
 
-CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT*
-CxPlatSocketAllocRecvContext(
+DATAPATH_RX_IO_BLOCK*
+CxPlatSocketAllocRxIoBlock(
     _In_ CXPLAT_SOCKET_PROC* SocketProc
     )
 {
     CXPLAT_DATAPATH_PARTITION* DatapathProc = SocketProc->DatapathProc;
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext;
+    DATAPATH_RX_IO_BLOCK* IoBlock;
     CXPLAT_POOL* OwningPool;
 
     if (SocketProc->Parent->UseRio) {
@@ -3205,27 +3175,27 @@ CxPlatSocketAllocRecvContext(
         OwningPool = &DatapathProc->RecvDatagramPool;
     }
 
-    RecvContext = CxPlatPoolAlloc(OwningPool);
+    IoBlock = CxPlatPoolAlloc(OwningPool);
 
-    if (RecvContext != NULL) {
-        RecvContext->Route.State = RouteResolved;
-        RecvContext->OwningPool = OwningPool;
-        RecvContext->ReferenceCount = 0;
-        RecvContext->SocketProc = SocketProc;
+    if (IoBlock != NULL) {
+        IoBlock->Route.State = RouteResolved;
+        IoBlock->OwningPool = OwningPool;
+        IoBlock->ReferenceCount = 0;
+        IoBlock->SocketProc = SocketProc;
 #if DEBUG
-        RecvContext->Sqe.IoType = 0;
+        IoBlock->Sqe.IoType = 0;
 #endif
     }
 
-    return RecvContext;
+    return IoBlock;
 }
 
 void
-CxPlatSocketFreeRecvContext(
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext
+CxPlatSocketFreeRxIoBlock(
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock
     )
 {
-    CxPlatPoolFree(RecvContext->OwningPool, RecvContext);
+    CxPlatPoolFree(IoBlock->OwningPool, IoBlock);
 }
 
 QUIC_STATUS
@@ -3494,9 +3464,9 @@ CxPlatSocketStartRioReceives(
         RIO_BUF Control = {0};
         DWORD RioFlags = 0;
 
-        CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext =
-            CxPlatSocketAllocRecvContext(SocketProc);
-        if (RecvContext == NULL) {
+        DATAPATH_RX_IO_BLOCK* IoBlock =
+            CxPlatSocketAllocRxIoBlock(SocketProc);
+        if (IoBlock == NULL) {
             Status = QUIC_STATUS_OUT_OF_MEMORY;
             QuicTraceEvent(
                 AllocFailure,
@@ -3510,21 +3480,21 @@ CxPlatSocketStartRioReceives(
             RioFlags |= RIO_MSG_DEFER;
         }
 
-        Data.BufferId = RecvContext->RioBufferId;
+        Data.BufferId = IoBlock->RioBufferId;
         Data.Offset = Datapath->RecvPayloadOffset;
         Data.Length = SocketProc->Parent->RecvBufLen;
-        RemoteAddr.BufferId = RecvContext->RioBufferId;
+        RemoteAddr.BufferId = IoBlock->RioBufferId;
         RemoteAddr.Offset =
-            FIELD_OFFSET(CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT, Route.RemoteAddress);
-        RemoteAddr.Length = sizeof(RecvContext->Route.RemoteAddress);
-        Control.BufferId = RecvContext->RioBufferId;
-        Control.Offset = FIELD_OFFSET(CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT, ControlBuf);
-        Control.Length = sizeof(RecvContext->ControlBuf);
-        RecvContext->Sqe.IoType = DATAPATH_IO_RIO_RECV;
+            FIELD_OFFSET(DATAPATH_RX_IO_BLOCK, Route.RemoteAddress);
+        RemoteAddr.Length = sizeof(IoBlock->Route.RemoteAddress);
+        Control.BufferId = IoBlock->RioBufferId;
+        Control.Offset = FIELD_OFFSET(DATAPATH_RX_IO_BLOCK, ControlBuf);
+        Control.Length = sizeof(IoBlock->ControlBuf);
+        IoBlock->Sqe.IoType = DATAPATH_IO_RIO_RECV;
 
         if (!Datapath->RioDispatch.RIOReceiveEx(
                 SocketProc->RioRq, &Data, 1, NULL, &RemoteAddr,
-                &Control, NULL, RioFlags, &RecvContext->Sqe.IoType)) {
+                &Control, NULL, RioFlags, &IoBlock->Sqe.IoType)) {
             int WsaError = WSAGetLastError();
             QuicTraceEvent(
                 DatapathErrorStatus,
@@ -3533,7 +3503,7 @@ CxPlatSocketStartRioReceives(
                 WsaError,
                 "RIOReceiveEx");
             Status = HRESULT_FROM_WIN32(WsaError);
-            CxPlatSocketFreeRecvContext(RecvContext);
+            CxPlatSocketFreeRxIoBlock(IoBlock);
             goto Error;
         }
 
@@ -3584,21 +3554,21 @@ CxPlatSocketStartWinsockReceive(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
     _Out_opt_ ULONG* SyncIoResult,
     _Out_opt_ uint16_t* SyncBytesReceived,
-    _Out_opt_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT** SyncRecvContext
+    _Out_opt_ DATAPATH_RX_IO_BLOCK** SyncIoBlock
     )
 {
     const CXPLAT_DATAPATH* Datapath = SocketProc->Parent->Datapath;
 
     CXPLAT_DBG_ASSERT((SyncIoResult != NULL) == (SyncBytesReceived != NULL));
-    CXPLAT_DBG_ASSERT((SyncIoResult != NULL) == (SyncRecvContext != NULL));
+    CXPLAT_DBG_ASSERT((SyncIoResult != NULL) == (SyncIoBlock != NULL));
     CXPLAT_DBG_ASSERT(SocketProc->Parent->Type != CXPLAT_SOCKET_TCP_LISTENER);
 
     //
     // Get a receive buffer we can pass to WinSock.
     //
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext =
-        CxPlatSocketAllocRecvContext(SocketProc);
-    if (RecvContext == NULL) {
+    DATAPATH_RX_IO_BLOCK* IoBlock =
+        CxPlatSocketAllocRxIoBlock(SocketProc);
+    if (IoBlock == NULL) {
         QuicTraceEvent(
             AllocFailure,
             "Allocation of '%s' failed. (%llu bytes)",
@@ -3614,19 +3584,19 @@ CxPlatSocketStartWinsockReceive(
     // held by the socket until it completes.
     //
 
-    CxPlatDatapathSqeInitialize(&RecvContext->Sqe.DatapathSqe, CXPLAT_CQE_TYPE_SOCKET_IO);
-    CxPlatStartDatapathIo(SocketProc, &RecvContext->Sqe, DATAPATH_IO_RECV);
+    CxPlatDatapathSqeInitialize(&IoBlock->Sqe.DatapathSqe, CXPLAT_CQE_TYPE_SOCKET_IO);
+    CxPlatStartDatapathIo(SocketProc, &IoBlock->Sqe, DATAPATH_IO_RECV);
 
-    RecvContext->WsaControlBuf.buf = ((CHAR*)RecvContext) + Datapath->RecvPayloadOffset;
-    RecvContext->WsaControlBuf.len = SocketProc->Parent->RecvBufLen;
+    IoBlock->WsaControlBuf.buf = ((CHAR*)IoBlock) + Datapath->RecvPayloadOffset;
+    IoBlock->WsaControlBuf.len = SocketProc->Parent->RecvBufLen;
 
-    RecvContext->WsaMsgHdr.name = (PSOCKADDR)&RecvContext->Route.RemoteAddress;
-    RecvContext->WsaMsgHdr.namelen = sizeof(RecvContext->Route.RemoteAddress);
-    RecvContext->WsaMsgHdr.lpBuffers = &RecvContext->WsaControlBuf;
-    RecvContext->WsaMsgHdr.dwBufferCount = 1;
-    RecvContext->WsaMsgHdr.Control.buf = RecvContext->ControlBuf;
-    RecvContext->WsaMsgHdr.Control.len = sizeof(RecvContext->ControlBuf);
-    RecvContext->WsaMsgHdr.dwFlags = 0;
+    IoBlock->WsaMsgHdr.name = (PSOCKADDR)&IoBlock->Route.RemoteAddress;
+    IoBlock->WsaMsgHdr.namelen = sizeof(IoBlock->Route.RemoteAddress);
+    IoBlock->WsaMsgHdr.lpBuffers = &IoBlock->WsaControlBuf;
+    IoBlock->WsaMsgHdr.dwBufferCount = 1;
+    IoBlock->WsaMsgHdr.Control.buf = IoBlock->ControlBuf;
+    IoBlock->WsaMsgHdr.Control.len = sizeof(IoBlock->ControlBuf);
+    IoBlock->WsaMsgHdr.dwFlags = 0;
 
     //
     // Call the appropriate WinSock API to start the receive. It may complete
@@ -3642,19 +3612,19 @@ CxPlatSocketStartWinsockReceive(
         Result =
             SocketProc->Parent->Datapath->WSARecvMsg(
                 SocketProc->Socket,
-                &RecvContext->WsaMsgHdr,
+                &IoBlock->WsaMsgHdr,
                 &BytesRecv,
-                &RecvContext->Sqe.DatapathSqe.Sqe.Overlapped,
+                &IoBlock->Sqe.DatapathSqe.Sqe.Overlapped,
                 NULL);
     } else {
         Result =
             WSARecv(
                 SocketProc->Socket,
-                &RecvContext->WsaControlBuf,
+                &IoBlock->WsaControlBuf,
                 1,
                 &BytesRecv,
-                &RecvContext->WsaMsgHdr.dwFlags,
-                &RecvContext->Sqe.DatapathSqe.Sqe.Overlapped,
+                &IoBlock->WsaMsgHdr.dwFlags,
+                &IoBlock->Sqe.DatapathSqe.Sqe.Overlapped,
                 NULL);
     }
 
@@ -3669,7 +3639,7 @@ CxPlatSocketStartWinsockReceive(
         // Update the SQE to indicate the failure.
         //
         if (SyncBytesReceived == NULL) {
-            RecvContext->Sqe.IoType = DATAPATH_IO_RECV_FAILURE;
+            IoBlock->Sqe.IoType = DATAPATH_IO_RECV_FAILURE;
             BytesRecv = (DWORD)WsaError;
         }
     }
@@ -3679,11 +3649,11 @@ CxPlatSocketStartWinsockReceive(
         // The receive completed inline (success or failure), and the caller is
         // prepared to handle it synchronously.
         //
-        CxPlatStopInlineDatapathIo(&RecvContext->Sqe);
+        CxPlatStopInlineDatapathIo(&IoBlock->Sqe);
         CXPLAT_DBG_ASSERT(BytesRecv < UINT16_MAX);
         *SyncBytesReceived = (uint16_t)BytesRecv;
         *SyncIoResult = WsaError;
-        *SyncRecvContext = RecvContext;
+        *SyncIoBlock = IoBlock;
         return QUIC_STATUS_SUCCESS;
     }
 
@@ -3691,7 +3661,7 @@ CxPlatSocketStartWinsockReceive(
     // Manually queue the IO completion for the receive since the caller isn't
     // prepared to handle it synchronously.
     //
-    QUIC_STATUS Status = CxPlatSocketEnqueueSqe(SocketProc, &RecvContext->Sqe, BytesRecv);
+    QUIC_STATUS Status = CxPlatSocketEnqueueSqe(SocketProc, &IoBlock->Sqe, BytesRecv);
     if (QUIC_FAILED(Status)) {
         //
         // N.B. The above function generally can only fail if the OS failed to
@@ -3699,8 +3669,8 @@ CxPlatSocketStartWinsockReceive(
         // and this likely should simply be treated as a fatal error.
         //
         CXPLAT_DBG_ASSERT(FALSE); // We don't expect tests to hit this.
-        CxPlatCancelDatapathIo(SocketProc, &RecvContext->Sqe);
-        CxPlatSocketFreeRecvContext(RecvContext);
+        CxPlatCancelDatapathIo(SocketProc, &IoBlock->Sqe);
+        CxPlatSocketFreeRxIoBlock(IoBlock);
         return Status;
     }
 
@@ -3713,7 +3683,7 @@ CxPlatSocketStartReceive(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
     _Out_opt_ ULONG* SyncIoResult,
     _Out_opt_ uint16_t* SyncBytesReceived,
-    _Out_opt_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT** SyncRecvContext
+    _Out_opt_ DATAPATH_RX_IO_BLOCK** SyncIoBlock
     )
 {
     QUIC_STATUS Status;
@@ -3724,7 +3694,7 @@ CxPlatSocketStartReceive(
     } else {
         Status =
             CxPlatSocketStartWinsockReceive(
-                SocketProc, SyncIoResult, SyncBytesReceived, SyncRecvContext);
+                SocketProc, SyncIoResult, SyncBytesReceived, SyncIoBlock);
     }
 
     return Status;
@@ -3733,7 +3703,7 @@ CxPlatSocketStartReceive(
 BOOLEAN
 CxPlatDataPathUdpRecvComplete(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext,
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock,
     _In_ ULONG IoResult,
     _In_ UINT16 NumberOfBytesTransferred
     )
@@ -3743,14 +3713,14 @@ CxPlatDataPathUdpRecvComplete(
         // Error from shutdown, silently ignore. Return immediately so the
         // receive doesn't get reposted.
         //
-        CxPlatSocketFreeRecvContext(RecvContext);
+        CxPlatSocketFreeRxIoBlock(IoBlock);
         return FALSE;
     }
 
-    PSOCKADDR_INET LocalAddr = &RecvContext->Route.LocalAddress;
-    PSOCKADDR_INET RemoteAddr = &RecvContext->Route.RemoteAddress;
+    PSOCKADDR_INET LocalAddr = &IoBlock->Route.LocalAddress;
+    PSOCKADDR_INET RemoteAddr = &IoBlock->Route.RemoteAddress;
     CxPlatConvertFromMappedV6(RemoteAddr, RemoteAddr);
-    RecvContext->Route.Queue = SocketProc;
+    IoBlock->Route.Queue = SocketProc;
 
     if (IsUnreachableErrorCode(IoResult)) {
 
@@ -3798,7 +3768,7 @@ CxPlatDataPathUdpRecvComplete(
 
         CXPLAT_DATAPATH* Datapath = SocketProc->Parent->Datapath;
         CXPLAT_RECV_DATA* Datagram;
-        PUCHAR RecvPayload = ((PUCHAR)RecvContext) + Datapath->RecvPayloadOffset;
+        PUCHAR RecvPayload = ((PUCHAR)IoBlock) + Datapath->RecvPayloadOffset;
 
         BOOLEAN FoundLocalAddr = FALSE;
         UINT16 MessageLength = NumberOfBytesTransferred;
@@ -3807,14 +3777,14 @@ CxPlatDataPathUdpRecvComplete(
         INT ECN = 0;
 
         if (SocketProc->Parent->UseRio) {
-            PRIO_CMSG_BUFFER RioRcvMsg = (PRIO_CMSG_BUFFER)RecvContext->ControlBuf;
-            RecvContext->WsaMsgHdr.Control.buf = RecvContext->ControlBuf + RIO_CMSG_BASE_SIZE;
-            RecvContext->WsaMsgHdr.Control.len = RioRcvMsg->TotalLength - RIO_CMSG_BASE_SIZE;
+            PRIO_CMSG_BUFFER RioRcvMsg = (PRIO_CMSG_BUFFER)IoBlock->ControlBuf;
+            IoBlock->WsaMsgHdr.Control.buf = IoBlock->ControlBuf + RIO_CMSG_BASE_SIZE;
+            IoBlock->WsaMsgHdr.Control.len = RioRcvMsg->TotalLength - RIO_CMSG_BASE_SIZE;
         }
 
-        for (WSACMSGHDR* CMsg = CMSG_FIRSTHDR(&RecvContext->WsaMsgHdr);
+        for (WSACMSGHDR* CMsg = CMSG_FIRSTHDR(&IoBlock->WsaMsgHdr);
             CMsg != NULL;
-            CMsg = CMSG_NXTHDR(&RecvContext->WsaMsgHdr, CMsg)) {
+            CMsg = CMSG_NXTHDR(&IoBlock->WsaMsgHdr, CMsg)) {
 
             if (CMsg->cmsg_level == IPPROTO_IPV6) {
                 if (CMsg->cmsg_type == IPV6_PKTINFO) {
@@ -3874,15 +3844,14 @@ CxPlatDataPathUdpRecvComplete(
 
         CXPLAT_DBG_ASSERT(NumberOfBytesTransferred <= SocketProc->Parent->RecvBufLen);
 
-        Datagram = (CXPLAT_RECV_DATA*)(RecvContext + 1);
+        Datagram = (CXPLAT_RECV_DATA*)(IoBlock + 1);
 
         for ( ;
             NumberOfBytesTransferred != 0;
             NumberOfBytesTransferred -= MessageLength) {
 
-            CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalDatagramContext =
-                CxPlatDataPathDatagramToInternalDatagramContext(Datagram);
-            InternalDatagramContext->RecvContext = RecvContext;
+            CXPLAT_CONTAINING_RECORD(
+                Datagram, DATAPATH_RX_PACKET, Data)->IoBlock = IoBlock;
 
             if (MessageLength > NumberOfBytesTransferred) {
                 //
@@ -3894,7 +3863,7 @@ CxPlatDataPathUdpRecvComplete(
             Datagram->Next = NULL;
             Datagram->Buffer = RecvPayload;
             Datagram->BufferLength = MessageLength;
-            Datagram->Route = &RecvContext->Route;
+            Datagram->Route = &IoBlock->Route;
             Datagram->PartitionIndex =
                 SocketProc->DatapathProc->PartitionIndex % SocketProc->DatapathProc->Datapath->PartitionCount;
             Datagram->TypeOfService = (uint8_t)ECN;
@@ -3908,7 +3877,7 @@ CxPlatDataPathUdpRecvComplete(
             //
             *DatagramChainTail = Datagram;
             DatagramChainTail = &Datagram->Next;
-            RecvContext->ReferenceCount++;
+            IoBlock->ReferenceCount++;
 
             Datagram = (CXPLAT_RECV_DATA*)
                 (((PUCHAR)Datagram) +
@@ -3923,7 +3892,7 @@ CxPlatDataPathUdpRecvComplete(
             }
         }
 
-        RecvContext = NULL;
+        IoBlock = NULL;
         CXPLAT_DBG_ASSERT(RecvDataChain);
 
         if (!SocketProc->Parent->PcpBinding) {
@@ -3950,8 +3919,8 @@ CxPlatDataPathUdpRecvComplete(
 
 Drop:
 
-    if (RecvContext != NULL) {
-        CxPlatSocketFreeRecvContext(RecvContext);
+    if (IoBlock != NULL) {
+        CxPlatSocketFreeRxIoBlock(IoBlock);
     }
 
     return TRUE;
@@ -3965,7 +3934,7 @@ CxPlatDataPathStartReceive(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
     _Out_opt_ ULONG* IoResult,
     _Out_opt_ uint16_t* InlineBytesTransferred,
-    _Out_opt_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT** RecvContext
+    _Out_opt_ DATAPATH_RX_IO_BLOCK** IoBlock
     )
 {
     const int32_t MAX_RECV_RETRIES = 10;
@@ -3977,7 +3946,7 @@ CxPlatDataPathStartReceive(
                 SocketProc,
                 IoResult,
                 InlineBytesTransferred,
-                RecvContext);
+                IoBlock);
     } while (Status == QUIC_STATUS_OUT_OF_MEMORY && ++RetryCount < MAX_RECV_RETRIES);
 
     if (Status == QUIC_STATUS_OUT_OF_MEMORY) {
@@ -4037,18 +4006,18 @@ CxPlatDataPathSocketProcessRioCompletion(
             switch (*IoType) {
             case DATAPATH_IO_RIO_RECV:
                 CXPLAT_DBG_ASSERT(Results[i].BytesTransferred <= UINT16_MAX);
-                CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext =
-                    CONTAINING_RECORD(IoType, CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT, Sqe.IoType);
+                DATAPATH_RX_IO_BLOCK* IoBlock =
+                    CONTAINING_RECORD(IoType, DATAPATH_RX_IO_BLOCK, Sqe.IoType);
 
                 if (UpcallAcquired) {
                     NeedReceive =
                         CxPlatDataPathRecvComplete(
                             SocketProc,
-                            RecvContext,
+                            IoBlock,
                             Results[i].Status,
                             (UINT16)Results[i].BytesTransferred);
                 } else {
-                    CxPlatFreeRecvContext(RecvContext);
+                    CxPlatFreeRxIoBlock(IoBlock);
                 }
 
                 SocketProc->RioRecvCount--;
@@ -4091,15 +4060,15 @@ CxPlatDataPathSocketProcessRioCompletion(
 BOOLEAN
 CxPlatDataPathTcpRecvComplete(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext,
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock,
     _In_ ULONG IoResult,
     _In_ UINT16 NumberOfBytesTransferred
     )
 {
     BOOLEAN NeedReceive = TRUE;
 
-    PSOCKADDR_INET RemoteAddr = &RecvContext->Route.RemoteAddress;
-    PSOCKADDR_INET LocalAddr = &RecvContext->Route.LocalAddress;
+    PSOCKADDR_INET RemoteAddr = &IoBlock->Route.RemoteAddress;
+    PSOCKADDR_INET LocalAddr = &IoBlock->Route.LocalAddress;
 
     if (IoResult == WSAENOTSOCK ||
         IoResult == WSA_OPERATION_ABORTED ||
@@ -4146,22 +4115,20 @@ CxPlatDataPathTcpRecvComplete(
         CXPLAT_DBG_ASSERT(NumberOfBytesTransferred <= SocketProc->Parent->RecvBufLen);
 
         CXPLAT_DATAPATH* Datapath = SocketProc->Parent->Datapath;
-        CXPLAT_RECV_DATA* Data = (CXPLAT_RECV_DATA*)(RecvContext + 1);
+        CXPLAT_RECV_DATA* Data = (CXPLAT_RECV_DATA*)(IoBlock + 1);
 
-        CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalDatagramContext =
-            CxPlatDataPathDatagramToInternalDatagramContext(Data);
-        InternalDatagramContext->RecvContext = RecvContext;
+        CXPLAT_CONTAINING_RECORD(Data, DATAPATH_RX_PACKET, Data)->IoBlock = IoBlock;
 
         Data->Next = NULL;
-        Data->Buffer = ((PUCHAR)RecvContext) + Datapath->RecvPayloadOffset;
+        Data->Buffer = ((PUCHAR)IoBlock) + Datapath->RecvPayloadOffset;
         Data->BufferLength = NumberOfBytesTransferred;
-        Data->Route = &RecvContext->Route;
+        Data->Route = &IoBlock->Route;
         Data->PartitionIndex = SocketProc->DatapathProc->PartitionIndex;
         Data->TypeOfService = 0;
         Data->Allocated = TRUE;
         Data->QueuedOnConnection = FALSE;
-        RecvContext->ReferenceCount++;
-        RecvContext = NULL;
+        IoBlock->ReferenceCount++;
+        IoBlock = NULL;
 
         SocketProc->Parent->Datapath->TcpHandlers.Receive(
             SocketProc->Parent,
@@ -4179,20 +4146,20 @@ CxPlatDataPathTcpRecvComplete(
 
 Drop:
 
-    if (RecvContext != NULL) {
-        CxPlatSocketFreeRecvContext(RecvContext);
+    if (IoBlock != NULL) {
+        CxPlatSocketFreeRxIoBlock(IoBlock);
     }
 
     return NeedReceive;
 }
 
 void
-CxPlatFreeRecvContext(
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext
+CxPlatFreeRxIoBlock(
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock
     )
 {
-    CXPLAT_DBG_ASSERT(RecvContext->ReferenceCount == 0);
-    CxPlatPoolFree(RecvContext->OwningPool, RecvContext);
+    CXPLAT_DBG_ASSERT(IoBlock->ReferenceCount == 0);
+    CxPlatPoolFree(IoBlock->OwningPool, IoBlock);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -4201,52 +4168,49 @@ CxPlatRecvDataReturn(
     _In_opt_ CXPLAT_RECV_DATA* RecvDataChain
     )
 {
-    CXPLAT_RECV_DATA* Datagram;
-
     LONG BatchedBufferCount = 0;
-    CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* BatchedInternalContext = NULL;
+    DATAPATH_RX_IO_BLOCK* BatchIoBlock = NULL;
 
+    CXPLAT_RECV_DATA* Datagram;
     while ((Datagram = RecvDataChain) != NULL) {
         RecvDataChain = RecvDataChain->Next;
 
-        CXPLAT_DATAPATH_INTERNAL_RECV_BUFFER_CONTEXT* InternalBufferContext =
-            CxPlatDataPathDatagramToInternalDatagramContext(Datagram);
-        CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* InternalContext =
-            InternalBufferContext->RecvContext;
+        DATAPATH_RX_IO_BLOCK* IoBlock =
+            CXPLAT_CONTAINING_RECORD(Datagram, DATAPATH_RX_PACKET, Data)->IoBlock;
 
-        if (BatchedInternalContext == InternalContext) {
+        if (BatchIoBlock == IoBlock) {
             BatchedBufferCount++;
         } else {
-            if (BatchedInternalContext != NULL &&
+            if (BatchIoBlock != NULL &&
                 InterlockedAdd(
-                    (PLONG)&BatchedInternalContext->ReferenceCount,
+                    (PLONG)&BatchIoBlock->ReferenceCount,
                     -BatchedBufferCount) == 0) {
                 //
                 // Clean up the data indication.
                 //
-                CxPlatSocketFreeRecvContext(BatchedInternalContext);
+                CxPlatSocketFreeRxIoBlock(BatchIoBlock);
             }
 
-            BatchedInternalContext = InternalContext;
+            BatchIoBlock = IoBlock;
             BatchedBufferCount = 1;
         }
     }
 
-    if (BatchedInternalContext != NULL &&
+    if (BatchIoBlock != NULL &&
         InterlockedAdd(
-            (PLONG)&BatchedInternalContext->ReferenceCount,
+            (PLONG)&BatchIoBlock->ReferenceCount,
             -BatchedBufferCount) == 0) {
         //
         // Clean up the data indication.
         //
-        CxPlatSocketFreeRecvContext(BatchedInternalContext);
+        CxPlatSocketFreeRxIoBlock(BatchIoBlock);
     }
 }
 
 BOOLEAN
 CxPlatDataPathRecvComplete(
     _In_ CXPLAT_SOCKET_PROC* SocketProc,
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext,
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock,
     _In_ ULONG IoResult,
     _In_ uint16_t BytesTransferred
     )
@@ -4255,14 +4219,14 @@ CxPlatDataPathRecvComplete(
         return
             CxPlatDataPathUdpRecvComplete(
                 SocketProc,
-                RecvContext,
+                IoBlock,
                 IoResult,
                 BytesTransferred);
     } else {
         return
             CxPlatDataPathTcpRecvComplete(
                 SocketProc,
-                RecvContext,
+                IoBlock,
                 IoResult,
                 BytesTransferred);
     }
@@ -4270,12 +4234,12 @@ CxPlatDataPathRecvComplete(
 
 void
 CxPlatDataPathSocketProcessReceive(
-    _In_ CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT* RecvContext,
+    _In_ DATAPATH_RX_IO_BLOCK* IoBlock,
     _In_ uint16_t BytesTransferred,
     _In_ ULONG IoResult
     )
 {
-    CXPLAT_SOCKET_PROC* SocketProc = RecvContext->SocketProc;
+    CXPLAT_SOCKET_PROC* SocketProc = IoBlock->SocketProc;
 
     CXPLAT_DBG_ASSERT(!SocketProc->Freed);
     if (!CxPlatRundownAcquire(&SocketProc->RundownRef)) {
@@ -4299,12 +4263,12 @@ CxPlatDataPathSocketProcessReceive(
         //
         CxPlatSocketContextRelease(SocketProc);
         if (!CxPlatDataPathRecvComplete(
-                SocketProc, RecvContext, IoResult, BytesTransferred) ||
+                SocketProc, IoBlock, IoResult, BytesTransferred) ||
             !CxPlatDataPathStartReceive(
                 SocketProc,
                 InlineReceiveCount > 1 ? &IoResult : NULL,
                 InlineReceiveCount > 1 ? &BytesTransferred : NULL,
-                InlineReceiveCount > 1 ? &RecvContext : NULL)) {
+                InlineReceiveCount > 1 ? &IoBlock : NULL)) {
             break;
         }
     }
@@ -5069,7 +5033,7 @@ CxPlatDataPathProcessCqe(
             //
             CXPLAT_DBG_ASSERT(Cqe->dwNumberOfBytesTransferred <= UINT16_MAX);
             CxPlatDataPathSocketProcessReceive(
-                CONTAINING_RECORD(Sqe, CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT, Sqe),
+                CONTAINING_RECORD(Sqe, DATAPATH_RX_IO_BLOCK, Sqe),
                 (uint16_t)Cqe->dwNumberOfBytesTransferred,
                 RtlNtStatusToDosError((NTSTATUS)Cqe->Internal));
             break;
@@ -5107,7 +5071,7 @@ CxPlatDataPathProcessCqe(
             // special (they loop internally).
             //
             CxPlatDataPathSocketProcessReceive(
-                CONTAINING_RECORD(Sqe, CXPLAT_DATAPATH_INTERNAL_RECV_CONTEXT, Sqe),
+                CONTAINING_RECORD(Sqe, DATAPATH_RX_IO_BLOCK, Sqe),
                 0,
                 (ULONG)Cqe->dwNumberOfBytesTransferred);
             break;


### PR DESCRIPTION
## Description

Cleans up a few things:

1. Creates a clear abstraction between QUIC and platform layer.
2. Renames QUIC layer objects to remove CXPLAT name.
3. Refactors internals of datapaths to have similar structs/names to make it easier to understand (and maybe converge eventually).

## Testing

Existing automation

## Documentation

N/A
