### PR TITLE
Migrate Send Logic to 64-bit Time

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -28,6 +28,57 @@ It uses asynchronous callbacks driven by the current execution model (see [below
 
 Currently, it also has preview support of XDP on Windows.
 
+```mermaid
+flowchart TB
+    Datapath-.->p1[Partition]
+    Datapath-.->Socket
+    Datapath-.->p2[Partition]
+    subgraph p1[Partition]
+    rx1["RX IO
+         Pool"]
+    tx1["TX IO
+         Pool"]
+    end
+    subgraph p2[Partition]
+    rx2["RX IO
+         Pool"]
+    tx2["TX IO
+         Pool"]
+    end
+    Socket-.->q1
+    Socket-.->q2
+    subgraph q1[Queue]
+    plat_sock1[Platform Socket]
+    end
+    q1-.->p1
+    subgraph q2[Queue]
+    plat_sock2[Platform Socket]
+    end
+    q2-.->p2
+    subgraph rxio[RX IO]
+    rx_meta[Internal Data]
+    rx_packet[IP/Client Data]
+    rx_buffer[Packet Payload]
+    end
+    rx1-.->rxio
+    rx2-.->rxio
+    subgraph txio[TX IO]
+    tx_meta[Internal Data]
+    tx_packet[IP/Client Data]
+    tx_buffer[Packet Payload]
+    end
+    tx1-.->txio
+    tx2-.->txio
+```
+
+There are a few high-level concepts for the datapath implementations:
+
+- **Datapath** - The top-level, public object that is used to create and manage all other options. It sets up multiple partitions for the given execution mode.
+- **Parition** - An internal object used to isolate different instances of data for performance. By isolating the data, sockets can be efficiently parallelized, usually on different processors. They maintain a pool for RX and TX IO blocks.
+- **Socket** - The public object that exposes a highly parallelized interface for sending and receiving packets in the current execution mode and partitions.
+- **Queue** - Another internal object used in conjunction with partitions to parallelize the work of a given socket.
+- **RX/TX IO** - A contiguous block of memory containing both internal/external metadata as well as the payload buffers. If batching (e.g. USO/URO) is supported by the datapath, then multiple IO blocks may be allocated together and organized slightly differently.
+
 ### Crypto
 
 The PAL exposes various cryptographic interfaces as well, such has encryption/decryption and cryptographic hashing. This layer currently supports BCrypt and OpenSSL variants on Windows, and OpenSSL on Linux.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -28,57 +28,6 @@ It uses asynchronous callbacks driven by the current execution model (see [below
 
 Currently, it also has preview support of XDP on Windows.
 
-```mermaid
-flowchart TB
-    Datapath-.->p1[Partition]
-    Datapath-.->Socket
-    Datapath-.->p2[Partition]
-    subgraph p1[Partition]
-    rx1["RX IO
-         Pool"]
-    tx1["TX IO
-         Pool"]
-    end
-    subgraph p2[Partition]
-    rx2["RX IO
-         Pool"]
-    tx2["TX IO
-         Pool"]
-    end
-    Socket-.->q1
-    Socket-.->q2
-    subgraph q1[Queue]
-    plat_sock1[Platform Socket]
-    end
-    q1-.->p1
-    subgraph q2[Queue]
-    plat_sock2[Platform Socket]
-    end
-    q2-.->p2
-    subgraph rxio[RX IO]
-    rx_meta[Internal Data]
-    rx_packet[IP/Client Data]
-    rx_buffer[Packet Payload]
-    end
-    rx1-.->rxio
-    rx2-.->rxio
-    subgraph txio[TX IO]
-    tx_meta[Internal Data]
-    tx_packet[IP/Client Data]
-    tx_buffer[Packet Payload]
-    end
-    tx1-.->txio
-    tx2-.->txio
-```
-
-There are a few high-level concepts for the datapath implementations:
-
-- **Datapath** - The top-level, public object that is used to create and manage all other options. It sets up multiple partitions for the given execution mode.
-- **Parition** - An internal object used to isolate different instances of data for performance. By isolating the data, sockets can be efficiently parallelized, usually on different processors. They maintain a pool for RX and TX IO blocks.
-- **Socket** - The public object that exposes a highly parallelized interface for sending and receiving packets in the current execution mode and partitions.
-- **Queue** - Another internal object used in conjunction with partitions to parallelize the work of a given socket.
-- **RX/TX IO** - A contiguous block of memory containing both internal/external metadata as well as the payload buffers. If batching (e.g. USO/URO) is supported by the datapath, then multiple IO blocks may be allocated together and organized slightly differently.
-
 ### Crypto
 
 The PAL exposes various cryptographic interfaces as well, such has encryption/decryption and cryptographic hashing. This layer currently supports BCrypt and OpenSSL variants on Windows, and OpenSSL on Linux.

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -151,7 +151,7 @@ BbrBandwidthFilterOnPacketAcked(
             if (!CxPlatTimeAtOrBefore64(AckEvent->AdjustedAckTime, AckedPacket->LastAckedPacketInfo.AdjustedAckTime)) {
                 AckElapsed = CxPlatTimeDiff64(AckedPacket->LastAckedPacketInfo.AdjustedAckTime, AckEvent->AdjustedAckTime);
             } else {
-                AckElapsed = CxPlatTimeDiff64(AckedPacket->LastAckedPacketInfo.AckTime, (uint32_t)TimeNow);
+                AckElapsed = CxPlatTimeDiff64(AckedPacket->LastAckedPacketInfo.AckTime, TimeNow);
             }
 
             CXPLAT_DBG_ASSERT(AckEvent->NumTotalAckedRetransmittableBytes >= AckedPacket->LastAckedPacketInfo.TotalBytesAcked);
@@ -160,11 +160,11 @@ BbrBandwidthFilterOnPacketAcked(
                            (AckEvent->NumTotalAckedRetransmittableBytes - AckedPacket->LastAckedPacketInfo.TotalBytesAcked) /
                            AckElapsed);
             }
-        } else if (!CxPlatTimeAtOrBefore64((uint32_t)TimeNow, AckedPacket->SentTime)) {
-            CXPLAT_DBG_ASSERT(CxPlatTimeDiff64(AckedPacket->SentTime, (uint32_t)TimeNow) != 0);
+        } else if (!CxPlatTimeAtOrBefore64(TimeNow, AckedPacket->SentTime)) {
+            CXPLAT_DBG_ASSERT(CxPlatTimeDiff64(AckedPacket->SentTime, TimeNow) != 0);
             SendRate = (kMicroSecsInSec * BW_UNIT *
                         AckEvent->NumTotalAckedRetransmittableBytes /
-                        CxPlatTimeDiff64(AckedPacket->SentTime, (uint32_t)TimeNow));
+                        CxPlatTimeDiff64(AckedPacket->SentTime, TimeNow));
         }
 
         if (SendRate == UINT64_MAX && AckRate == UINT64_MAX) {
@@ -999,7 +999,7 @@ BbrCongestionControlReset(
 
     Bbr->RttSampleExpired = TRUE;
     Bbr->MinRttTimestampValid = FALSE;
-    Bbr->MinRtt = UINT32_MAX;
+    Bbr->MinRtt = UINT64_MAX;
     Bbr->MinRttTimestamp = 0;
 
     QuicSlidingWindowExtremumReset(&Bbr->MaxAckHeightFilter);
@@ -1091,7 +1091,7 @@ BbrCongestionControlInitialize(
 
     Bbr->RttSampleExpired = TRUE;
     Bbr->MinRttTimestampValid = FALSE;
-    Bbr->MinRtt = UINT32_MAX;
+    Bbr->MinRtt = UINT64_MAX;
     Bbr->MinRttTimestamp = 0;
 
     Bbr->MaxAckHeightFilter = QuicSlidingWindowExtremumInitialize(

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -286,17 +286,17 @@ QuicConnLogBbr(
     QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
 
     QuicTraceEvent(
-            ConnBbr,
-            "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
-            Connection,
-            Bbr->BbrState,
-            Bbr->RecoveryState,
-            BbrCongestionControlGetCongestionWindow(Cc),
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->MinRtt,
-            BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
-            BbrCongestionControlIsAppLimited(Cc));
+        ConnBbr,
+        "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
+        Connection,
+        Bbr->BbrState,
+        Bbr->RecoveryState,
+        BbrCongestionControlGetCongestionWindow(Cc),
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->MinRtt,
+        BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
+        BbrCongestionControlIsAppLimited(Cc));
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -319,18 +319,18 @@ BbrCongestionControlLogOutFlowStatus(
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
 
     QuicTraceEvent(
-            ConnOutFlowStats,
-            "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
-            Connection,
-            Connection->Stats.Send.TotalBytes,
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->CongestionWindow,
-            0,
-            Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
-            Connection->SendBuffer.IdealBytes,
-            Connection->SendBuffer.PostedBytes,
-            Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
+        Connection,
+        Connection->Stats.Send.TotalBytes,
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->CongestionWindow,
+        0,
+        Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
+        Connection->SendBuffer.IdealBytes,
+        Connection->SendBuffer.PostedBytes,
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 }
 
 //

--- a/src/core/bbr.h
+++ b/src/core/bbr.h
@@ -78,7 +78,7 @@ typedef struct QUIC_CONGESTION_CONTROL_BBR {
     // If TRUE, there has been at least one MinRtt sample
     //
     BOOLEAN MinRttTimestampValid: 1;
-    
+
     //
     // The size of the initial congestion window in packets
     //
@@ -201,7 +201,7 @@ typedef struct QUIC_CONGESTION_CONTROL_BBR {
     QUIC_SLIDING_WINDOW_EXTREMUM MaxAckHeightFilter;
     QUIC_SLIDING_WINDOW_EXTREMUM_ENTRY MaxAckHeightFilterEntries[kBbrDefaultFilterCapacity];
 
-    uint32_t MinRtt; // microseconds
+    uint64_t MinRtt; // microseconds
 
     //
     // Time when MinRtt was sampled. Only valid if MinRttTimestampValid is set.

--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -21,24 +21,24 @@ typedef struct QUIC_ACK_EVENT {
     //
     uint64_t NumTotalAckedRetransmittableBytes;
 
-    QUIC_SENT_PACKET_METADATA* AckedPackets;
-
     uint32_t NumRetransmittableBytes;
+
+    QUIC_SENT_PACKET_METADATA* AckedPackets;
 
     //
     // Connection's current SmoothedRtt.
     //
-    uint32_t SmoothedRtt;
+    uint64_t SmoothedRtt;
 
     //
     // The smallest calculated RTT of the packets that were just ACKed.
     //
-    uint32_t MinRtt;
+    uint64_t MinRtt;
 
     //
     // Acked time minus ack delay.
     //
-    uint32_t AdjustedAckTime;
+    uint64_t AdjustedAckTime;
 
     BOOLEAN IsImplicit : 1;
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5400,7 +5400,7 @@ QuicConnRecvPostProcessing(
             CXPLAT_DBG_ASSERT((*Path)->DestCid != NULL);
             QuicPathValidate((*Path));
             (*Path)->SendChallenge = TRUE;
-            (*Path)->PathValidationStartTime = CxPlatTimeUs32();
+            (*Path)->PathValidationStartTime = CxPlatTimeUs64();
 
             //
             // NB: The path challenge payload is initialized here and reused
@@ -5417,7 +5417,7 @@ QuicConnRecvPostProcessing(
             if (Connection->Paths[0].IsPeerValidated) { // Not already doing peer validation.
                 Connection->Paths[0].IsPeerValidated = FALSE;
                 Connection->Paths[0].SendChallenge = TRUE;
-                Connection->Paths[0].PathValidationStartTime = CxPlatTimeUs32();
+                Connection->Paths[0].PathValidationStartTime = CxPlatTimeUs64();
                 CxPlatRandom(sizeof(Connection->Paths[0].Challenge), Connection->Paths[0].Challenge);
             }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -810,7 +810,7 @@ void
 QuicConnUpdateRtt(
     _In_ QUIC_CONNECTION* Connection,
     _In_ QUIC_PATH* Path,
-    _In_ uint32_t LatestRtt
+    _In_ uint64_t LatestRtt
     )
 {
     BOOLEAN RttUpdated;
@@ -839,7 +839,7 @@ QuicConnUpdateRtt(
         RttUpdated = TRUE;
 
     } else {
-        uint32_t PrevRtt = Path->SmoothedRtt;
+        uint64_t PrevRtt = Path->SmoothedRtt;
         if (Path->SmoothedRtt > LatestRtt) {
             Path->RttVariance = (3 * Path->RttVariance + Path->SmoothedRtt - LatestRtt) / 4;
         } else {
@@ -855,8 +855,8 @@ QuicConnUpdateRtt(
             RttUpdatedMsg,
             Connection,
             "Updated Rtt=%u.%03u ms, Var=%u.%03u",
-            Path->SmoothedRtt / 1000, Path->SmoothedRtt % 1000,
-            Path->RttVariance / 1000, Path->RttVariance % 1000);
+            (uint32_t)(Path->SmoothedRtt / 1000), (uint32_t)(Path->SmoothedRtt % 1000),
+            (uint32_t)(Path->RttVariance / 1000), (uint32_t)(Path->RttVariance % 1000));
     }
 }
 
@@ -1606,7 +1606,7 @@ QuicConnTryClose(
             // Enter 'closing period' to wait for a (optional) connection close
             // response.
             //
-            uint32_t Pto =
+            uint64_t Pto =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
                     &Connection->Paths[0],
@@ -6048,7 +6048,7 @@ QuicConnResetIdleTimeout(
             //
             // Idle timeout must be no less than the PTOs for closing.
             //
-            uint32_t MinIdleTimeoutMs =
+            uint64_t MinIdleTimeoutMs =
                 US_TO_MS(QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
                     Path,
@@ -6756,9 +6756,9 @@ QuicConnGetV2Statistics(
     Stats->GreaseBitNegotiated = Connection->Stats.GreaseBitNegotiated;
     Stats->EncryptionOffloaded = Connection->Stats.EncryptionOffloaded;
     Stats->EcnCapable = Path->EcnValidationState == ECN_VALIDATION_CAPABLE;
-    Stats->Rtt = Path->SmoothedRtt;
-    Stats->MinRtt = Path->MinRtt;
-    Stats->MaxRtt = Path->MaxRtt;
+    Stats->Rtt = (uint32_t)Path->SmoothedRtt;
+    Stats->MinRtt = (uint32_t)Path->MinRtt;
+    Stats->MaxRtt = (uint32_t)Path->MaxRtt;
     Stats->TimingStart = Connection->Stats.Timing.Start;
     Stats->TimingInitialFlightEnd = Connection->Stats.Timing.InitialFlightEnd;
     Stats->TimingHandshakeFlightEnd = Connection->Stats.Timing.HandshakeFlightEnd;
@@ -6956,9 +6956,9 @@ QuicConnParamGet(
         Stats->StatelessRetry = Connection->Stats.StatelessRetry;
         Stats->ResumptionAttempted = Connection->Stats.ResumptionAttempted;
         Stats->ResumptionSucceeded = Connection->Stats.ResumptionSucceeded;
-        Stats->Rtt = Path->SmoothedRtt;
-        Stats->MinRtt = Path->MinRtt;
-        Stats->MaxRtt = Path->MaxRtt;
+        Stats->Rtt = (uint32_t)Path->SmoothedRtt;
+        Stats->MinRtt = (uint32_t)Path->MinRtt;
+        Stats->MaxRtt = (uint32_t)Path->MaxRtt;
         Stats->Timing.Start = Connection->Stats.Timing.Start;
         Stats->Timing.InitialFlightEnd = Connection->Stats.Timing.InitialFlightEnd;
         Stats->Timing.HandshakeFlightEnd = Connection->Stats.Timing.HandshakeFlightEnd;
@@ -7298,7 +7298,6 @@ QuicConnApplyNewSettings(
             //
             // Send event to app to indicate result of negotiation if app cares.
             //
-
             QUIC_CONNECTION_EVENT Event;
             Event.Type = QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED;
             Event.RELIABLE_RESET_NEGOTIATED.IsNegotiated = Connection->State.ReliableResetStreamNegotiated;

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -858,7 +858,7 @@ QuicConnLogStatistics(
         ConnStatsV2,
         "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        Path->SmoothedRtt,
+        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,
@@ -1292,7 +1292,7 @@ void
 QuicConnUpdateRtt(
     _In_ QUIC_CONNECTION* Connection,
     _In_ QUIC_PATH* Path,
-    _In_ uint32_t LatestRtt
+    _In_ uint64_t LatestRtt
     );
 
 //

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -855,10 +855,10 @@ QuicConnLogStatistics(
     UNREFERENCED_PARAMETER(Path);
 
     QuicTraceEvent(
-        ConnStatsV2,
-        "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
+        ConnStatsV3,
+        "[conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
+        Path->SmoothedRtt,
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -788,8 +788,8 @@ CubicCongestionControlLogOutFlowStatus(
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
 
     QuicTraceEvent(
-        ConnOutFlowStats,
-        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
         Connection,
         Connection->Stats.Send.TotalBytes,
         Cubic->BytesInFlight,
@@ -799,7 +799,7 @@ CubicCongestionControlLogOutFlowStatus(
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0); // TODO - Make v2 event
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 }
 
 uint32_t

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -121,7 +121,7 @@ CubicCongestionHyStartResetPerRttRound(
 {
     Cubic->HyStartAckCount = 0;
     Cubic->MinRttInLastRound = Cubic->MinRttInCurrentRound;
-    Cubic->MinRttInCurrentRound = UINT32_MAX;
+    Cubic->MinRttInCurrentRound = UINT64_MAX;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -466,7 +466,7 @@ CubicCongestionControlOnDataAcknowledged(
                         AckEvent->MinRtt);
                 Cubic->HyStartAckCount++;
             } else if (Cubic->HyStartState == HYSTART_NOT_STARTED) {
-                const uint32_t Eta =
+                const uint64_t Eta =
                     CXPLAT_MIN(
                         QUIC_HYSTART_DEFAULT_MAX_ETA,
                         CXPLAT_MAX(
@@ -475,8 +475,8 @@ CubicCongestionControlOnDataAcknowledged(
                 //
                 // Looking for delay increase.
                 //
-                if (Cubic->MinRttInLastRound != UINT32_MAX &&
-                    Cubic->MinRttInCurrentRound != UINT32_MAX &&
+                if (Cubic->MinRttInLastRound != UINT64_MAX &&
+                    Cubic->MinRttInCurrentRound != UINT64_MAX &&
                     (Cubic->MinRttInCurrentRound >= Cubic->MinRttInLastRound + Eta)) {
                     //
                     // Exit Slow Start. Now we are going to do Conservative Slow Start for
@@ -799,7 +799,7 @@ CubicCongestionControlLogOutFlowStatus(
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
+        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0); // TODO - Make v2 event
 }
 
 uint32_t
@@ -885,7 +885,7 @@ CubicCongestionControlInitialize(
     Cubic->InitialWindowPackets = Settings->InitialWindowPackets;
     Cubic->CongestionWindow = DatagramPayloadLength * Cubic->InitialWindowPackets;
     Cubic->BytesInFlightMax = Cubic->CongestionWindow / 2;
-    Cubic->MinRttInCurrentRound = UINT32_MAX;
+    Cubic->MinRttInCurrentRound = UINT64_MAX;
     Cubic->HyStartRoundEnd = Connection->Send.NextPacketNumber;
     Cubic->HyStartState = HYSTART_NOT_STARTED;
     Cubic->CWndSlowStartGrowthDivisor = 1;

--- a/src/core/cubic.h
+++ b/src/core/cubic.h
@@ -96,12 +96,12 @@ typedef struct QUIC_CONGESTION_CONTROL_CUBIC {
     //
     QUIC_CUBIC_HYSTART_STATE HyStartState;
     uint32_t HyStartAckCount;
-    uint32_t MinRttInLastRound; // microseconds
-    uint32_t MinRttInCurrentRound; // microseconds
+    uint64_t MinRttInLastRound; // microseconds
+    uint64_t MinRttInCurrentRound; // microseconds
+    uint64_t CssBaselineMinRtt; // microseconds
     uint64_t HyStartRoundEnd; // Packet Number
     uint32_t CWndSlowStartGrowthDivisor;
     uint32_t ConservativeSlowStartRounds;
-    uint32_t CssBaselineMinRtt; // microseconds
 
     //
     // This variable tracks the largest packet that was outstanding at the time

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -341,29 +341,27 @@ QuicLossDetectionUpdateTimer(
         //
         Delay = 0;
 
-    } else if (OldestPacket != NULL) {
-        //
-        // Limit the timeout to the remainder of the disconnect timeout if there
-        // is an outstanding packet.
-        //
-        const uint64_t DisconnectTime =
-            OldestPacket->SentTime + MS_TO_US(Connection->Settings.DisconnectTimeoutMs);
-        if (CxPlatTimeAtOrBefore64(DisconnectTime, TimeNow)) {
-            Delay = 0;
-        } else {
-            Delay = CxPlatTimeDiff64(TimeNow, TimeFires);
-            const uint64_t MaxDelay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
-            if (Delay > MaxDelay) {
-                Delay = MaxDelay;
+    } else {
+        Delay = CxPlatTimeDiff64(TimeNow, TimeFires);
+
+        if (OldestPacket != NULL) {
+            //
+            // Limit the timeout to the remainder of the disconnect timeout if there
+            // is an outstanding packet.
+            //
+            const uint64_t DisconnectTime =
+                OldestPacket->SentTime + MS_TO_US(Connection->Settings.DisconnectTimeoutMs);
+            if (CxPlatTimeAtOrBefore64(DisconnectTime, TimeNow)) {
+                Delay = 0;
+            } else {
+                const uint64_t MaxDelay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
+                if (Delay > MaxDelay) {
+                    Delay = MaxDelay;
+                }
             }
         }
-
-    } else {
-        //
-        // Wait the normal delay.
-        //
-        Delay = CxPlatTimeDiff64(TimeNow, TimeFires);
     }
+
 
     if (Delay == 0 && ExecuteImmediatelyIfNecessary) {
         //

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -351,6 +351,7 @@ QuicLossDetectionUpdateTimer(
         if (CxPlatTimeAtOrBefore64(DisconnectTime, TimeNow)) {
             Delay = 0;
         } else {
+            Delay = CxPlatTimeDiff64(TimeNow, TimeFires);
             const uint64_t MaxDelay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
             if (Delay > MaxDelay) {
                 Delay = MaxDelay;

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -346,7 +346,10 @@ QuicLossDetectionUpdateTimer(
         if (TimeNow >= DisconnectTime) {
             Delay = 0;
         } else {
-            Delay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
+            const uint64_t MaxDelay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
+            if (Delay > MaxDelay) {
+                Delay = MaxDelay;
+            }
         }
     }
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -362,7 +362,6 @@ QuicLossDetectionUpdateTimer(
         }
     }
 
-
     if (Delay == 0 && ExecuteImmediatelyIfNecessary) {
         //
         // In some cases if the timer already should have elapsed we will

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -344,8 +344,8 @@ QuicLossDetectionUpdateTimer(
         const uint64_t DisconnectTime =
             OldestPacket->SentTime + MS_TO_US(Connection->Settings.DisconnectTimeoutMs);
         if (TimeNow >= DisconnectTime) {
-        Delay = 0;
-    } else {
+            Delay = 0;
+        } else {
             Delay = CxPlatTimeDiff64(TimeNow, DisconnectTime);
         }
     }
@@ -1292,7 +1292,7 @@ QuicLossDetectionProcessAckBlocks(
     uint32_t AckedRetransmittableBytes = 0;
     QUIC_CONNECTION* Connection = QuicLossDetectionGetConnection(LossDetection);
     uint64_t TimeNow = CxPlatTimeUs64();
-    uint64_t MinRtt = UINT32_MAX;
+    uint64_t MinRtt = UINT64_MAX;
     BOOLEAN NewLargestAck = FALSE;
     BOOLEAN NewLargestAckRetransmittable = FALSE;
     BOOLEAN NewLargestAckDifferentPath = FALSE;

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -331,9 +331,6 @@ QuicLossDetectionUpdateTimer(
                 LossDetection, Path, 1 << LossDetection->ProbeCount);
     }
 
-    //
-    // The units for the delay values start in microseconds.
-    //
     uint64_t Delay; // In microseconds
     if (CxPlatTimeAtOrBefore64(TimeFires, TimeNow)) {
         //

--- a/src/core/loss_detection.h
+++ b/src/core/loss_detection.h
@@ -25,22 +25,22 @@ typedef struct QUIC_LOSS_DETECTION {
     //
     // Sent time of last sent packet
     //
-    uint32_t TimeOfLastPacketSent;
+    uint64_t TimeOfLastPacketSent;
 
     //
     // Acked time of last acked packet
     //
-    uint32_t TimeOfLastPacketAcked;
+    uint64_t TimeOfLastPacketAcked;
 
     //
     // Sent time of last acked packet
     //
-    uint32_t TimeOfLastAckedPacketSent;
+    uint64_t TimeOfLastAckedPacketSent;
 
     //
     // Acked time minus ack delay.
     //
-    uint32_t AdjustedLastAckedTime;
+    uint64_t AdjustedLastAckedTime;
 
     //
     // Number of bytes sent so far
@@ -141,7 +141,7 @@ QuicLossDetectionUpdateTimer(
 // Returns the current PTO in microseconds.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
-uint32_t
+uint64_t
 QuicLossDetectionComputeProbeTimeout(
     _In_ QUIC_LOSS_DETECTION* LossDetection,
     _In_ const QUIC_PATH* Path,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -928,7 +928,7 @@ QuicPacketBuilderFinalize(
     //
     CXPLAT_DBG_ASSERT(Builder->Metadata->FrameCount != 0);
 
-    Builder->Metadata->SentTime = CxPlatTimeUs32();
+    Builder->Metadata->SentTime = CxPlatTimeUs64();
     Builder->Metadata->PacketLength =
         Builder->HeaderLength + PayloadLength;
     Builder->Metadata->Flags.EcnEctSet = Builder->EcnEctSet;

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -152,20 +152,20 @@ typedef struct QUIC_PATH {
     QUIC_CID_LIST_ENTRY* DestCid;
 
     //
+    // RTT moving average, computed as in RFC6298. Units of microseconds.
+    //
+    uint64_t SmoothedRtt;
+    uint64_t LatestRttSample;
+    uint64_t MinRtt;
+    uint64_t MaxRtt;
+    uint64_t RttVariance;
+
+    //
     // Used on the server side until the client's IP address has been validated
     // to prevent the server from being used for amplification attacks. A value
     // of UINT32_MAX indicates this variable does not apply.
     //
     uint32_t Allowance;
-
-    //
-    // RTT moving average, computed as in RFC6298. Units of microseconds.
-    //
-    uint32_t SmoothedRtt;
-    uint32_t MinRtt;
-    uint32_t MaxRtt;
-    uint32_t RttVariance;
-    uint32_t LatestRttSample;
 
     //
     // The last path challenge we received and needs to be sent back as in a
@@ -181,7 +181,7 @@ typedef struct QUIC_PATH {
     //
     // Time when path validation was begun. Used for timing out path validation.
     //
-    uint32_t PathValidationStartTime;
+    uint64_t PathValidationStartTime;
 
 } QUIC_PATH;
 

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1238,7 +1238,7 @@ QuicSendFlush(
                     "ECN unknown.");
             }
         } else {
-            uint32_t ThreePtosInUs =
+            uint64_t ThreePtosInUs =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
                     &Connection->Paths[0],

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -120,17 +120,17 @@ typedef struct LAST_ACKED_PACKET_INFO {
     //
     // SentTime of last acked packet
     //
-    uint32_t SentTime;
+    uint64_t SentTime;
 
     //
     // AckTime of last acked packet
     //
-    uint32_t AckTime;
+    uint64_t AckTime;
 
     //
     // Packet acked time minus ack delay of last acked packet
     //
-    uint32_t AdjustedAckTime;
+    uint64_t AdjustedAckTime;
 
 
 } LAST_ACKED_PACKET_INFO;
@@ -148,7 +148,7 @@ typedef struct QUIC_SENT_PACKET_METADATA {
     // Total bytes sent when the packet was sent (including this packet)
     //
     uint64_t TotalBytesSent;
-    uint32_t SentTime; // In microseconds
+    uint64_t SentTime; // In microseconds
     uint16_t PacketLength;
     uint8_t PathId;
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -126,7 +126,7 @@ QuicStreamInitialize(
     }
 
     Stream->MaxAllowedRecvOffset = Stream->RecvBuffer.VirtualBufferLength;
-    Stream->RecvWindowLastUpdate = CxPlatTimeUs32();
+    Stream->RecvWindowLastUpdate = CxPlatTimeUs64();
 
     Stream->Flags.Initialized = TRUE;
     *NewStream = Stream;

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -376,7 +376,7 @@ typedef struct QUIC_STREAM {
     uint64_t MaxAllowedRecvOffset;
 
     uint64_t RecvWindowBytesDelivered;
-    uint32_t RecvWindowLastUpdate;
+    uint64_t RecvWindowLastUpdate;
 
     //
     // Flags indicating the state of queued events.

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -675,7 +675,7 @@ QuicStreamOnBytesDelivered(
 
     if (Stream->RecvWindowBytesDelivered >= RecvBufferDrainThreshold) {
 
-        uint32_t TimeNow = CxPlatTimeUs32();
+        uint64_t TimeNow = CxPlatTimeUs64();
 
         //
         // Limit stream FC window growth by the connection FC window size.
@@ -683,9 +683,9 @@ QuicStreamOnBytesDelivered(
         if (Stream->RecvBuffer.VirtualBufferLength <
             Stream->Connection->Settings.ConnFlowControlWindow) {
 
-            uint32_t TimeThreshold = (uint32_t)
+            uint64_t TimeThreshold =
                 ((Stream->RecvWindowBytesDelivered * Stream->Connection->Paths[0].SmoothedRtt) / RecvBufferDrainThreshold);
-            if (CxPlatTimeDiff32(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
+            if (CxPlatTimeDiff64(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
 
                 //
                 // Buffer tuning:
@@ -709,7 +709,7 @@ QuicStreamOnBytesDelivered(
                 QuicTraceLogStreamVerbose(
                     IncreaseRxBuffer,
                     Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)",
+                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                     Stream->RecvBuffer.VirtualBufferLength * 2,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,

--- a/src/generated/linux/bbr.c.clog.h
+++ b/src/generated/linux/bbr.c.clog.h
@@ -25,17 +25,17 @@ extern "C" {
 // Decoder Ring for ConnBbr
 // [conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u
 // QuicTraceEvent(
-            ConnBbr,
-            "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
-            Connection,
-            Bbr->BbrState,
-            Bbr->RecoveryState,
-            BbrCongestionControlGetCongestionWindow(Cc),
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->MinRtt,
-            BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
-            BbrCongestionControlIsAppLimited(Cc));
+        ConnBbr,
+        "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
+        Connection,
+        Bbr->BbrState,
+        Bbr->RecoveryState,
+        BbrCongestionControlGetCongestionWindow(Cc),
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->MinRtt,
+        BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
+        BbrCongestionControlIsAppLimited(Cc));
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Bbr->BbrState = arg3
 // arg4 = arg4 = Bbr->RecoveryState = arg4
@@ -56,21 +56,21 @@ tracepoint(CLOG_BBR_C, ConnBbr , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnOutFlowStats
-// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u
+// Decoder Ring for ConnOutFlowStatsV2
+// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu
 // QuicTraceEvent(
-            ConnOutFlowStats,
-            "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
-            Connection,
-            Connection->Stats.Send.TotalBytes,
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->CongestionWindow,
-            0,
-            Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
-            Connection->SendBuffer.IdealBytes,
-            Connection->SendBuffer.PostedBytes,
-            Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
+        Connection,
+        Connection->Stats.Send.TotalBytes,
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->CongestionWindow,
+        0,
+        Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
+        Connection->SendBuffer.IdealBytes,
+        Connection->SendBuffer.PostedBytes,
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Bbr->BytesInFlight = arg4
@@ -80,11 +80,11 @@ tracepoint(CLOG_BBR_C, ConnBbr , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
-#ifndef _clog_12_ARGS_TRACE_ConnOutFlowStats
-#define _clog_12_ARGS_TRACE_ConnOutFlowStats(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\
-tracepoint(CLOG_BBR_C, ConnOutFlowStats , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);\
+#ifndef _clog_12_ARGS_TRACE_ConnOutFlowStatsV2
+#define _clog_12_ARGS_TRACE_ConnOutFlowStatsV2(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\
+tracepoint(CLOG_BBR_C, ConnOutFlowStatsV2 , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);\
 
 #endif
 

--- a/src/generated/linux/bbr.c.clog.h
+++ b/src/generated/linux/bbr.c.clog.h
@@ -70,7 +70,7 @@ tracepoint(CLOG_BBR_C, ConnBbr , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
             Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
             Connection->SendBuffer.IdealBytes,
             Connection->SendBuffer.PostedBytes,
-            Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
+            Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Bbr->BytesInFlight = arg4
@@ -80,7 +80,7 @@ tracepoint(CLOG_BBR_C, ConnBbr , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
 #ifndef _clog_12_ARGS_TRACE_ConnOutFlowStats
 #define _clog_12_ARGS_TRACE_ConnOutFlowStats(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\

--- a/src/generated/linux/bbr.c.clog.h.lttng.h
+++ b/src/generated/linux/bbr.c.clog.h.lttng.h
@@ -67,7 +67,7 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnBbr,
             Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
             Connection->SendBuffer.IdealBytes,
             Connection->SendBuffer.PostedBytes,
-            Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
+            Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Bbr->BytesInFlight = arg4
@@ -77,7 +77,7 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnBbr,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_BBR_C, ConnOutFlowStats,
     TP_ARGS(

--- a/src/generated/linux/bbr.c.clog.h.lttng.h
+++ b/src/generated/linux/bbr.c.clog.h.lttng.h
@@ -5,17 +5,17 @@
 // Decoder Ring for ConnBbr
 // [conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u
 // QuicTraceEvent(
-            ConnBbr,
-            "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
-            Connection,
-            Bbr->BbrState,
-            Bbr->RecoveryState,
-            BbrCongestionControlGetCongestionWindow(Cc),
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->MinRtt,
-            BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
-            BbrCongestionControlIsAppLimited(Cc));
+        ConnBbr,
+        "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u",
+        Connection,
+        Bbr->BbrState,
+        Bbr->RecoveryState,
+        BbrCongestionControlGetCongestionWindow(Cc),
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->MinRtt,
+        BbrCongestionControlGetBandwidth(Cc) / BW_UNIT,
+        BbrCongestionControlIsAppLimited(Cc));
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Bbr->BbrState = arg3
 // arg4 = arg4 = Bbr->RecoveryState = arg4
@@ -53,21 +53,21 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnBbr,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnOutFlowStats
-// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u
+// Decoder Ring for ConnOutFlowStatsV2
+// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu
 // QuicTraceEvent(
-            ConnOutFlowStats,
-            "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
-            Connection,
-            Connection->Stats.Send.TotalBytes,
-            Bbr->BytesInFlight,
-            Bbr->BytesInFlightMax,
-            Bbr->CongestionWindow,
-            0,
-            Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
-            Connection->SendBuffer.IdealBytes,
-            Connection->SendBuffer.PostedBytes,
-            Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
+        Connection,
+        Connection->Stats.Send.TotalBytes,
+        Bbr->BytesInFlight,
+        Bbr->BytesInFlightMax,
+        Bbr->CongestionWindow,
+        0,
+        Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
+        Connection->SendBuffer.IdealBytes,
+        Connection->SendBuffer.PostedBytes,
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Bbr->BytesInFlight = arg4
@@ -77,9 +77,9 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnBbr,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_BBR_C, ConnOutFlowStats,
+TRACEPOINT_EVENT(CLOG_BBR_C, ConnOutFlowStatsV2,
     TP_ARGS(
         const void *, arg2,
         unsigned long long, arg3,
@@ -90,7 +90,7 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnOutFlowStats,
         unsigned long long, arg8,
         unsigned long long, arg9,
         unsigned long long, arg10,
-        unsigned int, arg11), 
+        unsigned long long, arg11), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, arg2)
         ctf_integer(uint64_t, arg3, arg3)
@@ -101,7 +101,7 @@ TRACEPOINT_EVENT(CLOG_BBR_C, ConnOutFlowStats,
         ctf_integer(uint64_t, arg8, arg8)
         ctf_integer(uint64_t, arg9, arg9)
         ctf_integer(uint64_t, arg10, arg10)
-        ctf_integer(unsigned int, arg11, arg11)
+        ctf_integer(uint64_t, arg11, arg11)
     )
 )
 

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -881,13 +881,13 @@ tracepoint(CLOG_CONNECTION_C, ApplySettings , arg1);\
             RttUpdatedMsg,
             Connection,
             "Updated Rtt=%u.%03u ms, Var=%u.%03u",
-            Path->SmoothedRtt / 1000, Path->SmoothedRtt % 1000,
-            Path->RttVariance / 1000, Path->RttVariance % 1000);
+            (uint32_t)(Path->SmoothedRtt / 1000), (uint32_t)(Path->SmoothedRtt % 1000),
+            (uint32_t)(Path->RttVariance / 1000), (uint32_t)(Path->RttVariance % 1000));
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Path->SmoothedRtt / 1000 = arg3
-// arg4 = arg4 = Path->SmoothedRtt % 1000 = arg4
-// arg5 = arg5 = Path->RttVariance / 1000 = arg5
-// arg6 = arg6 = Path->RttVariance % 1000 = arg6
+// arg3 = arg3 = (uint32_t)(Path->SmoothedRtt / 1000) = arg3
+// arg4 = arg4 = (uint32_t)(Path->SmoothedRtt % 1000) = arg4
+// arg5 = arg5 = (uint32_t)(Path->RttVariance / 1000) = arg5
+// arg6 = arg6 = (uint32_t)(Path->RttVariance % 1000) = arg6
 ----------------------------------------------------------*/
 #ifndef _clog_7_ARGS_TRACE_RttUpdatedMsg
 #define _clog_7_ARGS_TRACE_RttUpdatedMsg(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5, arg6)\

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -944,13 +944,13 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ApplySettings,
             RttUpdatedMsg,
             Connection,
             "Updated Rtt=%u.%03u ms, Var=%u.%03u",
-            Path->SmoothedRtt / 1000, Path->SmoothedRtt % 1000,
-            Path->RttVariance / 1000, Path->RttVariance % 1000);
+            (uint32_t)(Path->SmoothedRtt / 1000), (uint32_t)(Path->SmoothedRtt % 1000),
+            (uint32_t)(Path->RttVariance / 1000), (uint32_t)(Path->RttVariance % 1000));
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Path->SmoothedRtt / 1000 = arg3
-// arg4 = arg4 = Path->SmoothedRtt % 1000 = arg4
-// arg5 = arg5 = Path->RttVariance / 1000 = arg5
-// arg6 = arg6 = Path->RttVariance % 1000 = arg6
+// arg3 = arg3 = (uint32_t)(Path->SmoothedRtt / 1000) = arg3
+// arg4 = arg4 = (uint32_t)(Path->SmoothedRtt % 1000) = arg4
+// arg5 = arg5 = (uint32_t)(Path->RttVariance / 1000) = arg5
+// arg6 = arg6 = (uint32_t)(Path->RttVariance % 1000) = arg6
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, RttUpdatedMsg,
     TP_ARGS(

--- a/src/generated/linux/connection.h.clog.h
+++ b/src/generated/linux/connection.h.clog.h
@@ -70,7 +70,7 @@ tracepoint(CLOG_CONNECTION_H, ConnInFlowStats , arg2, arg3);\
         ConnStatsV2,
         "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        Path->SmoothedRtt,
+        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,
@@ -79,8 +79,9 @@ tracepoint(CLOG_CONNECTION_H, ConnInFlowStats , arg2, arg3);\
         Connection->CongestionControl.Name,
         Connection->Stats.Send.EcnCongestionCount);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Path->SmoothedRtt = arg3
-// arg4 = arg4 = Connection->Stats.Send.CongestionCount = arg4
+// arg3 = arg3 = (uint32_t)Path->SmoothedRtt = arg3
+// arg4 = arg4 = // TODO - Make v3 of event
+        Connection->Stats.Send.CongestionCount = arg4
 // arg5 = arg5 = Connection->Stats.Send.PersistentCongestionCount = arg5
 // arg6 = arg6 = Connection->Stats.Send.TotalBytes = arg6
 // arg7 = arg7 = Connection->Stats.Recv.TotalBytes = arg7

--- a/src/generated/linux/connection.h.clog.h
+++ b/src/generated/linux/connection.h.clog.h
@@ -64,13 +64,13 @@ tracepoint(CLOG_CONNECTION_H, ConnInFlowStats , arg2, arg3);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnStatsV2
-// [conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u
+// Decoder Ring for ConnStatsV3
+// [conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u
 // QuicTraceEvent(
-        ConnStatsV2,
-        "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
+        ConnStatsV3,
+        "[conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
+        Path->SmoothedRtt,
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,
@@ -79,9 +79,8 @@ tracepoint(CLOG_CONNECTION_H, ConnInFlowStats , arg2, arg3);\
         Connection->CongestionControl.Name,
         Connection->Stats.Send.EcnCongestionCount);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = (uint32_t)Path->SmoothedRtt = arg3
-// arg4 = arg4 = // TODO - Make v3 of event
-        Connection->Stats.Send.CongestionCount = arg4
+// arg3 = arg3 = Path->SmoothedRtt = arg3
+// arg4 = arg4 = Connection->Stats.Send.CongestionCount = arg4
 // arg5 = arg5 = Connection->Stats.Send.PersistentCongestionCount = arg5
 // arg6 = arg6 = Connection->Stats.Send.TotalBytes = arg6
 // arg7 = arg7 = Connection->Stats.Recv.TotalBytes = arg7
@@ -89,9 +88,9 @@ tracepoint(CLOG_CONNECTION_H, ConnInFlowStats , arg2, arg3);\
 // arg9 = arg9 = Connection->CongestionControl.Name = arg9
 // arg10 = arg10 = Connection->Stats.Send.EcnCongestionCount = arg10
 ----------------------------------------------------------*/
-#ifndef _clog_11_ARGS_TRACE_ConnStatsV2
-#define _clog_11_ARGS_TRACE_ConnStatsV2(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)\
-tracepoint(CLOG_CONNECTION_H, ConnStatsV2 , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);\
+#ifndef _clog_11_ARGS_TRACE_ConnStatsV3
+#define _clog_11_ARGS_TRACE_ConnStatsV3(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)\
+tracepoint(CLOG_CONNECTION_H, ConnStatsV3 , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);\
 
 #endif
 

--- a/src/generated/linux/connection.h.clog.h.lttng.h
+++ b/src/generated/linux/connection.h.clog.h.lttng.h
@@ -52,13 +52,13 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnInFlowStats,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnStatsV2
-// [conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u
+// Decoder Ring for ConnStatsV3
+// [conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u
 // QuicTraceEvent(
-        ConnStatsV2,
-        "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
+        ConnStatsV3,
+        "[conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
+        Path->SmoothedRtt,
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,
@@ -67,9 +67,8 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnInFlowStats,
         Connection->CongestionControl.Name,
         Connection->Stats.Send.EcnCongestionCount);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = (uint32_t)Path->SmoothedRtt = arg3
-// arg4 = arg4 = // TODO - Make v3 of event
-        Connection->Stats.Send.CongestionCount = arg4
+// arg3 = arg3 = Path->SmoothedRtt = arg3
+// arg4 = arg4 = Connection->Stats.Send.CongestionCount = arg4
 // arg5 = arg5 = Connection->Stats.Send.PersistentCongestionCount = arg5
 // arg6 = arg6 = Connection->Stats.Send.TotalBytes = arg6
 // arg7 = arg7 = Connection->Stats.Recv.TotalBytes = arg7
@@ -77,10 +76,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnInFlowStats,
 // arg9 = arg9 = Connection->CongestionControl.Name = arg9
 // arg10 = arg10 = Connection->Stats.Send.EcnCongestionCount = arg10
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnStatsV2,
+TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnStatsV3,
     TP_ARGS(
         const void *, arg2,
-        unsigned int, arg3,
+        unsigned long long, arg3,
         unsigned int, arg4,
         unsigned int, arg5,
         unsigned long long, arg6,
@@ -90,7 +89,7 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnStatsV2,
         unsigned int, arg10), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, arg2)
-        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(uint64_t, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
         ctf_integer(unsigned int, arg5, arg5)
         ctf_integer(uint64_t, arg6, arg6)

--- a/src/generated/linux/connection.h.clog.h.lttng.h
+++ b/src/generated/linux/connection.h.clog.h.lttng.h
@@ -58,7 +58,7 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnInFlowStats,
         ConnStatsV2,
         "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
         Connection,
-        Path->SmoothedRtt,
+        (uint32_t)Path->SmoothedRtt, // TODO - Make v3 of event
         Connection->Stats.Send.CongestionCount,
         Connection->Stats.Send.PersistentCongestionCount,
         Connection->Stats.Send.TotalBytes,
@@ -67,8 +67,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_H, ConnInFlowStats,
         Connection->CongestionControl.Name,
         Connection->Stats.Send.EcnCongestionCount);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Path->SmoothedRtt = arg3
-// arg4 = arg4 = Connection->Stats.Send.CongestionCount = arg4
+// arg3 = arg3 = (uint32_t)Path->SmoothedRtt = arg3
+// arg4 = arg4 = // TODO - Make v3 of event
+        Connection->Stats.Send.CongestionCount = arg4
 // arg5 = arg5 = Connection->Stats.Send.PersistentCongestionCount = arg5
 // arg6 = arg6 = Connection->Stats.Send.TotalBytes = arg6
 // arg7 = arg7 = Connection->Stats.Recv.TotalBytes = arg7

--- a/src/generated/linux/cubic.c.clog.h
+++ b/src/generated/linux/cubic.c.clog.h
@@ -146,11 +146,11 @@ tracepoint(CLOG_CUBIC_C, ConnSpuriousCongestion , arg2);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnOutFlowStats
-// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u
+// Decoder Ring for ConnOutFlowStatsV2
+// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu
 // QuicTraceEvent(
-        ConnOutFlowStats,
-        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
         Connection,
         Connection->Stats.Send.TotalBytes,
         Cubic->BytesInFlight,
@@ -160,7 +160,7 @@ tracepoint(CLOG_CUBIC_C, ConnSpuriousCongestion , arg2);\
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Cubic->BytesInFlight = arg4
@@ -170,11 +170,11 @@ tracepoint(CLOG_CUBIC_C, ConnSpuriousCongestion , arg2);\
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
-#ifndef _clog_12_ARGS_TRACE_ConnOutFlowStats
-#define _clog_12_ARGS_TRACE_ConnOutFlowStats(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\
-tracepoint(CLOG_CUBIC_C, ConnOutFlowStats , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);\
+#ifndef _clog_12_ARGS_TRACE_ConnOutFlowStatsV2
+#define _clog_12_ARGS_TRACE_ConnOutFlowStatsV2(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\
+tracepoint(CLOG_CUBIC_C, ConnOutFlowStatsV2 , arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);\
 
 #endif
 

--- a/src/generated/linux/cubic.c.clog.h
+++ b/src/generated/linux/cubic.c.clog.h
@@ -160,7 +160,7 @@ tracepoint(CLOG_CUBIC_C, ConnSpuriousCongestion , arg2);\
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
+        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Cubic->BytesInFlight = arg4
@@ -170,7 +170,7 @@ tracepoint(CLOG_CUBIC_C, ConnSpuriousCongestion , arg2);\
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
 #ifndef _clog_12_ARGS_TRACE_ConnOutFlowStats
 #define _clog_12_ARGS_TRACE_ConnOutFlowStats(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)\

--- a/src/generated/linux/cubic.c.clog.h.lttng.h
+++ b/src/generated/linux/cubic.c.clog.h.lttng.h
@@ -148,11 +148,11 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnSpuriousCongestion,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for ConnOutFlowStats
-// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u
+// Decoder Ring for ConnOutFlowStatsV2
+// [conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu
 // QuicTraceEvent(
-        ConnOutFlowStats,
-        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u",
+        ConnOutFlowStatsV2,
+        "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
         Connection,
         Connection->Stats.Send.TotalBytes,
         Cubic->BytesInFlight,
@@ -162,7 +162,7 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnSpuriousCongestion,
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
+        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Cubic->BytesInFlight = arg4
@@ -172,9 +172,9 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnSpuriousCongestion,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnOutFlowStats,
+TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnOutFlowStatsV2,
     TP_ARGS(
         const void *, arg2,
         unsigned long long, arg3,
@@ -185,7 +185,7 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnOutFlowStats,
         unsigned long long, arg8,
         unsigned long long, arg9,
         unsigned long long, arg10,
-        unsigned int, arg11), 
+        unsigned long long, arg11), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, arg2)
         ctf_integer(uint64_t, arg3, arg3)
@@ -196,6 +196,6 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnOutFlowStats,
         ctf_integer(uint64_t, arg8, arg8)
         ctf_integer(uint64_t, arg9, arg9)
         ctf_integer(uint64_t, arg10, arg10)
-        ctf_integer(unsigned int, arg11, arg11)
+        ctf_integer(uint64_t, arg11, arg11)
     )
 )

--- a/src/generated/linux/cubic.c.clog.h.lttng.h
+++ b/src/generated/linux/cubic.c.clog.h.lttng.h
@@ -162,7 +162,7 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnSpuriousCongestion,
         Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent,
         Connection->SendBuffer.IdealBytes,
         Connection->SendBuffer.PostedBytes,
-        Path->GotFirstRttSample ? Path->SmoothedRtt : 0);
+        Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = Connection->Stats.Send.TotalBytes = arg3
 // arg4 = arg4 = Cubic->BytesInFlight = arg4
@@ -172,7 +172,7 @@ TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnSpuriousCongestion,
 // arg8 = arg8 = Connection->Send.PeerMaxData - Connection->Send.OrderedStreamBytesSent = arg8
 // arg9 = arg9 = Connection->SendBuffer.IdealBytes = arg9
 // arg10 = arg10 = Connection->SendBuffer.PostedBytes = arg10
-// arg11 = arg11 = Path->GotFirstRttSample ? Path->SmoothedRtt : 0 = arg11
+// arg11 = arg11 = Path->GotFirstRttSample ? (uint32_t)Path->SmoothedRtt : 0 = arg11
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CUBIC_C, ConnOutFlowStats,
     TP_ARGS(

--- a/src/generated/linux/loss_detection.c.clog.h
+++ b/src/generated/linux/loss_detection.c.clog.h
@@ -117,16 +117,16 @@ tracepoint(CLOG_LOSS_DETECTION_C, PacketTxLostFack , arg2, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PacketTxLostRack
-// [%c][TX][%llu] Lost: RACK %u ms
+// [%c][TX][%llu] Lost: RACK %llu ms
 // QuicTraceLogVerbose(
                         PacketTxLostRack,
-                        "[%c][TX][%llu] Lost: RACK %u ms",
+                        "[%c][TX][%llu] Lost: RACK %llu ms",
                         PtkConnPre(Connection),
                         Packet->PacketNumber,
-                        CxPlatTimeDiff32(Packet->SentTime, TimeNow));
+                        CxPlatTimeDiff64(Packet->SentTime, TimeNow));
 // arg2 = arg2 = PtkConnPre(Connection) = arg2
 // arg3 = arg3 = Packet->PacketNumber = arg3
-// arg4 = arg4 = CxPlatTimeDiff32(Packet->SentTime, TimeNow) = arg4
+// arg4 = arg4 = CxPlatTimeDiff64(Packet->SentTime, TimeNow) = arg4
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_PacketTxLostRack
 #define _clog_5_ARGS_TRACE_PacketTxLostRack(uniqueId, encoded_arg_string, arg2, arg3, arg4)\
@@ -205,12 +205,12 @@ tracepoint(CLOG_LOSS_DETECTION_C, PacketTxSpuriousLoss , arg2, arg3);\
             "[%c][TX][%llu] ACKed (%u.%03u ms)",
             PtkConnPre(Connection),
             Packet->PacketNumber,
-            PacketRtt / 1000,
-            PacketRtt % 1000);
+            (uint32_t)(PacketRtt / 1000),
+            (uint32_t)(PacketRtt % 1000));
 // arg2 = arg2 = PtkConnPre(Connection) = arg2
 // arg3 = arg3 = Packet->PacketNumber = arg3
-// arg4 = arg4 = PacketRtt / 1000 = arg4
-// arg5 = arg5 = PacketRtt % 1000 = arg5
+// arg4 = arg4 = (uint32_t)(PacketRtt / 1000) = arg4
+// arg5 = arg5 = (uint32_t)(PacketRtt % 1000) = arg5
 ----------------------------------------------------------*/
 #ifndef _clog_6_ARGS_TRACE_PacketTxAcked
 #define _clog_6_ARGS_TRACE_PacketTxAcked(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5)\
@@ -345,11 +345,11 @@ tracepoint(CLOG_LOSS_DETECTION_C, KeyChangeConfirmed , arg1);\
             "[conn][%p] Setting loss detection %hhu timer for %u us. (ProbeCount=%hu)",
             Connection,
             TimeoutType,
-            Delay,
+            (uint32_t)Delay,
             LossDetection->ProbeCount);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = TimeoutType = arg3
-// arg4 = arg4 = Delay = arg4
+// arg4 = arg4 = (uint32_t)Delay = arg4
 // arg5 = arg5 = LossDetection->ProbeCount = arg5
 ----------------------------------------------------------*/
 #ifndef _clog_6_ARGS_TRACE_ConnLossDetectionTimerSet

--- a/src/generated/linux/loss_detection.c.clog.h.lttng.h
+++ b/src/generated/linux/loss_detection.c.clog.h.lttng.h
@@ -99,26 +99,26 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PacketTxLostFack,
 
 /*----------------------------------------------------------
 // Decoder Ring for PacketTxLostRack
-// [%c][TX][%llu] Lost: RACK %u ms
+// [%c][TX][%llu] Lost: RACK %llu ms
 // QuicTraceLogVerbose(
                         PacketTxLostRack,
-                        "[%c][TX][%llu] Lost: RACK %u ms",
+                        "[%c][TX][%llu] Lost: RACK %llu ms",
                         PtkConnPre(Connection),
                         Packet->PacketNumber,
-                        CxPlatTimeDiff32(Packet->SentTime, TimeNow));
+                        CxPlatTimeDiff64(Packet->SentTime, TimeNow));
 // arg2 = arg2 = PtkConnPre(Connection) = arg2
 // arg3 = arg3 = Packet->PacketNumber = arg3
-// arg4 = arg4 = CxPlatTimeDiff32(Packet->SentTime, TimeNow) = arg4
+// arg4 = arg4 = CxPlatTimeDiff64(Packet->SentTime, TimeNow) = arg4
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PacketTxLostRack,
     TP_ARGS(
         unsigned char, arg2,
         unsigned long long, arg3,
-        unsigned int, arg4), 
+        unsigned long long, arg4), 
     TP_FIELDS(
         ctf_integer(unsigned char, arg2, arg2)
         ctf_integer(uint64_t, arg3, arg3)
-        ctf_integer(unsigned int, arg4, arg4)
+        ctf_integer(uint64_t, arg4, arg4)
     )
 )
 
@@ -201,12 +201,12 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PacketTxSpuriousLoss,
             "[%c][TX][%llu] ACKed (%u.%03u ms)",
             PtkConnPre(Connection),
             Packet->PacketNumber,
-            PacketRtt / 1000,
-            PacketRtt % 1000);
+            (uint32_t)(PacketRtt / 1000),
+            (uint32_t)(PacketRtt % 1000));
 // arg2 = arg2 = PtkConnPre(Connection) = arg2
 // arg3 = arg3 = Packet->PacketNumber = arg3
-// arg4 = arg4 = PacketRtt / 1000 = arg4
-// arg5 = arg5 = PacketRtt % 1000 = arg5
+// arg4 = arg4 = (uint32_t)(PacketRtt / 1000) = arg4
+// arg5 = arg5 = (uint32_t)(PacketRtt % 1000) = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PacketTxAcked,
     TP_ARGS(
@@ -362,11 +362,11 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, KeyChangeConfirmed,
             "[conn][%p] Setting loss detection %hhu timer for %u us. (ProbeCount=%hu)",
             Connection,
             TimeoutType,
-            Delay,
+            (uint32_t)Delay,
             LossDetection->ProbeCount);
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = TimeoutType = arg3
-// arg4 = arg4 = Delay = arg4
+// arg4 = arg4 = (uint32_t)Delay = arg4
 // arg5 = arg5 = LossDetection->ProbeCount = arg5
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, ConnLossDetectionTimerSet,

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -317,11 +317,11 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for IncreaseRxBuffer
-// [strm][%p] Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)
+// [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
                     IncreaseRxBuffer,
                     Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)",
+                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                     Stream->RecvBuffer.VirtualBufferLength * 2,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -312,11 +312,11 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
 
 /*----------------------------------------------------------
 // Decoder Ring for IncreaseRxBuffer
-// [strm][%p] Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)
+// [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
                     IncreaseRxBuffer,
                     Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)",
+                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                     Stream->RecvBuffer.VirtualBufferLength * 2,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,
@@ -331,15 +331,15 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, IncreaseRxBuffer,
     TP_ARGS(
         const void *, arg1,
         unsigned int, arg3,
-        unsigned int, arg4,
-        unsigned int, arg5,
-        unsigned int, arg6), 
+        unsigned long long, arg4,
+        unsigned long long, arg5,
+        unsigned long long, arg6), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, arg1)
         ctf_integer(unsigned int, arg3, arg3)
-        ctf_integer(unsigned int, arg4, arg4)
-        ctf_integer(unsigned int, arg5, arg5)
-        ctf_integer(unsigned int, arg6, arg6)
+        ctf_integer(uint64_t, arg4, arg4)
+        ctf_integer(uint64_t, arg5, arg5)
+        ctf_integer(uint64_t, arg6, arg6)
     )
 )
 

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -2176,6 +2176,44 @@
                 name="EcnCongestionCount"
                 />
           </template>
+          <template tid="tid_CONN_STATISTICS_V3">
+            <data
+                inType="win:Pointer"
+                name="Connection"
+                />
+            <data
+                inType="win:UInt64"
+                name="SmoothedRtt"
+                />
+            <data
+                inType="win:UInt32"
+                name="CongestionCount"
+                />
+            <data
+                inType="win:UInt32"
+                name="PersistentCongestionCount"
+                />
+            <data
+                inType="win:UInt64"
+                name="SendTotalBytes"
+                />
+            <data
+                inType="win:UInt64"
+                name="RecvTotalBytes"
+                />
+			<data
+                inType="win:UInt32"
+                name="CongestionWindow"
+                />
+            <data
+                inType="win:AnsiString"
+                name="Cc"
+                />
+            <data
+                inType="win:UInt32"
+                name="EcnCongestionCount"
+                />
+          </template>
           <template tid="tid_CONN_COUNT_COUNT">
             <data
                 inType="win:Pointer"
@@ -3344,6 +3382,15 @@
               symbol="QuicConnOutFlowStatsV2"
               template="tid_CONN_OUT_FLOW_STATS_V2"
               value="5193"
+              />
+          <event
+              keywords="ut:Connection ut:LowVolume"
+              level="win:Informational"
+              message="$(string.Etw.ConnStatsV2)"
+              opcode="Connection"
+              symbol="QuicConnStatsV3"
+              template="tid_CONN_STATISTICS_V3"
+              value="5194"
               />
           <!-- 6144 - 7167 | Stream Events -->
           <event

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -1138,6 +1138,48 @@
                 name="SmoothedRtt"
                 />
           </template>
+          <template tid="tid_CONN_OUT_FLOW_STATS_V2">
+            <data
+                inType="win:Pointer"
+                name="Connection"
+                />
+            <data
+                inType="win:UInt64"
+                name="BytesSent"
+                />
+            <data
+                inType="win:UInt32"
+                name="BytesInFlight"
+                />
+            <data
+                inType="win:UInt32"
+                name="BytesInFlightMax"
+                />
+            <data
+                inType="win:UInt32"
+                name="CongestionWindow"
+                />
+            <data
+                inType="win:UInt32"
+                name="SlowStartThreshold"
+                />
+            <data
+                inType="win:UInt64"
+                name="ConnectionFlowControl"
+                />
+            <data
+                inType="win:UInt64"
+                name="IdealBytes"
+                />
+            <data
+                inType="win:UInt64"
+                name="PostedBytes"
+                />
+            <data
+                inType="win:UInt64"
+                name="SmoothedRtt"
+                />
+          </template>
           <template tid="tid_CONN_OUT_FLOW_STREAM_STATS">
             <data
                 inType="win:Pointer"
@@ -3293,6 +3335,15 @@
               symbol="QuicConnRecvUdpDatagrams"
               template="tid_CONN_COUNT_COUNT"
               value="5192"
+              />
+          <event
+              keywords="ut:Connection ut:DataFlow"
+              level="win:Verbose"
+              message="$(string.Etw.ConnOutFlowStats)"
+              opcode="Connection"
+              symbol="QuicConnOutFlowStatsV2"
+              template="tid_CONN_OUT_FLOW_STATS_V2"
+              value="5193"
               />
           <!-- 6144 - 7167 | Stream Events -->
           <event

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -5605,7 +5605,7 @@
     },
     "IncreaseRxBuffer": {
       "ModuleProperites": {},
-      "TraceString": "[strm][%p] Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)",
+      "TraceString": "[strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
       "UniqueId": "IncreaseRxBuffer",
       "splitArgs": [
         {
@@ -5617,15 +5617,15 @@
           "MacroVariableName": "arg3"
         },
         {
-          "DefinationEncoding": "u",
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         },
         {
-          "DefinationEncoding": "u",
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg5"
         },
         {
-          "DefinationEncoding": "u",
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg6"
         }
       ],
@@ -7909,7 +7909,7 @@
     },
     "PacketTxLostRack": {
       "ModuleProperites": {},
-      "TraceString": "[%c][TX][%llu] Lost: RACK %u ms",
+      "TraceString": "[%c][TX][%llu] Lost: RACK %llu ms",
       "UniqueId": "PacketTxLostRack",
       "splitArgs": [
         {
@@ -7921,7 +7921,7 @@
           "MacroVariableName": "arg3"
         },
         {
-          "DefinationEncoding": "u",
+          "DefinationEncoding": "llu",
           "MacroVariableName": "arg4"
         }
       ],
@@ -14322,9 +14322,9 @@
         "EncodingString": "[conn][%p] Ignoring received unreachable event (inline)"
       },
       {
-        "UniquenessHash": "5d5005c9-b064-899a-abec-29608ab4c745",
+        "UniquenessHash": "b7c26581-5d5b-55a8-aa76-91132357a377",
         "TraceID": "IncreaseRxBuffer",
-        "EncodingString": "[strm][%p] Increasing max RX buffer size to %u (MinRtt=%u; TimeNow=%u; LastUpdate=%u)"
+        "EncodingString": "[strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)"
       },
       {
         "UniquenessHash": "9ed40f87-2b63-8343-5e37-2640d0a40e27",
@@ -15062,9 +15062,9 @@
         "EncodingString": "[%c][TX][%llu] Lost: FACK %llu packets"
       },
       {
-        "UniquenessHash": "79037f89-4d68-1fe1-8945-65ff684ef474",
+        "UniquenessHash": "29283bfa-4e6c-ce65-b4f9-fa2213f42ffd",
         "TraceID": "PacketTxLostRack",
-        "EncodingString": "[%c][TX][%llu] Lost: RACK %u ms"
+        "EncodingString": "[%c][TX][%llu] Lost: RACK %llu ms"
       },
       {
         "UniquenessHash": "114eda6f-e346-6701-573c-ad9cdbd6e082",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2223,6 +2223,50 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "ConnStatsV3": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u",
+      "UniqueId": "ConnStatsV3",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg8"
+        },
+        {
+          "DefinationEncoding": "s",
+          "MacroVariableName": "arg9"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg10"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "ConnTransportShutdown": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Transport Shutdown: %llu (Remote=%hhu) (QS=%hhu)",
@@ -13378,6 +13422,11 @@
         "UniquenessHash": "08f10184-5cf8-584f-cff9-1574f1c32b4f",
         "TraceID": "ConnStatsV2",
         "EncodingString": "[conn][%p] STATS: SRtt=%u CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u"
+      },
+      {
+        "UniquenessHash": "d642254e-2cef-c718-0275-fa330f25d71c",
+        "TraceID": "ConnStatsV3",
+        "EncodingString": "[conn][%p] STATS: SRtt=%llu CongestionCount=%u PersistentCongestionCount=%u SendTotalBytes=%llu RecvTotalBytes=%llu CongestionWindow=%u Cc=%s EcnCongestionCount=%u"
       },
       {
         "UniquenessHash": "421b9353-bbea-5599-f173-5911d85a776e",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1691,6 +1691,54 @@
       ],
       "macroName": "QuicTraceEvent"
     },
+    "ConnOutFlowStatsV2": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu",
+      "UniqueId": "ConnOutFlowStatsV2",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg7"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg8"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg9"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg10"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg11"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "ConnOutFlowStreamStats": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] OUT: StreamFC=%llu StreamSendWindow=%llu",
@@ -13210,6 +13258,11 @@
         "UniquenessHash": "9165bf3c-da91-8d88-41bc-6709ad299bed",
         "TraceID": "ConnOutFlowStats",
         "EncodingString": "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%u"
+      },
+      {
+        "UniquenessHash": "c4a4399a-7480-49c5-a291-82feafb39bca",
+        "TraceID": "ConnOutFlowStatsV2",
+        "EncodingString": "[conn][%p] OUT: BytesSent=%llu InFlight=%u InFlightMax=%u CWnd=%u SSThresh=%u ConnFC=%llu ISB=%llu PostedBytes=%llu SRtt=%llu"
       },
       {
         "UniquenessHash": "55425e95-f2a7-6b0d-41e9-82bdeb5d9082",

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -931,8 +931,8 @@ struct SentPacketMetadata : Struct {
         return ReadType<UINT64>("PacketNumber");
     }
 
-    UINT32 SentTime() {
-        return ReadType<UINT32>("SentTime"); // Microseconds
+    UINT64 SentTime() {
+        return ReadType<UINT64>("SentTime"); // Microseconds
     }
 
     UINT16 PacketLength() {

--- a/src/plugins/trace/dll/DataModel/ETW/QuicEtwEvent.cs
+++ b/src/plugins/trace/dll/DataModel/ETW/QuicEtwEvent.cs
@@ -220,7 +220,9 @@ namespace QuicTrace.DataModel.ETW
                     return new QuicConnectionOutFlowStreamStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadULong());
                 case QuicEventId.ConnRecvUdpDatagrams:
                     return new QuicConnectionRecvUdpDatagramsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadUInt(), data.ReadUInt());
-                case QuicEventId.ConnLogError:
+                case QuicEventId.ConnOutFlowStatsV2:
+                    return new QuicConnectionOutFlowStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadULong(), data.ReadULong());
+                 case QuicEventId.ConnLogError:
                 case QuicEventId.ConnLogWarning:
                 case QuicEventId.ConnLogInfo:
                 case QuicEventId.ConnLogVerbose:

--- a/src/plugins/trace/dll/DataModel/ETW/QuicEtwEvent.cs
+++ b/src/plugins/trace/dll/DataModel/ETW/QuicEtwEvent.cs
@@ -222,7 +222,9 @@ namespace QuicTrace.DataModel.ETW
                     return new QuicConnectionRecvUdpDatagramsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadUInt(), data.ReadUInt());
                 case QuicEventId.ConnOutFlowStatsV2:
                     return new QuicConnectionOutFlowStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadULong(), data.ReadULong());
-                 case QuicEventId.ConnLogError:
+                case QuicEventId.ConnStatsV3:
+                    return new QuicConnectionStatsV2Event(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadUInt());
+                case QuicEventId.ConnLogError:
                 case QuicEventId.ConnLogWarning:
                 case QuicEventId.ConnLogInfo:
                 case QuicEventId.ConnLogVerbose:

--- a/src/plugins/trace/dll/DataModel/LTTng/QuicLTTngEvent.cs
+++ b/src/plugins/trace/dll/DataModel/LTTng/QuicLTTngEvent.cs
@@ -130,7 +130,9 @@ namespace QuicTrace.DataModel.LTTng
                     return new QuicConnectionRecvUdpDatagramsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadUInt(), data.ReadUInt());
                 case nameof(QuicEventId.ConnOutFlowStatsV2):
                     return new QuicConnectionOutFlowStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadULong(), data.ReadULong());
-                 case nameof(QuicEventId.ConnLogError):
+                case nameof(QuicEventId.ConnStatsV3):
+                    return new QuicConnectionStatsV2Event(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadUInt());
+                case nameof(QuicEventId.ConnLogError):
                 case nameof(QuicEventId.ConnLogWarning):
                 case nameof(QuicEventId.ConnLogInfo):
                 case nameof(QuicEventId.ConnLogVerbose):

--- a/src/plugins/trace/dll/DataModel/LTTng/QuicLTTngEvent.cs
+++ b/src/plugins/trace/dll/DataModel/LTTng/QuicLTTngEvent.cs
@@ -128,7 +128,9 @@ namespace QuicTrace.DataModel.LTTng
                     return new QuicConnectionOutFlowStreamStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadULong());
                 case nameof(QuicEventId.ConnRecvUdpDatagrams):
                     return new QuicConnectionRecvUdpDatagramsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadUInt(), data.ReadUInt());
-                case nameof(QuicEventId.ConnLogError):
+                case nameof(QuicEventId.ConnOutFlowStatsV2):
+                    return new QuicConnectionOutFlowStatsEvent(timestamp, processor, processId, threadId, pointerSize, data.ReadPointer(), data.ReadULong(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadUInt(), data.ReadULong(), data.ReadULong(), data.ReadULong(), data.ReadULong());
+                 case nameof(QuicEventId.ConnLogError):
                 case nameof(QuicEventId.ConnLogWarning):
                 case nameof(QuicEventId.ConnLogInfo):
                 case nameof(QuicEventId.ConnLogVerbose):

--- a/src/plugins/trace/dll/DataModel/QuicConnection.cs
+++ b/src/plugins/trace/dll/DataModel/QuicConnection.cs
@@ -264,7 +264,8 @@ namespace QuicTrace.DataModel
             var tputEvents = new List<QuicRawTputData>();
             foreach (var evt in Events)
             {
-                if (evt.EventId == QuicEventId.ConnOutFlowStats)
+                if (evt.EventId == QuicEventId.ConnOutFlowStats ||
+                    evt.EventId == QuicEventId.ConnOutFlowStatsV2)
                 {
                     var _evt = evt as QuicConnectionOutFlowStatsEvent;
                     pktCreate.Update(_evt!.BytesSent, evt.TimeStamp, ref tputEvents);
@@ -420,6 +421,7 @@ namespace QuicTrace.DataModel
                         break;
                     }
                 case QuicEventId.ConnOutFlowStats:
+                case QuicEventId.ConnOutFlowStatsV2:
                     {
                         state.DataAvailableFlags |= QuicDataAvailableFlags.ConnectionTput;
                         var _evt = evt as QuicConnectionOutFlowStatsEvent;

--- a/src/plugins/trace/dll/DataModel/QuicConnection.cs
+++ b/src/plugins/trace/dll/DataModel/QuicConnection.cs
@@ -460,6 +460,7 @@ namespace QuicTrace.DataModel
                         break;
                     }
                 case QuicEventId.ConnStatsV2:
+                case QuicEventId.ConnStatsV3:
                     {
                         state.DataAvailableFlags |= QuicDataAvailableFlags.ConnectionTput;
                         var _evt = evt as QuicConnectionStatsV2Event;

--- a/src/plugins/trace/dll/DataModel/QuicEvent.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvent.cs
@@ -163,6 +163,7 @@ namespace QuicTrace.DataModel
         ConnCubicHyStart,
         ConnRecvUdpDatagrams,
         ConnOutFlowStatsV2,
+        ConnStatsV3,
 
         StreamCreated = 6144,
         StreamDestroyed,

--- a/src/plugins/trace/dll/DataModel/QuicEvent.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvent.cs
@@ -162,6 +162,7 @@ namespace QuicTrace.DataModel
         ConnStatsV2,
         ConnCubicHyStart,
         ConnRecvUdpDatagrams,
+        ConnOutFlowStatsV2,
 
         StreamCreated = 6144,
         StreamDestroyed,

--- a/src/plugins/trace/dll/DataModel/QuicEvents.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvents.cs
@@ -879,7 +879,7 @@ namespace QuicTrace.DataModel
 
     public class QuicConnectionStatsV2Event : QuicEvent
     {
-        public uint SmoothedRtt { get; }
+        public ulong SmoothedRtt { get; }
 
         public uint CongestionCount { get; }
 
@@ -896,7 +896,7 @@ namespace QuicTrace.DataModel
                 SmoothedRtt, CongestionCount, PersistentCongestionCount, SendTotalBytes, RecvTotalBytes, EcnCongestionCount);
 
         internal QuicConnectionStatsV2Event(Timestamp timestamp, ushort processor, uint processId, uint threadId, int pointerSize, ulong objectPointer,
-                                          uint smoothedRtt, uint congestionCount, uint persistentCongestionCount, ulong sendTotalBytes, ulong recvTotalBytes, uint ecnCongestionCount) :
+                                          ulong smoothedRtt, uint congestionCount, uint persistentCongestionCount, ulong sendTotalBytes, ulong recvTotalBytes, uint ecnCongestionCount) :
             base(QuicEventId.ConnStatsV2, QuicObjectType.Connection, timestamp, processor, processId, threadId, pointerSize, objectPointer)
         {
             SmoothedRtt = smoothedRtt;

--- a/src/plugins/trace/dll/DataModel/QuicEvents.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvents.cs
@@ -737,7 +737,7 @@ namespace QuicTrace.DataModel
 
         public ulong PostedBytes { get; }
 
-        public uint SmoothedRtt { get; }
+        public ulong SmoothedRtt { get; }
 
         public override string PayloadString =>
             string.Format("OUT: BytesSent={0} InFlight={1} InFlightMax={2} CWnd={3} SSThresh={4} ConnFC={5} ISB={6} PostedBytes={7} SRtt={8}",
@@ -745,7 +745,7 @@ namespace QuicTrace.DataModel
 
         internal QuicConnectionOutFlowStatsEvent(Timestamp timestamp, ushort processor, uint processId, uint threadId, int pointerSize, ulong objectPointer,
                                                  ulong bytesSent, uint bytesInFlight, uint bytesInFlightMax, uint congestionWindow, uint slowStartThreshold,
-                                                 ulong connectionFlowControl, ulong idealBytes, ulong postedBytes, uint smoothedRtt) :
+                                                 ulong connectionFlowControl, ulong idealBytes, ulong postedBytes, ulong smoothedRtt) :
             base(QuicEventId.ConnOutFlowStats, QuicObjectType.Connection, timestamp, processor, processId, threadId, pointerSize, objectPointer)
         {
             BytesSent = bytesSent;
@@ -928,7 +928,7 @@ namespace QuicTrace.DataModel
     public class QuicConnectionRecvUdpDatagramsEvent : QuicEvent
     {
         public uint DatagramCount { get; }
-    
+
         public uint ByteCount { get; }
 
         public override string PayloadString => string.Format("Recv {0} UDP datagrams, {1} bytes", DatagramCount, ByteCount);

--- a/src/plugins/trace/dll/DataModel/QuicWorker.cs
+++ b/src/plugins/trace/dll/DataModel/QuicWorker.cs
@@ -170,7 +170,8 @@ namespace QuicTrace.DataModel
                     LastConnection = null;
                 }
             }
-            else if (evt.EventId == QuicEventId.ConnOutFlowStats)
+            else if (evt.EventId == QuicEventId.ConnOutFlowStats ||
+                     evt.EventId == QuicEventId.ConnOutFlowStatsV2)
             {
                 LastConnection = connection;
             }


### PR DESCRIPTION
## Description

Updates the send logic to use 64-bit time instead of 32-bit. Makes calculating one-way delay time easier. Also required for larger RTT (i.e. space) scenarios.

## Testing

Existing automation

## Documentation

N/A
