### PR TITLE
Fix Attack Tool

### DIFF
--- a/src/tools/attack/packet_writer.cpp
+++ b/src/tools/attack/packet_writer.cpp
@@ -76,6 +76,7 @@ struct TlsContext
         Config.HkdfLabels = &HkdfLabels;
         Config.AlpnBuffer = AlpnListBuffer;
         Config.AlpnBufferLength = AlpnListBuffer[0] + 1;
+        Config.TPType = TLS_EXTENSION_TYPE_QUIC_TRANSPORT_PARAMETERS;
         Config.LocalTPBuffer =
             QuicCryptoTlsEncodeTransportParameters(&Connection, FALSE, &TP, NULL, &Config.LocalTPLength);
         if (!Config.LocalTPBuffer) {


### PR DESCRIPTION
## Description

Sometime in the past, the tool was broken in its TLS abstraction layer. This fixes that.

## Testing

Manually

## Documentation

N/A
