### PR TITLE
Set default toolchain file only for OneBranch/container builds

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -388,17 +388,17 @@ function CMake-Generate {
         if ($HostArch -ne $Arch) {
             if ($OneBranch) {
                 $Arguments += " -DONEBRANCH=1"
+                if ($ToolchainFile -eq "") {
+                    switch ($Arch) {
+                        "arm"   { $ToolchainFile = "cmake/toolchains/arm-linux.cmake" }
+                        "arm64" { $ToolchainFile = "cmake/toolchains/aarch64-linux.cmake" }
+                    }
+                }
             }
             $Arguments += " -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_CROSSCOMPILING=1 -DCMAKE_SYSROOT=$SysRoot"
             switch ($Arch) {
                 "arm64" { $Arguments += " -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_TARGET_ARCHITECTURE=arm64" }
                 "arm" { $Arguments += " -DCMAKE_CXX_COMPILER_TARGET=arm-linux-gnueabihf  -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf -DCMAKE_TARGET_ARCHITECTURE=arm" }
-            }
-            if ($ToolchainFile -eq "") {
-                switch ($Arch) {
-                    "arm"   { $ToolchainFile = "cmake/toolchains/arm-linux.cmake" }
-                    "arm64" { $ToolchainFile = "cmake/toolchains/aarch64-linux.cmake" }
-                }
             }
        }
     }


### PR DESCRIPTION
## Description

.NET builds msquic using the same script (script/build.ps1) that we use to build the project, which does not work well with their cross-compile method where a toolchain file is not used as reported in https://github.com/dotnet/msquic/pull/149.

This PR allows empty toolchain file for cross-compile. So, we only use a default toolchain file for our own OneBranch/container builds.

## Testing

Needs help from @wfurt to test it.

