### PR TITLE
Do not use pipe operator.

### DIFF
--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -43,9 +43,8 @@ jobs:
     - run: ./scripts/generate-docfx-yml.ps1 ./docs
       shell: pwsh
     - run: docfx docfx.json
-
+    - run: chmod +x ./scripts/commit-docfx-site.ps1
     - name: Commit Changes
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
-      run: chmod +x ./scripts/commit-docfx-site.ps1 
-      run: ./scripts/commit-docfx-site.ps1
-      shell: pwsh
+      - run: ./scripts/commit-docfx-site.ps1
+        shell: pwsh

--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -46,7 +46,6 @@ jobs:
 
     - name: Commit Changes
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: |
-          chmod +x ./scripts/update-docfx-site.ps1
-          ./scripts/update-docfx-site.ps1
-          shell: pwsh
+      run: chmod +x ./scripts/commit-docfx-site.ps1 
+      run: ./scripts/commit-docfx-site.ps1
+      shell: pwsh

--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -46,5 +46,5 @@ jobs:
     - run: chmod +x ./scripts/commit-docfx-site.ps1
     - name: Commit Changes
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
-      - run: ./scripts/commit-docfx-site.ps1
-        shell: pwsh
+      run: ./scripts/commit-docfx-site.ps1
+      shell: pwsh

--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -45,7 +45,7 @@ jobs:
     - run: docfx docfx.json
 
     - name: Commit Changes
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
       run: chmod +x ./scripts/commit-docfx-site.ps1 
       run: ./scripts/commit-docfx-site.ps1
       shell: pwsh

--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -43,8 +43,8 @@ jobs:
     - run: ./scripts/generate-docfx-yml.ps1 ./docs
       shell: pwsh
     - run: docfx docfx.json
-    - run: chmod +x ./scripts/commit-docfx-site.ps1
+    - run: chmod +x ./scripts/update-docfx-site.ps1
     - name: Commit Changes
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
-      run: ./scripts/commit-docfx-site.ps1
+      run: ./scripts/update-docfx-site.ps1
       shell: pwsh


### PR DESCRIPTION
## Description

![image](https://github.com/microsoft/msquic/assets/43735701/a0456186-a651-49bf-b0ac-f5044124511a)

We can see bash was used instead of powershell in this run: https://github.com/microsoft/msquic/actions/runs/6243171195/job/16948179512. That means the pipe operator did not work correctly.

Indentations are used by YAML pipes to discern distinct commands, spaces were used (previously I was unaware my tabs got converted to 4 spaces in vscode). 

To avoid this whole mess, avoid using pipes + indentations and separate out the `run` commands. 

Apologies for any inconveniences :)

## Testing

Added a clause to the workflow to allow commits on manual dispatch, for additional verification.

Here is a successful run (with commit): https://github.com/microsoft/msquic/actions/runs/6243193515/job/16948251428 

We can remove the workflow_run on-commit clause if it's decided that isn't smart for main branch. But we have that there for now to prove it all works (it worked before but indentation nonsense happened).

## Documentation

N/A
