### PR TITLE
Disable Segmentation Support on EIO

### DIFF
--- a/src/generated/linux/datapath_epoll.c.clog.h
+++ b/src/generated/linux/datapath_epoll.c.clog.h
@@ -223,6 +223,24 @@ tracepoint(CLOG_DATAPATH_EPOLL_C, DatapathSend , arg2, arg3, arg4, arg5, arg6_le
 
 
 
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+                    LibraryError,
+                    "[ lib] ERROR, %s.",
+                    "Disabling segmentation support globally");
+// arg2 = arg2 = "Disabling segmentation support globally" = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_LibraryError
+#define _clog_3_ARGS_TRACE_LibraryError(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_DATAPATH_EPOLL_C, LibraryError , arg2);\
+
+#endif
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/generated/linux/datapath_epoll.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_epoll.c.clog.h.lttng.h
@@ -245,3 +245,22 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_EPOLL_C, DatapathSend,
         ctf_sequence(char, arg7, arg7, unsigned int, arg7_len)
     )
 )
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for LibraryError
+// [ lib] ERROR, %s.
+// QuicTraceEvent(
+                    LibraryError,
+                    "[ lib] ERROR, %s.",
+                    "Disabling segmentation support globally");
+// arg2 = arg2 = "Disabling segmentation support globally" = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_DATAPATH_EPOLL_C, LibraryError,
+    TP_ARGS(
+        const char *, arg2), 
+    TP_FIELDS(
+        ctf_string(arg2, arg2)
+    )
+)

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2450,12 +2450,34 @@ CxPlatSendDataSend(
             Status = QUIC_STATUS_PENDING;
         } else {
             Status = errno;
+#ifdef UDP_SEGMENT
+            QuicTraceEvent(
+                DatapathErrorStatus,
+                "[data][%p] ERROR, %u, %s.",
+                SocketContext->Binding,
+                Status,
+                "sendmsg (GSO) failed");
+#else
             QuicTraceEvent(
                 DatapathErrorStatus,
                 "[data][%p] ERROR, %u, %s.",
                 SocketContext->Binding,
                 Status,
                 "sendmmsg failed");
+#endif
+
+            if (Status == EIO) {
+                //
+                // EIO generally indicates the GSO isn't supported by the NIC,
+                // so disable segmentation on the datapath globally.
+                //
+                QuicTraceEvent(
+                    LibraryError,
+                    "[ lib] ERROR, %s.",
+                    "Disabling segmentation support globally");
+                SendData->SocketContext->Binding->Datapath->Features &=
+                    ~CXPLAT_DATAPATH_FEATURE_SEND_SEGMENTATION;
+            }
 
             //
             // Unreachable events can sometimes come synchronously.

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2466,7 +2466,8 @@ CxPlatSendDataSend(
                 "sendmmsg failed");
 #endif
 
-            if (Status == EIO) {
+            if (Status == EIO &&
+                SocketContext->Binding->Datapath->Features & CXPLAT_DATAPATH_FEATURE_SEND_SEGMENTATION) {
                 //
                 // EIO generally indicates the GSO isn't supported by the NIC,
                 // so disable segmentation on the datapath globally.
@@ -2475,7 +2476,7 @@ CxPlatSendDataSend(
                     LibraryError,
                     "[ lib] ERROR, %s.",
                     "Disabling segmentation support globally");
-                SendData->SocketContext->Binding->Datapath->Features &=
+                SocketContext->Binding->Datapath->Features &=
                     ~CXPLAT_DATAPATH_FEATURE_SEND_SEGMENTATION;
             }
 


### PR DESCRIPTION
## Description

Update Linux epoll datapath to fallback to non-GSO sends if the `EIO` error is returned, which most likely indicates the NIC doesn't support it. This seems to be the case on at least some Android devices.

Fixed #3865.

## Testing

CI/CD for regression testing. Not sure how to actually test this fallback atm.

## Documentation

N/A