### PR TITLE
Backport v2.2: Fix syntax for pre-C23 standard compilers (#3736)

### DIFF
--- a/src/generated/stdout/quic_trace.c
+++ b/src/generated/stdout/quic_trace.c
@@ -102,7 +102,7 @@ void clog_stdout(struct clog_param * head, const char * const format, ...)
         }
     }
 
-JustPrint:
+JustPrint: ;
     // print the log line
     va_list ap;
     va_start(ap, format);


### PR DESCRIPTION
## Description

Backports #3736 to release/2.2
