### PR TITLE
Work Around Android Build Failures

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -482,7 +482,8 @@ function CMake-Generate {
         $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
-        $env:PATH = "$env:ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
+        $NDK = $env:ANDROID_NDK_LATEST_HOME.Replace('26.0.10792818', '25.2.9519653') # Temporary work around
+        $env:PATH = "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
         switch ($Arch) {
             "x86"   { $Arguments += " -DANDROID_ABI=x86"}
             "x64"   { $Arguments += " -DANDROID_ABI=x86_64" }
@@ -490,8 +491,7 @@ function CMake-Generate {
             "arm64" { $Arguments += " -DANDROID_ABI=arm64-v8a" }
         }
         $Arguments += " -DANDROID_PLATFORM=android-29"
-        $NDK = $env:ANDROID_NDK_LATEST_HOME
-        $env:ANDROID_NDK_HOME = $env:ANDROID_NDK_LATEST_HOME
+        $env:ANDROID_NDK_HOME = $NDK
         $NdkToolchainFile = "$NDK/build/cmake/android.toolchain.cmake"
         $Arguments += " -DANDROID_NDK=""$NDK"""
         $Arguments += " -DCMAKE_TOOLCHAIN_FILE=""$NdkToolchainFile"""


### PR DESCRIPTION
## Description

GitHub Runners started pushing a new version of the Android NDK that seems to be breaking openssl builds. This change continues to use the older version.

## Testing

CI/CD

## Documentation

None
