### PR TITLE
Avoid using unknown #pragma for non-MSVC compiler in public header files.

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -23,10 +23,10 @@ Supported Platforms:
 
 #ifdef _WIN32
 #pragma once
-#endif
 
 #pragma warning(disable:4201)  // nonstandard extension used: nameless struct/union
 #pragma warning(disable:4214)  // nonstandard extension used: bit field types other than int
+#endif
 
 #ifdef _KERNEL_MODE
 #include "msquic_winkernel.h"

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -18,7 +18,12 @@ Supported Platforms:
 
 --*/
 
+#ifdef _WIN32
 #pragma once
+#endif
+
+#ifndef _MSQUIC_HPP_
+#define _MSQUIC_HPP_
 
 #include "msquic.h"
 #include "msquicp.h"
@@ -1552,3 +1557,5 @@ struct QuicBufferScope {
     operator QUIC_BUFFER* () noexcept { return Buffer; }
     ~QuicBufferScope() noexcept { if (Buffer) { delete[](uint8_t*) Buffer; } }
 };
+
+#endif

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1558,4 +1558,4 @@ struct QuicBufferScope {
     ~QuicBufferScope() noexcept { if (Buffer) { delete[](uint8_t*) Buffer; } }
 };
 
-#endif
+#endif  //  _WIN32

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -14,7 +14,9 @@ Environment:
 
 --*/
 
+#ifdef _WIN32
 #pragma once
+#endif
 
 #ifndef _MSQUIC_POSIX_
 #define _MSQUIC_POSIX_


### PR DESCRIPTION
## Description

For non-MSVC compilers, <code>#pragma once</code> shall be replaced with more generic and reliable include guard method. In addition, <code>#pragma warning(disable:\*)</code> are not supported by non-MSVC compilers, it shall not be enabled in public header files (<code>\*.h</code> and <code>\*.hpp</code> files) for all non-MSVC compilers.

## Testing

Compile test.

## Documentation

No impact.
