### PR TITLE
Handle bad behavior by app in reliable shutdown path.

### DIFF
--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -861,16 +861,6 @@ QuicStreamIndicateSendShutdownComplete(
     );
 
 //
-// Enqueues a SendRequest from the temporary queue to the actual queue.
-//
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicStreamEnqueueSendRequest(
-    _In_ QUIC_STREAM* Stream,
-    _Inout_ QUIC_SEND_REQUEST* SendRequest
-);
-
-//
 // Indicates data has been queued up to be sent out on the stream.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -861,6 +861,16 @@ QuicStreamIndicateSendShutdownComplete(
     );
 
 //
+// Enqueues a SendRequest from the temporary queue to the actual queue.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicStreamEnqueueSendRequest(
+    _In_ QUIC_STREAM* Stream,
+    _Inout_ QUIC_SEND_REQUEST* SendRequest
+);
+
+//
 // Indicates data has been queued up to be sent out on the stream.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/generated/linux/stream_send.c.clog.h
+++ b/src/generated/linux/stream_send.c.clog.h
@@ -87,13 +87,13 @@ tracepoint(CLOG_STREAM_SEND_C, IndicateSendComplete , arg1, arg3);\
 // Decoder Ring for SendQueued
 // [strm][%p] Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)
 // QuicTraceLogStreamVerbose(
-            SendQueued,
-            Stream,
-            "Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)",
-            SendRequest,
-            SendRequest->TotalLength,
-            SendRequest->StreamOffset,
-            SendRequest->Flags);
+        SendQueued,
+        Stream,
+        "Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)",
+        SendRequest,
+        SendRequest->TotalLength,
+        SendRequest->StreamOffset,
+        SendRequest->Flags);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = SendRequest = arg3
 // arg4 = arg4 = SendRequest->TotalLength = arg4

--- a/src/generated/linux/stream_send.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_send.c.clog.h.lttng.h
@@ -70,13 +70,13 @@ TRACEPOINT_EVENT(CLOG_STREAM_SEND_C, IndicateSendComplete,
 // Decoder Ring for SendQueued
 // [strm][%p] Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)
 // QuicTraceLogStreamVerbose(
-            SendQueued,
-            Stream,
-            "Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)",
-            SendRequest,
-            SendRequest->TotalLength,
-            SendRequest->StreamOffset,
-            SendRequest->Flags);
+        SendQueued,
+        Stream,
+        "Send Request [%p] queued with %llu bytes at offset %llu (flags 0x%x)",
+        SendRequest,
+        SendRequest->TotalLength,
+        SendRequest->StreamOffset,
+        SendRequest->Flags);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = SendRequest = arg3
 // arg4 = arg4 = SendRequest->TotalLength = arg4


### PR DESCRIPTION
## Description

This PR proposes a solution to handle bad behavior by the app: the application exhibits undesirable behavior by attempting to send data after or during a send shutdown operation in the reliable reset path.

This PR also refactors the sendFlush method, and attempts to address the ETW trace misconfiguration in issue #3891 


## Testing

Added an extra send in Datateset after calling shutdown.

## Documentation

n/a
