### PR TITLE
Add JIT compilation to replace relative path ../src with full URL to prepare for docfx

### DIFF
--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -44,6 +44,10 @@ jobs:
     - run: chmod +x ./scripts/generate-docfx-yml.ps1
     - run: ./scripts/generate-docfx-yml.ps1 ./docs
       shell: pwsh
+    - run: chmod +x ./scripts/docfx-replace-url.ps1
+      shell: pwsh
+    - run: ./scripts/docfx-replace-url.ps1
+      shell: pwsh
     - run: docfx docfx.json
     - run: chmod +x ./scripts/update-docfx-site.ps1
     - name: Commit Changes

--- a/.github/workflows/publish-docfx.yml
+++ b/.github/workflows/publish-docfx.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main"]
     paths: ["docs/**", ".github/workflows/publish-docfx.yml"]
-  
+
   pull_request:
     branches: ["main"]
     paths: ["docs/**", ".github/workflows/publish-docfx.yml"]
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      with:
+        ref: main
     - name: Dotnet Setup
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2
       with:

--- a/scripts/docfx-replace-url.ps1
+++ b/scripts/docfx-replace-url.ps1
@@ -1,0 +1,23 @@
+# Define the custom link to replace "../src"
+$customLink = "https://github.com/microsoft/msquic/tree/main/src"
+
+# Get the directory of markdown files from the user input
+$dir = "./docs"
+
+# Get all the markdown files in the directory
+$files = Get-ChildItem -Path $dir -Filter *.md
+
+# Loop through each file
+foreach ($file in $files) {
+    # Read the file content as a string
+    $content = Get-Content -Path $file.FullName -Raw
+
+    # Replace all occurrences of "../src" with the custom link
+    $content = $content -replace "\.\./src", $customLink
+
+    # Write the modified content back to the file
+    Set-Content -Path $file.FullName -Value $content
+}
+
+# Write a message to indicate the completion of the task
+Write-Host "All done!"


### PR DESCRIPTION
## Description

In original docs, links were written with relative paths under the assumption that the user was browsing on github. Now that we have DocFx for our site, we need the absolute paths. This PR implements a JIT script to replace all the relative paths with their absolute paths.

## Testing

Using CI.

## Documentation

N/A
