### PR TITLE
Enable tcp offload before perf test

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -539,6 +539,7 @@ if ($IsLinux) {
         sudo apt-get install -y lttng-tools
         sudo apt-get install -y liblttng-ust-dev
         sudo apt-get install -y gdb
+        sudo apt-get install -y ethtool
 
         # Enable core dumps for the system.
         Write-Host "Setting core dump size limit"


### PR DESCRIPTION
## Description

offloading config depends on each system. This enables required tcp HW offloading for perf test for sure

## Testing

see automation

## Documentation

N/A
