### PR TITLE
datapath_epoll: adjust CXPLAT_MAX_IO_BATCH_SIZE arithmetic

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -41,7 +41,7 @@ CXPLAT_STATIC_ASSERT((SIZEOF_STRUCT_MEMBER(QUIC_BUFFER, Buffer) == sizeof(void*)
 // packet/datagram payloads (i.e. IPv6) that can fit in the large buffer.
 //
 const uint16_t CXPLAT_MAX_IO_BATCH_SIZE =
-    (CXPLAT_LARGE_IO_BUFFER_SIZE / (CXPLAT_MAX_MTU - CXPLAT_MIN_IPV6_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE));
+    (CXPLAT_LARGE_IO_BUFFER_SIZE / (1280 - CXPLAT_MIN_IPV6_HEADER_SIZE - CXPLAT_UDP_HEADER_SIZE));
 
 //
 // Contains all the info for a single RX IO operation. Multiple RX packets may


### PR DESCRIPTION
It should account for MIN MTU, not MAX.

Updates #3917

## Description

This PR increases the value for the constant controlling the max number of datagrams per coalesced group on Linux. Previously this value was lower than what the max batch size needed to reach in cases where MTU < 1500.

## Testing

I'm not familiar with related unit tests, but I have verified this fixes #3917 in functional testing.

## Documentation

Not to my knowledge.
