### PR TITLE
Fix perf command existence check

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -147,8 +147,8 @@ if ($IsLinux) {
         sudo apt-get install -y lttng-tools
         sudo apt-get install -y liblttng-ust-dev
     }
-    try { perf version | Out-Null }
-    catch {
+    perf version 2>&1 | Out-Null
+    if (!$?) {
         Write-Debug "Installing perf"
         sudo apt-get install -y linux-tools-$(uname -r)
         sudo wget https://raw.githubusercontent.com/brendangregg/FlameGraph/master/stackcollapse-perf.pl -O /usr/bin/stackcollapse-perf.pl


### PR DESCRIPTION
## Description

try-catch does not work to catch perf command existence.

## Testing

Sadly, the command result changes once the system install the linux-tools even after uninstall the tools. 

## Documentation

N/A
