### PR TITLE
Skip Datapath Global Param tests while in Kernel mode.

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2488,6 +2488,7 @@ void QuicTestGlobalParam()
         }
     }
 
+#ifndef _KERNEL_MODE
     //
     // QUIC_PARAM_GLOBAL_DATAPATH_FEATURES
     //
@@ -2530,10 +2531,8 @@ void QuicTestGlobalParam()
                     &Length,
                     &ActualFeatures));
         }
-
     }
 
-#ifndef _KERNEL_MODE
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     //
     // QUIC_PARAM_GLOBAL_EXECUTION_CONFIG


### PR DESCRIPTION
## Description

From recent CI testing, it looks like MsQuicLib.Datapath isn't being uninitialized, which is the case for Kernel mode tests.

In that case, tests that expect MsQuicLib.Datapath to be NULL is erroneously finding out it's still initialized.

In those cases, since we don't support them in Kernel mode, we will just skip them.

## Testing

N/A

## Documentation

N/A
