### PR TITLE
Do not hardcode Android version

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -482,7 +482,7 @@ function CMake-Generate {
         $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
-        $NDK = $env:ANDROID_NDK_LATEST_HOME.Replace('26.0.10792818', '25.2.9519653') # Temporary work around
+        $NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '25.2.9519653' # Temporary work around. Use RegEx to replace newer version.
         $env:PATH = "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
         switch ($Arch) {
             "x86"   { $Arguments += " -DANDROID_ABI=x86"}


### PR DESCRIPTION
## Description

Android is tweaking.
Old workaround didn't work due to slightly different newer version of Android being released... 
Just use regex to replace it.

## Testing

CI

## Documentation

N/A
