### PR TITLE
Turn off optimizations for functional tests for arm64

### DIFF
--- a/src/test/lib/precomp.h
+++ b/src/test/lib/precomp.h
@@ -42,3 +42,7 @@
 #include "TestConnection.h"
 #include "TestListener.h"
 #include "DrillDescriptor.h"
+
+#if defined(_ARM64_) || defined(_ARM64EC_)
+#pragma optimize("", off)
+#endif


### PR DESCRIPTION
## Description

Turn off optimizations for functional tests for arm64 to work around arm64 stack overflow due to compiler over-aggressive optimizations.

## Testing

Will need to inspect the disassembly from CI.

