### PR TITLE
Support Using Streams after Connection Closure

### DIFF
--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -59,6 +59,7 @@ void QuicTestRegistrationShutdownBeforeConnOpen();
 void QuicTestRegistrationShutdownAfterConnOpen();
 void QuicTestRegistrationShutdownAfterConnOpenBeforeStart();
 void QuicTestRegistrationShutdownAfterConnOpenAndStart();
+void QuicTestConnectionCloseBeforeStreamClose();
 
 //
 // Rejection Tests

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -356,6 +356,15 @@ TEST(OwnershipValidation, RegistrationShutdownAfterConnOpenAndStart) {
     }
 }
 
+TEST(OwnershipValidation, ConnectionCloseBeforeStreamClose) {
+    TestLogger Logger("ConnectionCloseBeforeStreamClose");
+    if (TestingKernelMode) {
+        // TODO ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_REG_SHUTDOWN_AFTER_OPEN_AND_START));
+    } else {
+        QuicTestConnectionCloseBeforeStreamClose();
+    }
+}
+
 TEST_P(WithBool, ValidateStream) {
     TestLoggerT<ParamType> Logger("QuicTestValidateStream", GetParam());
     if (TestingKernelMode) {

--- a/src/test/lib/OwnershipTest.cpp
+++ b/src/test/lib/OwnershipTest.cpp
@@ -230,3 +230,44 @@ void QuicTestRegistrationShutdownAfterConnOpenAndStart()
     TEST_TRUE(State.StateEvent.WaitTimeout(2000));
     TEST_EQUAL(1, State.ShutdownCount);
 }
+
+void QuicTestConnectionCloseBeforeStreamClose()
+{
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicRegistration ServerRegistration{true};
+    TEST_TRUE(ServerRegistration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+    MsQuicCredentialConfig ClientCredConfig;
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCredConfig);
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(ServerRegistration, Alpn, ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicAutoAcceptListener Listener(ServerRegistration, ServerConfiguration, MsQuicConnection::NoOpCallback);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
+    QuicAddr ServerLocalAddr(QuicAddrFamily);
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE);
+        TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+        Connection.Close();
+    }
+
+    {
+        MsQuicConnection Connection(Registration);
+        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+        MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE);
+        TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+        TEST_QUIC_SUCCEEDED(Stream.Start());
+        Connection.Close();
+    }
+}


### PR DESCRIPTION
## Description

Allows apps to not worry about close order between streams and connections.

## Testing

New test added. Also leverages existing tests (which found some other issues).

## Documentation

TODO?
