### PR TITLE
Fix epoll TCP implementation

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2487,14 +2487,20 @@ CxPlatSendDataSend(
 
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     CXPLAT_SOCKET_CONTEXT* SocketContext = SendData->SocketContext;
-    BOOLEAN Success =
-        SocketType == CXPLAT_SOCKET_UDP ?
+    BOOLEAN Success;
+
+    if (SocketType == CXPLAT_SOCKET_UDP) {
+        Success =
 #ifdef UDP_SEGMENT
             SendData->SegmentationSupported ?
-                CxPlatSendDataSendSegmented(SendData) :
+                CxPlatSendDataSendSegmented(SendData) : CxPlatSendDataSendMessages(SendData);
+#else
+            CxPlatSendDataSendMessages(SendData);
 #endif
-                CxPlatSendDataSendMessages(SendData) :
-            CxPlatSendDataSendTcp(SendData);
+    } else {
+        Success = CxPlatSendDataSendTcp(SendData);
+    }
+
     if (!Success) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             Status = QUIC_STATUS_PENDING;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1367,16 +1367,6 @@ CxPlatSocketCreateTcpInternal(
         goto Exit;
     }
 
-    if (IsServerSocket) {
-        //
-        // The return value is being ignored here, as if a system does not support
-        // bpf we still want the server to work. If this happens, the sockets will
-        // round robin, but each flow will be sent to the same socket, just not
-        // based on RSS.
-        //
-        (void)CxPlatSocketConfigureRss(SocketContext, 1);
-    }
-
     if (Type == CXPLAT_SOCKET_TCP_SERVER) {
         *NewBinding = Binding;
         Binding = NULL;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2459,24 +2459,18 @@ CxPlatSendDataSendTcp(
     _In_ CXPLAT_SEND_DATA* SendData
     )
 {
-    uint32_t TotalSize = SendData->TotalSize;
-    uint8_t *Buffer = SendData->Buffer;
-    while (TotalSize > 0) {
+    while (SendData->TotalSize > 0) {
         int BytesSent =
             send(
                 SendData->SocketContext->SocketFd,
-                Buffer,
-                TotalSize,
+                SendData->Buffer,
+                SendData->TotalSize,
                 0);
         if (BytesSent < 0) {
-            // forcibly send inline
-            if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                continue;
-            }
             return FALSE;
         }
-        Buffer += BytesSent;
-        TotalSize -= BytesSent;
+        SendData->Buffer += BytesSent;
+        SendData->TotalSize -= BytesSent;
     }
 
     return TRUE;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2101,6 +2101,7 @@ SendDataAlloc(
         SendData->ClientBuffer.Buffer = SendData->Buffer;
         SendData->ClientBuffer.Length = 0;
         SendData->TotalSize = 0;
+        SendData->TotalBytesSent = 0;
         SendData->SegmentSize =
             (Socket->Type != CXPLAT_SOCKET_UDP ||
              Socket->Datapath->Features & CXPLAT_DATAPATH_FEATURE_SEND_SEGMENTATION)

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1339,6 +1339,8 @@ CxPlatSocketCreateTcpInternal(
     } else {
         Binding->LocalAddress.Ip.sa_family = QUIC_ADDRESS_FAMILY_INET6;
     }
+
+    Binding->RecvBufLen = Datapath->RecvBlockSize - Datapath->RecvBlockBufferOffset;
     PartitionIndex =
         RemoteAddress ?
             ((uint16_t)(CxPlatProcCurrentNumber() % Datapath->PartitionCount)) : 0;
@@ -1991,7 +1993,7 @@ CxPlatSocketTcpRecvComplete(
     IoBlock->RefCount = 0;
 
     uint8_t* Buffer = (uint8_t*)IoBlock + DatapathPartition->Datapath->RecvBlockBufferOffset;
-    int NumberOfBytesTransferred = read(SocketContext->SocketFd, Buffer, CXPLAT_LARGE_IO_BUFFER_SIZE);
+    int NumberOfBytesTransferred = read(SocketContext->SocketFd, Buffer, SocketContext->Binding->RecvBufLen);
 
     if (NumberOfBytesTransferred == 0) {
         if (!SocketContext->Binding->DisconnectIndicated) {

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -782,6 +782,11 @@ typedef struct CXPLAT_SOCKET {
     uint16_t Mtu;
 
     //
+    // The size of a receive buffer's payload.
+    //
+    uint32_t RecvBufLen;
+
+    //
     // Indicates the binding connected to a remote IP address.
     //
     BOOLEAN Connected : 1;


### PR DESCRIPTION
## Description

There are a few bugs in the epoll TCP implementation.
1. TX: busy spinning on non-blocking socket regardless of whether eagain/ewouldblock is encountered.
2. RX: not draining all of the ready data upon EPOLLIN signal.
3. Wrong buffer length passed to read, which causes debug build to crash consistently.
4. Unnecessary RSS config for TCP server sockets.

Local perf test in WSL showed 2x perf improvement with loopback but the numbers from the perf machines didn't seem to move at all.

## Testing
CI
