### PR TITLE
Don't Affinitize Platform Worker

### DIFF
--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -150,7 +150,7 @@ CxPlatWorkersLazyStart(
     }
 
     CXPLAT_THREAD_CONFIG ThreadConfig = {
-        CXPLAT_THREAD_FLAG_SET_AFFINITIZE,
+        CXPLAT_THREAD_FLAG_SET_IDEAL_PROC,
         0,
         "cxplat_worker",
         CxPlatWorkerThread,


### PR DESCRIPTION
## Description

We've found concrete examples where CPU affinitization hurts latency significantly, and initial tests seem to indicate minimal negative impact of just setting ideal processor.

## Testing

CI/CD

## Documentation

N/A
