### PR TITLE
msquichelper.h: suppress GCC stringop-overflow warning

### DIFF
--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -265,6 +265,7 @@ EncodeHexBuffer(
     #define HEX_TO_CHAR(x) ((x) > 9 ? ('a' + ((x) - 10)) : '0' + (x))
     for (uint8_t i = 0; i < BufferLen; i++) {
         HexString[i*2]     = HEX_TO_CHAR(Buffer[i] >> 4);
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
         HexString[i*2 + 1] = HEX_TO_CHAR(Buffer[i] & 0xf);
     }
 }

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -265,7 +265,9 @@ EncodeHexBuffer(
     #define HEX_TO_CHAR(x) ((x) > 9 ? ('a' + ((x) - 10)) : '0' + (x))
     for (uint8_t i = 0; i < BufferLen; i++) {
         HexString[i*2]     = HEX_TO_CHAR(Buffer[i] >> 4);
+#ifndef _WIN32
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         HexString[i*2 + 1] = HEX_TO_CHAR(Buffer[i] & 0xf);
     }
 }


### PR DESCRIPTION
Updates #3918

## Description

Builds fail on Linux with more recent versions of GCC (12/13) due to:

```
/home/jwhited/msquic/src/inc/msquichelper.h:268:28: error: writing 16 bytes into a region of size 0 [-Werror=stringop-overflow=]
  268 |         HexString[i*2 + 1] = HEX_TO_CHAR(Buffer[i] & 0xf);
```

This PR suppresses that warning as it is likely a false positive.

## Testing

N/A

## Documentation

N/A
