### PR TITLE
Use a new 1ES image that's configured correctly

### DIFF
--- a/.azure/OneBranch.Tests.Official.yml
+++ b/.azure/OneBranch.Tests.Official.yml
@@ -29,7 +29,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -45,7 +45,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -63,7 +63,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -81,7 +81,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light

--- a/.azure/OneBranch.Tests.PullRequest.yml
+++ b/.azure/OneBranch.Tests.PullRequest.yml
@@ -29,7 +29,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -45,7 +45,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -63,7 +63,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light
@@ -81,7 +81,7 @@ stages:
   - template: ./obtemplates/run-bvt.yml
     parameters:
       pool: 1es-msquic-pool-internal
-      image: WSPrerelease
+      image: WinServerPrerelease
       platform: windows
       tls: schannel
       logProfile: Full.Light

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on:
      - self-hosted
      - "1ES.Pool=1es-msquic-pool"
-     - "1ES.ImageOverride=WSPrerelease"
+     - "1ES.ImageOverride=WinServerPrerelease"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
@@ -93,7 +93,7 @@ jobs:
     runs-on:
     - self-hosted
     - "1ES.Pool=1es-msquic-pool"
-    - "1ES.ImageOverride=WSPrerelease"
+    - "1ES.ImageOverride=WinServerPrerelease"
     env:
       main-timeout: 3600000
       main-repeat: 100
@@ -143,7 +143,7 @@ jobs:
     runs-on:
     - self-hosted
     - "1ES.Pool=1es-msquic-pool"
-    - "1ES.ImageOverride=WSPrerelease"
+    - "1ES.ImageOverride=WinServerPrerelease"
     env:
       main-timeout: 3600000
       pr-timeout: 600000

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -86,9 +86,9 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", xdp: "-UseXdp", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", xdp: "-UseXdp", test: "-Test" },
-          { config: "Debug", plat: "windows", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
         ]
-    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WSPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WSPrerelease'']') || matrix.vec.os }}
+    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease'']') || matrix.vec.os }}
     env:
       main-timeout: 3600000
       main-repeat: 100
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'windows'
       with:
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WSPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
@@ -150,9 +150,9 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", xdp: "-UseXdp", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", xdp: "-UseXdp", test: "-Test" },
-          { config: "Debug", plat: "windows", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
         ]
-    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WSPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WSPrerelease'']') || matrix.vec.os }}
+    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease'']') || matrix.vec.os }}
     env:
       main-timeout: 3600000
       pr-timeout: 600000
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'windows'
       with:
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WSPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,18 +110,18 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", xdp: "-UseXdp", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3", xdp: "-UseXdp", useqtip: "-UseQtip", test: "-Test" },
-          { config: "Debug", plat: "windows", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
-          { config: "Release", plat: "windows", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Release", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
         ]
-    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WSPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WSPrerelease'']') || matrix.vec.os }}
+    runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease'']') || matrix.vec.os }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Download Build Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       if: matrix.vec.plat == 'windows'
-      with: # note that BVT for WSPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WSPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
+      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -145,12 +145,12 @@ jobs:
         wevtutil.exe um $ManifestPath
         wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
     - name: Test
-      if: matrix.vec.os == 'WSPrerelease'
+      if: matrix.vec.os == 'WinServerPrerelease'
       shell: pwsh
       timeout-minutes: 120
       run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -GHA -LogProfile Full.Light -GenerateXmlResults ${{ matrix.vec.xdp }} ${{ matrix.vec.qtip }}
     - name: Test
-      if: matrix.vec.os != 'WSPrerelease'
+      if: matrix.vec.os != 'WinServerPrerelease'
       shell: pwsh
       timeout-minutes: 120
       run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults ${{ matrix.vec.xdp }} ${{ matrix.vec.qtip }}
@@ -170,22 +170,22 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", test: "-Test" },
           { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", test: "-Test" },
-          { config: "Debug", plat: "winkernel", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
-          { config: "Release", plat: "winkernel", os: "WSPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
+          { config: "Release", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", test: "-Test" },
         ]
-    runs-on: ${{ matrix.vec.plat == 'winkernel' && matrix.vec.os == 'WSPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WSPrerelease'']') || matrix.vec.os }}
+    runs-on: ${{ matrix.vec.plat == 'winkernel' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease'']') || matrix.vec.os }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Download Build Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-      with: # note that BVT for WSPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WSPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts for Testing From WinUser
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-      with: # note that BVT for WSPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-windows-${{ matrix.vec.os == 'WSPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-windows-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Prepare Machine
       shell: pwsh
@@ -220,7 +220,7 @@ jobs:
     runs-on:
     - self-hosted
     - "1ES.Pool=1es-msquic-pool"
-    - "1ES.ImageOverride=WSPrerelease"
+    - "1ES.ImageOverride=WinServerPrerelease"
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
## Description

WSPrerelease is misconfigured to replicate unnecessarily to our own compute gallery and storage account, which costs money. This can't be undone due to limitations of 1ES system.

## Testing

CI
