### PR TITLE
Fix Internal Build Break from XDP Kit Removal

### DIFF
--- a/.azure/azure-pipelines.periodic.yml
+++ b/.azure/azure-pipelines.periodic.yml
@@ -34,7 +34,7 @@ stages:
       arch: x64
       tls: schannel
       config: Release
-      extraPrepareArgs: -DisableTest -InstallXdpSdk
+      extraPrepareArgs: -DisableTest
       extraBuildArgs: -DisableTest -DisableTools -PGO
 
 - stage: build_winuser_openssl

--- a/.azure/obtemplates/build-winuser.yml
+++ b/.azure/obtemplates/build-winuser.yml
@@ -19,7 +19,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
-      arguments: -InstallXdpSdk -ForContainerBuild
+      arguments: -ForContainerBuild
   - task: PowerShell@2
     displayName: x64
     target: windows_build_container2


### PR DESCRIPTION
## Description

Removes leftover usages of old prepare-machine arguments.

## Testing

CI/CD

## Documentation

N/A
