### PR TITLE
Use American English Spelling of 'acknowledgment'

### DIFF
--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -78,7 +78,7 @@ The app then may respond to the event in a number of ways:
 
 ## Synchronous vs Asynchronous
 
-The app has the option of either processing the received data in the callback (synchronous) or queuing the work to a separate thread (asynchronous). If the app processes the data synchronously it must do so in a timely manner. Any significant delays will delay other QUIC processing (such as sending acknowledgements), which can cause protocol issues (dropped connections).
+The app has the option of either processing the received data in the callback (synchronous) or queuing the work to a separate thread (asynchronous). If the app processes the data synchronously it must do so in a timely manner. Any significant delays will delay other QUIC processing (such as sending acknowledgments), which can cause protocol issues (dropped connections).
 
 If the app wants to queue the data to a separate thread, the app must return `QUIC_STATUS_PENDING` from the receive callback. This informs MsQuic that the app still has an outstanding reference on the buffers, and it will not modify or free them. Once the app is done with the buffers it must call [StreamReceiveComplete](api/StreamReceiveComplete.md).
 

--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -107,7 +107,7 @@ This event is delivered whenever the transport (e.g. QUIC layer) determines the 
 
 - The handshake fails (any number of reasons).
 - The connection is idle for long enough.
-- The connection disconnects (loses contact with peer; no acknowledgements).
+- The connection disconnects (loses contact with peer; no acknowledgments).
 - The connection encounters a protocol violation.
 
 `Status`

--- a/docs/api/StreamShutdown.md
+++ b/docs/api/StreamShutdown.md
@@ -32,7 +32,7 @@ Value | Meaning
 **QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL**<br>1 | Indicates the app is gracefully shutting down the stream in the send direction.
 **QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND**<br>2 | Indicates the app is abortively shutting down the stream in the send direction.
 **QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE**<br>4 | Indicates the app is abortively shutting down the stream in the receive direction.
-**QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE**<br>8 | Indicates the app does not want to wait for the acknowledgement of the shutdown before getting the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event. Only allowed for abortive shutdowns.
+**QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE**<br>8 | Indicates the app does not want to wait for the acknowledgment of the shutdown before getting the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event. Only allowed for abortive shutdowns.
 
 `QUIC_STREAM_SHUTDOWN_FLAG_ABORT` is provided as a helper and is simply a logic OR of `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND` and `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE`.
 
@@ -48,7 +48,7 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 This function allows an app to (either gracefully or abortively) shut down one or both directions of a stream. For abortive shutdowns, the app specifies an `ErrorCode` that is transmitted to the peer to indicate why the shutdown happened. Graceful shutdowns have no error code as they are implied to be the normal operation of a stream.
 
-If the app doesn't care to wait for the acknowledgement of an abortive shutdown, it can use the `QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE` flag, which will result in MsQuic immediately (not necessarily inline to the call though) indicating the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event to the app, after which, the app may safely [StreamClose](StreamClose.md) the stream. MsQuic will internally maintain the stream for as long as necessary and then clean it up.
+If the app doesn't care to wait for the acknowledgment of an abortive shutdown, it can use the `QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE` flag, which will result in MsQuic immediately (not necessarily inline to the call though) indicating the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event to the app, after which, the app may safely [StreamClose](StreamClose.md) the stream. MsQuic will internally maintain the stream for as long as necessary and then clean it up.
 
 The stream can also be gracefully shutdown via the `QUIC_SEND_FLAG_FIN` flag. See [StreamSend](StreamSend.md) for more details.
 

--- a/src/core/ack_tracker.c
+++ b/src/core/ack_tracker.c
@@ -9,18 +9,18 @@ Abstract:
     (for duplicate packet detection) and all the packet numbers that need
     to be acknowledged via an ACK_FRAME sent back to the peer. It does all
     the framing for the ACK_FRAME. It also handles the receipt of an
-    acknowledgement for a previously sent ACK_FRAME. In response to that
-    acknowledgement, the Ack Tracker removes the packet number range (less than
+    acknowledgment for a previously sent ACK_FRAME. In response to that
+    acknowledgment, the Ack Tracker removes the packet number range (less than
     the largest packet number) that was sent in the ACK_FRAME from the current
     internal tracking structures. The result is that the Ack Tracker will
     continue to send ACK_FRAMES for received packet numbers until it receives
-    an acknowledgement for the frame; then those packet numbers are no longer
+    an acknowledgment for the frame; then those packet numbers are no longer
     sent in ACK_FRAMES.
 
     The reason the Ack Tracker removes all packet numbers less than or equal to
     the largest packet number in an ACK_FRAME when that frame is acknowledged
     is because we make the assumption that by the time it gets that
-    acknowledgement, everything in that range was either completely lost or
+    acknowledgment, everything in that range was either completely lost or
     included in the ACK_FRAME and has been acknowledged.
 
     There is a possible scenario where the Ack Tracker receives packets out of

--- a/src/core/bbr.h
+++ b/src/core/bbr.h
@@ -168,13 +168,13 @@ typedef struct QUIC_CONGESTION_CONTROL_BBR {
     uint64_t CycleStart;
 
     //
-    // Receiving acknowledgement of a packet after EndoOfRoundTrip will
+    // Receiving acknowledgment of a packet after EndoOfRoundTrip will
     // indicate the current round trip is ended
     //
     uint64_t EndOfRoundTrip;
 
     //
-    // Receiving acknowledgement of a packet after EndoOfRecovery will cause
+    // Receiving acknowledgment of a packet after EndoOfRecovery will cause
     // BBR to exit the recovery mode
     //
     uint64_t EndOfRecovery;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -4421,7 +4421,7 @@ QuicConnRecvDecryptAndAuthenticate(
 
     if (Packet->IsShortHeader) {
         QUIC_PACKET_SPACE* PacketSpace = Connection->Packets[QUIC_ENCRYPT_LEVEL_1_RTT];
-        if (Packet->KeyType == QUIC_PACKET_KEY_1_RTT_NEW) {
+        if (Paacknowledgment= QUIC_PACKET_KEY_1_RTT_NEW) {
 
             QuicCryptoUpdateKeyPhase(Connection, FALSE);
             PacketSpace->ReadKeyPhaseStartPacketNumber = Packet->PacketNumber;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -4421,7 +4421,7 @@ QuicConnRecvDecryptAndAuthenticate(
 
     if (Packet->IsShortHeader) {
         QUIC_PACKET_SPACE* PacketSpace = Connection->Packets[QUIC_ENCRYPT_LEVEL_1_RTT];
-        if (Paacknowledgment= QUIC_PACKET_KEY_1_RTT_NEW) {
+        if (Packet->KeyType == QUIC_PACKET_KEY_1_RTT_NEW) {
 
             QuicCryptoUpdateKeyPhase(Connection, FALSE);
             PacketSpace->ReadKeyPhaseStartPacketNumber = Packet->PacketNumber;

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -148,7 +148,7 @@ typedef union QUIC_CONNECTION_STATE {
         BOOLEAN ResumptionEnabled : 1;
 
         //
-        // When true, this indicates that reordering shouldn't elict an
+        // When true,acknowledgment that reordering shouldn't elict an
         // immediate acknowledgement.
         //
         BOOLEAN IgnoreReordering : 1;
@@ -446,13 +446,13 @@ typedef struct QUIC_CONNECTION {
 
     //
     // The number of packets that must be received before eliciting an immediate
-    // acknowledgement. May be updated by the peer via the ACK_FREQUENCY frame.
+    // acknowledgment. May be updated by the peer via the ACK_FREQUENCY frame.
     //
     uint8_t PacketTolerance;
 
     //
     // The number of packets we want the peer to wait before sending an
-    // immediate acknowledgement. Requires the ACK_FREQUENCY extension/frame to
+    // immediate acknowledgment. Requires the ACK_FREQUENCY extension/frame to
     // be able to send to the peer.
     //
     uint8_t PeerPacketTolerance;

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1584,7 +1584,7 @@ QuicLossDetectionProcessAckBlocks(
 
         //
         // Handle packet loss (and any possible congestion events) before
-        // data acknowledgement so that we have an accurate bytes in flight
+        // data acknowledgment so that we have an accurate bytes in flight
         // calculation for congestion events.
         //
         QuicLossDetectionDetectAndHandleLostPackets(LossDetection, TimeNow);

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -297,7 +297,7 @@ CXPLAT_STATIC_ASSERT(QUIC_INITIAL_PACKET_LENGTH >= QUIC_MIN_INITIAL_PACKET_LENGT
 //
 // The number of milliseconds that must elapse before a connection is
 // considered disconnected; that is, the time a connection waits for an
-// expected acknowledgement for packets it has sent before it considers the
+// expected acknowledgment for packets it has sent before it considers the
 // path dead.
 //
 #define QUIC_DEFAULT_DISCONNECT_TIMEOUT         16000   // 16 seconds, in ms

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1459,7 +1459,7 @@ QuicSendFlush(
             // We're scheduling limited, so we should tell the peer to use our
             // (max) batch size + 1 as the peer tolerance as a hint that they
             // should expect more than a single batch before needing to send an
-            // acknowledgement back.
+            // acknowledgment back.
             //
             QuicConnUpdatePeerPacketTolerance(Connection, Builder.TotalCountDatagrams + 1);
         }

--- a/src/core/transport_params.h
+++ b/src/core/transport_params.h
@@ -77,7 +77,7 @@ typedef struct QUIC_TRANSPORT_PARAMETERS {
 
     //
     // A variable-length integer representing the minimum amount of time in
-    // microseconds by which the endpoint can delay an acknowledgement. Values
+    // microseconds by which the endpoint can delay an acknowledgment. Values
     // of 2^24 or greater are invalid.
     //
     // The presence of the parameter also advertises support of the ACK

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -200,7 +200,7 @@ typedef union QUIC_CONNECTION_STATE {
         BOOLEAN ResumptionEnabled : 1;
 
         //
-        // When true, this indicates that reordering shouldn't elict an
+        // When true,acknowledgment that reordering shouldn't elict an
         // immediate acknowledgement.
         //
         BOOLEAN IgnoreReordering : 1;


### PR DESCRIPTION
## Description

Remove the 'e' used in British English version of the word.

## Testing

N/A

## Documentation

Updated
