### PR TITLE
Fix Internal Build Referencing Preview Features

### DIFF
--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -2117,6 +2117,7 @@ TEST(Misc, StreamBlockUnblockBidiConnFlowControl) {
     }
 }
 
+#ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
 TEST(Misc, StreamReliableReset) {
     TestLogger Logger("StreamReliableReset");
     if (TestingKernelMode) {
@@ -2134,6 +2135,7 @@ TEST(Misc, StreamReliableResetMultipleSends) {
         QuicTestStreamReliableResetMultipleSends();
     }
 }
+#endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 
 TEST(Misc, StreamBlockUnblockUnidiConnFlowControl) {
     TestLogger Logger("StreamBlockUnblockUnidiConnFlowControl");

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -1490,6 +1490,7 @@ QuicTestCtlEvtIoDeviceControl(
                 Params->CustomCertValidationParams.AcceptCert,
                 Params->CustomCertValidationParams.AsyncValidation));
         break;
+
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     case IOCTL_QUIC_RELIABLE_RESET_NEGOTIATION:
         CXPLAT_FRE_ASSERT(Params != nullptr);
@@ -1499,6 +1500,7 @@ QuicTestCtlEvtIoDeviceControl(
                 Params->FeatureNegotiationParams.ServerSupport,
                 Params->FeatureNegotiationParams.ClientSupport));
         break;
+
     case IOCTL_QUIC_ONE_WAY_DELAY_NEGOTIATION:
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -5003,6 +5003,8 @@ void QuicTestStreamParam()
             TEST_EQUAL(Length, sizeof(QUIC_STREAM_STATISTICS));
         }
     }
+
+#ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
     //
     // QUIC_PARAM_STREAM_RELIABLE_OFFSET
     // QUIC_PARAM_STREAM_RELIABLE_OFFSET_RECV
@@ -5071,6 +5073,7 @@ void QuicTestStreamParam()
                     &Buffer));
         }
     }
+#endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 }
 
 void

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3336,7 +3336,7 @@ struct StreamReliableReset {
     }
 };
 
-
+#ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
 void
 QuicTestStreamReliableReset(
     )
@@ -3410,6 +3410,7 @@ QuicTestStreamReliableReset(
         TEST_TRUE(Context.ShutdownErrorCode == AbortSendShutdownErrorCode);
     }
 }
+
 void
 QuicTestStreamReliableResetMultipleSends(
     )
@@ -3492,3 +3493,4 @@ QuicTestStreamReliableResetMultipleSends(
     // Test Error code matches what we sent.
     TEST_TRUE(Context.ShutdownErrorCode == AbortShutdownErrorCode);
 }
+#endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -1457,6 +1457,7 @@ QuicTestValidateStreamEvents9(
 {
     TestScopeLogger ScopeLogger(__FUNCTION__);
 
+#ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
     MsQuicSettings Settings;
     Settings.SetPeerBidiStreamCount(1).SetMinimumMtu(1280).SetMaximumMtu(1280);
     Settings.SetReliableResetEnabled(true);
@@ -1575,6 +1576,11 @@ QuicTestValidateStreamEvents9(
      TEST_TRUE(Server.Complete.WaitTimeout(1000));
     } // Stream scope
     } // Connections scope
+#else // QUIC_PARAM_STREAM_RELIABLE_OFFSET
+    UNREFERENCED_PARAMETER(Registration);
+    UNREFERENCED_PARAMETER(Listener);
+    UNREFERENCED_PARAMETER(ServerLocalAddr);
+#endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 }
 
 void QuicTestValidateStreamEvents(uint32_t Test)


### PR DESCRIPTION
## Description

Internal build doesn't use preview features for tests. The code needs to account for this at build time.

## Testing

CI/CD

## Documentation

N/A
