### PR TITLE
Fix Original Destination CID Query

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2427,8 +2427,6 @@ QuicConnGenerateLocalTransportParameters(
                 LocalTP->OriginalDestinationConnectionID,
                 Connection->OrigDestCID->Data,
                 Connection->OrigDestCID->Length);
-            CXPLAT_FREE(Connection->OrigDestCID, QUIC_POOL_CID);
-            Connection->OrigDestCID = NULL;
 
             if (Connection->State.HandshakeUsedRetryPacket) {
                 CXPLAT_DBG_ASSERT(SourceCid->Link.Next != NULL);
@@ -2648,8 +2646,6 @@ QuicConnValidateTransportParameterCIDs(
                 "Original destination CID from TP doesn't match");
             return FALSE;
         }
-        CXPLAT_FREE(Connection->OrigDestCID, QUIC_POOL_CID);
-        Connection->OrigDestCID = NULL;
         if (Connection->State.HandshakeUsedRetryPacket) {
             if (!(Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_RETRY_SOURCE_CONNECTION_ID)) {
                 QuicTraceEvent(

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -370,6 +370,13 @@ QuicTestConnect(
                         ClientSecrets.ServerTrafficSecret0,
                         ServerSecrets.SecretLength));
 
+                uint8_t ClientOrigCid[32], ServerOrigCid[32];
+                uint32_t ClientOrigCidLen, ServerOrigCidLen;
+                TEST_QUIC_SUCCEEDED(Client.GetOrigDestCid(ClientOrigCid, ClientOrigCidLen));
+                TEST_QUIC_SUCCEEDED(Server->GetOrigDestCid(ServerOrigCid, ServerOrigCidLen));
+                TEST_EQUAL(ClientOrigCidLen, ServerOrigCidLen);
+                TEST_TRUE(!memcmp(ClientOrigCid, ServerOrigCid, ClientOrigCidLen));
+
                 if (ClientUsesOldVersion) {
                     TEST_EQUAL(Server->GetQuicVersion(), OLD_SUPPORTED_VERSION);
                 } else {

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -388,6 +388,21 @@ TestConnection::SetRemoteAddr(
             &remoteAddr.SockAddr);
 }
 
+QUIC_STATUS
+TestConnection::GetOrigDestCid(
+    _Out_ uint8_t Bytes[32],
+    _Out_ uint32_t& Length
+    )
+{
+    Length = sizeof(uint8_t[32]);
+    return
+        MsQuic->GetParam(
+            QuicConnection,
+            QUIC_PARAM_CONN_ORIG_DEST_CID,
+            &Length,
+            Bytes);
+}
+
 QUIC_SETTINGS
 TestConnection::GetSettings() const
 {

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -253,6 +253,8 @@ public:
     QUIC_STATUS GetRemoteAddr(_Out_ QuicAddr &remoteAddr);
     QUIC_STATUS SetRemoteAddr(_In_ const QuicAddr &remoteAddr);
 
+    QUIC_STATUS GetOrigDestCid(_Out_ uint8_t Bytes[32], _Out_ uint32_t& Length);
+
     bool GetEcnEnabled();
     QUIC_STATUS SetEcnEnabled(bool value);
 


### PR DESCRIPTION
## Description

The original destination CID field was getting freed when it was no longer used, but that's not very helpful to external consumers of it, so we need to remove the early free logic.

## Testing

Updated the handshake tests to verify.

## Documentation

N/A
