### PR TITLE
Use a newer docker image for Onebranch build pipeline

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -27,7 +27,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'WindowsContainerImage2DockerTag'
   displayName: 'WindowsContainerImage2 DockerTag'
   type: string
-  default: 'vse2022.5'
+  default: '20231125.1' # if initializing docker takes too long, grab the a newer docker image from Docker.Official pipeline.
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning

--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -27,7 +27,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'WindowsContainerImage2DockerTag'
   displayName: 'WindowsContainerImage2 DockerTag'
   type: string
-  default: '20231125.1' # if initializing docker takes too long, grab the a newer docker image from Docker.Official pipeline.
+  default: '20231125.1' # if initializing docker takes too long, grab a newer docker image from Docker.Official pipeline.
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning


### PR DESCRIPTION
## Description

The current image isn't cached anymore. Use a newer image that's cached.

## Testing

OB CI
