### PR TITLE
Fix stdout Logging Build

### DIFF
--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -34,6 +34,7 @@ typedef struct QUIC_CREDENTIAL_CONFIG_HELPER {
     };
 } QUIC_CREDENTIAL_CONFIG_HELPER;
 
+#if defined(__cplusplus)
 //
 // Converts the QUIC Status Code to a string for console output.
 //
@@ -70,6 +71,7 @@ QuicStatusToString(
 
     return "UNKNOWN";
 }
+#endif // defined(__cplusplus)
 
 //
 // Helper function to get the RTT (in microseconds) from a MsQuic Connection or Stream handle.


### PR DESCRIPTION
## Description

Fixes #4001 because of a difference between C & C++ that only shows up when building stdout logging stuff.

## Testing

Built locally before and after.

## Documentation

N/A
