### PR TITLE
Fix cross-compile docker image building

### DIFF
--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -53,7 +53,9 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsof
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 
-RUN cat /etc/apt/sources.list | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
+    cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
+    rm /etc/apt/sources.list.int
 
 COPY arm-cross-compile-sources.list /etc/apt/sources.list.d/
 

--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -4,6 +4,8 @@ LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+SHELL ["/bin/bash", "-c"]
+
 RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-https \
     ca-certificates \
     gnupg \
@@ -57,7 +59,11 @@ RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
     cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
     rm /etc/apt/sources.list.int
 
-COPY arm-cross-compile-sources.list /etc/apt/sources.list.d/
+RUN echo $' \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal main restricted universe multiverse \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates main restricted universe multiverse \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse \n\
+' > /etc/apt/sources.list.d/arm-cross-compile-sources.list
 
 RUN apt-get update
 

--- a/.docker/ubuntu-20.04/arm-cross-compile-sources.list
+++ b/.docker/ubuntu-20.04/arm-cross-compile-sources.list
@@ -1,7 +1,0 @@
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal main restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates main restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal multiverse
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates multiverse
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse

--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -4,6 +4,8 @@ LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+SHELL ["/bin/bash", "-c"]
+
 RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-https \
     ca-certificates \
     gnupg \
@@ -57,7 +59,11 @@ RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
     cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
     rm /etc/apt/sources.list.int
 
-COPY arm-cross-compile-sources.list /etc/apt/sources.list.d/
+RUN echo $' \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse \n\
+deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse \n\
+' > /etc/apt/sources.list.d/arm-cross-compile-sources.list
 
 RUN apt-get update
 

--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -53,7 +53,9 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsof
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 
-RUN cat /etc/apt/sources.list | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
+    cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
+    rm /etc/apt/sources.list.int
 
 COPY arm-cross-compile-sources.list /etc/apt/sources.list.d/
 

--- a/.docker/ubuntu-22.04/arm-cross-compile-sources.list
+++ b/.docker/ubuntu-22.04/arm-cross-compile-sources.list
@@ -1,7 +1,0 @@
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy main restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-updates main restricted
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-updates universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy multiverse
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-updates multiverse
-deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse


### PR DESCRIPTION
## Description

One of the steps is modifying sources.list to add amd64 label for each repo. This step prints out the file and eventually redirects the output to the file itself. This doesn't work like a programming language where the statements are normally evaluated from left to right. The output of the redirection might get created before anything else, in which case, the resulting file will be empty. It seems like on a newer kernel, this particular step `RUN cat /etc/apt/sources.list | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list` always generates an empty file whereas on an older kernel, it always generates the result that the step is intended to do.

Just never overwrite the file itself in a unix pipeline!

## Testing

CI
