### PR TITLE
fix: apply lb settings after lb mode change

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -839,6 +839,8 @@ QuicLibrarySetGlobalParam(
             "[ lib] Updated load balancing mode = %hu",
             MsQuicLib.Settings.LoadBalancingMode);
 
+        QuicLibApplyLoadBalancingSetting();
+
         Status = QUIC_STATUS_SUCCESS;
         break;
     }


### PR DESCRIPTION
## Description

Without this fix, the CID prefix len: `MsQuicLib.CidServerIdLength` and source CID length (`MsQuicLib.CidTotalLength`) are not updated after changing the lb mode from disabled (default) to `QUIC_LOAD_BALANCING_SERVER_ID_IP` which causes the Server source CIDs are not prefixed with src IP. 


## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
