### PR TITLE
fix: apply lb settings after lb mode change

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -856,6 +856,9 @@ QuicLibrarySetGlobalParam(
 
         MsQuicLib.Settings.LoadBalancingMode = *(uint16_t*)Buffer;
         MsQuicLib.Settings.IsSet.LoadBalancingMode = TRUE;
+
+        QuicLibApplyLoadBalancingSetting();
+
         QuicTraceLogInfo(
             LibraryLoadBalancingModeSet,
             "[ lib] Updated load balancing mode = %hu",

--- a/src/core/unittest/SettingsTest.cpp
+++ b/src/core/unittest/SettingsTest.cpp
@@ -525,6 +525,31 @@ TEST(SettingsTest, GlobalSettingsSizesSet)
     }
 }
 
+TEST(SettingsTest, GlobalLoadBalancingServerIDSet)
+{
+    uint16_t Mode = QUIC_LOAD_BALANCING_SERVER_ID_IP;
+    uint16_t OldMode = MsQuicLib.Settings.LoadBalancingMode;
+
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        QuicLibrarySetGlobalParam(
+            QUIC_PARAM_GLOBAL_LOAD_BALACING_MODE,
+            sizeof(Mode),
+            &Mode));
+
+    ASSERT_EQ(Mode, MsQuicLib.Settings.LoadBalancingMode);
+    ASSERT_EQ(5, MsQuicLib.CidServerIdLength);
+    ASSERT_EQ(QUIC_CID_PID_LENGTH + QUIC_CID_PAYLOAD_LENGTH + 5, MsQuicLib.CidTotalLength);
+
+    // Revert
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        QuicLibrarySetGlobalParam(
+            QUIC_PARAM_GLOBAL_LOAD_BALACING_MODE,
+            sizeof(OldMode),
+            &OldMode));
+}
+
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 TEST(SettingsTest, GlobalExecutionConfigSetAndGet)
 {


### PR DESCRIPTION
## Description

Fixing an issue where the CID prefix
lengths (`MsQuicLib.CidServerIdLength` and `MsQuicLib.CidTotalLength`) weren't being updated properly when transitioning the lb mode from its default state (disabled) to `QUIC_LOAD_BALANCING_SERVER_ID_IP`. This resulted in the server source CIDs not being prefixed with the source IP

## Testing

New unittest:
```TEST(SettingsTest, GlobalLoadBalancingServerIDSet)```

## Documentation

NO
