### PR TITLE
Remove Windows 2019 Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [windows, uwp] # TODO: Support gamecore_console
-        os: ['windows-2019', 'windows-2022']
+        os: ['windows-2022']
         arch: [x86, x64, arm64]
         tls: [schannel, openssl, openssl3]
         static: ['', '-Static']
@@ -62,7 +62,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [winkernel]
-        os: ['windows-2019', 'windows-2022']
+        os: ['windows-2022']
         arch: [x64, arm64]
         tls: [schannel]
     uses: ./.github/workflows/build-reuse-winkernel.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
       if: matrix.vec.plat == 'windows'
       with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
@@ -178,12 +178,12 @@ jobs:
     - name: Download Build Artifacts
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
       with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts for Testing From WinUser
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
       with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-windows-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Prepare Machine
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl", test: "-Test" },
-          { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl3", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", sanitize: "-Sanitize", test: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", test: "-Test" },
@@ -120,8 +118,8 @@ jobs:
     - name: Download Build Artifacts
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
       if: matrix.vec.plat == 'windows'
-      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
@@ -179,13 +177,13 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Download Build Artifacts
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
-      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Download Build Artifacts for Testing From WinUser
       uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
-      with: # note that BVT for WinServerPrerelease uses binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-windows-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-windows-'windows-2022'-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.test }}
         path: artifacts
     - name: Prepare Machine
       shell: pwsh


### PR DESCRIPTION
## Description

No longer build on Windows Server 2019 as it is causing breaks in PGO. Still test on 2019, but use 2022 built binaries.

## Testing

CI/CD

## Documentation

N/A
