### PR TITLE
Restart Server on Each NetPerf Test Run

### DIFF
--- a/.github/workflows/build-reuse-winkernel.yml
+++ b/.github/workflows/build-reuse-winkernel.yml
@@ -73,11 +73,11 @@ jobs:
     - name: Build
       if: inputs.build == '-Test'
       shell: pwsh
-      run: msbuild msquic.kernel.sln /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.arch }} /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_GIT_HASH=${{ github.sha }}
+      run: msbuild msquic.kernel.sln /m /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.arch }} /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_GIT_HASH=${{ github.sha }}
     - name: Build
       if: inputs.build == ''
       shell: pwsh
-      run: msbuild msquic.kernel.sln /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.arch }} /p:QUIC_VER_SUFFIX=-official
+      run: msbuild msquic.kernel.sln /m /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.arch }} /p:QUIC_VER_SUFFIX=-official
     - name: Sign Kernel
       shell: pwsh
       run: scripts/sign.ps1 -Config ${{ inputs.config }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }}

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -330,7 +330,7 @@ function Install-TestCertificates {
     if (!$IsWindows -or !(Win-SupportsCerts)) { return } # Windows only
     $DnsNames = $env:computername,"localhost","127.0.0.1","::1","192.168.1.11","192.168.1.12","fc00::1:11","fc00::1:12"
     $NewRoot = $false
-    Write-Host "Searching for MsQuicTestRoot certificate..."
+    Write-Debug "Searching for MsQuicTestRoot certificate..."
     $RootCert = Get-ChildItem -path Cert:\LocalMachine\Root\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestRoot"}
     if (!$RootCert) {
         Write-Host "MsQuicTestRoot not found! Creating new MsQuicTestRoot certificate..."
@@ -342,10 +342,10 @@ function Install-TestCertificates {
         $NewRoot = $true
         Write-Host "New MsQuicTestRoot certificate installed!"
     } else {
-        Write-Host "Found existing MsQuicTestRoot certificate!"
+        Write-Debug "Found existing MsQuicTestRoot certificate!"
     }
 
-    Write-Host "Searching for MsQuicTestServer certificate..."
+    Write-Debug "Searching for MsQuicTestServer certificate..."
     $ServerCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestServer"}
     if (!$ServerCert) {
         Write-Host "MsQuicTestServer not found! Creating new MsQuicTestServer certificate..."
@@ -356,10 +356,10 @@ function Install-TestCertificates {
         Remove-Item $TempServerPath
         Write-Host "New MsQuicTestServer certificate installed!"
     } else {
-        Write-Host "Found existing MsQuicTestServer certificate!"
+        Write-Debug "Found existing MsQuicTestServer certificate!"
     }
 
-    Write-Host "Searching for MsQuicTestExpiredServer certificate..."
+    Write-Debug "Searching for MsQuicTestExpiredServer certificate..."
     $ExpiredServerCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestExpiredServer"}
     if (!$ExpiredServerCert) {
         Write-Host "MsQuicTestExpiredServer not found! Creating new MsQuicTestExpiredServer certificate..."
@@ -370,10 +370,10 @@ function Install-TestCertificates {
         Remove-Item $TempExpiredServerPath
         Write-Host "New MsQuicTestExpiredServer certificate installed!"
     } else {
-        Write-Host "Found existing MsQuicTestExpiredServer certificate!"
+        Write-Debug "Found existing MsQuicTestExpiredServer certificate!"
     }
 
-    Write-Host "Searching for MsQuicTestClient certificate..."
+    Write-Debug "Searching for MsQuicTestClient certificate..."
     $ClientCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestClient"}
     if (!$ClientCert) {
         Write-Host "MsQuicTestClient not found! Creating new MsQuicTestClient certificate..."
@@ -384,10 +384,10 @@ function Install-TestCertificates {
         Remove-Item $TempClientPath
         Write-Host "New MsQuicTestClient certificate installed!"
     } else {
-        Write-Host "Found existing MsQuicTestClient certificate!"
+        Write-Debug "Found existing MsQuicTestClient certificate!"
     }
 
-    Write-Host "Searching for MsQuicTestExpiredClient certificate..."
+    Write-Debug "Searching for MsQuicTestExpiredClient certificate..."
     $ExpiredClientCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestExpiredClient"}
     if (!$ExpiredClientCert) {
         Write-Host "MsQuicTestExpiredClient not found! Creating new MsQuicTestExpiredClient certificate..."
@@ -398,7 +398,7 @@ function Install-TestCertificates {
         Remove-Item $TempExpiredClientPath
         Write-Host "New MsQuicTestExpiredClient certificate installed!"
     } else {
-        Write-Host "Found existing MsQuicTestExpiredClient certificate!"
+        Write-Debug "Found existing MsQuicTestExpiredClient certificate!"
     }
 
     if ($NewRoot) {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -29,8 +29,8 @@ function Configure-DumpCollection {
             New-Item -Path $WerDumpRegPath -Force | Out-Null
         }
         $DumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/crashdumps"
-        Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value $DumpDir
-        Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2
+        Set-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -Value $DumpDir
+        Set-ItemProperty -Path $WerDumpRegPath -Name DumpType -Value 2
     } else {
         # TODO: Configure Linux to collect dumps.
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -208,12 +208,13 @@ function Invoke-Secnetperf {
             $successCount++
         } catch {
             Write-GHError $_
-            //$hasFailures = $true
+            #$hasFailures = $true
         }
         Start-Sleep -Seconds 1 | Out-Null
     }
     if ($successCount -eq 0) {
         $hasFailures = $true # For now, consider failure only if all failed
+    }
 
     } catch {
         Write-GHError "Exception while running test case!"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -19,13 +19,13 @@ function Configure-DumpCollection {
     param ($Session)
     if ($isWindows) {
         Invoke-Command -Session $Session -ScriptBlock {
-            if (!(Test-Path $Using:WerDumpRegPath) -and (Test-Administrator)) {
+            if (!(Test-Path $Using:WerDumpRegPath)) {
                 New-Item -Path $Using:WerDumpRegPath -Force | Out-Null
             }
             Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value "C:/_work/quic/artifacts/crashdumps"
             Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2
         }
-        if (!(Test-Path $WerDumpRegPath) -and (Test-Administrator)) {
+        if (!(Test-Path $WerDumpRegPath)) {
             New-Item -Path $WerDumpRegPath -Force | Out-Null
         }
         $DumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/crashdumps"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -157,10 +157,11 @@ function Invoke-Secnetperf {
             try { .\scripts\log.ps1 -Stop -OutputPath "./artifacts/logs/$metric-$tcp/client" -RawLogOnly }
             catch { Write-Host "Failed to stop logging on client!" }
             Invoke-Command -Session $Session -ScriptBlock {
-                try { & "$Using:RemoteDir/scripts/log.ps1" -Stop -OutputPath "$Using:RemoteDir/artifacts/logs/$Using:metric-$Using:tcp/server" -RawLogOnly }
+                try { & "$Using:RemoteDir/scripts/log.ps1" -Stop -OutputPath "$Using:RemoteDir/artifacts/logs/$Using:metric-$Using:tcp/server" -RawLogOnly
+                      dir "$Using:RemoteDir/artifacts/logs/$Using:metric-$Using:tcp" }
                 catch { Write-Host "Failed to stop logging on server!" }
             }
-            try { Copy-Item -FromSession $Session "$RemoteDir/artifacts/logs/$metric-$tcp/server*" "./artifacts/logs/$metric-$tcp/" }
+            try { Copy-Item -FromSession $Session "$RemoteDir/artifacts/logs/$metric-$tcp/*" "./artifacts/logs/$metric-$tcp/" }
             catch { Write-Host "Failed to copy server logs!" }
         }
     }}

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -106,7 +106,7 @@ function Invoke-Secnetperf {
 
     if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
         Invoke-Command -Session $Session -ScriptBlock {
-            & "$Using:RemoteDir/scripts/log.ps1" -Start -Profile $LogProfile -ProfileInScriptDirectory
+            & "$Using:RemoteDir/scripts/log.ps1" -Start -Profile $Using:LogProfile -ProfileInScriptDirectory
         }
         .\scripts\log.ps1 -Start -Profile $LogProfile
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -19,7 +19,7 @@ function Start-RemoteServer {
     $Job = Invoke-Command -Session $Session -ScriptBlock { iex $Using:Command } -AsJob
     # Poll the job for 10 seconds to see if it started.
     $StopWatch =  [system.diagnostics.stopwatch]::StartNew()
-    while ($StopWatch.ElapsedMilliseconds -lt 10000) {
+    while ($StopWatch.ElapsedMilliseconds -lt 30000) {
         $CurrentResults = Receive-Job -Job $Job -Keep -ErrorAction Continue
         if (![string]::IsNullOrWhiteSpace($CurrentResults)) {
             $DidMatch = $CurrentResults -match "Started!" # Look for the special string to indicate success.

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -3,6 +3,9 @@
     Various helper functions for running secnetperf tests.
 #>
 
+Set-StrictMode -Version 'Latest'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
 # Write a GitHub error message to the console.
 function Write-GHError($msg) {
     Write-Host "::error::$msg"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -150,5 +150,5 @@ function Invoke-Secnetperf {
         }
     }}
 
-    return [TestResult]::New($metric, $values, $hasFailures)
+    return [TestResult]::new($metric, $values, $hasFailures)
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -232,8 +232,10 @@ function Invoke-Secnetperf {
             try { Copy-Item -FromSession $Session "$RemoteDir/artifacts/logs/$metric-$tcp/*" "./artifacts/logs/$metric-$tcp/" }
             catch { Write-Host "Failed to copy server logs!" }
         }
-        Collect-LocalDumps "./artifacts/logs/$metric-$tcp/clientdumps"
-        Collect-RemoteDumps $Session "./artifacts/logs/$metric-$tcp/serverdumps"
+        if (Collect-LocalDumps "./artifacts/logs/$metric-$tcp/clientdumps" -or `
+            Collect-RemoteDumps $Session "./artifacts/logs/$metric-$tcp/serverdumps") {
+            $hasFailures = $true
+        }
     }}
 
     return [TestResult]::new($metric, $values, $hasFailures)

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -19,18 +19,17 @@ function Configure-DumpCollection {
     param ($Session)
     if ($isWindows) {
         Invoke-Command -Session $Session -ScriptBlock {
-            if (!(Test-Path $Using:WerDumpRegPath)) {
-                New-Item -Path $Using:WerDumpRegPath -Force | Out-Null
-            }
-            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value "C:/_work/quic/artifacts/crashdumps"
-            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2
-        }
-        if (!(Test-Path $WerDumpRegPath)) {
-            New-Item -Path $WerDumpRegPath -Force | Out-Null
+            $DumpDir = "C:/_work/quic/artifacts/crashdumps"
+            New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
+            New-Item -Path $Using:WerDumpRegPath -Force -ErrorAction Ignore | Out-Null
+            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value $DumpDir | Out-Null
+            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2 | Out-Null
         }
         $DumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/crashdumps"
-        Set-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -Value $DumpDir
-        Set-ItemProperty -Path $WerDumpRegPath -Name DumpType -Value 2
+        New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
+        New-Item -Path $WerDumpRegPath -Force -ErrorAction Ignore | Out-Null
+        Set-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -Value $DumpDir | Out-Null
+        Set-ItemProperty -Path $WerDumpRegPath -Name DumpType -Value 2 | Out-Null
     } else {
         # TODO: Configure Linux to collect dumps.
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -163,5 +163,5 @@ function Invoke-Secnetperf {
         }
     }}
 
-    return TestResult::New($metric, $Results, $encounterFailures)
+    return [TestResult]::New($metric, $Results, $encounterFailures)
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -75,7 +75,7 @@ class TestResult {
     TestResult (
         [string]$Metric,
         [System.Object[]]$Values,
-        [string]$EncounteredFailures
+        [bool]$EncounteredFailures
     ) {
         $this.Metric = $Metric;
         $this.Values = $Values;

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -137,7 +137,7 @@ function Invoke-Secnetperf {
             Write-GHError $_
             $hasFailures = $true
         }
-        Start-Sleep -Seconds 1
+        Start-Sleep -Seconds 1 | Out-Null
     }
 
     } catch {
@@ -147,7 +147,7 @@ function Invoke-Secnetperf {
         $hasFailures = $true
     } finally {
         # Stop the server
-        try { Stop-RemoteServer $Job $RemoteName } catch { } # Ignore failures for now
+        try { Stop-RemoteServer $Job $RemoteName | Out-Null } catch { } # Ignore failures for now
         if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
             .\scripts\log.ps1 -Stop -OutputPath "./artifacts/logs/$metric-$tcp/client" -RawLogOnly
         }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -19,8 +19,14 @@ function Configure-DumpCollection {
     param ($Session)
     if ($isWindows) {
         Invoke-Command -Session $Session -ScriptBlock {
+            if (!(Test-Path $Using:WerDumpRegPath) -and (Test-Administrator)) {
+                New-Item -Path $Using:WerDumpRegPath -Force | Out-Null
+            }
             Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value "C:/_work/quic/artifacts/crashdumps"
             Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2
+        }
+        if (!(Test-Path $WerDumpRegPath) -and (Test-Administrator)) {
+            New-Item -Path $WerDumpRegPath -Force | Out-Null
         }
         $DumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/crashdumps"
         Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value $DumpDir

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -69,12 +69,9 @@ function Stop-RemoteServer {
 
 # Invokes secnetperf with the given arguments for both TCP and QUIC.
 function Invoke-Secnetperf {
-    param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $ExeArgs, $MsQuicCommit, $i)
+    param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $ExeArgs, $MsQuicCommit, $testid, $SQL, $json)
 
-    $SQL = ""
-    $json = @{}
     $encounterFailures = $true
-    $testid = $i + 1
     $env = $isWindows ? 1 : 2
 
     # TODO: Improve this stuff
@@ -113,7 +110,6 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
         } catch {
             Write-GHError "Invoke-Expression exception encountered!"
             Write-GHError $_
-            Get-Error
             $_ | Format-List *
             $encounterFailures = $true
             continue
@@ -162,7 +158,6 @@ VALUES ($testid, '$MsQuicCommit', $env, $env, $num, NULL);
     } catch {
         Write-GHError "Inner exception while running test case!"
         Write-GHError $_
-        Get-Error
         $_ | Format-List *
         $encounterFailures = $true
     } finally {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -71,7 +71,8 @@ function Stop-RemoteServer {
 function Invoke-Secnetperf {
     param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $ExeArgs, $MsQuicCommit, $i)
 
-    $SQL = ""
+    $SQL = @"
+"@
     $json = @{}
     $encounterFailures = $true
 
@@ -150,7 +151,6 @@ VALUES ($testid, '$MsQuicCommit', $env, $env, $num, NULL);
 "@
         # Generate JSON as intermediary file for dashboard
         $json["$metric-$transport"] = $num
-        break
 
         Start-Sleep -Seconds 1
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -120,7 +120,7 @@ function Invoke-Secnetperf {
         try {
             $rawOutput = Invoke-Expression $command
             if ($null -eq $rawOutput) {
-                throw "Output is empty!."
+                throw "Output is empty!"
             }
             if ($rawOutput.Contains("Error")) {
                 throw $rawOutput.Substring(7) # Skip over the 'Error: ' prefix

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -185,6 +185,7 @@ function Invoke-Secnetperf {
     $Job = Start-RemoteServer $Session "$RemoteDir/$SecNetPerfPath $execMode"
 
     # Run the test multiple times, failing (for now) only if all tries fail.
+    # TODO: Once all failures have been fixed, consider all errors fatal.
     $successCount = 0
     for ($try = 0; $try -lt 3; $try++) {
         try {
@@ -246,11 +247,11 @@ function Invoke-Secnetperf {
         # Grab any crash dumps that were generated.
         if (Collect-LocalDumps "./artifacts/logs/$ArtifactName/clientdumps") {
             Write-Host "Dump file(s) generated locally"
-            $hasFailures = $true
+            #$hasFailures = $true
         }
         if (Collect-RemoteDumps $Session "./artifacts/logs/$ArtifactName/serverdumps") {
             Write-Host "Dump file(s) generated on peer"
-            $hasFailures = $true
+            #$hasFailures = $true
         }
     }}
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -71,8 +71,7 @@ function Stop-RemoteServer {
 function Invoke-Secnetperf {
     param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $ExeArgs, $MsQuicCommit, $i)
 
-    $SQL = @"
-"@
+    $SQL = ""
     $json = @{}
     $encounterFailures = $true
     $testid = $i + 1

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -11,11 +11,6 @@ function Write-GHError($msg) {
     Write-Host "::error::$msg"
 }
 
-# Write a GitHub warning message to the console.
-function Write-GHWarning($msg) {
-    Write-Host "::warning::$msg"
-}
-
 # Waits for a remote job to be ready based on looking for a particular string in
 # the output.
 function Start-RemoteServer {
@@ -39,7 +34,7 @@ function Start-RemoteServer {
     Stop-Job -Job $Job
     $RemoteResult = Receive-Job -Job $Job -ErrorAction Stop
     $RemoteResult = $RemoteResult -join "`n"
-    Write-GHWarning $RemoteResult.ToString()
+    Write-Host $RemoteResult.ToString()
     throw "Server failed to start!"
 }
 
@@ -66,7 +61,7 @@ function Stop-RemoteServer {
     Stop-Job -Job $Job
     $RemoteResult = Receive-Job -Job $Job -ErrorAction Stop
     $RemoteResult = $RemoteResult -join "`n"
-    Write-GHWarning $RemoteResult.ToString()
+    Write-Host $RemoteResult.ToString()
     throw "Server failed to stop!"
 }
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -112,7 +112,10 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
         try {
             $rawOutput = Invoke-Expression $command
         } catch {
+            Write-GHError "Invoke-Expression exception encountered!"
             Write-GHError $_
+            Get-Error
+            $_ | Format-List *
             $encounterFailures = $true
             continue
         }
@@ -159,7 +162,9 @@ VALUES ($testid, '$MsQuicCommit', $env, $env, $num, NULL);
 
     } catch {
         Write-GHError "Inner exception while running test case!"
-        $_.Exception | Format-List -Force | Write-GHError
+        Write-GHError $_
+        Get-Error
+        $_ | Format-List *
         $encounterFailures = $true
     } finally {
         # Stop the server

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -97,6 +97,8 @@ function Invoke-Secnetperf {
     $metric = "throughput-download"
     if ($exeArgs.Contains("plat:1")) {
         $metric = "latency"
+    } elseif ($exeArgs.Contains("prate:1")) {
+        $metric = "hps"
     } elseif ($exeArgs.Contains("-up")) {
         $metric = "throughput-upload"
     }
@@ -126,10 +128,13 @@ function Invoke-Secnetperf {
                 throw $rawOutput.Substring(7) # Skip over the 'Error: ' prefix
             }
             Write-Host $rawOutput
-            if ($exeArgs.Contains("plat:1")) {
+            if ($metric -eq "latency") {
                 $latency_percentiles = '(?<=\d{1,3}(?:\.\d{1,2})?th: )\d+'
                 $values[$tcp] += [regex]::Matches($rawOutput, $latency_percentiles) | ForEach-Object {$_.Value}
-            } else {
+            } elseif ($metric -eq "hps") {
+                $rawOutput -match '(\d+) HPS'
+                $values[$tcp] += $matches[1]
+            } else { # throughput
                 $rawOutput -match '@ (\d+) kbps'
                 $values[$tcp] += $matches[1]
             }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -105,6 +105,9 @@ function Invoke-Secnetperf {
     Write-Host "> $command"
 
     if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
+        Invoke-Command -Session $Session -ScriptBlock {
+            & "$Using:RemoteDir/scripts/log.ps1" -Start -Profile $LogProfile -ProfileInScriptDirectory
+        }
         .\scripts\log.ps1 -Start -Profile $LogProfile
     }
 
@@ -150,6 +153,10 @@ function Invoke-Secnetperf {
         try { Stop-RemoteServer $Job $RemoteName | Out-Null } catch { } # Ignore failures for now
         if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
             .\scripts\log.ps1 -Stop -OutputPath "./artifacts/logs/$metric-$tcp/client" -RawLogOnly
+            Invoke-Command -Session $Session -ScriptBlock {
+                & "$Using:RemoteDir/scripts/log.ps1" -Stop -OutputPath "$Using:RemoteDir/artifacts/logs/$Using:metric-$Using:tcp/server" -RawLogOnly
+            }
+            Copy-Item -FromSession $Session "$RemoteDir/artifacts/logs/$metric-$tcp/server*" "./artifacts/logs/$metric-$tcp/"
         }
     }}
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -157,9 +157,9 @@ function Invoke-Secnetperf {
         $encounterFailures = $true
     } finally {
         # Stop the server
-        Stop-RemoteServer $Job $RemoteName
+        try { Stop-RemoteServer $Job $RemoteName } catch { } # Ignore failures for now
         if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
-            .\scripts\log.ps1 -Stop -OutputPath "./artifacts/logs/$metric-$transport/client" -RawLogOnly
+            .\scripts\log.ps1 -Stop -OutputPath "./artifacts/logs/$metric-$tcp/client" -RawLogOnly
         }
     }}
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -150,8 +150,8 @@ Write-Host "`Writing json-test-results-$plat-$os-$arch-$tls.json..."
 $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$tls.json"
 
 } catch {
-    Write-GHError "Exception occurred!"
-    Write-GHError $_
+    Write-GHError "Outer exception while running tests!"
+    $_.Exception | Format-List -Force | Write-GHError
     $encounterFailures = $true
 } finally {
     # TODO: Do any further book keeping here.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -151,7 +151,9 @@ $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$t
 
 } catch {
     Write-GHError "Outer exception while running tests!"
-    $_.Exception | Format-List -Force | Write-GHError
+    Write-GHError $_
+    Get-Error
+    $_ | Format-List *
     $encounterFailures = $true
 } finally {
     # TODO: Do any further book keeping here.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -124,28 +124,9 @@ $SQL = @"
 INSERT OR IGNORE INTO Secnetperf_builds (Secnetperf_Commit, Build_date_time, TLS_enabled, Advanced_build_config)
 VALUES ('$MsQuicCommit', '$(Get-Date -Format "yyyy-MM-dd HH:mm:ss")', 1, 'TODO');
 
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Secnetperf_build_ID, Kernel_mode, Run_arguments, Test_name)
-VALUES ('throughput-upload-quic-$MsQuicCommit', '$MsQuicCommit', 0, '-target:netperf-peer -exec:maxtput -upload:10s', 'throughput-upload-quic');
-
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Secnetperf_build_ID, Kernel_mode, Run_arguments, Test_name)
-VALUES ('throughput-upload-tcp-$MsQuicCommit', '$MsQuicCommit', 0, '-target:netperf-peer -exec:maxtput -upload:10s -tcp:1', 'throughput-upload-tcp');
-
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Secnetperf_build_ID, Kernel_mode, Run_arguments, Test_name)
-VALUES ('throughput-download-quic-$MsQuicCommit', '$MsQuicCommit', 0, '-target:netperf-peer -exec:maxtput -download:10s', 'throughput-download-quic');
-
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Secnetperf_build_ID, Kernel_mode, Run_arguments, Test_name)
-VALUES ('throughput-download-tcp-$MsQuicCommit', '$MsQuicCommit', 0, '-target:netperf-peer -exec:maxtput -download:10s -tcp:1', 'throughput-download-tcp');
-
 "@
 
 $json = @{}
-
-$testIds = @(
-    "throughput-upload",
-    "throughput-download",
-    "hps",
-    "rps-1conn-1stream"
-)
 
 $exeArgs = @(
     "-exec:maxtput -up:10s -ptput:1",
@@ -154,9 +135,10 @@ $exeArgs = @(
     "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:10s -plat:1"
 )
 
-
 for ($i = 0; $i -lt $exeArgs.Count; $i++) {
-    $SQL += Invoke-Secnetperf $Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $exeArgs[$i] $testIds[$i]
+    $res = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $exeArgs[$i] $MsQuicCommit $i
+    $SQL += $res[0]
+    $json += $res[1]
 }
 
 # Save the test results (sql and json).

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -136,9 +136,9 @@ $exeArgs = @(
 )
 
 for ($i = 0; $i -lt $exeArgs.Count; $i++) {
-    $res = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $exeArgs[$i] $MsQuicCommit $i
-    $SQL += $res[0]
-    $json += $res[1]
+    $res = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $exeArgs[$i] $MsQuicCommit ($i+1) $SQL $json
+    $SQL = $res[0]
+    $json = $res[1]
     if ($res[2]) { $encounterFailures = $true }
 }
 
@@ -152,7 +152,6 @@ $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$t
 } catch {
     Write-GHError "Outer exception while running tests!"
     Write-GHError $_
-    Get-Error
     $_ | Format-List *
     $encounterFailures = $true
 }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -120,10 +120,8 @@ if (!$isWindows) {
 $PSDefaultParameterValues["Disabled"] = $true # TODO: Why?
 
 $SQL = @"
-
 INSERT OR IGNORE INTO Secnetperf_builds (Secnetperf_Commit, Build_date_time, TLS_enabled, Advanced_build_config)
 VALUES ('$MsQuicCommit', '$(Get-Date -Format "yyyy-MM-dd HH:mm:ss")', 1, 'TODO');
-
 "@
 
 $json = @{}
@@ -145,9 +143,10 @@ for ($i = 0; $i -lt $exeArgs.Count; $i++) {
 
     # Process the results and add them to the SQL and JSON.
     $SQL += @"
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($testid, 0, "$ExeArgs -tcp:0")
+`nINSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($testid, 0, "$ExeArgs -tcp:0")
 INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($testid, 0, "$ExeArgs -tcp:1")
 "@
+
     for ($i = 0; $i -lt $Result.Results.Length; $i++) {
         $transport = $i -eq 1 ? "tcp" : "quic"
         foreach ($item in $Result.Results[$i]) {
@@ -155,7 +154,7 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
             if ($Result.Metric.startsWith("throughput")) {
                 # Generate SQL statement. Assume LAST_INSERT_ROW_ID()
                 $SQL += @"
-INSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Latency_stats_ID)
+`nINSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Latency_stats_ID)
 VALUES ($testid, '$MsQuicCommit', $env, $env, $item, NULL);
 "@
             }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -173,6 +173,7 @@ $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$t
 } catch {
     Write-GHError "Outer exception while running tests!"
     Write-GHError $_
+    Get-Error
     $_ | Format-List *
     $encounterFailures = $true
 }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -159,8 +159,6 @@ VALUES ($TestId, '$MsQuicCommit', $env, $env, $item, NULL);
             }
         }
     }
-
-    Write-Host "Iteration Complate"
 }
 
 } catch {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -142,8 +142,8 @@ for ($i = 0; $i -lt $allTests.Count; $i++) {
     # Process the results and add them to the SQL and JSON.
     $TestId = $i + 1
     $SQL += @"
-`nINSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($TestId, 0, "$ExeArgs -tcp:0")
-INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($TestId, 0, "$ExeArgs -tcp:1")
+`nINSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($TestId, 0, "$ExeArgs -tcp:0");
+INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($TestId, 0, "$ExeArgs -tcp:1");
 "@
 
     for ($tcp = 0; $tcp -lt $Test.Values.Length; $tcp++) {
@@ -153,7 +153,7 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
             if ($Test.Metric.startsWith("throughput")) {
                 # Generate SQL statement. Assume LAST_INSERT_ROW_ID()
                 $SQL += @"
-`nINSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Latency_stats_ID)
+`nINSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Secnetperf_latency_stats_ID)
 VALUES ($TestId, '$MsQuicCommit', $env, $env, $item, NULL);
 "@
             }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -89,6 +89,18 @@ Copy-Item -ToSession $Session ./artifacts -Destination "$RemoteDir/artifacts" -R
 Copy-Item -ToSession $Session ./scripts -Destination "$RemoteDir/scripts" -Recurse
 Copy-Item -ToSession $Session ./src/manifest/MsQuic.wprp -Destination "$RemoteDir/scripts"
 
+$SQL = @"
+INSERT OR IGNORE INTO Secnetperf_builds (Secnetperf_Commit, Build_date_time, TLS_enabled, Advanced_build_config)
+VALUES ('$MsQuicCommit', '$(Get-Date -Format "yyyy-MM-dd HH:mm:ss")', 1, 'TODO');
+"@
+$json = @{}
+$exeArgs = @(
+    "-exec:maxtput -up:10s -ptput:1",
+    "-exec:maxtput -down:10s -ptput:1",
+    "-exec:maxtput -rconn:1 -share:1 -conns:100 -run:10s -prate:1",
+    "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:10s -plat:1"
+)
+$env = $isWindows ? 1 : 2
 $encounterFailures = $false
 
 try {
@@ -117,24 +129,7 @@ if (!$isWindows) {
     chmod +x "./$SecNetPerfPath"
 }
 
-$PSDefaultParameterValues["Disabled"] = $true # TODO: Why?
-
-$SQL = @"
-INSERT OR IGNORE INTO Secnetperf_builds (Secnetperf_Commit, Build_date_time, TLS_enabled, Advanced_build_config)
-VALUES ('$MsQuicCommit', '$(Get-Date -Format "yyyy-MM-dd HH:mm:ss")', 1, 'TODO');
-"@
-
-$json = @{}
-
-$exeArgs = @(
-    "-exec:maxtput -up:10s -ptput:1",
-    "-exec:maxtput -down:10s -ptput:1",
-    "-exec:maxtput -rconn:1 -share:1 -conns:100 -run:10s -prate:1",
-    "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:10s -plat:1"
-)
-
-$env = $isWindows ? 1 : 2
-
+# Run all the test cases.
 for ($i = 0; $i -lt $exeArgs.Count; $i++) {
     $ExeArgs = $exeArgs[$i]
     $testid = $i + 1
@@ -147,9 +142,9 @@ for ($i = 0; $i -lt $exeArgs.Count; $i++) {
 INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arguments) VALUES ($testid, 0, "$ExeArgs -tcp:1")
 "@
 
-    for ($i = 0; $i -lt $Result.Results.Length; $i++) {
-        $transport = $i -eq 1 ? "tcp" : "quic"
-        foreach ($item in $Result.Results[$i]) {
+    for ($tcp = 0; $tcp -lt $Result.Results.Length; $tcp++) {
+        $transport = $tcp -eq 1 ? "tcp" : "quic"
+        foreach ($item in $Result.Results[$tcp]) {
             $json["$($Result.Metric)-$transport"] = $item
             if ($Result.Metric.startsWith("throughput")) {
                 # Generate SQL statement. Assume LAST_INSERT_ROW_ID()
@@ -162,19 +157,19 @@ VALUES ($testid, '$MsQuicCommit', $env, $env, $item, NULL);
     }
 }
 
-# Save the test results (sql and json).
-Write-Host "`Writing test-results-$plat-$os-$arch-$tls.sql..."
-$SQL | Set-Content -Path "test-results-$plat-$os-$arch-$tls.sql"
-
-Write-Host "`Writing json-test-results-$plat-$os-$arch-$tls.json..."
-$json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$tls.json"
-
 } catch {
     Write-GHError "Outer exception while running tests!"
     Write-GHError $_
     Get-Error
     $_ | Format-List *
     $encounterFailures = $true
+} finally {
+    # Save the test results (sql and json).
+    Write-Host "`Writing test-results-$plat-$os-$arch-$tls.sql..."
+    $SQL | Set-Content -Path "test-results-$plat-$os-$arch-$tls.sql"
+
+    Write-Host "`Writing json-test-results-$plat-$os-$arch-$tls.json..."
+    $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$tls.json"
 }
 
 if ($encounterFailures) {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -139,6 +139,7 @@ for ($i = 0; $i -lt $exeArgs.Count; $i++) {
     $res = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $exeArgs[$i] $MsQuicCommit $i
     $SQL += $res[0]
     $json += $res[1]
+    if ($res[2]) { $encounterFailures = $true }
 }
 
 # Save the test results (sql and json).

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -136,6 +136,7 @@ if (!$isWindows) {
 for ($i = 0; $i -lt $exeArgs.Count; $i++) {
     $ExeArgs = $exeArgs[$i]
     $Test = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $ExeArgs
+    Write-Host "Test Complete:`n$Test"
     if ($Test.HasFailures) { $hasFailures = $true }
 
     # Process the results and add them to the SQL and JSON.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -151,8 +151,8 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
     for ($i = 0; $i -lt $Result.Results.Length; $i++) {
         $transport = $i -eq 1 ? "tcp" : "quic"
         foreach ($item in $Result.Results[$i]) {
-            $json["$metric-$transport"] = $item
-            if ($metric.startsWith("throughput")) {
+            $json["$($Result.Metric)-$transport"] = $item
+            if ($Result.Metric.startsWith("throughput")) {
                 # Generate SQL statement. Assume LAST_INSERT_ROW_ID()
                 $SQL += @"
 INSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Latency_stats_ID)

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -136,6 +136,7 @@ if (!$isWindows) {
 }
 
 # Run all the test cases.
+Write-Host "Setup complete! Running all tests..."
 for ($i = 0; $i -lt $allTests.Count; $i++) {
     $ExeArgs = $allTests[$i]
     $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $ExeArgs
@@ -163,6 +164,8 @@ VALUES ($TestId, '$MsQuicCommit', $env, $env, $item, NULL);
         }
     }
 }
+
+Write-Host "Tests complete!"
 
 } catch {
     Write-GHError "Exception while running tests!"

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -155,8 +155,6 @@ $json | ConvertTo-Json | Set-Content -Path "json-test-results-$plat-$os-$arch-$t
     Get-Error
     $_ | Format-List *
     $encounterFailures = $true
-} finally {
-    # TODO: Do any further book keeping here.
 }
 
 if ($encounterFailures) {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -135,8 +135,11 @@ if (!$isWindows) {
 # Run all the test cases.
 for ($i = 0; $i -lt $exeArgs.Count; $i++) {
     $ExeArgs = $exeArgs[$i]
-    $Test = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $ExeArgs
-    Write-Host "Test Complete:`n$Test"
+    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $ExeArgs
+    Write-Host "Test Complete:`n"
+    Write-Host $Output.GetType()
+    Write-Host $Output
+    $Test = $Output[-1]
     if ($Test.HasFailures) { $hasFailures = $true }
 
     # Process the results and add them to the SQL and JSON.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -121,6 +121,9 @@ if ($isWindows) { # TODO: Run on Linux too?
     }
 }
 
+# Configure the dump collection.
+Configure-DumpCollection $Session
+
 if (!$isWindows) {
     # Make sure the secnetperf binary is executable.
     Write-Host "Updating secnetperf permissions..."

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -75,7 +75,8 @@ PerfServer::Init(
     // Set up the special UDP listener to allow remote tear down.
     //
     QuicAddr TeardownLocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
-    CXPLAT_UDP_CONFIG UdpConfig = {&TeardownLocalAddress.SockAddr, 0, 0, 0, 0, this, 0};
+    CXPLAT_UDP_CONFIG UdpConfig = {&TeardownLocalAddress.SockAddr, 0};
+    UdpConfig.CallbackContext = this;
 #ifdef QUIC_OWNING_PROCESS
     UdpConfig.OwningProcess = QuicProcessGetCurrentProcess();
 #endif

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -75,7 +75,7 @@ PerfServer::Init(
     // Set up the special UDP listener to allow remote tear down.
     //
     QuicAddr TeardownLocalAddress {QUIC_ADDRESS_FAMILY_INET, (uint16_t)9999};
-    CXPLAT_UDP_CONFIG UdpConfig = {&TeardownLocalAddress.SockAddr, 0};
+    CXPLAT_UDP_CONFIG UdpConfig = {&TeardownLocalAddress.SockAddr, 0, 0, 0, 0, this, 0};
 #ifdef QUIC_OWNING_PROCESS
     UdpConfig.OwningProcess = QuicProcessGetCurrentProcess();
 #endif

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -218,7 +218,7 @@ QuicMainStart(
 
     uint32_t WatchdogTimeout = 0;
     if (TryGetValue(argc, argv, "watchdog", &WatchdogTimeout) && WatchdogTimeout != 0) {
-        Watchdog = new(std::nothrow) CxPlatWatchdog(WatchdogTimeout, "perf_watchdog");
+        Watchdog = new(std::nothrow) CxPlatWatchdog(WatchdogTimeout, "perf_watchdog", true);
     }
 
     const CXPLAT_UDP_DATAPATH_CALLBACKS DatapathCallbacks = {

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -344,9 +344,6 @@ TcpConnection::TcpConnection(
         WriteOutput("SecConfig load FAILED\n");
         return;
     }
-    if (!Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber())) {
-        return;
-    }
     Initialized = true;
 }
 
@@ -360,6 +357,9 @@ TcpConnection::Start(
     const QUIC_ADDR* RemoteAddress
     )
 {
+    if (!Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber())) {
+        return false;
+    }
     if (LocalAddress) {
         Family = QuicAddrGetFamily(LocalAddress);
     }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -1000,6 +1000,9 @@ bool TcpConnection::EncryptFrame(TcpFrame* Frame)
 
 QUIC_BUFFER* TcpConnection::NewSendBuffer()
 {
+    if (Shutdown) { // TODO: How do we actually get into this state?
+        return nullptr;
+    }
     if (!BatchedSendData) {
         CXPLAT_SEND_CONFIG SendConfig = { &Route, TLS_BLOCK_SIZE, CXPLAT_ECN_NON_ECT, 0 };
         BatchedSendData = CxPlatSendDataAlloc(Socket, &SendConfig);

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -122,6 +122,7 @@ TcpEngine::TcpEngine(
 TcpEngine::~TcpEngine() noexcept
 {
     // Loop over all connections and shut them down.
+    ShuttingDown = true;
     ConnectionLock.Acquire();
     while (!CxPlatListIsEmpty(&Connections)) {
         auto Connection = (TcpConnection*)CxPlatListRemoveHead(&Connections);
@@ -140,16 +141,24 @@ TcpEngine::~TcpEngine() noexcept
     delete [] Workers;
 }
 
-void TcpEngine::AddConnection(TcpConnection* Connection, uint16_t PartitionIndex)
+bool TcpEngine::AddConnection(TcpConnection* Connection, uint16_t PartitionIndex)
 {
+    bool Added = false;
     CXPLAT_DBG_ASSERT(PartitionIndex < ProcCount);
     CXPLAT_DBG_ASSERT(!Connection->Worker);
     Connection->PartitionIndex = PartitionIndex;
     Connection->Worker = &Workers[PartitionIndex];
     CXPLAT_FRE_ASSERT(Rundown.Acquire());
     ConnectionLock.Acquire();
-    CxPlatListInsertTail(&Connections, &Connection->EngineEntry);
+    if (!ShuttingDown) {
+        CxPlatListInsertTail(&Connections, &Connection->EngineEntry);
+        Added = true;
+    }
     ConnectionLock.Release();
+    if (!Added) {
+        Rundown.Release();
+    }
+    return Added;
 }
 
 void TcpEngine::RemoveConnection(TcpConnection* Connection)
@@ -357,7 +366,9 @@ TcpConnection::TcpConnection(
         }
     }
     QuicAddrSetPort(&Route.RemoteAddress, ServerPort);
-    Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber());
+    if (!Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber())) {
+        return;
+    }
     Initialized = true;
     if (QUIC_FAILED(
         CxPlatSocketCreateTcp(
@@ -389,7 +400,7 @@ TcpConnection::TcpConnection(
         this);
     Initialized = true;
     IndicateAccept = true;
-    Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber());
+    CXPLAT_FRE_ASSERT(Engine->AddConnection(this, (uint16_t)CxPlatProcCurrentNumber()));
     Queue();
 }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -124,9 +124,10 @@ TcpEngine::~TcpEngine() noexcept
     // Loop over all connections and shut them down.
     ShuttingDown = true;
     ConnectionLock.Acquire();
-    while (!CxPlatListIsEmpty(&Connections)) {
+    CXPLAT_LIST_ENTRY* Entry = Connections.Flink;
+    while (Entry != &Connections) {
         auto Connection = (TcpConnection*)CxPlatListRemoveHead(&Connections);
-        Connection->EngineEntry.Flink = NULL;
+        Entry = Entry->Flink;
         Connection->Shutdown = true;
         Connection->TotalSendCompleteOffset = UINT64_MAX;
         Connection->Queue();
@@ -165,7 +166,6 @@ void TcpEngine::RemoveConnection(TcpConnection* Connection)
     ConnectionLock.Acquire();
     if (Connection->EngineEntry.Flink) {
         CxPlatListEntryRemove(&Connection->EngineEntry);
-        Connection->EngineEntry.Flink = NULL;
     }
     ConnectionLock.Release();
     if (Connection->HasRundownRef) {

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -126,7 +126,7 @@ TcpEngine::~TcpEngine() noexcept
     ConnectionLock.Acquire();
     CXPLAT_LIST_ENTRY* Entry = Connections.Flink;
     while (Entry != &Connections) {
-        auto Connection = (TcpConnection*)CxPlatListRemoveHead(&Connections);
+        auto Connection = (TcpConnection*)Entry;
         Entry = Entry->Flink;
         Connection->Shutdown = true;
         Connection->TotalSendCompleteOffset = UINT64_MAX;

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -140,7 +140,7 @@ TcpEngine::~TcpEngine() noexcept
     delete [] Workers;
 }
 
-bool TcpEngine::AddConnection(TcpConnection* Connection, uint16_t PartitionIndex)
+void TcpEngine::AddConnection(TcpConnection* Connection, uint16_t PartitionIndex)
 {
     CXPLAT_DBG_ASSERT(PartitionIndex < ProcCount);
     CXPLAT_DBG_ASSERT(!Connection->Worker);

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -149,30 +149,26 @@ bool TcpEngine::AddConnection(TcpConnection* Connection, uint16_t PartitionIndex
     Connection->PartitionIndex = PartitionIndex;
     Connection->Worker = &Workers[PartitionIndex];
     if (Rundown.Acquire()) {
+        Connection->HasRundownRef = true;
         ConnectionLock.Acquire();
         if (!ShuttingDown) {
             CxPlatListInsertTail(&Connections, &Connection->EngineEntry);
             Added = true;
         }
         ConnectionLock.Release();
-        if (!Added) {
-            Rundown.Release();
-        }
     }
     return Added;
 }
 
 void TcpEngine::RemoveConnection(TcpConnection* Connection)
 {
-    bool Removed = false;
     ConnectionLock.Acquire();
     if (Connection->EngineEntry.Flink) {
         CxPlatListEntryRemove(&Connection->EngineEntry);
         Connection->EngineEntry.Flink = NULL;
-        Removed = true;
     }
     ConnectionLock.Release();
-    if (Removed) {
+    if (Connection->HasRundownRef) {
         Rundown.Release();
     }
 }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -122,7 +122,6 @@ TcpEngine::TcpEngine(
 TcpEngine::~TcpEngine() noexcept
 {
     // Loop over all connections and shut them down.
-    Shutdown = true;
     ConnectionLock.Acquire();
     while (!CxPlatListIsEmpty(&Connections)) {
         auto Connection = (TcpConnection*)CxPlatListRemoveHead(&Connections);
@@ -134,6 +133,7 @@ TcpEngine::~TcpEngine() noexcept
     ConnectionLock.Release();
     Rundown.ReleaseAndWait();
 
+    Shutdown = true;
     for (uint16_t i = 0; i < ProcCount; ++i) {
         Workers[i].Shutdown();
     }

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -102,7 +102,7 @@ public:
         TcpSendCompleteHandler SendCompleteHandler) noexcept;
     ~TcpEngine() noexcept;
     bool IsInitialized() const { return Initialized; }
-    void AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
+    bool AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
     void RemoveConnection(TcpConnection* Connection);
 };
 

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -266,14 +266,15 @@ public:
     TcpConnection(
         _In_ TcpEngine* Engine,
         _In_ const QUIC_CREDENTIAL_CONFIG* CredConfig,
+        _In_ void* Context = nullptr);
+    bool IsInitialized() const { return Initialized; }
+    void Close();
+    bool Start(
         _In_ QUIC_ADDRESS_FAMILY Family,
         _In_reads_or_z_opt_(QUIC_MAX_SNI_LENGTH)
             const char* ServerName,
         _In_ uint16_t ServerPort,
         _In_ const QUIC_ADDR* LocalAddress = nullptr,
-        _In_ const QUIC_ADDR* RemoteAddress = nullptr,
-        _In_ void* Context = nullptr);
-    bool IsInitialized() const { return Initialized; }
-    void Close();
+        _In_ const QUIC_ADDR* RemoteAddress = nullptr);
     bool Send(TcpSendData* Data);
 };

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -102,7 +102,7 @@ public:
         TcpSendCompleteHandler SendCompleteHandler) noexcept;
     ~TcpEngine() noexcept;
     bool IsInitialized() const { return Initialized; }
-    bool AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
+    void AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
     void RemoveConnection(TcpConnection* Connection);
 };
 

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -81,6 +81,7 @@ typedef TcpSendCompleteCallback* TcpSendCompleteHandler;
 class TcpEngine {
     friend class TcpWorker;
     bool Initialized{false};
+    bool ShuttingDown{false};
     bool Shutdown{false};
     const uint16_t ProcCount;
     TcpWorker* Workers;
@@ -102,7 +103,7 @@ public:
         TcpSendCompleteHandler SendCompleteHandler) noexcept;
     ~TcpEngine() noexcept;
     bool IsInitialized() const { return Initialized; }
-    void AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
+    bool AddConnection(TcpConnection* Connection, uint16_t PartitionIndex);
     void RemoveConnection(TcpConnection* Connection);
 };
 

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -176,6 +176,7 @@ class TcpConnection {
     bool IndicateAccept{false};
     bool IndicateConnect{false};
     bool IndicateSendComplete{false};
+    bool HasRundownRef{false};
     TcpConnection* Next{nullptr};
     TcpEngine* Engine;
     TcpWorker* Worker{nullptr};


### PR DESCRIPTION
## Description

Improvements to the NetPerf automation to restart the server for each test, but also includes several other fixes found along the way:

- Refactoring the helper to have a "run" of a test to run the server only for the time it takes to do the couple of tries for that test.
- Fix log collections (client and server).
- Collect crash dumps (Windows only for now) on client and server.
- Fix a bug in the perf server code that wasn't passing the context pointer in for a callback.
- Improvements (but not a complete fix yet) of the TCP cleanup path to handle some race conditions.

## Testing

NetPerf Automation

## Documentation

N/A
