### PR TITLE
Allow NMR helpers to not wait at all

### DIFF
--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1722,7 +1722,11 @@ __MsQuicClientAttachProvider(
                 NULL,
                 &ProviderContext,
                 (const void**)&Client->ProviderDispatch);
-        KeSetEvent(&Client->RegistrationCompleteEvent, IO_NO_INCREMENT, FALSE);
+        if (NT_SUCCESS(Status)) {
+            KeSetEvent(&Client->RegistrationCompleteEvent, IO_NO_INCREMENT, FALSE);
+        } else {
+            InterlockedDecrement(&Client->BindingCount);
+        }
     } else {
         Status = STATUS_NOINTERFACE;
     }

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1775,7 +1775,7 @@ NTSTATUS
 MsQuicNmrClientRegister(
     _Out_ HANDLE* ClientHandle,
     _In_ GUID* ClientModuleId,
-    _In_ ULONG TimeoutMs
+    _In_ ULONG TimeoutMs // zero = no wait, non-zero = some wait
     )
 {
     NPI_REGISTRATION_INSTANCE *ClientRegistrationInstance;
@@ -1819,7 +1819,7 @@ MsQuicNmrClientRegister(
         KeWaitForSingleObject(
             &Client->RegistrationCompleteEvent,
             Executive, KernelMode, FALSE,
-            TimeoutMs != 0 ? &Timeout : NULL);
+            &Timeout);
     if (Status != STATUS_SUCCESS) {
         Status = STATUS_UNSUCCESSFUL;
         goto Exit;


### PR DESCRIPTION
## Description

Passing zero as timeout will cause KeWaitForSingleObject to not wait at all. We will lose the ability to wait forever but that's not useful and can still be somewhat achieved by passing a ULONG_MAX.

## Testing

CI