### PR TITLE
Fix tests not targeting private msquic.sys

### DIFF
--- a/src/bin/winkernel/msquicpriv.kernel.vcxproj
+++ b/src/bin/winkernel/msquicpriv.kernel.vcxproj
@@ -72,7 +72,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ResourceCompile Include="msquicpriv.rc">
-      <PreprocessorDefinitions>VER_BUILD_ID=$(QUIC_VER_BUILD_ID);VER_SUFFIX=$(QUIC_VER_SUFFIX);VER_GIT_HASH=$(QUIC_VER_GIT_HASH);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;VER_BUILD_ID=$(QUIC_VER_BUILD_ID);VER_SUFFIX=$(QUIC_VER_SUFFIX);VER_GIT_HASH=$(QUIC_VER_GIT_HASH);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <PropertyGroup>

--- a/src/bin/winkernel/msquicpriv.kernel.vcxproj
+++ b/src/bin/winkernel/msquicpriv.kernel.vcxproj
@@ -72,7 +72,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ResourceCompile Include="msquicpriv.rc">
-      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;VER_BUILD_ID=$(QUIC_VER_BUILD_ID);VER_SUFFIX=$(QUIC_VER_SUFFIX);VER_GIT_HASH=$(QUIC_VER_GIT_HASH);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VER_BUILD_ID=$(QUIC_VER_BUILD_ID);VER_SUFFIX=$(QUIC_VER_SUFFIX);VER_GIT_HASH=$(QUIC_VER_GIT_HASH);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <PropertyGroup>
@@ -109,12 +109,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_TELEMETRY_ASSERTS=1;SECURITY_KERNEL;SECURITY_WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_TELEMETRY_ASSERTS=1;SECURITY_KERNEL;SECURITY_WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_TELEMETRY_ASSERTS=1;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_TELEMETRY_ASSERTS=1;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/src/bin/winkernel/nmrprovider.c
+++ b/src/bin/winkernel/nmrprovider.c
@@ -12,6 +12,7 @@ Abstract:
 #include "quic_platform.h"
 #include <wdm.h>
 #include "msquic.h"
+#include "msquicp.h"
 #include "quic_trace.h"
 #ifdef QUIC_CLOG
 #include "nmrprovider.c.clog.h"
@@ -96,8 +97,7 @@ MsQuicRegisterNmrProvider(
     NmrProvider.NpiProviderCharacteristics.ProviderDetachClient = MsQuicNmrProviderDetachClient;
 
 #ifdef QUIC_TEST_NMR_PROVIDER
-    C_ASSERT(MSQUIC_NPI_ID.Guid.Data4[7] != 0xff);
-    MSQUIC_NPI_ID.Guid.Data4[7] = 0xff;
+    QUIC_ENABLE_PRIVATE_NMR_PROVIDER();
 #endif
 
     ProviderRegistrationInstance = &NmrProvider.NpiProviderCharacteristics.ProviderRegistrationInstance;

--- a/src/bin/winkernel/nmrprovider.c
+++ b/src/bin/winkernel/nmrprovider.c
@@ -95,6 +95,11 @@ MsQuicRegisterNmrProvider(
     NmrProvider.NpiProviderCharacteristics.ProviderAttachClient = MsQuicNmrProviderAttachClient;
     NmrProvider.NpiProviderCharacteristics.ProviderDetachClient = MsQuicNmrProviderDetachClient;
 
+#ifdef QUIC_TEST_NMR_PROVIDER
+    C_ASSERT(MSQUIC_NPI_ID.Guid.Data4[7] != 0xff);
+    MSQUIC_NPI_ID.Guid.Data4[7] = 0xff;
+#endif
+
     ProviderRegistrationInstance = &NmrProvider.NpiProviderCharacteristics.ProviderRegistrationInstance;
     ProviderRegistrationInstance->Version = 0;
     ProviderRegistrationInstance->Size = sizeof(*ProviderRegistrationInstance);

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -140,7 +140,7 @@ typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
 
 #define QUIC_ENABLE_PRIVATE_NMR_PROVIDER(...) \
 do { \
-    MSQUIC_NPI_ID.Data4[7] = 0xff; \
+    MSQUIC_NPI_ID.Data1 = 0xDEADC0DE; \
 } while (FALSE)
 
 #if defined(__cplusplus)

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -138,6 +138,11 @@ typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
 #define QUIC_PARAM_STREAM_RELIABLE_OFFSET_RECV          0x88000000  // uint64_t
 #endif
 
+#define QUIC_ENABLE_PRIVATE_NMR_PROVIDER(...) \
+do { \
+    MSQUIC_NPI_ID.Data4[7] = 0xff; \
+} while (FALSE)
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -84,7 +84,9 @@ QuicTestCtlInitialize(
     WDF_IO_QUEUE_CONFIG QueueConfig;
     WDFQUEUE Queue;
 
+#ifdef QUIC_TEST_NMR_PROVIDER
     QUIC_ENABLE_PRIVATE_NMR_PROVIDER();
+#endif
 
     Status = MsQuicNmrClientRegister(&NmrClient, &MSQUIC_MODULE_ID, 5000);
     if (!NT_SUCCESS(Status)) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -18,6 +18,8 @@ Abstract:
 #include "control.cpp.clog.h"
 #endif
 
+#include "msquicp.h"
+
 const MsQuicApi* MsQuic;
 QUIC_CREDENTIAL_CONFIG ServerSelfSignedCredConfig;
 QUIC_CREDENTIAL_CONFIG ServerSelfSignedCredConfigClientAuth;
@@ -82,8 +84,7 @@ QuicTestCtlInitialize(
     WDF_IO_QUEUE_CONFIG QueueConfig;
     WDFQUEUE Queue;
 
-    C_ASSERT(MSQUIC_NPI_ID.Guid.Data4[7] != 0xff);
-    MSQUIC_NPI_ID.Guid.Data4[7] = 0xff; // To avoid collisions with the inbox driver.
+    QUIC_ENABLE_PRIVATE_NMR_PROVIDER();
 
     Status = MsQuicNmrClientRegister(&NmrClient, &MSQUIC_MODULE_ID, 5000);
     if (!NT_SUCCESS(Status)) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -82,6 +82,9 @@ QuicTestCtlInitialize(
     WDF_IO_QUEUE_CONFIG QueueConfig;
     WDFQUEUE Queue;
 
+    C_ASSERT(MSQUIC_NPI_ID.Guid.Data4[7] != 0xff);
+    MSQUIC_NPI_ID.Guid.Data4[7] = 0xff; // To avoid collisions with the inbox driver.
+
     Status = MsQuicNmrClientRegister(&NmrClient, &MSQUIC_MODULE_ID, 5000);
     if (!NT_SUCCESS(Status)) {
         QuicTraceEvent(

--- a/src/test/bin/winkernel/msquictestpriv.kernel.vcxproj
+++ b/src/test/bin/winkernel/msquictestpriv.kernel.vcxproj
@@ -94,12 +94,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <PreprocessorDefinitions>PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QUIC_TEST_NMR_PROVIDER;PRIVATE_LIBRARY;QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_DISABLE_0RTT_TESTS;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

The inbox msquic and the driver built by the CI/CD pipeline share the same NMR NPI. The tests might be testing the inbox version. This PR makes msquicpriv and tests use a private NPI that's different from the public msquic NMR NPI.

## Testing

CI