### PR TITLE
Fix a naming conflict in msquic.h

### DIFF
--- a/src/bin/winkernel/nmrprovider.c
+++ b/src/bin/winkernel/nmrprovider.c
@@ -29,8 +29,8 @@ MSQUIC_NMR_PROVIDER NmrProvider;
 const MSQUIC_NMR_DISPATCH MsQuicNmrDispatch = {
     .Version = 0,
     .Reserved = 0,
-    .MsQuicOpenVersion = MsQuicOpenVersion,
-    .MsQuicClose = MsQuicClose,
+    .OpenVersion = MsQuicOpenVersion,
+    .Close = MsQuicClose,
 };
 
 NTSTATUS

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1680,8 +1680,8 @@ DECLSPEC_SELECTANY GUID MSQUIC_MODULE_ID = {
 typedef struct MSQUIC_NMR_DISPATCH {
     uint16_t  Version;
     uint16_t  Reserved;
-    MsQuicOpenVersionFn MsQuicOpenVersion;
-    MsQuicCloseFn MsQuicClose;
+    MsQuicOpenVersionFn OpenVersion;
+    MsQuicCloseFn Close;
 } MSQUIC_NMR_DISPATCH;
 
 //

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -103,8 +103,8 @@ QuicTestCtlInitialize(
 
     MsQuic =
         new (std::nothrow) MsQuicApi(
-            QUIC_GET_DISPATCH(NmrClient)->MsQuicOpenVersion,
-            QUIC_GET_DISPATCH(NmrClient)->MsQuicClose);
+            QUIC_GET_DISPATCH(NmrClient)->OpenVersion,
+            QUIC_GET_DISPATCH(NmrClient)->Close);
     if (!MsQuic) {
         goto Error;
     }


### PR DESCRIPTION
## Description

MsQuicOpenVersion and MsQuicClose are defined as macros for 32 bit environment.

MsQuicOpenVersion and MsQuicClose are members of MSQUIC_NMR_DISPATCH.

The expanded code of the instances of MSQUIC_NMR_DISPATCH will become non-sense like `QUIC_GET_DISPATCH(QuicNmrHandle)->(QUIC_STATUS_NOT_SUPPORTED)`.

## Testing

CI
