### PR TITLE
Run secnetperf in Separate Process to Wait on (with Timeout)

### DIFF
--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -5,9 +5,35 @@ on:
   push:
     branches:
     - main
+    paths:
+    - .github/workflows/netperf.yml
+    - .gitmodules
+    - scripts/secnetperf.ps1
+    - scripts/secnetperf-helpers.psm1
+    - scripts/prepare-machine.ps1
+    - src/bin/*
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
+    - submodules/openssl/*
+    - submodules/openssl3/*
+    - submodules/xdp-for-windows/*
   pull_request:
     branches:
     - main
+    paths:
+    - .github/workflows/netperf.yml
+    - .gitmodules
+    - scripts/secnetperf.ps1
+    - scripts/secnetperf-helpers.psm1
+    - scripts/prepare-machine.ps1
+    - src/bin/*
+    - src/core/*
+    - src/platform/*
+    - src/perf/*
+    - submodules/openssl/*
+    - submodules/openssl3/*
+    - submodules/xdp-for-windows/*
 
 concurrency:
   # Cancel any workflow currently in progress for the same PR.

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -195,7 +195,7 @@ function Invoke-Secnetperf {
     for ($tcp = 0; $tcp -lt 2; $tcp++) {
 
     $artifactName = $tcp -eq 0 ? "$metric-quic" : "$metric-tcp"
-    $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "./artifacts/logs/$artifactName/clientdumps"
+    $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/logs/$artifactName/clientdumps"
     $execMode = $ExeArgs.Substring(0, $ExeArgs.IndexOf(' ')) # First arg is the exec mode
     $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfPath
     $fullArgs = "-target:netperf-peer $ExeArgs -tcp:$tcp -trimout -watchdog:45000"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -140,7 +140,7 @@ function Start-LocalTest {
         $pinfo.Arguments = $FullArgs
     } else {
         $pinfo.FileName = "bash"
-        $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $FullPath $FullArgs && echo Done`""
+        $pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $FullPath $FullArgs && echo ''`""
         $pinfo.WorkingDirectory = $OutputDir
     }
     $pinfo.RedirectStandardOutput = $true

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -134,7 +134,6 @@ function Stop-RemoteServer {
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
     param ($FullPath, $FullArgs, $OutputDir)
-    mkdir $OutputDir -ErrorAction Ignore | Out-Null
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if ($IsWindows) {
         $pinfo.FileName = $FullPath
@@ -193,14 +192,19 @@ function Invoke-Secnetperf {
         $metric = "throughput-upload"
     }
 
+    New-Item -ItemType Directory "artifacts/logs" -ErrorAction Ignore | Out-Null
+
     for ($tcp = 0; $tcp -lt 2; $tcp++) {
 
     $artifactName = $tcp -eq 0 ? "$metric-quic" : "$metric-tcp"
-    $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/logs/$artifactName/clientdumps"
     $execMode = $ExeArgs.Substring(0, $ExeArgs.IndexOf(' ')) # First arg is the exec mode
     $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfPath
     $fullArgs = "-target:netperf-peer $ExeArgs -tcp:$tcp -trimout -watchdog:45000"
     Write-Host "> $fullArgs"
+
+    New-Item -ItemType Directory "artifacts/logs/$artifactName" -ErrorAction Ignore | Out-Null
+    $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/logs/$artifactName/clientdumps"
+    New-Item -ItemType Directory $localDumpDir -ErrorAction Ignore | Out-Null
 
     if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
         Invoke-Command -Session $Session -ScriptBlock {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -213,11 +213,12 @@ function Invoke-Secnetperf {
 
     for ($tcp = 0; $tcp -lt 2; $tcp++) {
 
-    Write-Host "> secnetperf $ExeArgs -tcp:$tcp"
+    #Write-Host "> secnetperf $ExeArgs -tcp:$tcp"
     $artifactName = $tcp -eq 0 ? "$metric-quic" : "$metric-tcp"
     $execMode = $ExeArgs.Substring(0, $ExeArgs.IndexOf(' ')) # First arg is the exec mode
     $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfPath
     $fullArgs = "-target:netperf-peer $ExeArgs -tcp:$tcp -trimout -watchdog:45000"
+    Write-Host "> $fullPath $fullArgs"
 
     New-Item -ItemType Directory "artifacts/logs/$artifactName" -ErrorAction Ignore | Out-Null
     $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/logs/$artifactName/clientdumps"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -166,7 +166,7 @@ function Wait-LocalTest {
     }
     [System.Threading.Tasks.Task]::WaitAll(@($StdOut, $StdError))
     $consoleTxt = $StdOut.Result.Trim()
-    if ($null -eq $consoleTxt) {
+    if ($null -eq $consoleTxt -or $consoleTxt.Length -eq 0) {
         throw "secnetperf: No console output (possibly crashed)!"
     }
     if ($consoleTxt.Contains("Error")) {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -134,6 +134,12 @@ function Stop-RemoteServer {
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
     param ($FullPath, $FullArgs, $OutputDir)
+    if (!(Test-Path $FullPath)) {
+        throw "$FullPath does not exist!"
+    }
+    if (!(Test-Path $OutputDir)) {
+        throw "$OutputDir does not exist!"
+    }
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if ($IsWindows) {
         $pinfo.FileName = $FullPath

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -182,10 +182,10 @@ function Get-TestOutput {
         $latency_percentiles = '(?<=\d{1,3}(?:\.\d{1,2})?th: )\d+'
         return [regex]::Matches($Output, $latency_percentiles) | ForEach-Object {$_.Value}
     } elseif ($Metric -eq "hps") {
-        $rawOutput -match '(\d+) HPS'
+        $rawOutput -match '(\d+) HPS' | Out-Null
         return $matches[1]
     } else { # throughput
-        $Output -match '@ (\d+) kbps'
+        $Output -match '@ (\d+) kbps' | Out-Null
         return $matches[1]
     }
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -49,7 +49,6 @@ function Collect-LocalDumps {
             Remove-Item -Path "./artifacts/crashdumps/*" -Force
             return $true
         }
-    } else {
     }
     return $false
 }
@@ -73,6 +72,7 @@ function Collect-RemoteDumps {
             return $true
         }
     } else {
+        # TODO - Collect Linux dumps.
     }
     return $false
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -165,7 +165,7 @@ function Wait-LocalTest {
         throw "secnetperf: Nonzero exit code: $($Process.ExitCode)"
     }
     [System.Threading.Tasks.Task]::WaitAll(@($StdOut, $StdError))
-    $consoleTxt = $StdOut.Result
+    $consoleTxt = $StdOut.Result.Trim()
     if ($null -eq $consoleTxt) {
         throw "secnetperf: No console output (possibly crashed)!"
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -134,6 +134,7 @@ function Stop-RemoteServer {
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
     param ($FullPath, $FullArgs, $OutputDir)
+    mkdir $OutputDir -ErrorAction Ignore | Out-Null
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if ($IsWindows) {
         $pinfo.FileName = $FullPath

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -143,7 +143,7 @@ function Start-LocalTest {
         $pinfo.Arguments = $FullArgs
         #$pinfo.FileName = "bash"
         #$pinfo.Arguments = "-c `"ulimit -c unlimited && LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $FullPath $FullArgs && echo Done`""
-        #$pinfo.WorkingDirectory = $OutputDir
+        $pinfo.WorkingDirectory = $OutputDir
     }
     $pinfo.RedirectStandardOutput = $true
     $pinfo.RedirectStandardError = $true
@@ -213,11 +213,11 @@ function Invoke-Secnetperf {
 
     for ($tcp = 0; $tcp -lt 2; $tcp++) {
 
+    Write-Host "> secnetperf $ExeArgs -tcp:$tcp"
     $artifactName = $tcp -eq 0 ? "$metric-quic" : "$metric-tcp"
     $execMode = $ExeArgs.Substring(0, $ExeArgs.IndexOf(' ')) # First arg is the exec mode
     $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfPath
     $fullArgs = "-target:netperf-peer $ExeArgs -tcp:$tcp -trimout -watchdog:45000"
-    Write-Host "> $fullArgs"
 
     New-Item -ItemType Directory "artifacts/logs/$artifactName" -ErrorAction Ignore | Out-Null
     $localDumpDir = Join-Path (Split-Path $PSScriptRoot -Parent) "artifacts/logs/$artifactName/clientdumps"

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -181,6 +181,18 @@ VALUES ($TestId, '$MsQuicCommit', $env, $env, $item, NULL);
 
 Write-Host "Tests complete!"
 
+if (Get-ChildItem -Path ./artifacts/logs -File -Recurse) {
+    # Logs or dumps were generated. Copy the necessary symbols/files to the same
+    # direcotry be able to open them.
+    Write-Host "Copying debuggig files to logs directory..."
+    if ($isWindows) {
+        Copy-Item "$SecNetPerfDir/*.pdb" ./artifacts/logs
+    } else {
+        Copy-Item "$SecNetPerfDir/libmsquic.so" ./artifacts/logs
+        Copy-Item "$SecNetPerfDir/secnetperf" ./artifacts/logs
+    }
+}
+
 } catch {
     Write-GHError "Exception while running tests!"
     Write-GHError $_

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -131,7 +131,8 @@ if (!$isWindows) {
         $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$Using:RemoteDir/$Using:SecNetPerfDir"
         chmod +x "$Using:RemoteDir/$Using:SecNetPerfPath"
     }
-    $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:./$SecNetPerfDir"
+    $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfDir
+    $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$fullPath"
     chmod +x "./$SecNetPerfPath"
 }
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -184,7 +184,7 @@ Write-Host "Tests complete!"
 if (Get-ChildItem -Path ./artifacts/logs -File -Recurse) {
     # Logs or dumps were generated. Copy the necessary symbols/files to the same
     # direcotry be able to open them.
-    Write-Host "Copying debuggig files to logs directory..."
+    Write-Host "Copying debugging files to logs directory..."
     if ($isWindows) {
         Copy-Item "$SecNetPerfDir/*.pdb" ./artifacts/logs
     } else {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -135,12 +135,14 @@ if (!$isWindows) {
     $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$fullPath"
     chmod +x "./$SecNetPerfPath"
 
-    # Enable core dumps for the system.
-    Write-Host "Setting core dump size limit..."
-    sudo sh -c "echo 'root soft core unlimited' >> /etc/security/limits.conf"
-    sudo sh -c "echo 'root hard core unlimited' >> /etc/security/limits.conf"
-    sudo sh -c "echo '* soft core unlimited' >> /etc/security/limits.conf"
-    sudo sh -c "echo '* hard core unlimited' >> /etc/security/limits.conf"
+    if ((Get-Content "/etc/security/limits.conf") -notcontains "root soft core unlimited") {
+        # Enable core dumps for the system.
+        Write-Host "Setting core dump size limit..."
+        sudo sh -c "echo 'root soft core unlimited' >> /etc/security/limits.conf"
+        sudo sh -c "echo 'root hard core unlimited' >> /etc/security/limits.conf"
+        sudo sh -c "echo '* soft core unlimited' >> /etc/security/limits.conf"
+        sudo sh -c "echo '* hard core unlimited' >> /etc/security/limits.conf"
+    }
 
     # Set the core dump pattern.
     Write-Host "Setting core dump pattern..."

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -134,6 +134,17 @@ if (!$isWindows) {
     $fullPath = Join-Path (Split-Path $PSScriptRoot -Parent) $SecNetPerfDir
     $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$fullPath"
     chmod +x "./$SecNetPerfPath"
+
+    # Enable core dumps for the system.
+    Write-Host "Setting core dump size limit..."
+    sudo sh -c "echo 'root soft core unlimited' >> /etc/security/limits.conf"
+    sudo sh -c "echo 'root hard core unlimited' >> /etc/security/limits.conf"
+    sudo sh -c "echo '* soft core unlimited' >> /etc/security/limits.conf"
+    sudo sh -c "echo '* hard core unlimited' >> /etc/security/limits.conf"
+
+    # Set the core dump pattern.
+    Write-Host "Setting core dump pattern..."
+    sudo sh -c "echo -n '%e.%p.%t.core' > /proc/sys/kernel/core_pattern"
 }
 
 # Run all the test cases.


### PR DESCRIPTION
## Description

We've been seeing hangs on shutdown, so we are going to try running the test in a separate process so we can wait with a timeout. Also updated the yaml to trigger when necessary. Finally, should enable core dump collection for Linux.

## Testing

netperf automation

## Documentation

N/A
