### PR TITLE
Add Filter Support for netperf Tests

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -422,7 +422,7 @@ function Invoke-Secnetperf {
         $clientArgs += " -pconn:1"
     }
 
-    if (!Check-TestFilter $clientArgs $Filter) {
+    if (!(Check-TestFilter $clientArgs $Filter)) {
         Write-Host "> secnetperf $clientArgs SKIPPED!"
         continue
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -334,6 +334,38 @@ function Wait-LocalTest {
     return $consoleTxt
 }
 
+# Test the args to see if they match one of the positive patterns but none of
+# the negative patterns (prefixed by '-'). '?' matches any single character;
+# '*' matches any substring; ';' separates two patterns.
+function Check-TestFilter {
+    param ($ExeArgs, $Filter)
+
+    if (!$Filter) { return $true } # No filter means run everything
+
+    $positivePatterns = $Filter.Split(';')
+    $negativePatterns = $positivePatterns | Where-Object { $_ -like '-*' } | ForEach-Object { $_.TrimStart('-') }
+
+    foreach ($pattern in $positivePatterns) {
+        if ($pattern -like '-*') {
+            continue
+        }
+
+        Write-Host "Testing positive pattern: $pattern"
+
+        if ($ExeArgs -like $pattern) {
+            foreach ($negativePattern in $negativePatterns) {
+                Write-Host "Testing negative pattern: $negativePattern"
+                if ($ExeArgs -like $negativePattern) {
+                    return $false
+                }
+            }
+            return $true
+        }
+    }
+
+    return $false
+}
+
 # Parses the console output of secnetperf to extract the metric value.
 function Get-TestOutput {
     param ($Output, $Metric)
@@ -355,7 +387,7 @@ function Get-TestOutput {
 
 # Invokes secnetperf with the given arguments for both TCP and QUIC.
 function Invoke-Secnetperf {
-    param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $TestId, $ExeArgs, $io)
+    param ($Session, $RemoteName, $RemoteDir, $SecNetPerfPath, $LogProfile, $TestId, $ExeArgs, $io, $Filter)
 
     $metric = "throughput"
     if ($exeArgs.Contains("plat:1")) {
@@ -389,6 +421,12 @@ function Invoke-Secnetperf {
         $serverArgs += " -pconn:1"
         $clientArgs += " -pconn:1"
     }
+
+    if (!Check-TestFilter $clientArgs $Filter) {
+        Write-Host "> secnetperf $clientArgs SKIPPED!"
+        continue
+    }
+
     $artifactName = $tcp -eq 0 ? "$TestId-quic" : "$TestId-tcp"
     New-Item -ItemType Directory "artifacts/logs/$artifactName" -ErrorAction Ignore | Out-Null
     $artifactDir = Repo-Path "artifacts/logs/$artifactName"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -349,12 +349,8 @@ function Check-TestFilter {
         if ($pattern -like '-*') {
             continue
         }
-
-        Write-Host "Testing positive pattern: $pattern"
-
         if ($ExeArgs -like $pattern) {
             foreach ($negativePattern in $negativePatterns) {
-                Write-Host "Testing negative pattern: $negativePattern"
                 if ($ExeArgs -like $negativePattern) {
                     return $false
                 }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -25,6 +25,11 @@ This script assumes the latest MsQuic commit is built and downloaded as artifact
 .PARAMETER io
     The network IO interface to be used (not all are supported on all platforms).
 
+.PARAMETER filter
+    Run only the tests whose arguments match one of the positive patterns but
+    none of the negative patterns (prefixed by '-'). '?' matches any single
+    character; '*' matches any substring; ';' separates two patterns.
+
 #>
 
 # Import the helper module.
@@ -55,6 +60,9 @@ param (
     [Parameter(Mandatory = $false)]
     [ValidateSet("", "iocp", "rio", "xdp", "qtip", "wsk", "epoll", "kqueue")]
     [string]$io = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$filter = "",
 
     [Parameter(Mandatory = $false)]
     [string]$RemoteName = "netperf-peer"
@@ -189,7 +197,7 @@ if (!$isWindows) {
 Write-Host "Setup complete! Running all tests"
 foreach ($testId in $allTests.Keys) {
     $ExeArgs = $allTests[$testId] + " -io:$io"
-    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $testId $ExeArgs $io
+    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $SecNetPerfPath $LogProfile $testId $ExeArgs $io $filter
     $Test = $Output[-1]
     if ($Test.HasFailures) { $hasFailures = $true }
 


### PR DESCRIPTION
## Description

You can specify a filter when manually running perf tests now to only run a subset.

## Testing

Manual CI/CD runs

## Documentation

N/A
