### PR TITLE
Update Schannel Logic to Handler Larger Output Buffers

### DIFF
--- a/src/generated/linux/tls_schannel.c.clog.h
+++ b/src/generated/linux/tls_schannel.c.clog.h
@@ -100,6 +100,24 @@ tracepoint(CLOG_TLS_SCHANNEL_C, SchannelAchCompleteInline , arg2);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SchannelOutBufferTooSmall
+// [conn][%p] Increasing TLS output buffer size
+// QuicTraceLogConnInfo(
+            SchannelOutBufferTooSmall,
+            TlsContext->Connection,
+            "Increasing TLS output buffer size");
+// arg1 = arg1 = TlsContext->Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_SchannelOutBufferTooSmall
+#define _clog_3_ARGS_TRACE_SchannelOutBufferTooSmall(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_TLS_SCHANNEL_C, SchannelOutBufferTooSmall , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SchannelHandshakeComplete
 // [conn][%p] Handshake complete (resume=%hu)
 // QuicTraceLogConnInfo(

--- a/src/generated/linux/tls_schannel.c.clog.h.lttng.h
+++ b/src/generated/linux/tls_schannel.c.clog.h.lttng.h
@@ -69,6 +69,25 @@ TRACEPOINT_EVENT(CLOG_TLS_SCHANNEL_C, SchannelAchCompleteInline,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SchannelOutBufferTooSmall
+// [conn][%p] Increasing TLS output buffer size
+// QuicTraceLogConnInfo(
+            SchannelOutBufferTooSmall,
+            TlsContext->Connection,
+            "Increasing TLS output buffer size");
+// arg1 = arg1 = TlsContext->Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_TLS_SCHANNEL_C, SchannelOutBufferTooSmall,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SchannelHandshakeComplete
 // [conn][%p] Handshake complete (resume=%hu)
 // QuicTraceLogConnInfo(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -9274,6 +9274,18 @@
       ],
       "macroName": "QuicTraceLogConnInfo"
     },
+    "SchannelOutBufferTooSmall": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Increasing TLS output buffer size",
+      "UniqueId": "SchannelOutBufferTooSmall",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        }
+      ],
+      "macroName": "QuicTraceLogConnInfo"
+    },
     "SchannelProcessingData": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Processing %u received bytes",
@@ -15225,6 +15237,11 @@
         "UniquenessHash": "1197fc0e-03e3-58cf-6637-f912c96fa67b",
         "TraceID": "SchannelMissingData",
         "EncodingString": "[conn][%p] TLS message missing %u bytes of data"
+      },
+      {
+        "UniquenessHash": "71eb6726-56e9-ad9d-83d2-930ce22a51f3",
+        "TraceID": "SchannelOutBufferTooSmall",
+        "EncodingString": "[conn][%p] Increasing TLS output buffer size"
       },
       {
         "UniquenessHash": "183e91b7-6ad7-7a8b-0d77-94004bde6757",

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2132,7 +2132,16 @@ CxPlatTlsWriteDataToSchannel(
             SchannelOutBufferTooSmall,
             TlsContext->Connection,
             "Increasing TLS output buffer size");
-        uint16_t NewBufferLength = State->BufferAllocLength << 2; // TODO - Where to get the new length from?
+        uint16_t NewBufferLength = State->BufferAllocLength << 1;
+        if (NewBufferLength < State->BufferAllocLength) { // Integer overflow.
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "TLS buffer too large");
+            Result |= CXPLAT_TLS_RESULT_ERROR;
+            break;
+        }
         uint8_t* NewBuffer = CXPLAT_ALLOC_NONPAGED(NewBufferLength, QUIC_POOL_TLS_BUFFER);
         if (NewBuffer == NULL) {
             QuicTraceEvent(

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -221,7 +221,7 @@ QuicTestConnect(
     }
 
     StatelessRetryHelper RetryHelper(ServerStatelessRetry);
-    PrivateTransportHelper TpHelper(MultiPacketClientInitial);
+    PrivateTransportHelper TpHelper(MultiPacketClientInitial, !!ResumptionTicket);
     RandomLossHelper LossHelper(RandomLossPercentage);
 
     {

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -318,15 +318,16 @@ struct StatelessRetryHelper
 };
 
 #define PRIVATE_TP_TYPE   77
-#define PRIVATE_TP_LENGTH 4132
+#define PRIVATE_TP_LENGTH 4134
+#define PRIVATE_TP_LENGTH_RESUMPTION 1234
 
 struct PrivateTransportHelper : QUIC_PRIVATE_TRANSPORT_PARAMETER
 {
-    PrivateTransportHelper(bool Enabled) {
+    PrivateTransportHelper(bool Enabled, bool Resumption = false) {
         if (Enabled) {
             Type = PRIVATE_TP_TYPE;
-            Length = PRIVATE_TP_LENGTH;
-            Buffer = new(std::nothrow) uint8_t[PRIVATE_TP_LENGTH];
+            Length = Resumption ? PRIVATE_TP_LENGTH_RESUMPTION : PRIVATE_TP_LENGTH;
+            Buffer = new(std::nothrow) uint8_t[Length];
             TEST_TRUE(Buffer != nullptr);
         } else {
             Buffer = nullptr;

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -318,7 +318,7 @@ struct StatelessRetryHelper
 };
 
 #define PRIVATE_TP_TYPE   77
-#define PRIVATE_TP_LENGTH 2345
+#define PRIVATE_TP_LENGTH 4132
 
 struct PrivateTransportHelper : QUIC_PRIVATE_TRANSPORT_PARAMETER
 {

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -318,15 +318,15 @@ struct StatelessRetryHelper
 };
 
 #define PRIVATE_TP_TYPE   77
-#define PRIVATE_TP_LENGTH 4134
-#define PRIVATE_TP_LENGTH_RESUMPTION 1234
+#define PRIVATE_TP_LENGTH 2345
+#define PRIVATE_TP_LENGTH_HUGE 4134
 
 struct PrivateTransportHelper : QUIC_PRIVATE_TRANSPORT_PARAMETER
 {
     PrivateTransportHelper(bool Enabled, bool Resumption = false) {
         if (Enabled) {
             Type = PRIVATE_TP_TYPE;
-            Length = Resumption ? PRIVATE_TP_LENGTH_RESUMPTION : PRIVATE_TP_LENGTH;
+            Length = Resumption ? PRIVATE_TP_LENGTH : PRIVATE_TP_LENGTH_HUGE;
             Buffer = new(std::nothrow) uint8_t[Length];
             TEST_TRUE(Buffer != nullptr);
         } else {


### PR DESCRIPTION
## Description

A user reported an issue with the schannel variant of MsQuic sometimes not working, and it was an issue with too large of output buffers. This change updates the code to dynamically increase the buffer size as necessary.

**Note** - We might want to backport this.

## Testing

Updated a test to exercise the new code paths.

## Documentation

N/A
