### PR TITLE
Add Fedora 39 to OneBranch.Publish.yml

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -60,6 +60,7 @@ parameters:
   default:
   - microsoft-fedora36-prod-yum
   - microsoft-fedora38-prod-yum
+  - microsoft-fedora39-prod-yum
   - microsoft-rhel9.0-prod-yum
 - name: debug # debug mode will not actually upload and publish packages
   type: boolean


### PR DESCRIPTION
## Description

Add Fedora 39 to the list of rpm packages that get published

## Testing

I do not believe I have the ability to force a publish, so I doubt I can test this.

## Documentation

Most documentation already says dotnet core and msquic support fedora 37+, so I do not think anything needs updated.
