### PR TITLE
try without -ConfigurationName to work with lab machine

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -93,7 +93,7 @@ if ($isWindows -and ($LogProfile -eq "" -or $LogProfile -eq "NULL")) {
 # Set up the connection to the peer over remote powershell.
 Write-Host "Connecting to $RemoteName"
 if ($isWindows) {
-    $Session = New-PSSession -ComputerName $RemoteName
+    $Session = New-PSSession -ComputerName $RemoteName -ConfigurationName PowerShell.7
 } else {
     $Session = New-PSSession -HostName $RemoteName -UserName secnetperf -SSHTransport
 }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -152,17 +152,17 @@ mkdir ./artifacts/logs | Out-Null
 
 # Prepare the machines for the testing.
 if ($isWindows) {
-    Write-Host "Preparing local machine for testing"
-    ./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
+    # Write-Host "Preparing local machine for testing"
+    # ./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
 
-    Write-Host "Preparing peer machine for testing"
-    Invoke-Command -Session $Session -ScriptBlock {
-        & "$Using:RemoteDir/scripts/prepare-machine.ps1" -ForTest -InstallSigningCertificates
-    }
+    # Write-Host "Preparing peer machine for testing"
+    # Invoke-Command -Session $Session -ScriptBlock {
+    #     & "$Using:RemoteDir/scripts/prepare-machine.ps1" -ForTest -InstallSigningCertificates
+    # }
 
-    $HasTestSigning = $false
-    try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
-    if (!$HasTestSigning) { Write-Host "Test Signing Not Enabled!" }
+    # $HasTestSigning = $false
+    # try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
+    # if (!$HasTestSigning) { Write-Host "Test Signing Not Enabled!" }
 }
 
 # Configure the dump collection.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -93,7 +93,7 @@ if ($isWindows -and ($LogProfile -eq "" -or $LogProfile -eq "NULL")) {
 # Set up the connection to the peer over remote powershell.
 Write-Host "Connecting to $RemoteName"
 if ($isWindows) {
-    $Session = New-PSSession -ComputerName $RemoteName -ConfigurationName PowerShell.7
+    $Session = New-PSSession -ComputerName $RemoteName
 } else {
     $Session = New-PSSession -HostName $RemoteName -UserName secnetperf -SSHTransport
 }


### PR DESCRIPTION
## Description

For some reason having -Configurationname Powershell.7 breaks WSMan on the lab machine.

## Testing

N/A

## Documentation

N/A
