### PR TITLE
Fix missing headers in NuGet packaging script

### DIFF
--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -112,8 +112,8 @@ foreach ($Arch in $Architectures) {
 
 $HeaderDir = Join-Path $RootDir "src/inc"
 $Headers = @(Join-Path $HeaderDir "msquic.h")
-$Headers = @(Join-Path $HeaderDir "msquicp.h")
-$Headers = @(Join-Path $HeaderDir "msquic.hpp")
+$Headers += Join-Path $HeaderDir  "msquicp.h"
+$Headers += Join-Path $HeaderDir  "msquic.hpp"
 $Headers += Join-Path $HeaderDir  "msquic_winuser.h"
 
 $IncludePath = Join-Path $NativeDir "include"


### PR DESCRIPTION
## Description

Fixes #4102 
Fix regression in `scripts/package-nuget.ps1` script: `$Headers` array was getting overwritten vs. appended.

## Testing

None

## Documentation

None
