### PR TITLE
Fix overflow in winkernel CxPlatEventWaitWithTimeout

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -870,6 +870,8 @@ CxPlatInternalEventWaitWithTimeout(
     struct timespec Ts = {0, 0};
     int Result;
 
+    CXPLAT_DBG_ASSERT(TimeoutMs != UINT32_MAX);
+
     //
     // Get absolute time.
     //

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -465,7 +465,7 @@ _CxPlatEventWaitWithTimeout(
     )
 {
     LARGE_INTEGER Timeout100Ns;
-    Timeout100Ns.QuadPart = Int32x32To64(TimeoutMs, -10000);
+    Timeout100Ns.QuadPart = -1 * UInt32x32To64(TimeoutMs, 10000);
     return KeWaitForSingleObject(Event, Executive, KernelMode, FALSE, &Timeout100Ns);
 }
 #define CxPlatEventWaitWithTimeout(Event, TimeoutMs) \

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -465,6 +465,7 @@ _CxPlatEventWaitWithTimeout(
     )
 {
     LARGE_INTEGER Timeout100Ns;
+    CXPLAT_DBG_ASSERT(TimeoutMs != UINT32_MAX);
     Timeout100Ns.QuadPart = -1 * UInt32x32To64(TimeoutMs, 10000);
     return KeWaitForSingleObject(Event, Executive, KernelMode, FALSE, &Timeout100Ns);
 }

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -673,7 +673,7 @@ typedef HANDLE CXPLAT_EVENT;
 #define CxPlatEventWaitForever(Event) WaitForSingleObject(Event, INFINITE)
 inline
 BOOLEAN
-_CxPlatEventWaitWithTimeout(
+CxPlatEventWaitWithTimeout(
     _In_ CXPLAT_EVENT Event,
     _In_ uint32_t TimeoutMs
     )
@@ -681,7 +681,6 @@ _CxPlatEventWaitWithTimeout(
     CXPLAT_DBG_ASSERT(TimeoutMs != UINT32_MAX);
     return WAIT_OBJECT_0 == WaitForSingleObject(Event, TimeoutMs);
 }
-#define CxPlatEventWaitWithTimeout(Event, TimeoutMs) _CxPlatEventWaitWithTimeout(Event, TimeoutMs)
 
 //
 // Event Queue Interfaces

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -671,8 +671,17 @@ typedef HANDLE CXPLAT_EVENT;
 #define CxPlatEventSet(Event) SetEvent(Event)
 #define CxPlatEventReset(Event) ResetEvent(Event)
 #define CxPlatEventWaitForever(Event) WaitForSingleObject(Event, INFINITE)
-#define CxPlatEventWaitWithTimeout(Event, timeoutMs) \
-    (WAIT_OBJECT_0 == WaitForSingleObject(Event, timeoutMs))
+inline
+BOOLEAN
+_CxPlatEventWaitWithTimeout(
+    _In_ CXPLAT_EVENT Event,
+    _In_ uint32_t TimeoutMs
+    )
+{
+    CXPLAT_DBG_ASSERT(TimeoutMs != UINT32_MAX);
+    return WAIT_OBJECT_0 == WaitForSingleObject(Event, TimeoutMs);
+}
+#define CxPlatEventWaitWithTimeout(Event, TimeoutMs) _CxPlatEventWaitWithTimeout(Event, TimeoutMs)
 
 //
 // Event Queue Interfaces


### PR DESCRIPTION
## Description
When UINT32_MAX is passed as a timeout value to CxPlatEventWaitWithTimeout on the winkernel platform, an arithmetic overflow happens resulting in a positive timeout value and the wait timing out immediately. The winuser and posix platform implementations of CxPlatEventWaitWithTimeout appear to handle this case gracefully, even though callers should really be using CxPlatEventWaitForever for the infinite wait case. Fixing winkernel to handle this gracefully to eliminate this developer trap.

Also adding asserts to catch cases where the developer is calling the CxPlatEventWaitWithTimeout API incorrectly.

## Testing
Local testing w/ debugger confirmation of overflow and the fix.

## Documentation
N/A
