### PR TITLE
Limit the scope of metadata events in MsQuic.wprp

### DIFF
--- a/src/manifest/MsQuic.wprp
+++ b/src/manifest/MsQuic.wprp
@@ -308,4 +308,12 @@
     <Profile Id="SpinQuicWarnings.Light.Memory" Base="SpinQuicWarnings.Light.File" Name="SpinQuicWarnings" Description="Used for SpinQuic Testing" LoggingMode="Memory" DetailLevel="Light"/>
 
   </Profiles>
+  <TraceMergeProperties>
+    <TraceMergeProperty  Id="MsquicTraceMerge_Default" Name="MsquicTraceMerge_Default">
+    <CustomEvents>
+      <CustomEvent Value="ImageId"/>
+      <CustomEvent Value="BuildInfo"/>
+    </CustomEvents>
+    </TraceMergeProperty>
+  </TraceMergeProperties>
 </WindowsPerformanceRecorder>


### PR DESCRIPTION
## Description

Only collect build/image name for metadata events. The default set is too noisy and largely useless.

## Testing

Locally tested
