### PR TITLE
Fix Get-NetView Execution

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -145,7 +145,7 @@ Invoke-Command -Session $Session -ScriptBlock {
 }
 
 # Collect some info about machine state.
-if ($NoLogs -and $isWindows) {
+if (!$NoLogs -and $isWindows) {
     $Arguments = "-SkipNetsh"
     if (Get-Help Get-NetView -Parameter SkipWindowsRegistry -ErrorAction Ignore) {
         $Arguments += " -SkipWindowsRegistry"


### PR DESCRIPTION
## Description

`Get-NetView` was only supposed to run if logs are collected. This fix negates a negative to achieve this now.

## Testing

CI/CD

## Documentation

N/A
