### PR TITLE
Process Full Latency Output and Encode in Json

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -404,19 +404,19 @@ function Get-LatencyOutput {
 
     # Parse through the data and extract the Value and Percentile columns and
     # convert to an array. Ignore the trailing data.
-    $data = @()
+    $values = @()
+    $percentiles = @()
     foreach ($line in $contents) {
         if ($line -match "^\s*(\d+\.\d+)\s+(\d+\.\d+)") {
-            $value = [int]$matches[1]
-            $percentile = [double]$matches[2]
-            $data += New-Object PSObject -Property @{
-                "Value" = $value
-                "Percentile" = $percentile
-            }
+            $values += [int]$matches[1]
+            $percentiles += [double]$matches[2]
         }
     }
 
-    return $data
+    return [pscustomobject]@{
+        Values = $values
+        Percentiles = $percentiles
+    }
 }
 
 # Invokes secnetperf with the given arguments for both TCP and QUIC.

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -520,7 +520,7 @@ function Invoke-Secnetperf {
             Write-Host $rawOutput
             $values[$tcp] += Get-TestOutput $rawOutput $metric
             if ($extraOutput) {
-                $latency[$tcp] = Get-LatencyOutput $extraOutput
+                $latency[$tcp] += Get-LatencyOutput $extraOutput
             }
             $rawOutput | Add-Content $clientOut
             $successCount++

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -329,7 +329,7 @@ Write-Host "Tests complete!"
     Write-Host "`Writing test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
     $SQL | Set-Content -Path "test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
     Write-Host "`Writing json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
-    $json | ConvertTo-Json | Set-Content -Path "json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
+    $json | ConvertTo-Json -Depth 4 | Set-Content -Path "json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
 }
 
 # Clear out any exit codes from previous commands.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -326,10 +326,10 @@ Write-Host "Tests complete!"
     } catch { }
 
     # Save the test results (sql and json).
-    Write-Host "`Writing test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
-    $SQL | Set-Content -Path "test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
-    Write-Host "`Writing json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
-    $json | ConvertTo-Json -Depth 4 | Set-Content -Path "json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
+    Write-Host "`Writing test-results-$environment-$os-$arch-$tls-$io.sql"
+    $SQL | Set-Content -Path "test-results-$environment-$os-$arch-$tls-$io.sql"
+    Write-Host "`Writing json-test-results-$environment-$os-$arch-$tls-$io.json"
+    $json | ConvertTo-Json -Depth 4 | Set-Content -Path "json-test-results-$environment-$os-$arch-$tls-$io.json"
 }
 
 # Clear out any exit codes from previous commands.

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -284,6 +284,7 @@ VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $env, $env, $item, NULL, "$io", "$t
 "@
             }
         } elseif ($Test.Metric -eq "latency") {
+            $json["$testId-$transport-lat"] = $Test.Latency[$tcp]
             # Test.Values[...] is a flattened 1D array of the form: [ first run + RPS, second run + RPS, third run + RPS..... ], ie. if each run has 8 values + RPS, then the array has 27 elements (8*3 + 3)
             for ($offset = 0; $offset -lt $Test.Values[$tcp].Length; $offset += 9) {
                 $SQL += @"


### PR DESCRIPTION
## Description

Updates the secnetperf scripts to process the latency output files and grab the data we need, then encode it in the json output.

## Testing

Manual netperf job; CI/CD

## Documentation

N/A
