### PR TITLE
Enable dynamic environment

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -206,7 +206,8 @@ $allTests["tput-down"] = "-exec:maxtput -down:12s -ptput:1"
 $allTests["hps-conns-100"] = "-exec:maxtput -rconn:1 -share:1 -conns:100 -run:12s -prate:1"
 $allTests["rps-up-512-down-4000"] = "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:20s -plat:1"
 
-$env = $isWindows ? 1 : 2
+$envIDClient = "__CLIENT_ENV__"
+$envIDServer = "__SERVER_ENV__"
 $hasFailures = $false
 
 try {
@@ -280,7 +281,7 @@ INSERT OR IGNORE INTO Secnetperf_tests (Secnetperf_test_ID, Kernel_mode, Run_arg
             foreach ($item in $Test.Values[$tcp]) {
                 $SQL += @"
 `nINSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Secnetperf_latency_stats_ID, io, tls)
-VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $env, $env, $item, NULL, "$io", "$tls");
+VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $envIDClient, $envIDServer, $item, NULL, "$io", "$tls");
 "@
             }
         } elseif ($Test.Metric -eq "latency") {
@@ -290,7 +291,7 @@ VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $env, $env, $item, NULL, "$io", "$t
 `nINSERT INTO Secnetperf_latency_stats (p0, p50, p90, p99, p999, p9999, p99999, p999999)
 VALUES ($($Test.Values[$tcp][$offset]), $($Test.Values[$tcp][$offset+1]), $($Test.Values[$tcp][$offset+2]), $($Test.Values[$tcp][$offset+3]), $($Test.Values[$tcp][$offset+4]), $($Test.Values[$tcp][$offset+5]), $($Test.Values[$tcp][$offset+6]), $($Test.Values[$tcp][$offset+7]));
 INSERT INTO Secnetperf_test_runs (Secnetperf_test_ID, Secnetperf_commit, Client_environment_ID, Server_environment_ID, Result, Secnetperf_latency_stats_ID, io, tls)
-VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $env, $env, $($Test.Values[$tcp][$offset+8]), LAST_INSERT_ROWID(), "$io", "$tls");
+VALUES ("$TestId-tcp-$tcp", "$MsQuicCommit", $envIDClient, $envIDServer, $($Test.Values[$tcp][$offset+8]), LAST_INSERT_ROWID(), "$io", "$tls");
 "@
             }
         }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -326,10 +326,10 @@ Write-Host "Tests complete!"
     } catch { }
 
     # Save the test results (sql and json).
-    Write-Host "`Writing test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
-    $SQL | Set-Content -Path "test-results-$environment-$plat-$os-$arch-$tls-$io.sql"
-    Write-Host "`Writing json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
-    $json | ConvertTo-Json | Set-Content -Path "json-test-results-$environment-$plat-$os-$arch-$tls-$io.json"
+    Write-Host "`Writing test-results-$environment-$os-$arch-$tls-$io.sql"
+    $SQL | Set-Content -Path "test-results-$environment-$os-$arch-$tls-$io.sql"
+    Write-Host "`Writing json-test-results-$environment-$os-$arch-$tls-$io.json"
+    $json | ConvertTo-Json | Set-Content -Path "json-test-results-$environment-$os-$arch-$tls-$io.json"
 }
 
 # Clear out any exit codes from previous commands.


### PR DESCRIPTION
## Description

As of today, the current logic for assigning environment IDs to test runs is using $isWindows.

A lot of work has been done on netperf's side to enable querying / dynamic environments, so we should adjust the driver script to work with that interface.

## Testing

CI

## Documentation

N/A
