### PR TITLE
Cache all metadata we need to unblock JSON refactor

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -210,6 +210,8 @@ $envIDClient = "__CLIENT_ENV__"
 $envIDServer = "__SERVER_ENV__"
 $hasFailures = $false
 
+$json["run_args"] = $allTests
+
 try {
 
 # Prepare the machines for the testing.


### PR DESCRIPTION
## Description

As detailed in this issue: https://github.com/microsoft/netperf/issues/92 

It's apparent that if we do all post-processing of SQL-related stuff at the end, that makes simple a lot of logic. 

To start this refactor, we need to pass all relevant metadata in the intermediary JSON files we produce.

Once the full refactor is done, we can safely delete the code that produces the SQL files. 

## Testing

CI

## Documentation

N/A
