### PR TITLE
Fix Verify Check to Account for Race Conditions

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1300,7 +1300,9 @@ MsQuicStreamReceiveComplete(
         (Connection->WorkerThreadID == CxPlatCurThreadID()) ||
         !Connection->State.HandleClosed);
 
-    QUIC_CONN_VERIFY(Connection, BufferLength <= Stream->RecvPendingLength);
+    QUIC_CONN_VERIFY(Connection,
+        (Stream->RecvPendingLength == 0) || // Stream might have been shutdown already
+        BufferLength <= Stream->RecvPendingLength);
 
     QuicTraceEvent(
         StreamAppReceiveCompleteCall,


### PR DESCRIPTION
## Description

Stress tests recently started failing because of `QUIC_CONN_VERIFY` check that tries to make sure the app doesn't try to complete more than it was actually given in past receives. The problem is that there is a race condition where this value can be cleared on stream shutdown. So this change just ignores cases where the pending length has already been cleared.

## Testing

Automation

## Documentation

N/A
