### PR TITLE
Fix CodeCoverage Upload

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -235,7 +235,9 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab
       with:
+        fail_ci_if_error: true
         files: msquiccoverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
     - name: Code Coverage Summary Report
       uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
       with:


### PR DESCRIPTION
## Description

Looks like recent breaking changes to code coverage caused our uploads to start failing. This PR tries to fix that.

## Testing

Automation

## Documentation

N/A
