### PR TITLE
Enable SPGO for OneBranch Builds

### DIFF
--- a/.azure/obtemplates/build-winkernel.yml
+++ b/.azure/obtemplates/build-winkernel.yml
@@ -11,6 +11,7 @@ jobs:
     ob_outputDirectory: $(Build.SourcesDirectory)\artifacts\bin\winkernel
     ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
     ob_sdl_codeSignValidation_excludes: -|**\*.sys # Disable signing requirements for KM builds
+    ob_spgo_enabled: true # Enable SPGO
   steps:
   - script: scripts\onebranch-build-kernel.cmd ${{ parameters.config }} x64
     displayName: x64

--- a/.azure/obtemplates/build-winuser.yml
+++ b/.azure/obtemplates/build-winuser.yml
@@ -12,6 +12,7 @@ jobs:
     ob_outputDirectory: $(Build.SourcesDirectory)\artifacts\bin\${{ parameters.platform }}
     ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
     ob_sdl_codeSignValidation_excludes: -|**\*.exe # Disable signing requirements for test executables
+    ob_spgo_enabled: true # Enable SPGO
   steps:
   - task: PowerShell@2
     displayName: Prepare Build Machine


### PR DESCRIPTION
## Description

Sets a flag to enable automatic SPGO build information to be included when building Windows code.

## Testing

Automation

## Documentation

N/A
