### PR TITLE
Skip Unit Tests in Code Coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -74,7 +74,7 @@ jobs:
       shell: pwsh
       timeout-minutes: 120
       continue-on-error: true
-      run: scripts/test.ps1 -NoProgress -IsolationMode Batch -CodeCoverage -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -LogProfile Full.Light ${{ matrix.vec.xdp }} ${{ matrix.vec.qtip }}
+      run: scripts/test.ps1 -NoProgress -IsolationMode Batch -SkipUnitTests -CodeCoverage -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -LogProfile Full.Light ${{ matrix.vec.xdp }} ${{ matrix.vec.qtip }}
     - name: Upload Results
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
       with:

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -240,7 +240,9 @@ public:
         Config.Name = Name;
         Config.Callback = WatchdogThreadCallback;
         Config.Context = this;
-        CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(WatchdogThread.Create(&Config)));
+        if (WatchdogTimeoutMs != UINT32_MAX) {
+            CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(WatchdogThread.Create(&Config)));
+        }
     }
     ~CxPlatWatchdog() noexcept {
         ShutdownEvent.Set();


### PR DESCRIPTION
## Description

For some reason the platform unittests were failing, causing the BVTs never to be run in code coverage.

## Testing

CI/CD

## Documentation

N/A
