### PR TITLE
Persist BestResult / BestResultCommit / Baseline for all results, regardless of regression. 

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -577,7 +577,6 @@ function Invoke-Secnetperf {
 }
 
 function CheckRegressionResult($values, $testid, $transport, $regressionJson, $envStr) {
-    # Returns true if there is a regression in this new run.
 
     $sum = 0
     foreach ($item in $values) {
@@ -585,12 +584,21 @@ function CheckRegressionResult($values, $testid, $transport, $regressionJson, $e
     }
     $avg = $sum / $values.Length
     $Testid = "$testid-$transport"
+
+    $res = @{
+        Baseline = "N/A"
+        BestResult = "N/A"
+        BestResultCommit = "N/A"
+        CumulativeResult = "N/A"
+        AggregateFunction = "N/A"
+        HasRegression = $false
+    }
+
     try {
-        # TODO: baseline is a bad name. Use LowerThreshold / UpperThreshold instead.
         $baseline = $regressionJson.$Testid.$envStr.baseline
     } catch {
         Write-Host "No regression baseline found"
-        return "NULL"
+        return $res
     }
 
     try {
@@ -599,54 +607,67 @@ function CheckRegressionResult($values, $testid, $transport, $regressionJson, $e
         $BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
         if ($avg -lt $baseline) {
             Write-GHError "🤮 Regression detected in $Testid for $envStr. Baseline: $baseline, New: $avg, BestResult: $BestResult, Noise: $Noise, BestResultCommit: $BestResultCommit"
-            return "🤮 Baseline: $baseline, New: $avg, BestResult: $BestResult, Noise: $Noise, BestResultCommit: $BestResultCommit"
+            return @{
+                Baseline = $baseline
+                BestResult = $BestResult
+                BestResultCommit = $BestResultCommit
+                CumulativeResult = $avg
+                AggregateFunction = "AVG"
+                HasRegression = $true
+            }
         }
     } catch {
-        Write-Host "Not using a watermark-based regression method."
+        Write-Host "Not using a watermark-based regression method. Skipping."
     }
 
-    if ($avg -lt $baseline) {
-        Write-GHError "Regression detected in $Testid for $envStr. Baseline: $baseline, New: $avg"
-        return "🤮 Baseline: $baseline, New: $avg"
-    }
-    return "NULL"
+    return $res
 }
 
 function CheckRegressionLat($values, $regressionJson, $testid, $transport, $envStr) {
-    # $values is a flattened 1D array of the form:
-    # [ first run + RPS, second run + RPS, third run + RPS..... ],
-    # ie. if each run has 8 values + RPS, then the array has 27 elements (8*3 + 3)
-    # We store each subarray as [P0, P50, P90, P99 ... RPS, P0, ...]
-    # So just compute the average of P0, P50, P99 across the N runs, and compare that against the baseline.
-    $P0Avg = 0
-    $P50Avg = 0
-    $P99Avg = 0
+
+    # TODO: Right now, we are not using a watermark based method for regression detection of latency percentile values because we don't know how to determine a "Best Ever" distribution.
+    #       (we are just looking at P0, P50, P99 columns, and computing the baseline for each percentile as the mean - 2 * std of the last 20 runs. )
+    #       So, the summary table omits a "BestEver" and "Baseline" column for latency. In fact, we ignore the "mean - 2*std" signal entirely. Need to determine how we compare distributions.
+
+    $RpsAvg = 0
     $NumRuns = $values.Length / 9
     for ($offset = 0; $offset -lt $values.Length; $offset += 9) {
-        $P0Avg += $values[$offset]
-        $P50Avg += $values[$offset + 1]
-        $P99Avg += $values[$offset + 3]
+        $RpsAvg += $values[$offset + 8]
     }
-    $P0Avg /= $NumRuns
-    $P50Avg /= $NumRuns
-    $P99Avg /= $NumRuns
+
+    $RpsAvg /= $NumRuns
     $Testid = "$testid-$transport"
+
+    $res = @{
+        Baseline = "N/A"
+        BestResult = "N/A"
+        BestResultCommit = "N/A"
+        CumulativeResult = "N/A"
+        AggregateFunction = "N/A"
+        HasRegression = $false
+    }
+
     try {
-        $P0UpperBound= $regressionJson.$Testid.$envStr.latencyUpperBound.P0
-        $P50UpperBound= $regressionJson.$Testid.$envStr.latencyUpperBound.P50
-        $P99UpperBound= $regressionJson.$Testid.$envStr.latencyUpperBound.P99
+        $RPSLowerBound = $regressionJson.$Testid.$envStr.baseline
+        $BestResult = $regressionJson.$Testid.$envStr.BestResult
+        $BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
     } catch {
-        Write-Host "No regression upper bounds found"
-        return "NULL"
+        Write-Host "No regression baseline found"
+        return $res
     }
 
-    # There is a regression if ALL 3 values are more than their upper bound.
-    if ($P0Avg -gt $P0UpperBound -and $P50Avg -gt $P50UpperBound -and $P99Avg -gt $P99UpperBound) {
-        Write-GHError "Latency Regression detected in $Testid for $envStr."
-        Write-GHError "P0: $P0Avg, P50: $P50Avg, P99: $P99Avg"
-        Write-GHError "P0 upper bound: $P0UpperBound, P50 upper bound: $P50UpperBound, P99 upper bound: $P99UpperBound"
-        return "🤮 (Percentile avg, Upperbound) P0: ($P0Avg, $P0UpperBound) P50: ($P50Avg, $P50UpperBound) P99: ($P99Avg, $P99UpperBound)"
+    if ($RpsAvg -lt $RPSLowerBound) {
+        Write-GHError "RPS Regression detected in $Testid for $envStr."
+        Write-GHError "RPS: $RpsAvg, RPS lower bound: $RPSLowerBound"
+        return @{
+            Baseline = $RPSLowerBound
+            BestResult = $BestResult
+            BestResultCommit = $BestResultCommit
+            CumulativeResult = $RpsAvg
+            AggregateFunction = "AVG"
+            HasRegression = $true
+        }
     }
 
-    return "NULL"
+    return $res
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -602,7 +602,7 @@ function CheckRegressionResult($values, $testid, $transport, $regressionJson, $e
         $res.AggregateFunction = "AVG"
 
         if ($avg -lt $res.Baseline) {
-            Write-GHError "🤮 Regression detected in $Testid for $envStr. Baseline: $baseline, New: $avg, BestResult: $BestResult, Noise: $Noise, BestResultCommit: $BestResultCommit"
+            Write-GHError "Regression detected in $Testid for $envStr. See summary table for details."
             $res.HasRegression = $true
         }
     } catch {
@@ -644,8 +644,7 @@ function CheckRegressionLat($values, $regressionJson, $testid, $transport, $envS
         $res.AggregateFunction = "AVG"
 
         if ($RpsAvg -lt $res.Baseline) {
-            Write-GHError "RPS Regression detected in $Testid for $envStr."
-            Write-GHError "RPS: $RpsAvg, RPS lower bound: $RPSLowerBound"
+            Write-GHError "RPS Regression detected in $Testid for $envStr. See summary table for details."
             $res.HasRegression = $true
         }
     } catch {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -598,6 +598,8 @@ function CheckRegressionResult($values, $testid, $transport, $regressionJson, $e
         $res.Baseline = $regressionJson.$Testid.$envStr.baseline
         $res.BestResult = $regressionJson.$Testid.$envStr.BestResult
         $res.BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
+        $res.CumulativeResult = $avg
+        $res.AggregateFunction = "AVG"
 
         if ($avg -lt $res.Baseline) {
             Write-GHError "🤮 Regression detected in $Testid for $envStr. Baseline: $baseline, New: $avg, BestResult: $BestResult, Noise: $Noise, BestResultCommit: $BestResultCommit"
@@ -638,6 +640,8 @@ function CheckRegressionLat($values, $regressionJson, $testid, $transport, $envS
         $res.Baseline = $regressionJson.$Testid.$envStr.baseline
         $res.BestResult = $regressionJson.$Testid.$envStr.BestResult
         $res.BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
+        $res.CumulativeResult = $RpsAvg
+        $res.AggregateFunction = "AVG"
 
         if ($RpsAvg -lt $res.Baseline) {
             Write-GHError "RPS Regression detected in $Testid for $envStr."

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -595,26 +595,13 @@ function CheckRegressionResult($values, $testid, $transport, $regressionJson, $e
     }
 
     try {
-        $baseline = $regressionJson.$Testid.$envStr.baseline
-    } catch {
-        Write-Host "No regression baseline found"
-        return $res
-    }
+        $res.Baseline = $regressionJson.$Testid.$envStr.baseline
+        $res.BestResult = $regressionJson.$Testid.$envStr.BestResult
+        $res.BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
 
-    try {
-        $BestResult = $regressionJson.$Testid.$envStr.BestResult
-        $Noise = $regressionJson.$Testid.$envStr.Noise
-        $BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
-        if ($avg -lt $baseline) {
+        if ($avg -lt $res.Baseline) {
             Write-GHError "🤮 Regression detected in $Testid for $envStr. Baseline: $baseline, New: $avg, BestResult: $BestResult, Noise: $Noise, BestResultCommit: $BestResultCommit"
-            return @{
-                Baseline = $baseline
-                BestResult = $BestResult
-                BestResultCommit = $BestResultCommit
-                CumulativeResult = $avg
-                AggregateFunction = "AVG"
-                HasRegression = $true
-            }
+            $res.HasRegression = $true
         }
     } catch {
         Write-Host "Not using a watermark-based regression method. Skipping."
@@ -648,25 +635,17 @@ function CheckRegressionLat($values, $regressionJson, $testid, $transport, $envS
     }
 
     try {
-        $RPSLowerBound = $regressionJson.$Testid.$envStr.baseline
-        $BestResult = $regressionJson.$Testid.$envStr.BestResult
-        $BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
-    } catch {
-        Write-Host "No regression baseline found"
-        return $res
-    }
+        $res.Baseline = $regressionJson.$Testid.$envStr.baseline
+        $res.BestResult = $regressionJson.$Testid.$envStr.BestResult
+        $res.BestResultCommit = $regressionJson.$Testid.$envStr.BestResultCommit
 
-    if ($RpsAvg -lt $RPSLowerBound) {
-        Write-GHError "RPS Regression detected in $Testid for $envStr."
-        Write-GHError "RPS: $RpsAvg, RPS lower bound: $RPSLowerBound"
-        return @{
-            Baseline = $RPSLowerBound
-            BestResult = $BestResult
-            BestResultCommit = $BestResultCommit
-            CumulativeResult = $RpsAvg
-            AggregateFunction = "AVG"
-            HasRegression = $true
+        if ($RpsAvg -lt $res.Baseline) {
+            Write-GHError "RPS Regression detected in $Testid for $envStr."
+            Write-GHError "RPS: $RpsAvg, RPS lower bound: $RPSLowerBound"
+            $res.HasRegression = $true
         }
+    } catch {
+        Write-Host "Not using a watermark-based regression method."
     }
 
     return $res

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -272,8 +272,7 @@ foreach ($testId in $allTests.Keys) {
         if ($Test.Metric -eq "latency") {
             $json["$testId-$transport-lat"] = $Test.Latency[$tcp]
             $LatencyRegression = CheckRegressionLat $Test.Values[$tcp] $regressionJson $testId $transport "$os-$arch-$environment-$io-$tls"
-            $json["$testId-$transport-regression"] = $LatencyRegression[0]
-            # $json["$testId-$transport-lat-regression"] = $LatencyRegression[1]
+            $json["$testId-$transport-regression"] = $LatencyRegression
         } else {
             $ResultRegression = CheckRegressionResult $Test.Values[$tcp] $testId $transport $regressionJson "$os-$arch-$environment-$io-$tls"
             $json["$testId-$transport-regression"] = $ResultRegression

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -268,16 +268,15 @@ foreach ($testId in $allTests.Keys) {
         if ($Test.Values[$tcp].Length -eq 0) { continue }
         $transport = $tcp -eq 1 ? "tcp" : "quic"
         $json["$testId-$transport"] = $Test.Values[$tcp]
-        $ResultRegression = CheckRegressionResult $Test.Values[$tcp] $testId $transport $regressionJson "$os-$arch-$environment-$io-$tls"
-        if ($ResultRegression -ne "NULL") {
-            $json["$testId-$transport-regression"] = $ResultRegression
-        }
+
         if ($Test.Metric -eq "latency") {
             $json["$testId-$transport-lat"] = $Test.Latency[$tcp]
             $LatencyRegression = CheckRegressionLat $Test.Values[$tcp] $regressionJson $testId $transport "$os-$arch-$environment-$io-$tls"
-            if ($LatencyRegression -ne "NULL") {
-                $json["$testId-$transport-lat-regression"] = $LatencyRegression
-            }
+            $json["$testId-$transport-regression"] = $LatencyRegression[0]
+            # $json["$testId-$transport-lat-regression"] = $LatencyRegression[1]
+        } else {
+            $ResultRegression = CheckRegressionResult $Test.Values[$tcp] $testId $transport $regressionJson "$os-$arch-$environment-$io-$tls"
+            $json["$testId-$transport-regression"] = $ResultRegression
         }
     }
 }


### PR DESCRIPTION
## Description

To increase observability and developer productivity, we want to make each netperf run output a comprehensive summary. 

With this commit on netperf: https://github.com/microsoft/netperf/commit/2f147803a8784802404433a21c27aea2937f550f, we added functionality to see how each run compares against the best run. 

This PR makes the necessary test code changes to work with the recent patch. 

## Testing

CI

## Documentation

N/A