### PR TITLE
add memory alignment for ARM32

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -76,7 +76,7 @@ typedef struct DATAPATH_RX_IO_BLOCK {
 
 } DATAPATH_RX_IO_BLOCK;
 
-typedef struct DATAPATH_RX_PACKET {
+typedef struct __attribute__((aligned(16))) DATAPATH_RX_PACKET {
     //
     // The IO block that owns the packet.
     //


### PR DESCRIPTION
## Description

Fixes #3958 
Support arm32 memory alignment

## Testing

Tested and passed on raspberry pi.
It had been failed at processing 3rd or 4th packets consistently (during handshake). now it has gone with the fix.

## Documentation

_Is there any documentation impact for this change?_
