### PR TITLE
Fix Publish of Cross-Compile Docker Image Tag

### DIFF
--- a/.github/workflows/docker-publish-xcomp.yml
+++ b/.github/workflows/docker-publish-xcomp.yml
@@ -70,5 +70,5 @@ jobs:
           context: .docker/ubuntu-${{ matrix.version }}
           file: .docker/ubuntu-${{ matrix.version }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu-${{ matrix.version }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

The automation is expecting `ubuntu:22.04` as the tag, but it is publishing only `22.04`. This PR fixes the publish.

## Testing

CI/CD

## Documentation

N/A
