### PR TITLE
Work around fpm dependencies for ubuntu 20.04

### DIFF
--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     lttng-tools \
     perl \
     nasm \
-    ruby \
+    ruby3.0 \
     ruby-dev \
     rpm \
     libssl-dev \

--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     lttng-tools \
     perl \
     nasm \
-    ruby3.0 \
+    ruby \
     ruby-dev \
     rpm \
     libssl-dev \
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     gdb \
   && rm -rf /var/lib/apt/lists/*
 
+RUN gem install --version 2.8.1 dotenv
 RUN gem install fpm
 
 RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \


### PR DESCRIPTION
## Description

See if that resolves the failure blocking the docker image build