### PR TITLE
Don't do full drain on chunks containing future buffered data

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -917,7 +917,7 @@ QuicRecvBufferDrain(
             //
             QuicRangeSize(&RecvBuffer->WrittenRanges) > 1) {
             QuicRecvBufferPartialDrain(RecvBuffer, DrainLength);
-            return PartialDrain;
+            return !PartialDrain;
         }
 
         DrainLength = QuicRecvBufferFullDrain(RecvBuffer, DrainLength);

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -923,7 +923,6 @@ QuicRecvBufferDrain(
         DrainLength = QuicRecvBufferFullDrain(RecvBuffer, DrainLength);
     } while (DrainLength != 0);
 
-    // return TRUE;
     return QuicRecvBufferHasUnreadData(RecvBuffer);
 }
 

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -909,7 +909,7 @@ QuicRecvBufferDrain(
     do {
         if ((uint64_t)RecvBuffer->ReadLength > DrainLength ||
             //
-            // If there are more than 2 written ranges, it means that there may be
+            // If there are 2 or more written ranges, it means that there may be
             // more data later in the chunk that couldn't be read because there is a gap.
             //
             RecvBuffer->WrittenRanges.UsedLength > 1) {

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -907,7 +907,12 @@ QuicRecvBufferDrain(
     }
 
     do {
-        if ((uint64_t)RecvBuffer->ReadLength > DrainLength) {
+        if ((uint64_t)RecvBuffer->ReadLength > DrainLength ||
+            //
+            // If there are more than 2 written ranges, it means that there may be
+            // more data later in the chunk that couldn't be read because there is a gap.
+            //
+            RecvBuffer->WrittenRanges.UsedLength > 1) {
             QuicRecvBufferPartialDrain(RecvBuffer, DrainLength);
             return FALSE;
         }

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -923,7 +923,7 @@ QuicRecvBufferDrain(
         DrainLength = QuicRecvBufferFullDrain(RecvBuffer, DrainLength);
     } while (DrainLength != 0);
 
-    return QuicRecvBufferHasUnreadData(RecvBuffer);
+    return TRUE;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/src/core/unittest/RecvBufferTest.cpp
+++ b/src/core/unittest/RecvBufferTest.cpp
@@ -659,7 +659,7 @@ TEST_P(WithMode, DrainFrontChunkWithPendingGap)
     RecvBuf.Read(&ReadOffset, &BufferCount, ReadBuffers);
     ASSERT_EQ(1ul, BufferCount);
     ASSERT_EQ(1ul, ReadBuffers[0].Length);
-    ASSERT_FALSE(RecvBuf.Drain(1));
+    ASSERT_TRUE(RecvBuf.Drain(1));
 
     // insert missing chunk and drain the rest
     InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
@@ -679,7 +679,7 @@ TEST_P(WithMode, DrainFrontChunkWithPendingGap)
         TotalRead += ReadBuffers[i].Length;
     }
     ASSERT_EQ(2ul, TotalRead);
-    ASSERT_TRUE(RecvBuf.Drain(1)); // more data left in buffer
+    ASSERT_FALSE(RecvBuf.Drain(1)); // more data left in buffer
 
     if (GetParam() != QUIC_RECV_BUF_MODE_MULTIPLE) {
         BufferCount = ARRAYSIZE(ReadBuffers);
@@ -690,7 +690,7 @@ TEST_P(WithMode, DrainFrontChunkWithPendingGap)
         }
         ASSERT_EQ(1ul, TotalRead);
     }
-    ASSERT_FALSE(RecvBuf.Drain(1));
+    ASSERT_TRUE(RecvBuf.Drain(1));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/core/unittest/RecvBufferTest.cpp
+++ b/src/core/unittest/RecvBufferTest.cpp
@@ -659,7 +659,7 @@ TEST_P(WithMode, DrainFrontChunkWithPendingGap)
     RecvBuf.Read(&ReadOffset, &BufferCount, ReadBuffers);
     ASSERT_EQ(1ul, BufferCount);
     ASSERT_EQ(1ul, ReadBuffers[0].Length);
-    RecvBuf.Drain(1);
+    ASSERT_FALSE(RecvBuf.Drain(1));
 
     // insert missing chunk and drain the rest
     InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
@@ -679,6 +679,18 @@ TEST_P(WithMode, DrainFrontChunkWithPendingGap)
         TotalRead += ReadBuffers[i].Length;
     }
     ASSERT_EQ(2ul, TotalRead);
+    ASSERT_TRUE(RecvBuf.Drain(1)); // more data left in buffer
+
+    if (GetParam() != QUIC_RECV_BUF_MODE_MULTIPLE) {
+        BufferCount = ARRAYSIZE(ReadBuffers);
+        RecvBuf.Read(&ReadOffset, &BufferCount, ReadBuffers);
+        TotalRead = 0;
+        for (uint32_t i = 0; i < BufferCount; ++i) {
+            TotalRead += ReadBuffers[i].Length;
+        }
+        ASSERT_EQ(1ul, TotalRead);
+    }
+    ASSERT_FALSE(RecvBuf.Drain(1));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/core/unittest/RecvBufferTest.cpp
+++ b/src/core/unittest/RecvBufferTest.cpp
@@ -625,6 +625,62 @@ TEST_P(WithMode, RecvCrypto) // Note - Values based on a previous failing MsQuic
     }
 }
 
+TEST_P(WithMode, DrainFrontChunkWithPendingGap)
+{
+    RecvBuffer RecvBuf;
+    ASSERT_EQ(QUIC_STATUS_SUCCESS, RecvBuf.Initialize(GetParam(), false));
+    uint64_t InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    BOOLEAN NewDataReady = FALSE;
+
+    // place data at some future offset
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(
+            2,
+            1,
+            &InOutWriteLength,
+            &NewDataReady));
+    ASSERT_FALSE(RecvBuf.HasUnreadData());
+
+    // place data to the front and drain
+    InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(
+            0,
+            1,
+            &InOutWriteLength,
+            &NewDataReady));
+    ASSERT_TRUE(NewDataReady);
+
+    uint64_t ReadOffset;
+    QUIC_BUFFER ReadBuffers[3];
+    uint32_t BufferCount = ARRAYSIZE(ReadBuffers);
+    RecvBuf.Read(&ReadOffset, &BufferCount, ReadBuffers);
+    ASSERT_EQ(1ul, BufferCount);
+    ASSERT_EQ(1ul, ReadBuffers[0].Length);
+    RecvBuf.Drain(1);
+
+    // insert missing chunk and drain the rest
+    InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(
+            1,
+            1,
+            &InOutWriteLength,
+            &NewDataReady));
+    ASSERT_TRUE(NewDataReady);
+
+    BufferCount = ARRAYSIZE(ReadBuffers);
+    RecvBuf.Read(&ReadOffset, &BufferCount, ReadBuffers);
+    uint64_t TotalRead = 0;
+    for (uint32_t i = 0; i < BufferCount; ++i) {
+        TotalRead += ReadBuffers[i].Length;
+    }
+    ASSERT_EQ(2ul, TotalRead);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     RecvBufferTest,
     WithMode,


### PR DESCRIPTION
## Description

This PR fixes bug where in certain situations, MsQuic would drop/corrupt data when received out of order + specific read timing from application side.

## Testing

Failing test added to detect future regressions.

## Documentation

N/A.