### PR TITLE
Add logic to remove any logging residue. 

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -224,10 +224,10 @@ function Cleanup-State {
     }
 
     # Clean up any ETL residue.
-    try { .\scripts\log.ps1 -Stop -OutputPath "$artifactDir/client" -RawLogOnly }
+    try { .\scripts\log.ps1 -Cancel }
     catch { Write-Host "Failed to stop logging on client!" }
     Invoke-Command -Session $Session -ScriptBlock {
-        try { & "$Using:RemoteDir/scripts/log.ps1" -Stop -OutputPath "$Using:remoteArtifactDir/server" -RawLogOnly }
+        try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel }
         catch { Write-Host "Failed to stop logging on server!" }
     }
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -224,14 +224,12 @@ function Cleanup-State {
     }
 
     # Clean up any ETL residue.
-    try {
-        if ($isWindows) {
-            $homeDirectory = $env:USERPROFILE
-        } else {
-            $homeDirectory = $env:HOME
-        }
-        Remove-Item $homeDirectory/AppData/Local/Temp -Recurse -Force
-    } catch { Write-Host "Failed to find and cleanup residual ETL files. Ignoring. Message: $_" }
+    try { .\scripts\log.ps1 -Stop -OutputPath "$artifactDir/client" -RawLogOnly }
+    catch { Write-Host "Failed to stop logging on client!" }
+    Invoke-Command -Session $Session -ScriptBlock {
+        try { & "$Using:RemoteDir/scripts/log.ps1" -Stop -OutputPath "$Using:remoteArtifactDir/server" -RawLogOnly }
+        catch { Write-Host "Failed to stop logging on server!" }
+    }
 }
 
 # Waits for a remote job to be ready based on looking for a particular string in

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -222,6 +222,16 @@ function Cleanup-State {
             if ($null -ne (Get-Service msquicpriv -ErrorAction Ignore)) { throw "msquicpriv still running remotely!" }
         }
     }
+
+    # Clean up any ETL residue.
+    try {
+        if ($isWindows) {
+            $homeDirectory = $env:USERPROFILE
+        } else {
+            $homeDirectory = $env:HOME
+        }
+        Remove-Item $homeDirectory/AppData/Local/Temp -Recurse -Force
+    } catch { Write-Host "Failed to find and cleanup residual ETL files. Ignoring. Message: $_" }
 }
 
 # Waits for a remote job to be ready based on looking for a particular string in


### PR DESCRIPTION
## Description

Thus far for secnetperf runs, we have relied on the Github runner agent to cleanup any managed directories pertaining to github actions. 

However, MsQuic modifies directories outside of the ones managed by Github Actions. 

Specifically, for logs, we know the /artifacts/logs gets cleaned up after every run, but /AppData/Local/Temp remains. 

So we must clean them up too. 

## Testing

CI 

## Documentation

N/A