### PR TITLE
Implement workaround for log.ps1 not working on Lab Linux

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -190,7 +190,7 @@ function Perf-Cancel {
     if (!$IsLinux) {
         throw "perf command wapper is only for Linux"
     } else {
-        pkill perf
+        sudo pkill perf
         try { Remove-Item -Path $TempPerfDir -Recurse -Force | Out-Null } catch { }
     }
 }

--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -190,7 +190,7 @@ function Perf-Cancel {
     if (!$IsLinux) {
         throw "perf command wapper is only for Linux"
     } else {
-        sudo pkill perf
+        pkill perf
         try { Remove-Item -Path $TempPerfDir -Recurse -Force | Out-Null } catch { }
     }
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -224,12 +224,12 @@ function Cleanup-State {
     }
 
     # Clean up any ETL residue.
-    try { .\scripts\log.ps1 -Cancel }
-    catch { Write-Host "Failed to stop logging on client!" }
-    Invoke-Command -Session $Session -ScriptBlock {
-        try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel }
-        catch { Write-Host "Failed to stop logging on server!" }
-    }
+    # try { .\scripts\log.ps1 -Cancel }
+    # catch { Write-Host "Failed to stop logging on client!" }
+    # Invoke-Command -Session $Session -ScriptBlock {
+    #     try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel }
+    #     catch { Write-Host "Failed to stop logging on server!" }
+    # }
 }
 
 # Waits for a remote job to be ready based on looking for a particular string in

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -221,15 +221,14 @@ function Cleanup-State {
             if ($null -ne (Get-Service msquicpriv -ErrorAction Ignore)) { throw "secnetperfdrvpriv still running remotely!" }
             if ($null -ne (Get-Service msquicpriv -ErrorAction Ignore)) { throw "msquicpriv still running remotely!" }
         }
+        # Clean up any ETL residue.
+        try { .\scripts\log.ps1 -Cancel }
+        catch { Write-Host "Failed to stop logging on client!" }
+        Invoke-Command -Session $Session -ScriptBlock {
+            try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel }
+            catch { Write-Host "Failed to stop logging on server!" }
+        }
     }
-
-    # Clean up any ETL residue.
-    # try { .\scripts\log.ps1 -Cancel }
-    # catch { Write-Host "Failed to stop logging on client!" }
-    # Invoke-Command -Session $Session -ScriptBlock {
-    #     try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel }
-    #     catch { Write-Host "Failed to stop logging on server!" }
-    # }
 }
 
 # Waits for a remote job to be ready based on looking for a particular string in


### PR DESCRIPTION
## Description

Earlier, we merged PRs to always cancel logging prior to each run because we noticed MsQuic was building up residual ETL traces, causing the storage to balloon. This is necessary until we get to dynamic, temporary lab VMs.

However, after merging those PRs, that surfaced an issue with the usage of "sudo" in the Log.ps1 script when we run it in our lab Linux VMs. 

This PR makes it so we do the cancellation of logs on Windows systems, to properly garbage collect the residual ETLs, which looks to be a Windows-only issue anyway. 

## Testing

CI

## Documentation

N/A