### PR TITLE
Fix pkgconfig setting to link with pkg-config

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -396,6 +396,13 @@ function CMake-Generate {
                 "arm64" { $Arguments += " -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_TARGET_ARCHITECTURE=arm64" }
                 "arm" { $Arguments += " -DCMAKE_CXX_COMPILER_TARGET=arm-linux-gnueabihf  -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf -DCMAKE_TARGET_ARCHITECTURE=arm" }
             }
+
+            # to build with pkg-config
+            switch ($Arch) {
+                "arm"   { $env:PKG_CONFIG_PATH="$SysRoot/usr/lib/arm-linux-gnueabihf/pkgconfig" }
+                "arm64" { $env:PKG_CONFIG_PATH="$SysRoot/usr/lib/aarch64-linux-gnu/pkgconfig" }
+                default { $env:PKG_CONFIG_PATH="$SysRoot/usr/lib/x86_64-linux-gnu/pkgconfig" }
+            }
        }
     }
     if ($ToolchainFile -ne "") {


### PR DESCRIPTION
## Description

`apt-get install pkg-config` affects linking of libcrypto.so. arm build tries to link x86-64's libcrypto.so
This environment variable assists pkg-config to search right directory.

## Testing

tested with commit da24f2d027fed3c55b315a1717be189ca4b9b657 with this change.
Works fine.

## Documentation

_Is there any documentation impact for this change?_
