### PR TITLE
Fix Bug in SpinQuic Around Receive Complete

### DIFF
--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -380,6 +380,10 @@ QUIC_STATUS QUIC_API SpinQuicHandleStreamEvent(HQUIC Stream, void* , QUIC_STREAM
         break;
     }
     case QUIC_STREAM_EVENT_RECEIVE: {
+        if (Event->RECEIVE.TotalBufferLength == 0) {
+            ctx->PendingRecvLength = UINT64_MAX; // TODO - Add more complex handling
+            break;
+        }
         int Random = GetRandom(5);
         std::lock_guard<std::mutex> Lock(ctx->Connection.Lock);
         CXPLAT_DBG_ASSERT(ctx->PendingRecvLength == UINT64_MAX);


### PR DESCRIPTION
## Description

SpinQuic was incorrectly doing multiple receive completes for a single receive indiciation, because it was marking `PendingRecvLength` as non-zero when it did a partial receive. That was incorrect. Fixed that, and improved synchronization around a few other things.

## Testing

Local and CI runs

## Documentation

N/A
