### PR TITLE
Revert AppData removal in log.ps1

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -265,10 +265,6 @@ function Log-Start {
 function Log-Cancel {
     if ($IsWindows) {
         try { wpr.exe -cancel -instancename $InstanceName 2>&1 } catch { }
-        try {
-            $homeDirectory = $env:USERPROFILE
-            Remove-Item $homeDirectory/AppData/Local/Temp -Recurse -Force
-        } catch { }
     } elseif ($IsMacOS) {
     } else {
         if (!(Test-Path $TempLTTngDir)) {


### PR DESCRIPTION
## Description

Recently we noticed buildup of ETL logs in AppData by MsQuic in our windows perf machines.

A temporary workaround was to remove them each time we cancelled logs.

However, this has some unforeseen consequences. 

Since we're implementing temporary VMs anyway, we should revert those workarounds. 

Merge when ready.

## Testing

CI

## Documentation

N/A
