### PR TITLE
Update SpinQuic to Validate Bytes in Stream Receive aren't Corrupted

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1118,6 +1118,12 @@ MsQuicStreamSend(
         goto Exit;
     }
 
+    //
+    // From here on, we cannot fail the call because the stream has been queued
+    // and possibly already started to be processed.
+    //
+    Status = QUIC_STATUS_PENDING;
+
     if (SendInline) {
 
         CXPLAT_PASSIVE_CODE();
@@ -1139,8 +1145,6 @@ MsQuicStreamSend(
                 "Allocation of '%s' failed. (%llu bytes)",
                 "STRM_SEND operation",
                 0);
-
-            Status = QUIC_STATUS_OUT_OF_MEMORY;
 
             //
             // We failed to alloc the operation we needed to queue, so make sure
@@ -1178,8 +1182,6 @@ MsQuicStreamSend(
         //
         QuicConnQueueOper(Connection, Oper);
     }
-
-    Status = QUIC_STATUS_PENDING;
 
 Exit:
 

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -363,11 +363,16 @@ QuicDatagramQueueSend(
         goto Exit;
     }
 
+    //
+    // From here on, we cannot fail the call because the stream has been queued
+    // and possibly already started to be processed.
+    //
+    Status = QUIC_STATUS_PENDING;
+
     if (QueueOper) {
         QUIC_OPERATION* Oper =
             QuicOperationAlloc(Connection->Worker, QUIC_OPER_TYPE_API_CALL);
         if (Oper == NULL) {
-            Status = QUIC_STATUS_OUT_OF_MEMORY;
             QuicTraceEvent(
                 AllocFailure,
                 "Allocation of '%s' failed. (%llu bytes)",
@@ -375,6 +380,9 @@ QuicDatagramQueueSend(
                 0);
             goto Exit;
         }
+
+        // TODO - Kill the connection?
+
         Oper->API_CALL.Context->Type = QUIC_API_TYPE_DATAGRAM_SEND;
 
         //
@@ -382,8 +390,6 @@ QuicDatagramQueueSend(
         //
         QuicConnQueueOper(Connection, Oper);
     }
-
-    Status = QUIC_STATUS_PENDING;
 
 Exit:
 

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -1009,6 +1009,8 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
                     if (QUIC_SUCCEEDED(
                         MsQuic.StreamSend(Stream, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(16), Buffer))) {
                         StreamCtx->SendOffset = (uint8_t)(StreamCtx->SendOffset + Length);
+                    } else {
+                        delete Buffer;
                     }
                 }
             }
@@ -1140,7 +1142,9 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
             if (Buffer) {
                 Buffer->Buffer = Gb.SendBuffer;
                 Buffer->Length = MaxBufferSizes[GetRandom(BufferCount)];
-                MsQuic.DatagramSend(Connection, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(8), Buffer);
+                if (QUIC_FAILED(MsQuic.DatagramSend(Connection, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(8), Buffer))) {
+                    delete Buffer;
+                }
             }
             break;
         }

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -1003,10 +1003,13 @@ void Spin(Gbs& Gb, LockableVector<HQUIC>& Connections, std::vector<HQUIC>* Liste
                 auto StreamCtx = SpinQuicStream::Get(Stream);
                 auto Buffer = new(std::nothrow) QUIC_BUFFER;
                 if (Buffer) {
+                    const uint32_t Length = MaxBufferSizes[GetRandom(BufferCount)];
                     Buffer->Buffer = Gb.SendBuffer + StreamCtx->SendOffset;
-                    Buffer->Length = MaxBufferSizes[GetRandom(BufferCount)];
-                    StreamCtx->SendOffset = (uint8_t)(StreamCtx->SendOffset + Buffer->Length);
-                    MsQuic.StreamSend(Stream, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(16), Buffer);
+                    Buffer->Length = Length;
+                    if (QUIC_SUCCEEDED(
+                        MsQuic.StreamSend(Stream, Buffer, 1, (QUIC_SEND_FLAGS)GetRandom(16), Buffer))) {
+                        StreamCtx->SendOffset = (uint8_t)(StreamCtx->SendOffset + Length);
+                    }
                 }
             }
             break;

--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -791,9 +791,9 @@ void SpinQuicSetRandomConnectionParam(HQUIC Connection, uint16_t ThreadID)
         break;
     case QUIC_PARAM_CONN_DATAGRAM_SEND_ENABLED:                     // uint8_t (BOOLEAN)
         break; // Get Only
-    case QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION:                   // uint8_t (BOOLEAN)
-        Helper.SetUint8(QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION, (uint8_t)GetRandom(2));
-        break;
+    //case QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION:                   // uint8_t (BOOLEAN)
+    //    Helper.SetUint8(QUIC_PARAM_CONN_DISABLE_1RTT_ENCRYPTION, (uint8_t)GetRandom(2));
+    //    break;
     case QUIC_PARAM_CONN_RESUMPTION_TICKET:                         // uint8_t[]
         // TODO
         break;


### PR DESCRIPTION
## Description

SpinQuic now always sends data so the value is equal to (offset % 256) and verifies this on the receive path.

## Testing

Automation

## Documentation

N/A
