### PR TITLE
docker multistage build for xdp support

### DIFF
--- a/.docker/ubuntu-20.04/Dockerfile
+++ b/.docker/ubuntu-20.04/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04@sha256:f2034e7195f61334e6caff6ecf2e965f92d11e888309065da85ff50c617732b8
+# Stage 1: Base image
+FROM ubuntu:20.04@sha256:f2034e7195f61334e6caff6ecf2e965f92d11e888309065da85ff50c617732b8 as base
 
 LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 
@@ -6,7 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-https \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
     ca-certificates \
     gnupg \
     software-properties-common \
@@ -16,34 +18,24 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     apt-add-repository ppa:lttng/stable-2.13 && \
     apt-get update && apt-get install -y tzdata && apt-get install -y \
     build-essential \
-    gcc-arm-linux-gnueabihf \
-    g++-arm-linux-gnueabihf \
-    binutils-arm-linux-gnueabihf \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu \
-    binutils-aarch64-linux-gnu \
     cmake \
     clang \
     git \
     make \
     sudo \
-    liblttng-ust-dev \
     lttng-tools \
     perl \
     nasm \
     ruby \
     ruby-dev \
     rpm \
-    libssl-dev \
-    libnuma-dev \
     cppcheck \
     clang-tidy \
     gdb \
-  && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN gem install --version 2.8.1 dotenv
 RUN gem install fpm
-
 RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     sudo dpkg -i packages-microsoft-prod.deb && \
     sudo add-apt-repository universe && \
@@ -51,10 +43,33 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsof
     sudo apt-get install -y \
         # INSTALL POWERSHELl
         powershell \
-  && rm -rf /var/lib/apt/lists/*
+   && rm -rf /var/lib/apt/lists/*
 
-RUN dpkg --add-architecture arm64
-RUN dpkg --add-architecture armhf
+RUN git config --global safe.directory '*'
+
+# Stage 2: x86_64 build
+FROM base AS x86_64-build
+
+RUN apt-get update -y && apt-get install -y \
+    liblttng-ust-dev \
+    libssl-dev \
+    libnuma-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stage 3: ARM build
+FROM base AS arm-build
+
+RUN apt-get update && apt-get install -y \
+    gcc-arm-linux-gnueabihf \
+    g++-arm-linux-gnueabihf \
+    binutils-arm-linux-gnueabihf \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN dpkg --add-architecture arm64 && \
+    dpkg --add-architecture armhf
 
 RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
     cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
@@ -66,15 +81,11 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates main restricted un
 deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list.d/arm-cross-compile-sources.list
 
-RUN apt-get update
-
-RUN apt-get install --no-install-recommends -y liblttng-ust-dev:arm64 \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y liblttng-ust-dev:arm64 \
     liblttng-ust-dev:armhf \
     libssl-dev:arm64 \
     libssl-dev:armhf \
     libnuma-dev:arm64 \
     libnuma-dev:armhf \
     && rm -rf /var/lib/apt/lists/*
-
-RUN git config --global safe.directory '*'
-

--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update -y && apt-get install -y \
     liblttng-ust-dev \
     libssl-dev \
     libnuma-dev \
-    && "deb [arch=amd64] http://cz.archive.ubuntu.com/ubuntu noble main" > /etc/apt/sources.list.d/xdp.list \
+    && echo "deb [arch=amd64] http://cz.archive.ubuntu.com/ubuntu noble main" > /etc/apt/sources.list.d/xdp.list \
     && apt-get update -y && apt-get install -y -t noble \
     libnl-3-dev \
     libnl-genl-3-dev \

--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:22.04@sha256:6042500cf4b44023ea1894effe7890666b0c5c7871ed83a97c36c76ae560bb9b
+# Stage 1: Base image
+FROM ubuntu:22.04@sha256:6042500cf4b44023ea1894effe7890666b0c5c7871ed83a97c36c76ae560bb9b AS base
 
 LABEL org.opencontainers.image.source https://github.com/microsoft/msquic
 
@@ -6,7 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-https \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
     ca-certificates \
     gnupg \
     software-properties-common \
@@ -14,31 +16,46 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main' && \
     apt-add-repository ppa:lttng/stable-2.13 && \
-    apt-get update && apt-get install -y tzdata && apt-get install -y \
+    apt-get update && \
+    apt-get install -y tzdata \
     build-essential \
-    gcc-arm-linux-gnueabihf \
-    g++-arm-linux-gnueabihf \
-    binutils-arm-linux-gnueabihf \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu \
-    binutils-aarch64-linux-gnu \
     cmake \
     clang \
     git \
     make \
     sudo \
-    liblttng-ust-dev \
     lttng-tools \
     perl \
     nasm \
     ruby \
     ruby-dev \
     rpm \
-    libssl-dev \
-    libnuma-dev \
     cppcheck \
     clang-tidy \
     gdb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN gem install fpm
+RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    sudo dpkg -i packages-microsoft-prod.deb && \
+    sudo add-apt-repository universe && \
+    sudo apt-get update -y && \
+    sudo apt-get install -y \
+        # INSTALL POWERSHELl
+        powershell \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global safe.directory '*'
+
+# Stage 2: x86_64 build
+FROM base AS x86_64-build
+
+RUN apt-get update -y && apt-get install -y \
+    liblttng-ust-dev \
+    libssl-dev \
+    libnuma-dev \
+    && "deb [arch=amd64] http://cz.archive.ubuntu.com/ubuntu noble main" > /etc/apt/sources.list.d/xdp.list \
+    && apt-get update -y && apt-get install -y -t noble \
     libnl-3-dev \
     libnl-genl-3-dev \
     libnl-route-3-dev \
@@ -49,27 +66,24 @@ RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-h
     libpcap-dev \
     libelf-dev \
     libc6-dev-i386 \
-  && rm -rf /var/lib/apt/lists/*
+    libxdp-dev \
+    libbpf-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN gem install fpm
+# Stage 3: ARM build
+FROM base AS arm-build
 
-RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    sudo dpkg -i packages-microsoft-prod.deb && \
-    sudo add-apt-repository universe && \
-    sudo apt-get update -y && \
-    sudo apt-get install -y \
-        # INSTALL POWERSHELl
-        powershell \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    gcc-arm-linux-gnueabihf \
+    g++-arm-linux-gnueabihf \
+    binutils-arm-linux-gnueabihf \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q https://github.com/libbpf/bpftool/releases/download/v7.2.0/bpftool-v7.2.0-amd64.tar.gz -O bpftool-amd64.tar.gz && \
-    tar xvzf bpftool-amd64.tar.gz && \
-    chmod +x ./bpftool && \
-    mv ./bpftool /usr/sbin/bpftool && \
-    rm -rf bpftool-amd64.tar.gz
-
-RUN dpkg --add-architecture arm64
-RUN dpkg --add-architecture armhf
+RUN dpkg --add-architecture arm64 && \
+    dpkg --add-architecture armhf
 
 RUN mv /etc/apt/sources.list /etc/apt/sources.list.int && \
     cat /etc/apt/sources.list.int | grep "^deb" | sed 's/deb /deb [arch=amd64] /g' > /etc/apt/sources.list && \
@@ -81,14 +95,12 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-updates main restricted un
 deb [arch=armhf,arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list.d/arm-cross-compile-sources.list
 
-RUN apt-get update
-
-RUN apt-get --no-install-recommends install -y liblttng-ust-dev:arm64 \
+RUN apt-get update \
+    && apt-get --no-install-recommends install -y \
+    liblttng-ust-dev:arm64 \
     liblttng-ust-dev:armhf \
     libssl-dev:arm64 \
     libssl-dev:armhf \
     libnuma-dev:arm64 \
     libnuma-dev:armhf \
     && rm -rf /var/lib/apt/lists/*
-
-RUN git config --global safe.directory '*'

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -81,7 +81,7 @@ jobs:
     name: Build
     runs-on: ${{ inputs.os }}
     container:
-      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}', inputs.os) || '' }}
+      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, inputs.arch == 'x64' || inputs.arch == 'x86' ? 'x86_64' : 'arm') || '' }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -81,7 +81,7 @@ jobs:
     name: Build
     runs-on: ${{ inputs.os }}
     container:
-      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, (startsWith(inputs.arch, 'x') && 'x86_64') || 'arm') }}
+      image: ${{ (inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, (startsWith(inputs.arch, 'x') && 'x86_64') || 'arm')) || '' }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -81,7 +81,7 @@ jobs:
     name: Build
     runs-on: ${{ inputs.os }}
     container:
-      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, inputs.arch == 'x64' || inputs.arch == 'x86' ? 'x86_64' : 'arm') || '' }}
+      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, startsWith(inputs.arch, 'x') && 'x86_64' || 'arm')) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -81,7 +81,7 @@ jobs:
     name: Build
     runs-on: ${{ inputs.os }}
     container:
-      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, startsWith(inputs.arch, 'x') && 'x86_64' || 'arm')) }}
+      image: ${{ inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, (startsWith(inputs.arch, 'x') && 'x86_64') || 'arm') }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/docker-publish-xcomp.yml
+++ b/.github/workflows/docker-publish-xcomp.yml
@@ -28,6 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['20.04', '22.04']
+        target: ['x86_64', 'arm']
 
     name: Build
     runs-on: ubuntu-latest
@@ -70,5 +71,6 @@ jobs:
           context: .docker/ubuntu-${{ matrix.version }}
           file: .docker/ubuntu-${{ matrix.version }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu-${{ matrix.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu-${{ matrix.version }}-${{ matrix.target }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: ${{ matrix.target }}-build


### PR DESCRIPTION
## Description

Installing libxdp/libbpf conflicts libc6 version for arm cross compile toolset.
Multistage build to avoid installing toolset on one image.

## Testing

Locally passed `docker build --target ${arch|-build` and `pwsh ./scripts/build.ps1 -Arch ${arch}` for each arch
Ubuntu 20.04 cannot build xdp related source code as bpf.h (linux-libc-dev) header doesn't have required struct declaration.
This can be avoided by apt-get upgrade linux-libc-dev, but not good from CI/CD point of view.
 
## Documentation

N/A