### PR TITLE
Bug Fix 

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -257,6 +257,7 @@ function Install-NASM {
     if (!(Test-Path $NasmExe) -and $env:GITHUB_PATH -eq $null) {
         Write-Host "Downloading NASM"
         $NasmArch = "win64"
+        mkdir artifacts
         if (![System.Environment]::Is64BitOperatingSystem) { $NasmArch = "win32" }
         try {
             Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/$NasmVersion/win64/nasm-$NasmVersion-$NasmArch.zip" -OutFile "artifacts\nasm.zip"


### PR DESCRIPTION
## Description

Bug fix, when running on some windows systems file "prepare-machine.ps1" Invoke-WebRequest will fail if output directory "scripts/artifacts" does not exist, fixed by adding explicit mkdir for artifacts directory.

## Testing

No tests needed.

## Documentation

No documentation change.
