### PR TITLE
Fix libc6-dev-i386 to install cause of corruption

### DIFF
--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update -y && apt-get install -y \
     libssl-dev \
     libnuma-dev \
     && echo "deb [arch=amd64] http://cz.archive.ubuntu.com/ubuntu noble main" > /etc/apt/sources.list.d/xdp.list \
-    && apt-get update -y && apt-get install -y -t noble \
+    && apt-get update -y && apt-get install --no-install-recommends -y -t noble \
     libnl-3-dev \
     libnl-genl-3-dev \
     libnl-route-3-dev \


### PR DESCRIPTION
## Description

libc6-dev-i386 installs & upgrade additional packages which breaks building "Release" build.

## Testing

locally tested. especially for Release build.

## Documentation

N/A
