### PR TITLE
CodeQL Classification

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,14 @@
+# This file configures CodeQL runs and TSA bug autofiling. For more information, see:
+# https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+# (Access restricted to Microsoft employees only.)
+
+# The following paths are explicitly classified which indicates they should no
+# be analyzed by CodeQL and generate alerts.
+path_classifiers:
+  docs:
+    - docs
+  generated:
+    - src/cs
+    - src/generated
+  submodules:
+    - subodules


### PR DESCRIPTION
## Description

Tells internal CodeQL scans to ignore some directories that we don't care about alerts for.

## Testing

Required to be merged and go through full OneBranch pipeline run before we can verify.

## Documentation

N/A
