### PR TITLE
Fail on Stream Blocked Immediate

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -828,6 +828,19 @@ MsQuicStreamStart(
         goto Exit;
     }
 
+    if (Flags & QUIC_STREAM_START_FLAG_FAIL_BLOCKED) {
+        BOOLEAN NewStreamBlocked;
+        Status =
+            QuicStreamSetNewLocalStreamID(
+                &Connection->Streams,
+                TRUE,
+                Stream,
+                &NewStreamBlocked);
+        if (QUIC_FAILED(Status)) {
+            goto Exit;
+        }
+    }
+
     QUIC_OPERATION* Oper =
         QuicOperationAlloc(Connection->Worker, QUIC_OPER_TYPE_API_CALL);
     if (Oper == NULL) {

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -256,8 +256,6 @@ QuicStreamStart(
         Status =
             QuicStreamSetNewLocalStream(
                 &Stream->Connection->Streams,
-                Type,
-                !!(Flags & QUIC_STREAM_START_FLAG_FAIL_BLOCKED),
                 Stream);
         if (QUIC_FAILED(Status)) {
             goto Exit;
@@ -763,7 +761,7 @@ QuicStreamParamGet(
             break;
         }
 
-        if (!Stream->Flags.Started) {
+        if (Stream->ID == UINT64_MAX) {
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }

--- a/src/core/stream_set.h
+++ b/src/core/stream_set.h
@@ -51,6 +51,11 @@ typedef struct QUIC_STREAM_SET {
     //
     CXPLAT_LIST_ENTRY ClosedStreams;
 
+    //
+    // Used to protect access to the Type variable across threads.
+    //
+    CXPLAT_DISPATCH_LOCK TypesLock;
+
 #if DEBUG
     //
     // The list of allocated streams for leak tracking.
@@ -173,14 +178,25 @@ QuicStreamSetGetFlowControlSummary(
     );
 
 //
+// Assigns a new local stream ID to the stream. May be called on the app thread,
+// and at dispatch level.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_STATUS
+QuicStreamSetNewLocalStreamID(
+    _Inout_ QUIC_STREAM_SET* StreamSet,
+    _In_ BOOLEAN FailOnBlocked,
+    _In_ QUIC_STREAM* Stream,
+    _Out_ BOOLEAN* NewStreamBlocked
+    );
+
+//
 // Creates a new local stream.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicStreamSetNewLocalStream(
     _Inout_ QUIC_STREAM_SET* StreamSet,
-    _In_ uint8_t Type,
-    _In_ BOOLEAN FailOnBlocked,
     _In_ QUIC_STREAM* Stream
     );
 


### PR DESCRIPTION
## Description

A prototype change to update the `StreamStart` API to fail inline if the app passes `QUIC_STREAM_START_FLAG_FAIL_BLOCKED`.

## Testing

CI/CD

## Documentation

TODO
