### PR TITLE
show warning prompt for installing Linux XDP deps

### DIFF
--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -99,7 +99,7 @@ jobs:
         chown -R $(id -u):$(id -g) $PWD
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 ${{ inputs.plat == 'linux' && '-ForContainerBuild' || '-ForBuild' }} -Tls ${{ inputs.tls }} ${{ inputs.xdp }}
+      run: scripts/prepare-machine.ps1 ${{ inputs.plat == 'linux' && '-ForContainerBuild' || '-ForBuild' }} -Tls ${{ inputs.tls }}
     - name: Build For Test
       if: inputs.build == '-Test'
       shell: pwsh

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
     - name: Download Package
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
     - name: Download Package
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
     - name: Download Package
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/package-reuse-linux.yml
+++ b/.github/workflows/package-reuse-linux.yml
@@ -83,7 +83,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForBuild ${{ inputs.xdp }} ${{ inputs.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForBuild ${{ inputs.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/package-reuse-linux.yml
+++ b/.github/workflows/package-reuse-linux.yml
@@ -83,7 +83,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare Machine
       shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForBuild ${{ inputs.xdp }}
+      run: scripts/prepare-machine.ps1 -ForBuild ${{ inputs.xdp }} ${{ inputs.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
       shell: pwsh
     - name: spinquic (PR)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -73,7 +73,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-InstallLinuxXdpByForce", build: "-Test"  },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl3", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", sanitize: "-Sanitize", build: "-Test" },
@@ -110,7 +110,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.force }}
       shell: pwsh
     - name: spinquic (PR)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
       shell: pwsh
     - name: spinquic (PR)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -73,7 +73,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-InstallLinuxXdpByForce", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-ForceXdpInstall", build: "-Test"  },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl3", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", sanitize: "-Sanitize", build: "-Test" },

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -75,7 +75,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-ForceXdpInstall", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", build: "-Test"  },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "macos", os: "macos-12", arch: "x64", tls: "openssl3", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", sanitize: "-Sanitize", build: "-Test" },
@@ -112,7 +112,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.force }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
       shell: pwsh
     - name: spinquic (PR)
       if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-InstallLinuxXdpByForce", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-ForceXdpInstall", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl3", build: "-Test" },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-ForceXdpInstall", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl3", build: "-Test" },
@@ -135,7 +135,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.force }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
       shell: pwsh
     - name: Install ETW Manifest
       if: matrix.vec.plat == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
-          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", build: "-Test"  },
+          { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp", force: "-InstallLinuxXdpByForce", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2019", arch: "x64", tls: "openssl3", build: "-Test" },
@@ -134,7 +134,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.force }}
       shell: pwsh
     - name: Install ETW Manifest
       if: matrix.vec.plat == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
         name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.build }}
         path: artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
       shell: pwsh
     - name: Interop
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
       shell: pwsh
     - name: Install ETW Manifest
       if: matrix.vec.plat == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       run: |
         sudo chmod -R 777 artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == "-UseXdp" && "-ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }} ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
       shell: pwsh
     - name: Install ETW Manifest
       if: matrix.vec.plat == 'windows'
@@ -232,7 +232,7 @@ jobs:
         name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.build }}
         path: artifacts
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == "-UseXdp" && "-UseXdp -ForceXdpInstall" || "" }}
+      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp == '-UseXdp' && '-UseXdp -ForceXdpInstall' || '' }}
       shell: pwsh
     - name: Interop
       shell: pwsh

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -184,7 +184,7 @@ sudo dnf install libatomic
 #### Linux XDP
 Linux XDP is experimentally supported on amd64 && Ubuntu 22.04LTS.  
 Commands below install dependencies and setup runtime environment.  
-**<span style="color:red;">WARN: This might break your system by installing Ubuntu 24.04LTS packages. Do not run on production environment and need to understand the side effect </span>**
+**<span style="color:red;">WARN: This might break your system by installing Ubuntu 24.04LTS packages on ubuntu 22.04.Do not run on production environment and need to understand the side effect. You can workaround this prompt by `-ForceXdpInstall` </span>**
 ```sh
 $ pwsh ./scripts/prepare-machine.ps1 -UseXdp
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARN !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -192,6 +192,9 @@ Linux XDP installs dependencies from Ubuntu 24.04 packages, which should affect 
 You need to understand the impact of this on your environment before proceeding
 Type 'YES' to proceed: YES
 
+or
+
+$ pwsh ./scripts/prepare-machine.ps1 -UseXdp -ForceXdpInstall
 $ pwsh ./scripts/build.ps1 -EnableLinuxXDP
 ```
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -183,13 +183,19 @@ sudo dnf install libatomic
 
 #### Linux XDP
 Linux XDP is experimentally supported on amd64 && Ubuntu 22.04LTS.  
-Commands below automatically install dependencies and setup runtime environment.
+Commands below install dependencies and setup runtime environment.  
+**<span style="color:red;">WARN: This might break your system by installing Ubuntu 24.04LTS packages. Do not run on production environment and need to understand the side effect </span>**
 ```sh
-pwsh ./scripts/prepare-machine.ps1 -UseXdp
-pwsh ./scripts/build.ps1 -EnableLinuxXDP
+$ pwsh ./scripts/prepare-machine.ps1 -UseXdp
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARN !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Linux XDP installs dependencies from Ubuntu 24.04 packages, which should affect your environment
+You need to understand the impact of this on your environment before proceeding
+Type 'YES' to proceed: YES
+
+$ pwsh ./scripts/build.ps1 -EnableLinuxXDP
 ```
 
-`./scripts/prepare-machine.ps1` internally does the below commands:
+`./scripts/prepare-machine.ps1` internally does the below commands. This might break your environment.
 ```sh
 # for libxdp v1.4.2
 sudo apt-add-repository "deb http://mirrors.kernel.org/ubuntu noble main" -y

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -71,6 +71,9 @@ param (
     [switch]$UseXdp,
 
     [Parameter(Mandatory = $false)]
+    [switch]$InstallLinuxXdpByForce,
+
+    [Parameter(Mandatory = $false)]
     [switch]$InstallArm64Toolchain,
 
     [Parameter(Mandatory = $false)]
@@ -96,6 +99,19 @@ param (
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
+
+if ($IsLinux -and $UseXdp) {
+    if (!$InstallLinuxXdpByForce) {
+        Write-Host "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARN !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        Write-Host "Linux XDP installs dependencies from Ubuntu 24.04 packages, which should affect your environment"
+        Write-Host "You need to understand the impact of this on your environment before proceeding"
+        $userInput = Read-Host "Type 'YES' to proceed"
+        if ($userInput -ne 'YES') {
+            Write-Output "User did not type YES. Exiting script."
+            exit
+        }
+    }
+}
 
 $PrepConfig = & (Join-Path $PSScriptRoot get-buildconfig.ps1) -Tls $Tls
 $Tls = $PrepConfig.Tls

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -71,7 +71,7 @@ param (
     [switch]$UseXdp,
 
     [Parameter(Mandatory = $false)]
-    [switch]$InstallLinuxXdpByForce,
+    [switch]$ForceXdpInstall,
 
     [Parameter(Mandatory = $false)]
     [switch]$InstallArm64Toolchain,
@@ -101,7 +101,8 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 if ($IsLinux -and $UseXdp) {
-    if (!$InstallLinuxXdpByForce) {
+    $IsUbuntu2404 = (Get-Content -Path /etc/os-release | Select-String -Pattern "24.04") -ne $null
+    if (!$IsUbuntu2404 -and !$ForceXdpInstall) {
         Write-Host "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARN !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         Write-Host "Linux XDP installs dependencies from Ubuntu 24.04 packages, which should affect your environment"
         Write-Host "You need to understand the impact of this on your environment before proceeding"


### PR DESCRIPTION
## Description

Fix of https://github.com/microsoft/msquic/issues/4299
Currently Linux XDP setup is for Ubuntu 22.04, but installing dependencies from Ubuntu 24.04 which should break the environment.
This change shows warning to user before actually execute prepare-machine.ps1

## Testing

Locally works this "YES" prompt

## Documentation

wrote.
