### PR TITLE
Leave callback to release datagram

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1345,7 +1345,7 @@ QuicConnOnShutdownComplete(
             "Indicating QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE");
         (void)QuicConnIndicateEvent(Connection, &Event);
 
-        Connection->ClientCallbackHandler = NULL;
+        // Connection->ClientCallbackHandler = NULL;
     }
 
     //


### PR DESCRIPTION
## Description

memory leak when a datagram sent -> connection shutdown (clear callback) -> datagram discarded

## Testing

see automation

## Documentation

N/A
