### PR TITLE
QuicTestValidateConnectionEvents3 fix to use duoNic with normal socket

### DIFF
--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -499,7 +499,7 @@ QuicTestValidateConnectionEvents3(
 
     QUIC_BUFFER* ResumptionTicket = nullptr;
     QuicTestPrimeResumption(
-        QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+        QuicAddrGetFamily(&ServerLocalAddr.SockAddr) == QUIC_ADDRESS_FAMILY_INET ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6,
         Registration,
         ServerConfiguration,
         ClientConfiguration,


### PR DESCRIPTION
## Description

One fix of https://github.com/microsoft/msquic/issues/4309

## Testing
Build without "-EnableLinuxXDP"
`./artifacts/bin/linux/x64_Debug_openssl3/msquictest --gtest_filter="ParameterValidation/WithValidateConnectionEventArgs.ValidateConnectionEvents/2" --duoNic`
Locally passed

## Documentation

N/A
