### PR TITLE
Uninitialize LossDetection earlier to cleanup Datagram frame

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1322,6 +1322,9 @@ QuicConnOnShutdownComplete(
     Connection->State.ShutdownComplete = TRUE;
     Connection->State.UpdateWorker = FALSE;
 
+    // call earlier then others for frames which requires ClientCallbackHandler to freeing app memory (Datagram)
+    QuicLossDetectionUninitialize(&Connection->LossDetection);
+
     QuicTraceEvent(
         ConnShutdownComplete,
         "[conn][%p] Shutdown complete, PeerFailedToAcknowledged=%hhu.",
@@ -1368,7 +1371,6 @@ QuicConnOnShutdownComplete(
     // Clean up the rest of the internal state.
     //
     QuicTimerWheelRemoveConnection(&Connection->Worker->TimerWheel, Connection);
-    QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
 
     if (!Connection->State.ExternalOwner) {

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -369,8 +369,8 @@ QuicConnFree(
     QuicOperationQueueUninitialize(&Connection->OperQ);
     QuicStreamSetUninitialize(&Connection->Streams);
     QuicSendBufferUninitialize(&Connection->SendBuffer);
+    QuicDatagramSendShutdown(&Connection->Datagram);
     QuicDatagramUninitialize(&Connection->Datagram);
-    QuicDatagramFree(&Connection->Datagram);
     if (Connection->Configuration != NULL) {
         QuicConfigurationRelease(Connection->Configuration);
         Connection->Configuration = NULL;
@@ -1351,7 +1351,7 @@ QuicConnOnShutdownComplete(
     QuicTimerWheelRemoveConnection(&Connection->Worker->TimerWheel, Connection);
     QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
-    QuicDatagramUninitialize(&Connection->Datagram);
+    QuicDatagramSendShutdown(&Connection->Datagram);
 
     if (Connection->State.ExternalOwner) {
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1350,6 +1350,7 @@ QuicConnOnShutdownComplete(
     QuicTimerWheelRemoveConnection(&Connection->Worker->TimerWheel, Connection);
     QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
+    QuicDatagramUninitialize(&Connection->Datagram);
 
     if (Connection->State.ExternalOwner) {
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -370,6 +370,7 @@ QuicConnFree(
     QuicStreamSetUninitialize(&Connection->Streams);
     QuicSendBufferUninitialize(&Connection->SendBuffer);
     QuicDatagramUninitialize(&Connection->Datagram);
+    QuicDatagramFree(&Connection->Datagram);
     if (Connection->Configuration != NULL) {
         QuicConfigurationRelease(Connection->Configuration);
         Connection->Configuration = NULL;

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -145,6 +145,14 @@ QuicDatagramUninitialize(
     )
 {
     QuicDatagramSendShutdown(Datagram);
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicDatagramFree(
+    _In_ QUIC_DATAGRAM* Datagram
+    )
+{
     CXPLAT_DBG_ASSERT(Datagram->SendQueue == NULL);
     CXPLAT_DBG_ASSERT(Datagram->ApiQueue == NULL);
     CxPlatDispatchLockUninitialize(&Datagram->ApiQueueLock);
@@ -330,6 +338,7 @@ QuicDatagramQueueSend(
     BOOLEAN QueueOper = TRUE;
     QUIC_CONNECTION* Connection = QuicDatagramGetConnection(Datagram);
 
+    CxPlatDispatchLockAcquire(&Datagram->ApiQueueLock);
     if (!Datagram->SendEnabled) {
         QuicTraceEvent(
             ConnError,
@@ -346,7 +355,6 @@ QuicDatagramQueueSend(
                 "Datagram send request is longer than allowed");
             Status = QUIC_STATUS_INVALID_PARAMETER;
         } else {
-            CxPlatDispatchLockAcquire(&Datagram->ApiQueueLock);
             QUIC_SEND_REQUEST** ApiQueueTail = &Datagram->ApiQueue;
             while (*ApiQueueTail != NULL) {
                 ApiQueueTail = &((*ApiQueueTail)->Next);
@@ -354,9 +362,9 @@ QuicDatagramQueueSend(
             }
             *ApiQueueTail = SendRequest;
             Status = QUIC_STATUS_SUCCESS;
-            CxPlatDispatchLockRelease(&Datagram->ApiQueueLock);
         }
     }
+    CxPlatDispatchLockRelease(&Datagram->ApiQueueLock);
 
     if (QUIC_FAILED(Status)) {
         CxPlatPoolFree(&Connection->Worker->SendRequestPool, SendRequest);
@@ -402,9 +410,6 @@ QuicDatagramSendFlush(
     _In_ QUIC_DATAGRAM* Datagram
     )
 {
-    if (!Datagram->SendEnabled) {
-        return;
-    }
     CxPlatDispatchLockAcquire(&Datagram->ApiQueueLock);
     QUIC_SEND_REQUEST* ApiQueue = Datagram->ApiQueue;
     Datagram->ApiQueue = NULL;

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -144,15 +144,6 @@ QuicDatagramUninitialize(
     _In_ QUIC_DATAGRAM* Datagram
     )
 {
-    QuicDatagramSendShutdown(Datagram);
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicDatagramFree(
-    _In_ QUIC_DATAGRAM* Datagram
-    )
-{
     CXPLAT_DBG_ASSERT(Datagram->SendQueue == NULL);
     CXPLAT_DBG_ASSERT(Datagram->ApiQueue == NULL);
     CxPlatDispatchLockUninitialize(&Datagram->ApiQueueLock);

--- a/src/core/datagram.h
+++ b/src/core/datagram.h
@@ -54,6 +54,12 @@ QuicDatagramUninitialize(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
+QuicDatagramFree(
+    _In_ QUIC_DATAGRAM* Datagram
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
 QuicDatagramSendShutdown(
     _In_ QUIC_DATAGRAM* Datagram
     );

--- a/src/core/datagram.h
+++ b/src/core/datagram.h
@@ -54,12 +54,6 @@ QuicDatagramUninitialize(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
-QuicDatagramFree(
-    _In_ QUIC_DATAGRAM* Datagram
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
 QuicDatagramSendShutdown(
     _In_ QUIC_DATAGRAM* Datagram
     );

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -623,6 +623,7 @@ QuicLossDetectionOnPacketAcknowledged(
                 Packet->Flags.SuspectedLost ?
                     QUIC_DATAGRAM_SEND_ACKNOWLEDGED_SPURIOUS :
                     QUIC_DATAGRAM_SEND_ACKNOWLEDGED);
+            Packet->Frames[i].DATAGRAM.ClientContext = NULL;
             break;
 
         case QUIC_FRAME_HANDSHAKE_DONE:

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -154,7 +154,7 @@ QuicPacketBuilderCleanup(
         QuicLossDetectionUpdateTimer(&Builder->Connection->LossDetection, FALSE);
     }
 
-    QuicSentPacketMetadataReleaseFrames(Builder->Metadata);
+    QuicSentPacketMetadataReleaseFrames(Builder->Metadata, Builder->Connection);
 
     CxPlatSecureZeroMemory(Builder->HpMask, sizeof(Builder->HpMask));
 }

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -187,7 +187,8 @@ QuicPacketTraceType(
 
 void
 QuicSentPacketMetadataReleaseFrames(
-    _In_ QUIC_SENT_PACKET_METADATA* Metadata
+    _In_ QUIC_SENT_PACKET_METADATA* Metadata,
+    _In_ QUIC_CONNECTION* Connection
     );
 
 //
@@ -243,6 +244,6 @@ QuicSentPacketPoolGetPacketMetadata(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicSentPacketPoolReturnPacketMetadata(
-    _In_ QUIC_SENT_PACKET_POOL* Pool,
-    _In_ QUIC_SENT_PACKET_METADATA* Metadata
+    _In_ QUIC_SENT_PACKET_METADATA* Metadata,
+    _In_ QUIC_CONNECTION* Connection
     );


### PR DESCRIPTION
## Description

App allocated buffer for Datagram Frame has been leaking due to
- missing callback handler when waiting Ack for the Datagram frame.
- allocation failure for packet metadata

## Testing

Ran local test. No leak detected. No leak found from my own memory tracker either.
`./artifacts/bin/linux/x64_Debug_openssl3/spinquic both -timeout:600000 -repeat_count:20 -alloc_fail:100`
`./artifacts/bin/linux/x64_Debug_openssl/spinquic both -timeout:600000 -repeat_count:20 -alloc_fail:100`

Let's see automation results

## Documentation

N/A
