### PR TITLE
retry connection if timed out

### DIFF
--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -820,6 +820,7 @@ TestConnection::HandleConnectionEvent(
                 QuicTraceLogInfo(
                     TestIgnoreConnectionTimeout,
                     "[test] Ignoring timeout unexpected status because of random loss");
+                ConnectionTimeout = true;
             } else {
                 TEST_FAILURE(
                     "Unexpected transport Close Error, expected=0x%x, actual=0x%x",

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -63,6 +63,7 @@ class TestConnection
     bool HasRandomLoss      : 1;
     bool AsyncCustomValidation : 1;
     bool CustomValidationResultSet : 1;
+    bool ConnectionTimeout : 1;
 
     bool ExpectedResumed    : 1;
     QUIC_STATUS ExpectedCustomTicketValidationResult;
@@ -193,6 +194,7 @@ public:
     bool GetTransportClosed() const { return TransportClosed; }
     bool GetIsShutdown() const { return IsShutdown; }
     bool GetShutdownTimedOut() const { return ShutdownTimedOut; }
+    bool GetConnectionTimeout() const { return ConnectionTimeout; }
 
     bool GetExpectedResumed() const { return ExpectedResumed; };
     void SetExpectedResumed(bool Value) { ExpectedResumed = Value; }


### PR DESCRIPTION
## Description

Sometimes test automation reaches the IDLE.TIMEOUT limits (10 sec). then close the connection.
This checks the timeout status and retry connection
https://github.com/microsoft/msquic/issues/4328

## Testing

N/A

## Documentation

N/A
