### PR TITLE
Update Docker image to fix ubuntu22 test runtime issue

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -76,19 +76,13 @@ extends:
         image: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:${{ parameters.WindowsContainerImage2DockerTag }}'
         type: Windows
       - container: linux_build_container # Default container
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-x86_64'
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-cross'
         type: Linux
-      - container: ubuntu_2004_x86_64
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-x86_64'
+      - container: ubuntu_2204_xdp
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-xdp'
         type: Linux
-      - container: ubuntu_2004_arm
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-arm'
-        type: Linux
-      - container: ubuntu_2204_x86_64
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-x86_64'
-        type: Linux
-      - container: ubuntu_2204_arm
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-arm'
+      - container: ubuntu_2204_cross
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-cross'
         type: Linux
 
     stages:

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -72,19 +72,13 @@ extends:
         image: 'cdpxb7b51c2f738e43e48f7605d9a8e5f6d700.azurecr.io/b7b51c2f-738e-43e4-8f76-05d9a8e5f6d7/official/msquicbuild:${{ parameters.WindowsContainerImage2DockerTag }}'
         type: Windows
       - container: linux_build_container # Default container
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-x86_64'
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-cross'
         type: Linux
-      - container: ubuntu_2004_x86_64
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-x86_64'
+      - container: ubuntu_2204_xdp
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-xdp'
         type: Linux
-      - container: ubuntu_2004_arm
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-arm'
-        type: Linux
-      - container: ubuntu_2204_x86_64
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-x86_64'
-        type: Linux
-      - container: ubuntu_2204_arm
-        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-arm'
+      - container: ubuntu_2204_cross
+        image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-cross'
         type: Linux
 
     stages:

--- a/.azure/obtemplates/build-linux.yml
+++ b/.azure/obtemplates/build-linux.yml
@@ -17,9 +17,9 @@ jobs:
   - task: PowerShell@2
     displayName: Prepare Build Machine
     ${{ if eq(parameters.tls, 'openssl') }}:
-      target: ubuntu_2004_x86_64
+      target: linux_build_container
     ${{ else }}:
-      target: ubuntu_2204_x86_64
+      target: ubuntu_2204_xdp
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
@@ -27,9 +27,9 @@ jobs:
   - task: PowerShell@2
     displayName: x64
     ${{ if eq(parameters.tls, 'openssl') }}:
-      target: ubuntu_2004_x86_64
+      target: linux_build_container
     ${{ else }}:
-      target: ubuntu_2204_x86_64
+      target: ubuntu_2204_xdp
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
@@ -37,9 +37,9 @@ jobs:
   - task: PowerShell@2
     displayName: arm64
     ${{ if eq(parameters.tls, 'openssl') }}:
-      target: ubuntu_2004_arm
+      target: linux_build_container
     ${{ else }}:
-      target: ubuntu_2204_arm
+      target: ubuntu_2204_cross
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
@@ -47,9 +47,9 @@ jobs:
   - task: PowerShell@2
     displayName: arm
     ${{ if eq(parameters.tls, 'openssl') }}:
-      target: ubuntu_2004_arm
+      target: linux_build_container
     ${{ else }}:
-      target: ubuntu_2204_arm
+      target: ubuntu_2204_cross
     inputs:
       pwsh: true
       filePath: scripts/build.ps1

--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -85,7 +85,7 @@ jobs:
     name: Build
     runs-on: ${{ inputs.os }}
     container:
-      image: ${{ (inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, (startsWith(inputs.arch, 'x') && 'x86_64') || 'arm')) || '' }}
+      image: ${{ (inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-{1}', inputs.os, ((inputs.xdp == '-UseXdp' && inputs.os == 'ubuntu-22.04') && 'xdp') || 'cross')) || '' }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29


### PR DESCRIPTION
## Description

ubuntu22.04 epoll test get affected by mismatched libc due to XDP dependencies which come from ubuntu 24.04 repository.
The new docker image doesn't reuse xdp environment for normal socket datapath.

## Testing

See automation

## Documentation

N/A
