### PR TITLE
Fix test log path sanitation

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -379,7 +379,11 @@ function Start-TestExecutable([String]$Arguments, [String]$OutputDir) {
 # Asynchronously starts a single msquictest test case running.
 function Start-TestCase([String]$Name, [int]$Trial = 1) {
 
-    $InstanceName = $Name.Replace("/", "_")
+    # Get a string of invalid chars for filenames
+    $InvalidChars = [System.IO.Path]::GetInvalidFileNameChars() -join ''
+    # Escape those chars for use in a regex and put them inside a regex set (the square brackets)
+    $InvalidCharsToReplace = "[{0}]" -f [RegEx]::Escape($InvalidChars)
+    $InstanceName = $Name -replace $InvalidCharsToReplace, "_"
     $LocalLogDir = Join-Path $LogDir ($InstanceName + "_$Trial")
     mkdir $LocalLogDir | Out-Null
 


### PR DESCRIPTION
## Description

An issue encountered when adding a new test resulted in the powershell process crashing. The problem was the auto-generated test name contained characters that were invalid in a directory path, which wasn't sanitized by the existing log path creation code. This resulted in powershell crashing when trying to create the log directory.

This change updates the log path creation code to sanitize the test name for all invalid path characters. 

## Testing

Locally run works fine and CI to validate other platforms.

## Documentation

N/A
