### PR TITLE
install dotnet in prepare-machine.ps1

### DIFF
--- a/scripts/log_wrapper.sh
+++ b/scripts/log_wrapper.sh
@@ -15,5 +15,5 @@ if [ $sessionCreated -eq 0 ]; then
     lttng destroy msquic
 
     babeltrace --names all $dirname/data > $dirname/quic.babel.txt
-    ./submodules/clog/src/clog2text/clog2text_lttng/bin/Release/net6.0/publish/clog2text_lttng -i $dirname/quic.babel.txt -s ./src/manifest/clog.sidecar -o $dirname/quic.log --showTimestamp --showCpuInfo
+    ./submodules/clog/src/clog2text/clog2text_lttng/bin/Debug/net6.0/publish/clog2text_lttng -i $dirname/quic.babel.txt -s ./src/manifest/clog.sidecar -o $dirname/quic.log --showTimestamp --showCpuInfo
 fi

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -462,6 +462,7 @@ function Install-DotnetTool {
 function Install-Dotnet {
     if (!$IsLinux) {
         Write-Host "Linux only"
+        return
     }
 
     Write-Host "Installing dotnet"

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -459,7 +459,23 @@ function Install-DotnetTool {
     }
 }
 
+function Install-Dotnet {
+    if (!$IsLinux) {
+        Write-Host "Linux only"
+    }
+
+    Write-Host "Installing dotnet"
+    # known issue https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu
+    sudo bash -c "echo 'Package: dotnet* aspnet* netstandard*' >> /etc/apt/preferences"
+    sudo bash -c "echo 'Pin: origin packages.microsoft.com' >> /etc/apt/preferences"
+    sudo bash -c "echo 'Pin-Priority: -10' >> /etc/apt/preferences"
+    sudo apt-get update -y
+    sudo apt-get install dotnet-sdk-6.0 aspnetcore-runtime-6.0 dotnet-runtime-6.0
+}
+
 function Install-Clog2Text {
+    Install-Dotnet
+
     Write-Host "Initializing clog submodule"
     git submodule init $RootDir/submodules/clog
     git submodule update

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -481,7 +481,7 @@ function Install-Dotnet {
     }
 
     sudo apt-get update -y
-    sudo apt-get install dotnet-sdk-6.0 aspnetcore-runtime-6.0 dotnet-runtime-6.0
+    sudo apt-get install -y dotnet-sdk-6.0 aspnetcore-runtime-6.0 dotnet-runtime-6.0
 }
 
 function Install-Clog2Text {

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -466,10 +466,20 @@ function Install-Dotnet {
     }
 
     Write-Host "Installing dotnet"
-    # known issue https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu
-    sudo bash -c "echo 'Package: dotnet* aspnet* netstandard*' >> /etc/apt/preferences"
-    sudo bash -c "echo 'Pin: origin packages.microsoft.com' >> /etc/apt/preferences"
-    sudo bash -c "echo 'Pin-Priority: -10' >> /etc/apt/preferences"
+
+    # Check /etc/apt/preperences whether it has the known issue workaround
+    if (Test-Path /etc/apt/preferences) {
+        $hasKnownIssueWorkaround = (Get-Content /etc/apt/preferences | Select-String -Pattern "Package: dotnet* aspnet* netstandard*") -ne $null
+        if (!$hasKnownIssueWorkaround) {
+            # known issue https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu
+            sudo bash -c "echo 'Package: dotnet* aspnet* netstandard*' >> /etc/apt/preferences"
+            sudo bash -c "echo 'Pin: origin packages.microsoft.com' >> /etc/apt/preferences"
+            sudo bash -c "echo 'Pin-Priority: -10' >> /etc/apt/preferences"
+        } else {
+            Write-Host "Known issue workaround already applied"
+        }
+    }
+
     sudo apt-get update -y
     sudo apt-get install dotnet-sdk-6.0 aspnetcore-runtime-6.0 dotnet-runtime-6.0
 }


### PR DESCRIPTION
## Description

Installing dotnet always hit known issue
https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu

The cause should be because we already set repository for powershell which conflicts with the dotnet components.

## Testing

Locally done

## Documentation

N/A
