### PR TITLE
Add infrastructure to enable 2-machine network testing on 1ES Azure pools.

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -693,7 +693,7 @@ function Invoke-Secnetperf {
         $StateDir = "/etc/_state"
     }
     if ($Environment -eq "azure") {
-        Start-RemoteServerPassive $Session "$sudo$RemoteDir/$SecNetPerfPath $serverArgs" $StateDir
+        Start-RemoteServerPassive $Session "$sudo$RemoteDir/$SecNetPerfPath $serverArgs" $StateDir $RunId $SyncerSecret
         Wait-StartRemoteServerPassive "$sudo$clientPath" $RemoteName $artifactDir
     } else {
         $job = Start-RemoteServer $Session "$sudo$RemoteDir/$SecNetPerfPath $serverArgs"
@@ -737,7 +737,7 @@ function Invoke-Secnetperf {
     } finally {
         # Stop the server.
         if ($Environment -eq "azure") {
-            Stop-RemoteServerAsyncAwait $Session $StateDir $RemoteName
+            Stop-RemoteServerAsyncAwait $Session $StateDir $RemoteName $RunId $SyncerSecret
         } else {
             try { Stop-RemoteServer $job $RemoteName | Add-Content $serverOut } catch { }
         }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -662,15 +662,17 @@ function Invoke-Secnetperf {
     $artifactDir = Repo-Path "artifacts/logs/$artifactName"
     $remoteArtifactDir = "$RemoteDir/artifacts/logs/$artifactName"
     New-Item -ItemType Directory $artifactDir -ErrorAction Ignore | Out-Null
-    Invoke-Command -Session $Session -ScriptBlock {
-        New-Item -ItemType Directory $Using:remoteArtifactDir -ErrorAction Ignore | Out-Null
+    if (!($Session -eq "NOT_SUPPORTED")) {
+        Invoke-Command -Session $Session -ScriptBlock {
+            New-Item -ItemType Directory $Using:remoteArtifactDir -ErrorAction Ignore | Out-Null
+        }
     }
 
     $clientOut = (Join-Path $artifactDir "client.console.log")
     $serverOut = (Join-Path $artifactDir "server.console.log")
 
     # Start logging on both sides, if configured.
-    if ($LogProfile -ne "" -and $LogProfile -ne "NULL") {
+    if ($LogProfile -ne "" -and $LogProfile -ne "NULL" -and !($Session -eq "NOT_SUPPORTED")) {
         Invoke-Command -Session $Session -ScriptBlock {
             try { & "$Using:RemoteDir/scripts/log.ps1" -Cancel } catch {} # Cancel any previous logging
             & "$Using:RemoteDir/scripts/log.ps1" -Start -Profile $Using:LogProfile -ProfileInScriptDirectory

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -431,7 +431,7 @@ function Wait-StartRemoteServerPassive {
     for ($i = 0; $i -lt 30; $i++) {
         Start-Sleep -Seconds 5 | Out-Null
         Write-Host "Attempt $i to start the remote server, command: $FullPath -target:$RemoteName"
-        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir
+        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir $true
         $ConsoleOutput = Wait-LocalTest $Process $OutputDir $false 30000 $true
         Write-Host "Wait-StartRemoteServerPassive: $ConsoleOutput"
         $DidMatch = $ConsoleOutput -match "Completed" # Look for the special string to indicate success.
@@ -445,9 +445,9 @@ function Wait-StartRemoteServerPassive {
 
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
-    param ($FullPath, $FullArgs, $OutputDir)
+    param ($FullPath, $FullArgs, $OutputDir, $is1es = $false)
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
-    if ($IsWindows) {
+    if ($IsWindows -and $is1es) {
         $pinfo.FileName = $FullPath
         $pinfo.Arguments = $FullArgs
     } else {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -306,6 +306,9 @@ function Start-RemoteServerPassive {
         }
         $CurrState = $Response.Content | ConvertFrom-Json
         $CurrState.Commands += $Command
+        $CurrState = [pscustomobject]@{
+            value=$CurrState
+        }
         $StateJson = $CurrState | ConvertTo-Json
         $Response = Invoke-WebRequest -Uri "$url/setkeyvalue?key=$RunId" -Headers $headers -Method Post -Body $StateJson -ContentType "application/json"
         if ($Response.StatusCode -ne 200) {
@@ -427,8 +430,10 @@ function Wait-StartRemoteServerPassive {
 
     for ($i = 0; $i -lt 30; $i++) {
         Start-Sleep -Seconds 5 | Out-Null
+        Write-Host "Attempt $i to start the remote server, command: $FullPath -target:$RemoteName"
         $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir
         $ConsoleOutput = Wait-LocalTest $Process $OutputDir $false 30000 $true
+        Write-Host "Wait-StartRemoteServerPassive: $ConsoleOutput"
         $DidMatch = $ConsoleOutput -match "Completed" # Look for the special string to indicate success.
         if ($DidMatch) {
             return

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -292,9 +292,10 @@ function Start-RemoteServerPassive {
         } catch {
             Write-Host "Unable to fetch state. Creating a new one now."
             $state = [pscustomobject]@{
+                value=[pscustomobject]@{
                 "SeqNum" = 0
                 "Commands" = @($Command)
-            }
+            }}
             $StateJson = $state | ConvertTo-Json
             $Response = Invoke-WebRequest -Uri "$url/setkeyvalue?key=$RunId" -Headers $headers -Method Post -Body $StateJson -ContentType "application/json"
             if ($Response.StatusCode -ne 200) {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -289,7 +289,9 @@ function Start-RemoteServerPassive {
         # Find the highest lexicographically sorted file name
         $max = 0
         foreach ($file in $files) {
-            $num = [int]($file.Name -replace "[^0-9]", "")
+            # Remove .ps1 extension from file.Name
+            $filename = $file.Name.split(".")[0]
+            $num = [int]($filename -replace "[^0-9]", "")
             if ($num -gt $max) {
                 $max = $num
             }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -290,21 +290,18 @@ function Start-RemoteServerPassive {
         try {
             $Response = Invoke-WebRequest -Uri "$url/getkeyvalue?key=$RunId" -Headers $headers
         } catch {
-            if ($Response.StatusCode -eq 404) {
-                Write-Host "State not existing, creating it now."
-                $state = [pscustomobject]@{
-                    "SeqNum" = 0
-                    "Commands" = @($Command)
-                }
-                $StateJson = $state | ConvertTo-Json
-                $Response = Invoke-WebRequest -Uri "$url/setkeyvalue?key=$RunId" -Headers $headers -Method Post -Body $StateJson -ContentType "application/json"
-                if ($Response.StatusCode -ne 200) {
-                    Write-GHError "[Start-Remote-Passive] Failed to set the key value!"
-                    throw "Failed to set the key value!"
-                }
-                return
+            Write-Host "Unable to fetch state. Creating a new one now."
+            $state = [pscustomobject]@{
+                "SeqNum" = 0
+                "Commands" = @($Command)
             }
-            throw "Error code not 404."
+            $StateJson = $state | ConvertTo-Json
+            $Response = Invoke-WebRequest -Uri "$url/setkeyvalue?key=$RunId" -Headers $headers -Method Post -Body $StateJson -ContentType "application/json"
+            if ($Response.StatusCode -ne 200) {
+                Write-GHError "[Start-Remote-Passive] Failed to set the key value!"
+                throw "Failed to set the key value!"
+            }
+            return
         }
         $CurrState = $Response.Content | ConvertFrom-Json
         $CurrState.Commands += $Command

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -3,8 +3,6 @@
     Various helper functions for running secnetperf tests.
 #>
 
-Using module ..\..\netperf\p2p-common.psm1
-
 Set-StrictMode -Version "Latest"
 $PSDefaultParameterValues["*:ErrorAction"] = "Stop"
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -284,6 +284,7 @@ function Start-RemoteServer {
 function Start-RemoteServerPassive {
     param ($Session, $Command, $RemoteStateDir, $RunId, $SyncerSecret)
     if ($Session -eq "NOT_SUPPORTED") {
+        Write-Host "Command to start server: $Command"
         $headers = @{
             "secret" = "$SyncerSecret"
         }
@@ -311,7 +312,7 @@ function Start-RemoteServerPassive {
         }
         return
     }
-    
+
     Invoke-Command -Session $Session -ScriptBlock {
         if (!(Test-Path $Using:RemoteStateDir)) {
             New-Item -ItemType Directory $Using:RemoteStateDir | Out-Null

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -281,7 +281,7 @@ function Start-RemoteServer {
 function Start-RemoteServerPassive {
     param ($Session, $Command, $RemoteStateDir)
     Invoke-Command -Session $Session -ScriptBlock {
-        if (!Test-Path $Using:RemoteStateDir) {
+        if (!(Test-Path $Using:RemoteStateDir)) {
             New-Item -ItemType Directory $Using:RemoteStateDir | Out-Null
         }
         # Fetch all files names inside the directory
@@ -326,7 +326,7 @@ function Stop-RemoteServer {
 }
 
 function Stop-RemoteServerPassive {
-    param ($Session, $RemoteStateDir)
+    param ($Session, $RemoteStateDir, $RemoteAddress)
     # Ping side-channel socket on 9999 to tell the app to die
     $Socket = New-Object System.Net.Sockets.UDPClient
     $BytesToSend = @(
@@ -647,7 +647,7 @@ function Invoke-Secnetperf {
     } finally {
         # Stop the server.
         if ($Environment -eq "azure") {
-            Stop-RemoteServerPassive $Session $StateDir
+            Stop-RemoteServerPassive $Session $StateDir $RemoteName
         } else {
             try { Stop-RemoteServer $job $RemoteName | Add-Content $serverOut } catch { }
         }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -294,10 +294,11 @@ function Start-RemoteServerPassive {
                 $max = $num
             }
         }
+        $newmax = $max + 1
         # Create a new file with the next number
-        Write-Host "Creating new file execute_$($max + 1).ps1"
-        New-Item -ItemType File (Join-Path $Using:RemoteStateDir ("execute_$($max + 1).ps1")) | Out-Null
-        $newFile = Join-Path $Using:RemoteStateDir ("execute_$($max + 1).ps1")
+        Write-Host "Creating new file execute_$newmax.ps1"
+        New-Item -ItemType File (Join-Path $Using:RemoteStateDir ("execute_$newmax.ps1")) | Out-Null
+        $newFile = Join-Path $Using:RemoteStateDir ("execute_$newmax.ps1")
         Set-Content -Path $newFile -Value $Using:Command
     }
     # Wait for the server process to fetch and execute that file

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -431,7 +431,7 @@ function Wait-StartRemoteServerPassive {
     for ($i = 0; $i -lt 30; $i++) {
         Start-Sleep -Seconds 5 | Out-Null
         Write-Host "Attempt $i to start the remote server, command: $FullPath -target:$RemoteName"
-        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir $true
+        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir
         $ConsoleOutput = Wait-LocalTest $Process $OutputDir $false 30000 $true
         Write-Host "Wait-StartRemoteServerPassive: $ConsoleOutput"
         $DidMatch = $ConsoleOutput -match "Completed" # Look for the special string to indicate success.
@@ -445,9 +445,9 @@ function Wait-StartRemoteServerPassive {
 
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
-    param ($FullPath, $FullArgs, $OutputDir, $is1es = $false)
+    param ($FullPath, $FullArgs, $OutputDir)
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
-    if ($IsWindows -and $is1es) {
+    if ($IsWindows) {
         $pinfo.FileName = $FullPath
         $pinfo.Arguments = $FullArgs
     } else {

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -345,7 +345,8 @@ function Stop-RemoteServerPassive {
         Start-Sleep -Seconds 5 | Out-Null
         $files = Invoke-Command -Session $Session -ScriptBlock { Get-ChildItem $Using:RemoteStateDir }
         foreach ($file in $files) {
-            $num = [int]($file.Name -replace "[^0-9]", "")
+            $filename = $file.Name.split(".")[0]
+            $num = [int]($filename -replace "[^0-9]", "")
             if ($num -gt $MaxSeqNum) {
                 $MaxSeqNum = $num
             }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -295,6 +295,8 @@ function Start-RemoteServerPassive {
             }
         }
         # Create a new file with the next number
+        Write-Host "Creating new file execute_$($max + 1).ps1"
+        New-Item -ItemType File (Join-Path $Using:RemoteStateDir ("execute_$($max + 1).ps1")) | Out-Null
         $newFile = Join-Path $Using:RemoteStateDir ("execute_$($max + 1).ps1")
         Set-Content -Path $newFile -Value $Using:Command
     }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -239,7 +239,7 @@ $json["run_args"] = $allTests
 try {
 
 # Prepare the machines for the testing.
-if ($isWindows) {
+if ($isWindows -and !($environment -eq "azure")) {
     Write-Host "Preparing local machine for testing"
     ./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -159,6 +159,7 @@ if ($RemotePowershellSupported -eq "TRUE") {
 
 if (!($environment -eq "azure") && !($Session -eq "NOT_SUPPORTED")) {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
+    Write-Host "NOT RUNNING ON AZURE AND POWERSHELL SUPPORTED"
     Cleanup-State $Session $RemoteDir
 }
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -77,7 +77,10 @@ param (
     [string]$RemotePowershellSupported = "TRUE",
 
     [Parameter(Mandatory = $false)]
-    [string]$RunId = "0"
+    [string]$RunId = "0",
+
+    [Parameter(Mandatory = $false)]
+    [string]$SyncerSecret = "0"
 )
 
 Set-StrictMode -Version "Latest"
@@ -316,7 +319,7 @@ $regressionJson = Get-Content -Raw -Path "watermark_regression.json" | ConvertFr
 Write-Host "Setup complete! Running all tests"
 foreach ($testId in $allTests.Keys) {
     $ExeArgs = $allTests[$testId] + " -io:$io"
-    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $UserName $SecNetPerfPath $LogProfile $testId $ExeArgs $io $filter $environment
+    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $UserName $SecNetPerfPath $LogProfile $testId $ExeArgs $io $filter $environment $RunId $SyncerSecret
     $Test = $Output[-1]
     if ($Test.HasFailures) { $hasFailures = $true }
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -284,18 +284,20 @@ if (!($Session -eq "NOT_SUPPORTED")) {
 if ($useXDP -and $isWindows -and !($Session -eq "NOT_SUPPORTED")) { Install-XDP $Session $RemoteDir }
 if ($io -eq "wsk" -and !($Session -eq "NOT_SUPPORTED")) { Install-Kernel $Session $RemoteDir $SecNetPerfDir }
 
-if (!$isWindows -and !($Session -eq "NOT_SUPPORTED")) {
+if (!$isWindows) {
     # Make sure the secnetperf binary is executable.
     Write-Host "Updating secnetperf permissions"
     $GRO = "on"
     if ($io -eq "xdp") {
         $GRO = "off"
     }
-    Invoke-Command -Session $Session -ScriptBlock {
-        $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$Using:RemoteDir/$Using:SecNetPerfDir"
-        chmod +x "$Using:RemoteDir/$Using:SecNetPerfPath"
-        if ($Using:os -eq "ubuntu-22.04") {
-            sudo sh -c "ethtool -K eth0 generic-receive-offload $Using:GRO"
+    if (!($Session -eq "NOT_SUPPORTED")) {
+        Invoke-Command -Session $Session -ScriptBlock {
+            $env:LD_LIBRARY_PATH = "${env:LD_LIBRARY_PATH}:$Using:RemoteDir/$Using:SecNetPerfDir"
+            chmod +x "$Using:RemoteDir/$Using:SecNetPerfPath"
+            if ($Using:os -eq "ubuntu-22.04") {
+                sudo sh -c "ethtool -K eth0 generic-receive-offload $Using:GRO"
+            }
         }
     }
     $fullPath = Repo-Path $SecNetPerfDir

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -90,6 +90,7 @@ if (!$isWindows) {
 # Azure environment specific setup.
 if ($environment -eq "azure") {
     if ($isWindows) {
+        Write-Host "Setting RemoteDir to C:/ on 1ES Azure environments."
         $RemoteDir = "C:/"
     } else {
         # TODO
@@ -118,6 +119,7 @@ $Attempts = 0
 while ($Attempts -lt 5) {
     if ($environment -eq "azure") {
         if ($isWindows) {
+            Write-Host "Attempting to connect..."
             $Session = New-PSSession -ComputerName $RemoteName
         } else {
             # TODO

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -121,6 +121,8 @@ while ($Attempts -lt 5) {
         if ($isWindows) {
             Write-Host "Attempting to connect..."
             $Session = New-PSSession -ComputerName $RemoteName
+            $Session
+            break
         } else {
             # TODO
         }
@@ -137,6 +139,7 @@ while ($Attempts -lt 5) {
         }
         break
     } catch {
+        Write-Host "Error connecting to $RemoteName: $_"
         $Attempts += 1
         Start-Sleep -Seconds 10
     }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -114,7 +114,10 @@ while ($Attempts -lt 5) {
             $Session
             break
         } else {
-            # TODO
+            # On Azure in 1ES Linux environments, remote powershell is not supported (yet).
+            $Session = "NOT_SUPPORTED"
+            Write-Host "Remote PowerShell is not supported in Azure 1ES Linux environments"
+            break
         }
         continue
     }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -160,6 +160,7 @@ if ($RemotePowershellSupported -eq "TRUE") {
 if (!($environment -eq "azure") && !($Session -eq "NOT_SUPPORTED")) {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
     Write-Host "NOT RUNNING ON AZURE AND POWERSHELL SUPPORTED"
+    Write-Host "Session: $Session, $(!($Session -eq "NOT_SUPPORTED"))"
     Cleanup-State $Session $RemoteDir
 }
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -302,7 +302,7 @@ $regressionJson = Get-Content -Raw -Path "watermark_regression.json" | ConvertFr
 Write-Host "Setup complete! Running all tests"
 foreach ($testId in $allTests.Keys) {
     $ExeArgs = $allTests[$testId] + " -io:$io"
-    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $UserName $SecNetPerfPath $LogProfile $testId $ExeArgs $io $filter
+    $Output = Invoke-Secnetperf $Session $RemoteName $RemoteDir $UserName $SecNetPerfPath $LogProfile $testId $ExeArgs $io $filter $environment
     $Test = $Output[-1]
     if ($Test.HasFailures) { $hasFailures = $true }
 

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -86,6 +86,16 @@ if (!$isWindows) {
         $RemoteDir = "/home/$UserName/_work/quic"
     }
 }
+
+# Azure environment specific setup.
+if ($environment -eq "azure") {
+    if ($isWindows) {
+        $RemoteDir = "C:/"
+    } else {
+        # TODO
+    }
+}
+
 $SecNetPerfDir = "artifacts/bin/$plat/$($arch)_Release_$tls"
 $SecNetPerfPath = "$SecNetPerfDir/secnetperf"
 if ($io -eq "") {
@@ -106,6 +116,14 @@ $useXDP = ($io -eq "xdp" -or $io -eq "qtip")
 Write-Host "Connecting to $RemoteName"
 $Attempts = 0
 while ($Attempts -lt 5) {
+    if ($environment -eq "azure") {
+        if ($isWindows) {
+            $Session = New-PSSession -ComputerName $RemoteName
+        } else {
+            # TODO
+        }
+        continue
+    }
     try {
         if ($isWindows) {
             $username = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultUserName

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -110,7 +110,7 @@ while ($Attempts -lt 5) {
     if ($environment -eq "azure") {
         if ($isWindows) {
             Write-Host "Attempting to connect..."
-            $Session = New-PSSession -ComputerName $RemoteName
+            $Session = New-PSSession -ComputerName $RemoteName -ConfigurationName PowerShell.7
             $Session
             break
         } else {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -140,8 +140,10 @@ if ($null -eq $Session) {
     exit 1
 }
 
-# Make sure nothing is running from a previous run.
-Cleanup-State $Session $RemoteDir
+if (!($environment -eq "azure")) {
+    # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
+    Cleanup-State $Session $RemoteDir
+}
 
 # Create intermediary files.
 New-Item -ItemType File -Name "latency.txt"

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -139,7 +139,7 @@ while ($Attempts -lt 5) {
         }
         break
     } catch {
-        Write-Host "Error connecting to $RemoteName: $_"
+        Write-Host "Error $_"
         $Attempts += 1
         Start-Sleep -Seconds 10
     }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -157,7 +157,7 @@ if ($RemotePowershellSupported -eq "TRUE") {
     Write-Host "Remote PowerShell is not supported in this environment"
 }
 
-if (!($environment -eq "azure") && !($Session -eq "NOT_SUPPORTED")) {
+if (!($environment -eq "azure") -and !($Session -eq "NOT_SUPPORTED")) {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
     Write-Host "NOT RUNNING ON AZURE AND POWERSHELL SUPPORTED"
     Write-Host "Session: $Session, $(!($Session -eq "NOT_SUPPORTED"))"

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -87,16 +87,6 @@ if (!$isWindows) {
     }
 }
 
-# Azure environment specific setup.
-if ($environment -eq "azure") {
-    if ($isWindows) {
-        Write-Host "Setting RemoteDir to C:/ on 1ES Azure environments."
-        $RemoteDir = "C:/"
-    } else {
-        # TODO
-    }
-}
-
 $SecNetPerfDir = "artifacts/bin/$plat/$($arch)_Release_$tls"
 $SecNetPerfPath = "$SecNetPerfDir/secnetperf"
 if ($io -eq "") {


### PR DESCRIPTION
## Description

This PR adds the scripts and workflow templates to enable 2 machine testing on 1ES pools. 

Note: a lot of stuff can be re-factored and cleaned up for a better user experience. This should be done in a follow up PR, as this PR is already pretty massive. 

The work done here follows: 
![image](https://github.com/microsoft/netperf/assets/43735701/d535ed29-3854-4203-b2ff-b7717c6103a5)


## Testing

See: https://github.com/microsoft/netperf/actions/runs/9586048711

## Documentation

N/A
