### PR TITLE
Fix debug builds of msquic targeting UWP.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,9 +598,9 @@ if(WIN32)
     endif()
 
     if (NOT QUIC_STATIC_LINK_CRT AND NOT QUIC_STATIC_LINK_PARTIAL_CRT)
-        # We are using dynamic linking. Ensure that only the release version of CRT is used.
-        message(STATUS "Configuring for release version of dynamically linked CRT")
-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+        # We are using dynamic linking. Ensure that only the dynamic CRT is used.
+        message(STATUS "Configuring for dynamically linked CRT")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     endif()
 
 else() #!WIN32


### PR DESCRIPTION
Resolves the following compiler errors after `vcpkg install ms-quic:x64-uwp`. These errors are due to being built with /RTC1, but being linked with a release CRT that doesn't have the RTC stubs necessary for that.

```console
[61/62] C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\bin\CMakeFiles\msquic.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1440~1.338\bin\Hostx64\x64\link.exe  CMakeFiles\MsQuicEtw_Resource.dir\inc\MsQuicEtw.rc.res src\bin\CMakeFiles\msquic.dir\winuser\dllmain.c.obj src\bin\CMakeFiles\msquic.dir\msquic.rc.res  /out:bin\Debug\msquic.dll /implib:obj\Debug\msquic.lib /pdb:bin\Debug\msquic.pdb /dll /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD:NO /APPCONTAINER /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO  /nologo  /debug /DEF:"D:/vcpkg2/buildtrees/ms-quic/x64-uwp-dbg/src/bin/msquic.def"  /guard:cf /DYNAMICBASE  obj\Debug\core.lib  obj\Debug\platform.lib  wbemuuid.lib  winmm.lib  _deps\opensslquic-build\openssl\debug\lib\libssl.lib  _deps\opensslquic-build\openssl\debug\lib\libcrypto.lib  OneCore.lib  ws2_32.lib  ntdll.lib && cd ."
FAILED: bin/Debug/msquic.dll obj/Debug/msquic.lib
C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\bin\CMakeFiles\msquic.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1440~1.338\bin\Hostx64\x64\link.exe  CMakeFiles\MsQuicEtw_Resource.dir\inc\MsQuicEtw.rc.res src\bin\CMakeFiles\msquic.dir\winuser\dllmain.c.obj src\bin\CMakeFiles\msquic.dir\msquic.rc.res  /out:bin\Debug\msquic.dll /implib:obj\Debug\msquic.lib /pdb:bin\Debug\msquic.pdb /dll /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD:NO /APPCONTAINER /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO  /nologo  /debug /DEF:"D:/vcpkg2/buildtrees/ms-quic/x64-uwp-dbg/src/bin/msquic.def"  /guard:cf /DYNAMICBASE  obj\Debug\core.lib  obj\Debug\platform.lib  wbemuuid.lib  winmm.lib  _deps\opensslquic-build\openssl\debug\lib\libssl.lib  _deps\opensslquic-build\openssl\debug\lib\libcrypto.lib  OneCore.lib  ws2_32.lib  ntdll.lib && cd ."
LINK: command "C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1440~1.338\bin\Hostx64\x64\link.exe CMakeFiles\MsQuicEtw_Resource.dir\inc\MsQuicEtw.rc.res src\bin\CMakeFiles\msquic.dir\winuser\dllmain.c.obj src\bin\CMakeFiles\msquic.dir\msquic.rc.res /out:bin\Debug\msquic.dll /implib:obj\Debug\msquic.lib /pdb:bin\Debug\msquic.pdb /dll /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD:NO /APPCONTAINER /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO /nologo /debug /DEF:D:/vcpkg2/buildtrees/ms-quic/x64-uwp-dbg/src/bin/msquic.def /guard:cf /DYNAMICBASE obj\Debug\core.lib obj\Debug\platform.lib wbemuuid.lib winmm.lib _deps\opensslquic-build\openssl\debug\lib\libssl.lib _deps\opensslquic-build\openssl\debug\lib\libcrypto.lib OneCore.lib ws2_32.lib ntdll.lib" failed (exit code 1120) with the following output:
LINK : warning LNK4075: ignoring '/MANIFESTUAC' due to '/MANIFEST:NO' specification
   Creating library obj\Debug\msquic.lib and object obj\Debug\msquic.exp
platform.lib(datapath_raw_dummy.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(certificates_capi.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(pcp.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(cert_capi.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(hashtable.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(crypt.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(platform_worker.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(datapath_winuser.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(datapath_win.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(storage_winuser.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(crypt_openssl.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
platform.lib(tls_openssl.c.obj) : error LNK2001: unresolved external symbol _RTC_InitBase
```