### PR TITLE
Add increments into STREAMS_AVAILABLE event

### DIFF
--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -190,6 +190,14 @@ The number of bidirectional streams the peer is willing to accept.
 
 The number of unidirectional streams the peer is willing to accept.
 
+`BidirectionalIncrement`
+
+The increment of how many additional bidirectional streams the peer is willing to accept.
+
+`UnidirectionalIncrement`
+
+The increment of how many additional of unidirectional streams the peer is willing to accept.
+
 ## QUIC_CONNECTION_EVENT_PEER_NEEDS_STREAMS
 
 This event indicates the peer is currently blocked on the number of parallel streams the app has configured it is willing to accept.

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -2702,6 +2702,12 @@ namespace Microsoft.Quic
 
                 [NativeTypeName("uint16_t")]
                 internal ushort UnidirectionalCount;
+
+                [NativeTypeName("uint16_t")]
+                internal ushort BidirectionalIncrement;
+
+                [NativeTypeName("uint16_t")]
+                internal ushort UnidirectionalIncrement;
             }
 
             internal partial struct _PEER_NEEDS_STREAMS_e__Struct

--- a/src/generated/linux/stream_set.c.clog.h
+++ b/src/generated/linux/stream_set.c.clog.h
@@ -117,20 +117,24 @@ tracepoint(CLOG_STREAM_SET_C, MaxStreamCountUpdated , arg1, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamsAvailable
-// [conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]
+// [conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]
 // QuicTraceLogConnVerbose(
         IndicateStreamsAvailable,
         Connection,
-        "Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]",
+        "Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]",
         Event.STREAMS_AVAILABLE.BidirectionalCount,
-        Event.STREAMS_AVAILABLE.UnidirectionalCount);
+        Event.STREAMS_AVAILABLE.UnidirectionalCount,
+        Event.STREAMS_AVAILABLE.BidirectionalIncrement,
+        Event.STREAMS_AVAILABLE.UnidirectionalIncrement);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Event.STREAMS_AVAILABLE.BidirectionalCount = arg3
 // arg4 = arg4 = Event.STREAMS_AVAILABLE.UnidirectionalCount = arg4
+// arg5 = arg5 = Event.STREAMS_AVAILABLE.BidirectionalIncrement = arg5
+// arg6 = arg6 = Event.STREAMS_AVAILABLE.UnidirectionalIncrement = arg6
 ----------------------------------------------------------*/
-#ifndef _clog_5_ARGS_TRACE_IndicateStreamsAvailable
-#define _clog_5_ARGS_TRACE_IndicateStreamsAvailable(uniqueId, arg1, encoded_arg_string, arg3, arg4)\
-tracepoint(CLOG_STREAM_SET_C, IndicateStreamsAvailable , arg1, arg3, arg4);\
+#ifndef _clog_7_ARGS_TRACE_IndicateStreamsAvailable
+#define _clog_7_ARGS_TRACE_IndicateStreamsAvailable(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5, arg6)\
+tracepoint(CLOG_STREAM_SET_C, IndicateStreamsAvailable , arg1, arg3, arg4, arg5, arg6);\
 
 #endif
 

--- a/src/generated/linux/stream_set.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_set.c.clog.h.lttng.h
@@ -91,26 +91,34 @@ TRACEPOINT_EVENT(CLOG_STREAM_SET_C, MaxStreamCountUpdated,
 
 /*----------------------------------------------------------
 // Decoder Ring for IndicateStreamsAvailable
-// [conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]
+// [conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]
 // QuicTraceLogConnVerbose(
         IndicateStreamsAvailable,
         Connection,
-        "Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]",
+        "Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]",
         Event.STREAMS_AVAILABLE.BidirectionalCount,
-        Event.STREAMS_AVAILABLE.UnidirectionalCount);
+        Event.STREAMS_AVAILABLE.UnidirectionalCount,
+        Event.STREAMS_AVAILABLE.BidirectionalIncrement,
+        Event.STREAMS_AVAILABLE.UnidirectionalIncrement);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Event.STREAMS_AVAILABLE.BidirectionalCount = arg3
 // arg4 = arg4 = Event.STREAMS_AVAILABLE.UnidirectionalCount = arg4
+// arg5 = arg5 = Event.STREAMS_AVAILABLE.BidirectionalIncrement = arg5
+// arg6 = arg6 = Event.STREAMS_AVAILABLE.UnidirectionalIncrement = arg6
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_STREAM_SET_C, IndicateStreamsAvailable,
     TP_ARGS(
         const void *, arg1,
         unsigned short, arg3,
-        unsigned short, arg4), 
+        unsigned short, arg4,
+        unsigned short, arg5,
+        unsigned short, arg6), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, arg1)
         ctf_integer(unsigned short, arg3, arg3)
         ctf_integer(unsigned short, arg4, arg4)
+        ctf_integer(unsigned short, arg5, arg5)
+        ctf_integer(unsigned short, arg6, arg6)
     )
 )
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1209,6 +1209,8 @@ typedef struct QUIC_CONNECTION_EVENT {
         struct {
             uint16_t BidirectionalCount;
             uint16_t UnidirectionalCount;
+            uint16_t BidirectionalIncrement;
+            uint16_t UnidirectionalIncrement;
         } STREAMS_AVAILABLE;
         struct {
             BOOLEAN Bidirectional;

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -6106,7 +6106,7 @@
     },
     "IndicateStreamsAvailable": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]",
+      "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]",
       "UniqueId": "IndicateStreamsAvailable",
       "splitArgs": [
         {
@@ -6120,6 +6120,14 @@
         {
           "DefinationEncoding": "hu",
           "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg6"
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
@@ -15032,9 +15040,9 @@
         "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_START_COMPLETE [Status=0x%x ID=%llu Accepted=%hhu]"
       },
       {
-        "UniquenessHash": "26bdd068-e9fa-9f1e-2d26-60dbed5c5080",
+        "UniquenessHash": "50a79808-57c9-3862-b8fd-ef4f4bf53b8d",
         "TraceID": "IndicateStreamsAvailable",
-        "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu]"
+        "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE [bi=%hu uni=%hu bi_inc=%hu uni_inc=%hu]"
       },
       {
         "UniquenessHash": "c7899737-8445-73b7-9221-5db9217dbdce",


### PR DESCRIPTION
## Description

In case the current count of available streams is bellow 0, STREAMS_AVAILABLE event will indicate 0, making it impossible to know the actual update that came over the wire.

## Alternatives

- Report the number from the frame / initial setting directly (`MaxStreams` value) instead of the increments.
- Use different naming for the properties.

## Testing

No existing tests cover the pre-existing values in this event, but this was tested with .NET runtime and System.Net.Quic that plans to take advantage of this feature for it's own stream counting (https://github.com/dotnet/runtime/commit/36210649c502c006e0bdd1439f9ba4c8a976df28)

## Documentation

Updated.


cc @MihaZupan @rzikm @CarnaViire @liveans 