### PR TITLE
Handle error from RawDataPathInitialize

### DIFF
--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -637,6 +637,15 @@ CxPlatSocketGetRemoteAddress(
     );
 
 //
+// Queries a raw socket availability.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+CxPlatSocketRawSocketAvailable(
+    _In_ CXPLAT_SOCKET* Socket
+    );
+
+//
 // Called to return a chain of datagrams received from the registered receive
 // callback.
 //

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1580,6 +1580,15 @@ CxPlatSocketGetRemoteAddress(
     *Address = Socket->RemoteAddress;
 }
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+CxPlatSocketRawSocketAvailable(
+    _In_ CXPLAT_SOCKET* Socket
+    )
+{
+    return FALSE;
+}
+
 void
 CxPlatRecvDataReturn(
     _In_opt_ CXPLAT_RECV_DATA* RecvDataChain

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -1586,6 +1586,7 @@ CxPlatSocketRawSocketAvailable(
     _In_ CXPLAT_SOCKET* Socket
     )
 {
+    UNREFERENCED_PARAMETER(Socket);
     return FALSE;
 }
 

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2081,6 +2081,7 @@ CxPlatSocketRawSocketAvailable(
     _In_ CXPLAT_SOCKET* Socket
     )
 {
+    UNREFERENCED_PARAMETER(Socket);
     return FALSE;
 }
 

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2076,6 +2076,15 @@ CxPlatSocketGetRemoteAddress(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+CxPlatSocketRawSocketAvailable(
+    _In_ CXPLAT_SOCKET* Socket
+    )
+{
+    return FALSE;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 DATAPATH_RX_IO_BLOCK*
 CxPlatSocketAllocRxIoBlock(
     _In_ CXPLAT_DATAPATH* Datapath,

--- a/src/platform/datapath_xplat.c
+++ b/src/platform/datapath_xplat.c
@@ -57,6 +57,8 @@ CxPlatDataPathInitialize(
                 RawDatapathInitFail,
                 "[ raw] Failed to initialize raw datapath, status:%d", Status);
             (*NewDataPath)->RawDataPath = NULL;
+            CxPlatDataPathUninitialize(*NewDataPath);
+            *NewDataPath = NULL;
         }
     }
 

--- a/src/platform/datapath_xplat.c
+++ b/src/platform/datapath_xplat.c
@@ -56,7 +56,6 @@ CxPlatDataPathInitialize(
             QuicTraceLogVerbose(
                 RawDatapathInitFail,
                 "[ raw] Failed to initialize raw datapath, status:%d", Status);
-            Status = QUIC_STATUS_SUCCESS;
             (*NewDataPath)->RawDataPath = NULL;
         }
     }

--- a/src/platform/datapath_xplat.c
+++ b/src/platform/datapath_xplat.c
@@ -249,6 +249,15 @@ CxPlatSocketGetRemoteAddress(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+CxPlatSocketRawSocketAvailable(
+    _In_ CXPLAT_SOCKET* Socket
+    )
+{
+    return Socket->RawSocketAvailable;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 void
 CxPlatRecvDataReturn(
     _In_opt_ CXPLAT_RECV_DATA* RecvDataChain

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -427,7 +427,7 @@ QuicAddr DataPathTest::UnspecIPv4;
 QuicAddr DataPathTest::UnspecIPv6;
 
 struct CxPlatDataPath {
-    QUIC_EXECUTION_CONFIG DefaultExecutionConfig { QUIC_EXECUTION_CONFIG_FLAG_NONE, 0, 1, {0} };
+    QUIC_EXECUTION_CONFIG DefaultExecutionConfig { QUIC_EXECUTION_CONFIG_FLAG_NONE, 0, 0, {0} };
     CXPLAT_DATAPATH* Datapath {nullptr};
     QUIC_STATUS InitStatus;
     CxPlatDataPath(

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -728,9 +728,6 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(nullptr, Socket.Socket);
     QUIC_ADDR LocalAddr = Socket.GetLocalAddress();
     ASSERT_NE(LocalAddr.Ipv4.sin_port, (uint16_t)0);
-    // [::] or [fc00::1:11]
-    bool Any = memcmp(&LocalAddr.Ipv6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0;
-    ASSERT_TRUE((UseDuoNic ^ Any));
 }
 
 TEST_F(DataPathTest, UdpRebind)

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -728,11 +728,9 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(nullptr, Socket.Socket);
     QUIC_ADDR LocalAddr = Socket.GetLocalAddress();
     ASSERT_NE(LocalAddr.Ipv4.sin_port, (uint16_t)0);
-    if (!UseDuoNic) {
-        // [::] or [fc00::1:11]
-        bool Any = memcmp(&LocalAddr.Ipv6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0;
-        ASSERT_TRUE((!UseDuoNic ^ Any));
-    }
+    // [::] or [fc00::1:11]
+    bool Any = memcmp(&LocalAddr.Ipv6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0;
+    ASSERT_TRUE((!UseDuoNic ^ Any));
 }
 
 TEST_F(DataPathTest, UdpRebind)

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -677,6 +677,7 @@ TEST_F(DataPathTest, Initialize)
         CxPlatDataPath Datapath(&EmptyUdpCallbacks, nullptr, 0, &Config);
         VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
         ASSERT_NE(nullptr, Datapath.Datapath);
+        ASSERT_TRUE(Datapath.IsSupported(CXPLAT_DATAPATH_FEATURE_RAW));
     }
 }
 
@@ -727,6 +728,10 @@ TEST_F(DataPathTest, UdpBind)
     VERIFY_QUIC_SUCCESS(Socket.GetInitStatus());
     ASSERT_NE(nullptr, Socket.Socket);
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
+    if (UseDuoNic) {
+        ASSERT_TRUE(Datapath.IsSupported(CXPLAT_DATAPATH_FEATURE_RAW) && UseDuoNic);
+        ASSERT_TRUE(Socket.Route.DatapathType == 2); // CXPLAT_DATAPATH_TYPE_RAW
+    }
 }
 
 TEST_F(DataPathTest, UdpRebind)

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -672,8 +672,7 @@ TEST_F(DataPathTest, Initialize)
         VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
         ASSERT_NE(nullptr, Datapath.Datapath);
     }
-    if (UseDuoNic)
-    {
+    if (UseDuoNic) {
         QUIC_EXECUTION_CONFIG Config = { QUIC_EXECUTION_CONFIG_FLAG_XDP, 0, 1, {0} };
         CxPlatDataPath Datapath(&EmptyUdpCallbacks, nullptr, 0, &Config);
         VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -726,8 +726,7 @@ TEST_F(DataPathTest, UdpBind)
     CxPlatSocket Socket(Datapath);
     VERIFY_QUIC_SUCCESS(Socket.GetInitStatus());
     ASSERT_NE(nullptr, Socket.Socket);
-    QUIC_ADDR LocalAddr = Socket.GetLocalAddress();
-    ASSERT_NE(LocalAddr.Ipv4.sin_port, (uint16_t)0);
+    ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
 TEST_F(DataPathTest, UdpRebind)

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -427,7 +427,7 @@ QuicAddr DataPathTest::UnspecIPv4;
 QuicAddr DataPathTest::UnspecIPv6;
 
 struct CxPlatDataPath {
-    QUIC_EXECUTION_CONFIG DefaultExecutionConfig { QUIC_EXECUTION_CONFIG_FLAG_XDP, 0, 0, {0} };
+    QUIC_EXECUTION_CONFIG DefaultExecutionConfig { QUIC_EXECUTION_CONFIG_FLAG_NONE, 0, 1, {0} };
     CXPLAT_DATAPATH* Datapath {nullptr};
     QUIC_STATUS InitStatus;
     CxPlatDataPath(
@@ -437,6 +437,9 @@ struct CxPlatDataPath {
         _In_opt_ QUIC_EXECUTION_CONFIG* Config = nullptr
         ) noexcept
     {
+        if (UseDuoNic && Config == nullptr) {
+            DefaultExecutionConfig.Flags = QUIC_EXECUTION_CONFIG_FLAG_XDP;
+        }
         InitStatus =
             CxPlatDataPathInitialize(
                 ClientRecvContextLength,
@@ -664,12 +667,6 @@ TEST_F(DataPathTest, Initialize)
     }
     {
         QUIC_EXECUTION_CONFIG Config = { QUIC_EXECUTION_CONFIG_FLAG_NONE, UINT32_MAX, 1, {0} };
-        CxPlatDataPath Datapath(&EmptyUdpCallbacks, nullptr, 0, &Config);
-        VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
-        ASSERT_NE(nullptr, Datapath.Datapath);
-    }
-    {
-        QUIC_EXECUTION_CONFIG Config = { QUIC_EXECUTION_CONFIG_FLAG_NONE, 0, 1, {0} };
         CxPlatDataPath Datapath(&EmptyUdpCallbacks, nullptr, 0, &Config);
         VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
         ASSERT_NE(nullptr, Datapath.Datapath);

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -730,7 +730,7 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(LocalAddr.Ipv4.sin_port, (uint16_t)0);
     // [::] or [fc00::1:11]
     bool Any = memcmp(&LocalAddr.Ipv6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0;
-    ASSERT_TRUE((!UseDuoNic ^ Any));
+    ASSERT_TRUE((UseDuoNic ^ Any));
 }
 
 TEST_F(DataPathTest, UdpRebind)


### PR DESCRIPTION
## Description

Error from RawDataPathInitialize has been ignored because it is optional.
Handle the error as the raw datapath is now user opt-in.

## Testing

See automation

## Documentation

N/A
