### PR TITLE
[release/2.3] Add memory alignment for ARM32

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -76,7 +76,7 @@ typedef struct DATAPATH_RX_IO_BLOCK {
 
 } DATAPATH_RX_IO_BLOCK;
 
-typedef struct DATAPATH_RX_PACKET {
+typedef struct __attribute__((aligned(16))) DATAPATH_RX_PACKET {
     //
     // The IO block that owns the packet.
     //


### PR DESCRIPTION
## Description

Backport of #4208 

The fix was for an alignment problem -> arm is sensitive in places where  x64 is not.

## Testing

Manually tested

## Documentation

No

/cc @ManickaP