### PR TITLE
Always Ignore Invalid Tokens

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3830,7 +3830,7 @@ QuicConnRecvHeader(
                 QuicPacketDecodeRetryTokenV1(Packet, &TokenBuffer, &TokenLength);
             } else {
                 CXPLAT_DBG_ASSERT(TokenBuffer != NULL);
-                if (!QuicPacketValidateInitialToken(
+                if (QuicPacketValidateInitialToken(
                         Connection,
                         Packet,
                         TokenLength,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3824,7 +3824,6 @@ QuicConnRecvHeader(
         QUIC_PATH* Path = &Connection->Paths[0];
         if (!Path->IsPeerValidated && (Packet->ValidToken || TokenLength != 0)) {
 
-            BOOLEAN InvalidRetryToken = FALSE;
             if (Packet->ValidToken) {
                 CXPLAT_DBG_ASSERT(TokenBuffer == NULL);
                 CXPLAT_DBG_ASSERT(TokenLength == 0);
@@ -3835,14 +3834,12 @@ QuicConnRecvHeader(
                         Connection,
                         Packet,
                         TokenLength,
-                        TokenBuffer,
-                        &InvalidRetryToken) &&
-                    InvalidRetryToken) {
-                    return FALSE;
+                        TokenBuffer)) {
+                    Packet->ValidToken = TRUE;
                 }
             }
 
-            if (!InvalidRetryToken) {
+            if (Packet->ValidToken) {
                 CXPLAT_DBG_ASSERT(TokenBuffer != NULL);
                 CXPLAT_DBG_ASSERT(TokenLength == sizeof(QUIC_TOKEN_CONTENTS));
 

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -314,8 +314,7 @@ QuicPacketValidateInitialToken(
     _In_ const QUIC_RX_PACKET* const Packet,
     _In_range_(>, 0) uint16_t TokenLength,
     _In_reads_(TokenLength)
-        const uint8_t* TokenBuffer,
-    _Inout_ BOOLEAN* DropPacket
+        const uint8_t* TokenBuffer
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)


### PR DESCRIPTION
## Description

This updates the code to always ignore invalid tokens, instead of dropping packets with invalid Retry tokens. This is necessary because it's possible the client sends a NEW_TOKEN token from a different server to you, which you then interpret as a bad RETRY token. This would result in all connection attemps from that client in this case to fail. The best answer is to just ignore these bad tokens.

## Testing

CI/CD

## Documentation

N/A
