### PR TITLE
Publish Ubuntu 24.04

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -98,7 +98,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -128,7 +128,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -158,7 +158,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -188,7 +188,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3
+          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -308,7 +308,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3
+          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -248,15 +248,15 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2204_openssl
-          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl
+          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
+          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.ubuntu2204repos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl/gen -r ${{ repo }} -n "*.deb"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl3/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
@@ -278,15 +278,15 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2404_openssl
-          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl
+          artifact: drop_package_linux_distribution_ubuntu_2404_openssl3
+          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.ubuntu2404repos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl/gen -r ${{ repo }} -n "*.deb"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl3/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -185,16 +185,16 @@ stages:
     displayName: Upload Ubuntu packages to repos
     strategy:
       matrix:
-        ubuntu2004:
-          os: ubuntu2004
+        ubuntu_2004:
+          os: ubuntu_2004
           tls: openssl
           repo: [microsoft-ubuntu-xenial-prod-apt, microsoft-ubuntu-bionic-prod-apt, microsoft-ubuntu-focal-prod-apt, microsoft-ubuntu-groovy-prod-apt, microsoft-ubuntu-hirsute-prod-apt]
-        ubuntu2204:
-          os: ubuntu2204
+        ubuntu_2204:
+          os: ubuntu_2204
           tls: openssl3
           repo: [microsoft-ubuntu-jammy-prod-apt, microsoft-ubuntu-kinetic-prod-apt, microsoft-ubuntu-lunar-prod-apt, microsoft-ubuntu-mantic-prod-apt]
-        ubuntu2404:
-          os: ubuntu2404
+        ubuntu_2404:
+          os: ubuntu_2404
           tls: openssl3
           repo: [microsoft-ubuntu-noble-prod-apt]
     timeoutInMinutes: 120

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -56,6 +56,25 @@ parameters:
 - name: debug # debug mode will not actually upload and publish packages
   type: boolean
   default: false
+- name: ubuntu2004repos
+  type: object
+  default:
+  - microsoft-ubuntu-xenial-prod-apt
+  - microsoft-ubuntu-bionic-prod-apt
+  - microsoft-ubuntu-focal-prod-apt
+  - microsoft-ubuntu-groovy-prod-apt
+  - microsoft-ubuntu-hirsute-prod-apt
+- name: ubuntu2204repos
+  type: object
+  default:
+  - microsoft-ubuntu-jammy-prod-apt
+  - microsoft-ubuntu-kinetic-prod-apt
+  - microsoft-ubuntu-lunar-prod-apt
+  - microsoft-ubuntu-mantic-prod-apt
+- name: ubuntu2404repos
+  type: object
+  default:
+  - microsoft-ubuntu-noble-prod-apt
 
 stages:
 - stage: UploadPackage_stage
@@ -181,22 +200,8 @@ stages:
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_ubuntu
-    displayName: Upload Ubuntu packages to repos
-    strategy:
-      matrix:
-        ubuntu_2004:
-          os: ubuntu_2004
-          tls: openssl
-          repo: [microsoft-ubuntu-xenial-prod-apt, microsoft-ubuntu-bionic-prod-apt, microsoft-ubuntu-focal-prod-apt, microsoft-ubuntu-groovy-prod-apt, microsoft-ubuntu-hirsute-prod-apt]
-        ubuntu_2204:
-          os: ubuntu_2204
-          tls: openssl3
-          repo: [microsoft-ubuntu-jammy-prod-apt, microsoft-ubuntu-kinetic-prod-apt, microsoft-ubuntu-lunar-prod-apt, microsoft-ubuntu-mantic-prod-apt]
-        ubuntu_2404:
-          os: ubuntu_2404
-          tls: openssl3
-          repo: [microsoft-ubuntu-noble-prod-apt]
+  - job: UploadPackage_ubuntu2004
+    displayName: Upload Ubuntu 20.04 packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -213,14 +218,75 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_${{ os }}_${{ tls }}
-          path: $(Build.SourcesDirectory)/artifacts/signed/${{ os }}_${{ tls }}
+          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2004_openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/${{ os }}_${{ tls }}/gen -r ${{ repo }} -n "*.deb"
+      - ${{ each repo in parameters.ubuntu2004repos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2004_openssl/gen -r ${{ repo }} -n "*.deb"
+          condition: eq(${{ parameters.debug }}, false)
+          displayName: ${{ repo }}
+          continueOnError: true
+  - job: UploadPackage_ubuntu2204
+    displayName: Upload Ubuntu 22.04 packages to repos
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+    - group: MsQuicAADApp
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_ubuntu_2204_openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl
+      - task: DownloadSecureFile@1
+        name:  pmcv4cert
+        displayName: 'Download cert for PMC v4'
+        inputs:
+          secureFile: 'auth.pem'
+      - ${{ each repo in parameters.ubuntu2204repos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl/gen -r ${{ repo }} -n "*.deb"
+          condition: eq(${{ parameters.debug }}, false)
+          displayName: ${{ repo }}
+          continueOnError: true
+  - job: UploadPackage_ubuntu
+    displayName: Upload Ubuntu 24.04 packages to repos
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+    - group: MsQuicAADApp
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_ubuntu_2404_openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl
+      - task: DownloadSecureFile@1
+        name:  pmcv4cert
+        displayName: 'Download cert for PMC v4'
+        inputs:
+          secureFile: 'auth.pem'
+      - ${{ each repo in parameters.ubuntu2404repos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -39,22 +39,12 @@ parameters:
 - name: openssldebrepos
   type: object
   default:
-  - microsoft-ubuntu-xenial-prod-apt
   - microsoft-debian-stretch-prod-apt
-  - microsoft-ubuntu-bionic-prod-apt
   - microsoft-debian-buster-prod-apt
-  - microsoft-ubuntu-focal-prod-apt
-  - microsoft-ubuntu-groovy-prod-apt
-  - microsoft-ubuntu-hirsute-prod-apt
   - microsoft-debian-bullseye-prod-apt
 - name: openssl3debrepos
   type: object
   default:
-  - microsoft-ubuntu-noble-prod-apt
-  - microsoft-ubuntu-jammy-prod-apt
-  - microsoft-ubuntu-kinetic-prod-apt
-  - microsoft-ubuntu-lunar-prod-apt
-  - microsoft-ubuntu-mantic-prod-apt
   - microsoft-debian-bookworm-prod-apt
 - name: openssl3rpmrepos
   type: object
@@ -188,6 +178,49 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.openssl3debrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.deb"
+          condition: eq(${{ parameters.debug }}, false)
+          displayName: ${{ repo }}
+          continueOnError: true
+  - job: UploadPackage_ubuntu
+    displayName: Upload Ubuntu packages to repos
+    strategy:
+      matrix:
+        ubuntu2004:
+          os: ubuntu2004
+          tls: openssl
+          repo: [microsoft-ubuntu-xenial-prod-apt, microsoft-ubuntu-bionic-prod-apt, microsoft-ubuntu-focal-prod-apt, microsoft-ubuntu-groovy-prod-apt, microsoft-ubuntu-hirsute-prod-apt]
+        ubuntu2204:
+          os: ubuntu2204
+          tls: openssl3
+          repo: [microsoft-ubuntu-jammy-prod-apt, microsoft-ubuntu-kinetic-prod-apt, microsoft-ubuntu-lunar-prod-apt, microsoft-ubuntu-mantic-prod-apt]
+        ubuntu2404:
+          os: ubuntu2404
+          tls: openssl3
+          repo: [microsoft-ubuntu-noble-prod-apt]
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+    - group: MsQuicAADApp
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_${{ os }}_${{ tls }}
+          path: $(Build.SourcesDirectory)/artifacts/signed/${{ os }}_${{ tls }}
+      - task: DownloadSecureFile@1
+        name:  pmcv4cert
+        displayName: 'Download cert for PMC v4'
+        inputs:
+          secureFile: 'auth.pem'
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/${{ os }}_${{ tls }}/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -50,6 +50,7 @@ parameters:
 - name: openssl3debrepos
   type: object
   default:
+  - microsoft-ubuntu-noble-prod-apt
   - microsoft-ubuntu-jammy-prod-apt
   - microsoft-ubuntu-kinetic-prod-apt
   - microsoft-ubuntu-lunar-prod-apt

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -56,7 +56,7 @@ parameters:
 - name: debug # debug mode will not actually upload and publish packages
   type: boolean
   default: false
-- name: ubuntu2004repos
+- name: ubuntu20repos
   type: object
   default:
   - microsoft-ubuntu-xenial-prod-apt
@@ -64,14 +64,14 @@ parameters:
   - microsoft-ubuntu-focal-prod-apt
   - microsoft-ubuntu-groovy-prod-apt
   - microsoft-ubuntu-hirsute-prod-apt
-- name: ubuntu2204repos
+- name: ubuntu22repos
   type: object
   default:
   - microsoft-ubuntu-jammy-prod-apt
   - microsoft-ubuntu-kinetic-prod-apt
   - microsoft-ubuntu-lunar-prod-apt
   - microsoft-ubuntu-mantic-prod-apt
-- name: ubuntu2404repos
+- name: ubuntu24repos
   type: object
   default:
   - microsoft-ubuntu-noble-prod-apt
@@ -200,8 +200,8 @@ stages:
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_ubuntu2004
-    displayName: Upload Ubuntu 20.04 packages to repos
+  - job: UploadPackage_ubuntu20
+    displayName: Upload Ubuntu 20 packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -225,13 +225,13 @@ stages:
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu2004repos }}:
+      - ${{ each repo in parameters.ubuntu20repos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2004_openssl/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_ubuntu2204
-    displayName: Upload Ubuntu 22.04 packages to repos
+  - job: UploadPackage_ubuntu22
+    displayName: Upload Ubuntu 22 packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -255,13 +255,13 @@ stages:
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu2204repos }}:
+      - ${{ each repo in parameters.ubuntu22repos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl3/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_ubuntu
-    displayName: Upload Ubuntu 24.04 packages to repos
+  - job: UploadPackage_ubuntu24
+    displayName: Upload Ubuntu 24 packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -285,7 +285,7 @@ stages:
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu2404repos }}:
+      - ${{ each repo in parameters.ubuntu24repos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl3/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}


### PR DESCRIPTION
## Description

Update package publish pipeline to distinguish ubuntu version. Previously openssl versions are used, but now both ubuntu22 and 24 use openssl3.

## Testing



## Documentation


