### PR TITLE
Fix package distribution. Specify OS explicitly

### DIFF
--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -46,6 +46,7 @@ jobs:
     inputs:
       pwsh: false
       filePath: scripts/package-distribution.ps1
+      arguments: -OS $(os)
   - script: | # prepare 2 sets of packages for signing with different keys (gen = general purpose, cbl = cbl-mariner)
       mkdir $(Build.SourcesDirectory)/artifacts/dist/gen
       find $(Build.SourcesDirectory)/artifacts/dist -type f -exec mv -t $(Build.SourcesDirectory)/artifacts/dist/gen/ {} +

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -14,7 +14,7 @@ CONFIG=Release
 NAME=libmsquic
 TLS=openssl
 TLSVERSION=1.1
-UBUNTU=
+XDP="False"
 CONFLICTS=
 DESCRIPTION="Microsoft implementation of the IETF QUIC protocol"
 VENDOR="Microsoft"
@@ -86,9 +86,9 @@ while :; do
             shift
             OUTPUT=$1
             ;;
-        -u|-ubuntu|--ubuntu)
+        -x|-xdp|--xdp)
             shift
-            UBUNTU=$1
+            XDP=$1
             ;;
         -t|-tls|--tls)
             shift
@@ -134,8 +134,9 @@ echo "ARCH=$ARCH PKGARCH=$PKGARCH ARTIFACTS=$ARTIFACTS"
 mkdir -p ${OUTPUT}
 
 if [ "$OS" == "linux" ]; then
-  # Ubuntu 24.04 dependencies are not fully validated on redhat/centos etc.
-  if [ "$UBUNTU" != '2404' ]; then
+  # XDP is only validated on Ubuntu 24.04 and x64
+  if [ "$XDP" == "False" ] || [[ "$ARCH" == arm* ]]; then
+    echo "Building rpm package"
     # RedHat/CentOS
     FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
     FILES="${FILES} ${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}"
@@ -183,7 +184,8 @@ if [ "$OS" == "linux" ]; then
      FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
   fi
 
-  if [ "$UBUNTU" == '2404' ]; then
+  if [ "$XDP" == "True" ] && [[ "$ARCH" == x* ]]; then
+    echo "Building deb package (XDP)"
     fpm \
       --force \
       --input-type dir \
@@ -211,6 +213,7 @@ if [ "$OS" == "linux" ]; then
       --log error \
       ${FILES} ${ARTIFACTS}/datapath_raw_xdp_kern.o=/usr/${LIBDIR}/datapath_raw_xdp_kern.o
   else
+    echo "Building deb package"
     fpm \
       --force \
       --input-type dir \

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -184,6 +184,12 @@ if [ "$OS" == "linux" ]; then
      FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
   fi
 
+  # XDP means Ubuntu 24.04 which installs libssl3t64 instead of libssl3
+  BITS=''
+  if [ "$XDP" == "True" ]; then
+      BITS='t64'
+  fi
+
   if [ "$XDP" == "True" ] && [[ "$ARCH" == x* ]]; then
     echo "Building deb package (XDP)"
     fpm \
@@ -194,7 +200,7 @@ if [ "$OS" == "linux" ]; then
       --name ${NAME} \
       --provides ${NAME} \
       --conflicts ${CONFLICTS} \
-      --depends "libssl${TLSVERSION}" \
+      --depends "libssl${TLSVERSION}${BITS}" \
       --depends "libnuma1" \
       --depends "libxdp1" \
       --depends "libbpf1" \
@@ -222,7 +228,7 @@ if [ "$OS" == "linux" ]; then
       --name ${NAME} \
       --provides ${NAME} \
       --conflicts ${CONFLICTS} \
-      --depends "libssl${TLSVERSION}" \
+      --depends "libssl${TLSVERSION}${BITS}" \
       --depends "libnuma1" \
       --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
       --description "${DESCRIPTION}" \

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -14,6 +14,7 @@ CONFIG=Release
 NAME=libmsquic
 TLS=openssl
 TLSVERSION=1.1
+TIME64DISTRO="False"
 XDP="False"
 CONFLICTS=
 DESCRIPTION="Microsoft implementation of the IETF QUIC protocol"
@@ -89,6 +90,10 @@ while :; do
         -x|-xdp|--xdp)
             shift
             XDP=$1
+            ;;
+        -time64|--time64)
+            shift
+            TIME64DISTRO=$1
             ;;
         -t|-tls|--tls)
             shift
@@ -184,9 +189,8 @@ if [ "$OS" == "linux" ]; then
      FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
   fi
 
-  # XDP means Ubuntu 24.04 which installs libssl3t64 instead of libssl3
   BITS=''
-  if [ "$XDP" == "True" ]; then
+  if [ "$TIME64DISTRO" == "True" ]; then
       BITS='t64'
   fi
 

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -6,6 +6,17 @@
 
 #>
 
+param (
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("ubuntu_2404", "ubuntu_2204", "ubuntu_2004", "")]
+    [string]$OS = ""
+)
+
+$UseXdp = $false
+if ($OS -eq "ubuntu_2404") {
+    $UseXdp = $true
+}
+
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
@@ -167,17 +178,13 @@ foreach ($Build in $AllBuilds) {
         if ($BuildBaseName -like "*openssl3*") {
             $Tls = "openssl3"
         }
-        $UbuntuVersion = "none"
-        $match = [regex]::Match($BuildBaseName, "ubuntu_(\d{4})")
-        if ($match.Success) {
-            $UbuntuVersion = $match.Groups[1].Value
-        }
+
         if ($BuildBaseName -like "*arm64_*") {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm64 --tls $Tls --ubuntu $UbuntuVersion
+            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm64 --tls $Tls --xdp $UseXdp
         } elseif ($BuildBaseName -like "*arm_*") {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm --tls $Tls --ubuntu $UbuntuVersion
+            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm --tls $Tls --xdp $UseXdp
         } else {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --tls $Tls --ubuntu $UbuntuVersion # x64
+            & $RootDir/scripts/make-packages.sh --output $DistDir --tls $Tls --xdp $UseXdp # x64
         }
         Set-Location $OldLoc
     }

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -13,8 +13,10 @@ param (
 )
 
 $UseXdp = $false
+$Time64Distro = $false
 if ($OS -eq "ubuntu_2404") {
     $UseXdp = $true
+    $Time64Distro = $true
 }
 
 Set-StrictMode -Version 'Latest'
@@ -180,11 +182,11 @@ foreach ($Build in $AllBuilds) {
         }
 
         if ($BuildBaseName -like "*arm64_*") {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm64 --tls $Tls --xdp $UseXdp
+            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm64 --tls $Tls --xdp $UseXdp --time64 $Time64Distro
         } elseif ($BuildBaseName -like "*arm_*") {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm --tls $Tls --xdp $UseXdp
+            & $RootDir/scripts/make-packages.sh --output $DistDir --arch arm --tls $Tls --xdp $UseXdp --time64 $Time64Distro
         } else {
-            & $RootDir/scripts/make-packages.sh --output $DistDir --tls $Tls --xdp $UseXdp # x64
+            & $RootDir/scripts/make-packages.sh --output $DistDir --tls $Tls --xdp $UseXdp --time64 $Time64Distro # x64
         }
         Set-Location $OldLoc
     }


### PR DESCRIPTION
## Description

Checking artifact directory name doesn't work for identifying Ubuntu version for XDP build.

## Testing

locally done and used internal repo

## Documentation

N/A
