### PR TITLE
Fix HPS test on WSK

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -578,12 +578,6 @@ function Invoke-Secnetperf {
         continue
     }
 
-    # These scenarios are currently broken! TODO - Figure out why and fix them.
-    # if ($io -eq "wsk" -and $metric -eq "hps") {
-    #     Write-Host "> secnetperf $clientArgs BROKEN!"
-    #     continue
-    # }
-
      # Linux XDP requires sudo for now
     $useSudo = (!$isWindows -and $io -eq "xdp")
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -579,10 +579,10 @@ function Invoke-Secnetperf {
     }
 
     # These scenarios are currently broken! TODO - Figure out why and fix them.
-    if ($io -eq "wsk" -and $metric -eq "hps") {
-        Write-Host "> secnetperf $clientArgs BROKEN!"
-        continue
-    }
+    # if ($io -eq "wsk" -and $metric -eq "hps") {
+    #     Write-Host "> secnetperf $clientArgs BROKEN!"
+    #     continue
+    # }
 
      # Linux XDP requires sudo for now
     $useSudo = (!$isWindows -and $io -eq "xdp")


### PR DESCRIPTION
## Description

Right now, we are skipping all HPS tests on kernel mode msquic. 

Let's enable it, and use netperf to figure out whether or not we have a bug somewhere. 

## Testing

CI

## Documentation

N/A