### PR TITLE
Lock OperQ before checking content

### DIFF
--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -564,7 +564,10 @@ QuicWorkerProcessConnection(
     if (!Connection->State.UpdateWorker) {
         if (Connection->HasQueuedWork) {
             Connection->Stats.Schedule.LastQueueTime = CxPlatTimeUs32();
-            if (&Connection->OperQ.List.Flink != Connection->OperQ.PriorityTail) {
+            CxPlatDispatchLockAcquire(&Connection->OperQ.Lock);
+            BOOLEAN HasPriorityWork = (&Connection->OperQ.List.Flink != Connection->OperQ.PriorityTail);
+            CxPlatDispatchLockRelease(&Connection->OperQ.Lock);
+            if (HasPriorityWork) {
                 // priority operations are still pending
                 CxPlatListInsertTail(*Worker->PriorityConnectionsTail, &Connection->WorkerLink);
                 Worker->PriorityConnectionsTail = &Connection->WorkerLink.Flink;


### PR DESCRIPTION
## Description

There is stall issue which maybe related to multi recv feature.
Try adding lock to OperQ.

## Testing

see automation. might need to run may times.

## Documentation

_Is there any documentation impact for this change?_
