### PR TITLE
Add ref option to workflow dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: BVT
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        required: false
+        default: ''
+        type: string
   push:
     branches:
     - main
@@ -37,6 +42,7 @@ jobs:
       arch: ${{ matrix.vec.arch }}
       tls: ${{ matrix.vec.tls }}
       build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
   build-windows:
     name: Build WinUser
@@ -59,6 +65,7 @@ jobs:
       tls: ${{ matrix.vec.tls }}
       sanitize: ${{ matrix.vec.sanitize }}
       build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
   build-unix:
     name: Build Unix
@@ -86,6 +93,7 @@ jobs:
       sanitize: ${{ matrix.vec.sanitize }}
       build: ${{ matrix.vec.build }}
       xdp: ${{ matrix.vec.xdp }}
+      ref: ${{ inputs.ref || '' }}
 
   bvt:
     name: BVT
@@ -120,6 +128,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        ref: ${{ inputs.ref || '' }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       if: matrix.vec.plat == 'windows'
@@ -184,6 +194,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        ref: ${{ inputs.ref || '' }}
     - name: Download Build Artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with: # note we always use binaries built on windows-2022.
@@ -233,6 +245,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         fetch-depth: 0
+        ref: ${{ inputs.ref || '' }}
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.build }}


### PR DESCRIPTION
## Description

While triaging a kernel test failure in MsCodeHub mirror from the latest ingestion, 839a2fbde9a2cecdcf0c41649037fa091cbb0e06,
it became apparent that reproducing the failure (kernel mode test) would be challenging using the current CI setup. 

This PR makes it so a developer can target a specific version of MsQuic while running the BVT test suite. 

## Testing

CI

## Documentation

N/A
