### PR TITLE
Publish package to more distros and refactoring

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -78,10 +78,10 @@ extends:
       - container: linux_build_container # Default container
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-cross'
         type: Linux
-      - container: ubuntu_2204_cross
+      - container: kernel5_15_cross
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-cross'
         type: Linux
-      - container: ubuntu_2404_cross
+      - container: kernel6_8_cross
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-24.04-cross'
         type: Linux
 
@@ -176,33 +176,28 @@ extends:
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          job_and_artifact_suffix: 'openssl_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
-          os: ubuntu_2204
+          kernel: "kernel5_15"
           tls: openssl3
-          job_and_artifact_suffix: 'openssl3_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          os: ubuntu_2204
+          kernel: "kernel5_15"
           tls: openssl3
-          job_and_artifact_suffix: 'openssl3_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
-          os: ubuntu_2404
+          kernel: "kernel6_8"
           tls: openssl3
           xdp: "-UseXdp"
-          job_and_artifact_suffix: 'openssl3_xdp_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          os: ubuntu_2404
+          kernel: "kernel6_8"
           tls: openssl3
           xdp: "-UseXdp"
-          job_and_artifact_suffix: 'openssl3_xdp_Debug'
 
     - stage: package_linux
       displayName: Package Linux

--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -176,28 +176,33 @@ extends:
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
+          job_and_artifact_suffix: 'openssl_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
           os: ubuntu_2204
           tls: openssl3
+          job_and_artifact_suffix: 'openssl3_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
           os: ubuntu_2204
           tls: openssl3
+          job_and_artifact_suffix: 'openssl3_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
           os: ubuntu_2404
           tls: openssl3
           xdp: "-UseXdp"
+          job_and_artifact_suffix: 'openssl3_xdp_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
           os: ubuntu_2404
           tls: openssl3
           xdp: "-UseXdp"
+          job_and_artifact_suffix: 'openssl3_xdp_Debug'
 
     - stage: package_linux
       displayName: Package Linux

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -85,8 +85,8 @@ stages:
 - stage: UploadPackage_stage
   condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
-  - job: UploadPackage_openssl_debs
-    displayName: Upload openSSL based DEB packages to repos
+  - job: UploadPackage_kernel5_4_debs
+    displayName: Upload kernel5_4 based DEB packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -104,19 +104,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel5_4
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel5_4
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel5_4debrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/gen -r ${{ repo }} -n "*.deb"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel5_4/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl_rpms
-    displayName: Upload openSSL based RPM packages to repos
+  - job: UploadPackage_kernel5_4_rpms
+    displayName: Upload kernel5_4 based RPM packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -134,19 +134,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel5_4
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel5_4
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel5_4rpmrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/gen -r ${{ repo }} -n "*.rpm"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel5_4/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl_rpms_cbl
-    displayName: Upload openSSL based RPM packages to CBL repos
+  - job: UploadPackage_kernel5_4_rpms_cbl
+    displayName: Upload kernel5_4 based RPM packages to CBL repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -164,19 +164,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel5_4
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel5_4
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel5_4rpmcblrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/cbl -r ${{ repo }} -n "*.rpm"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel5_4/cbl -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl3_xdp_rpms_cbl
-    displayName: Upload openSSL3 and XDP based RPM packages to CBL repos
+  - job: UploadPackage_kernel6_8_rpms_cbl
+    displayName: Upload kernel6_8 based RPM packages to CBL repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -194,19 +194,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel6_8
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel6_8
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel6_8cblrpmrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/cbl -r ${{ repo }} -n "*.rpm"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel6_8/cbl -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl3_debs
-    displayName: Upload openSSL3 based DEB packages to repos
+  - job: UploadPackage_kernel5_15_debs
+    displayName: Upload kernel5_15 based DEB packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -224,19 +224,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel5_15
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel5_15
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel5_15debrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.deb"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel5_15/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl3_xdp_debs
-    displayName: Upload openSSL3 and XDP based DEB packages to repos
+  - job: UploadPackage_kernel6_8_debs
+    displayName: Upload kernel6_8 based DEB packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -254,19 +254,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel6_8
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel6_8
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel6_8debrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.deb"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel6_8/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl3_rpms
-    displayName: Upload openSSL3 based RPM packages to repos
+  - job: UploadPackage_kernel5_15_rpms
+    displayName: Upload kernel5_15 based RPM packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -284,19 +284,19 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel5_15
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel5_15
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel5_15rpmrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.rpm"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel5_15/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_openssl3_xdp_rpms
-    displayName: Upload openSSL3 and XDP based RPM packages to repos
+  - job: UploadPackage_kernel6_8_rpms
+    displayName: Upload kernel6_8 based RPM packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -314,14 +314,14 @@ stages:
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
           artifact: drop_package_linux_distribution_kernel6_8
-          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/kernel6_8
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.kernel6_8rpmrepos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.rpm"
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/kernel6_8/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -71,8 +71,12 @@ parameters:
   default:
   - microsoft-ubuntu-noble-prod-apt
 - name: openssl3xdprpmrepos
+  type: object
+  default:
   - microsoft-fedora40-prod-yum
 - name: openssl3xdprpmcblrepos
+  type: object
+  default:
   - cbl-mariner-3.0-prod-Microsoft-x86_64-yum
 
 stages:

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -15,69 +15,71 @@ variables:
   DisableDockerDetector: true
 
 parameters:
-- name: opensslrpmcblrepos
+  # build on ubuntu 20.04 openssl 1.1
+- name: kernel5_4rpmcblrepos
   type: object
   default:
   - cbl-mariner-1.0-prod-Microsoft-x86_64-rpms-yum
   - cbl-mariner-2.0-prod-Microsoft-x86_64-yum
   - cbl-mariner-2.0-prod-Microsoft-aarch64-yum
-- name: opensslrpmrepos
+- name: kernel5_4rpmrepos
   type: object
   default:
-  - microsoft-sles12-prod-yum
-  - microsoft-sles15-prod-yum
-  - microsoft-centos7-prod-yum
-  - microsoft-centos8-prod-yum
-  - microsoft-opensuse15-prod-yum
-  - microsoft-fedora32-prod-yum
-  - microsoft-fedora33-prod-yum
-  - microsoft-fedora34-prod-yum
-  - microsoft-fedora35-prod-yum
-  - microsoft-rhel7.3-prod-yum
-  - microsoft-rhel8.0-prod-yum
-  - microsoft-rhel8.1-prod-yum
-- name: openssl3rpmrepos
+  - microsoft-sles12-prod-yum     # 12 3.12
+  - microsoft-sles15-prod-yum     # 15 4.12
+  - microsoft-centos7-prod-yum    # 7 3.10
+  - microsoft-centos8-prod-yum    # 8 4.18
+  - microsoft-opensuse15-prod-yum # 15 4.12
+  - microsoft-fedora32-prod-yum   # 32 5.6
+  - microsoft-fedora33-prod-yum   # 33 5.8
+  - microsoft-fedora34-prod-yum   # 34 5.11
+  - microsoft-fedora35-prod-yum   # 35 5.14
+  - microsoft-rhel7.3-prod-yum    # 7.3 3.10
+  - microsoft-rhel8.0-prod-yum    # 8.0 4.18
+  - microsoft-rhel8.1-prod-yum    # 8.1 4.18
+- name: kernel5_4debrepos
   type: object
   default:
-  - microsoft-fedora36-prod-yum
-  - microsoft-fedora37-prod-yum
-  - microsoft-fedora38-prod-yum
-  - microsoft-fedora39-prod-yum # maybe fedora 36-39 can use xdp
-  - microsoft-rhel9.0-prod-yum
-- name: debug # debug mode will not actually upload and publish packages
-  type: boolean
-  default: false
-- name: openssldebrepos
+  - microsoft-ubuntu-xenial-prod-apt   # 16.04 4.4
+  - microsoft-ubuntu-bionic-prod-apt   # 18.04 4.15
+  - microsoft-ubuntu-focal-prod-apt    # 20.04 5.4
+  - microsoft-ubuntu-groovy-prod-apt   # 20.10 5.8
+  - microsoft-ubuntu-hirsute-prod-apt  # 21.04 5.11
+  - microsoft-debian-stretch-prod-apt  #  9 4.9
+  - microsoft-debian-buster-prod-apt   # 10 4.19
+  - microsoft-debian-bullseye-prod-apt # 11 5.10
+
+  # built on ubuntu 22.04, openssl3
+- name: kernel5_15rpmrepos
   type: object
   default:
-  - microsoft-ubuntu-xenial-prod-apt
-  - microsoft-ubuntu-bionic-prod-apt
-  - microsoft-ubuntu-focal-prod-apt
-  - microsoft-ubuntu-groovy-prod-apt
-  - microsoft-ubuntu-hirsute-prod-apt
-  - microsoft-debian-stretch-prod-apt
-  - microsoft-debian-buster-prod-apt
-  - microsoft-debian-bullseye-prod-apt
-- name: openssl3debrepos
+  - microsoft-fedora36-prod-yum   # 36 5.17
+  - microsoft-fedora37-prod-yum   # 37 6.0
+  - microsoft-fedora38-prod-yum   # 38 6.2
+  - microsoft-fedora39-prod-yum   # 39 6.5
+  - microsoft-rhel9.0-prod-yum    # 9.0 5.14
+- name: kernel5_15debrepos
   type: object
   default:
-  - microsoft-ubuntu-jammy-prod-apt
-  - microsoft-ubuntu-kinetic-prod-apt
-  - microsoft-ubuntu-lunar-prod-apt
-  - microsoft-ubuntu-mantic-prod-apt
-  - microsoft-debian-bookworm-prod-apt # maybe debian 12 can use xdp
-- name: openssl3xdpdebrepos
+  - microsoft-ubuntu-jammy-prod-apt    # 22.04 5.15
+  - microsoft-ubuntu-kinetic-prod-apt  # 22.10 5.19
+  - microsoft-ubuntu-lunar-prod-apt    # 23.04 6.2
+  - microsoft-ubuntu-mantic-prod-apt   # 23.10 6.5
+  - microsoft-debian-bookworm-prod-apt # 12    6.1
+
+  # built on ubuntu 24.04 openssl3 XDP
+- name: kernel6_8cblrpmrepos
   type: object
   default:
-  - microsoft-ubuntu-noble-prod-apt
-- name: openssl3xdprpmrepos
+  - azurelinux-3.0-prod-ms-oss-x86_64-yum # 3.0 6.8
+- name: kernel6_8rpmrepos
   type: object
   default:
-  - microsoft-fedora40-prod-yum
-- name: openssl3xdprpmcblrepos
+  - microsoft-fedora40-prod-yum           # 40 6.8
+- name: kernel6_8debrepos
   type: object
   default:
-  - azurelinux-3.0-prod-ms-oss-x86_64-yum
+  - microsoft-ubuntu-noble-prod-apt       # 24.04 6.8
 
 stages:
 - stage: UploadPackage_stage
@@ -101,14 +103,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_kernel5_4
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssldebrepos }}:
+      - ${{ each repo in parameters.kernel5_4debrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -131,14 +133,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_kernel5_4
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.opensslrpmrepos }}:
+      - ${{ each repo in parameters.kernel5_4rpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -161,14 +163,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl
+          artifact: drop_package_linux_distribution_kernel5_4
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.opensslrpmcblrepos }}:
+      - ${{ each repo in parameters.kernel5_4rpmcblrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/cbl -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -191,14 +193,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3_xdp
+          artifact: drop_package_linux_distribution_kernel6_8
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssl3xdprpmcblrepos }}:
+      - ${{ each repo in parameters.kernel6_8cblrpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/cbl -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -221,14 +223,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3
+          artifact: drop_package_linux_distribution_kernel5_15
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssl3debrepos }}:
+      - ${{ each repo in parameters.kernel5_15debrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -251,14 +253,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3_xdp
+          artifact: drop_package_linux_distribution_kernel6_8
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssl3xdpdebrepos }}:
+      - ${{ each repo in parameters.kernel6_8debrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -281,14 +283,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3
+          artifact: drop_package_linux_distribution_kernel5_15
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssl3rpmrepos }}:
+      - ${{ each repo in parameters.kernel5_15rpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
@@ -311,14 +313,14 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_openssl3_xdp
+          artifact: drop_package_linux_distribution_kernel6_8
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.openssl3xdprpmrepos }}:
+      - ${{ each repo in parameters.kernel6_8rpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -77,7 +77,7 @@ parameters:
 - name: openssl3xdprpmcblrepos
   type: object
   default:
-  - cbl-mariner-3.0-prod-Microsoft-x86_64-yum
+  - azurelinux-3.0-prod-ms-oss-x86_64-yum
 
 stages:
 - stage: UploadPackage_stage

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -71,7 +71,7 @@ parameters:
 - name: kernel6_8cblrpmrepos
   type: object
   default:
-  - azurelinux-3.0-prod-ms-oss-x86_64-yum # 3.0 6.8
+  - azurelinux-3.0-prod-ms-oss-x86_64-yum # 3.0 6.6
 - name: kernel6_8rpmrepos
   type: object
   default:

--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -32,31 +32,22 @@ parameters:
   - microsoft-fedora32-prod-yum
   - microsoft-fedora33-prod-yum
   - microsoft-fedora34-prod-yum
-  - microsoft-fedora37-prod-yum
+  - microsoft-fedora35-prod-yum
   - microsoft-rhel7.3-prod-yum
   - microsoft-rhel8.0-prod-yum
   - microsoft-rhel8.1-prod-yum
-- name: openssldebrepos
-  type: object
-  default:
-  - microsoft-debian-stretch-prod-apt
-  - microsoft-debian-buster-prod-apt
-  - microsoft-debian-bullseye-prod-apt
-- name: openssl3debrepos
-  type: object
-  default:
-  - microsoft-debian-bookworm-prod-apt
 - name: openssl3rpmrepos
   type: object
   default:
   - microsoft-fedora36-prod-yum
+  - microsoft-fedora37-prod-yum
   - microsoft-fedora38-prod-yum
-  - microsoft-fedora39-prod-yum
+  - microsoft-fedora39-prod-yum # maybe fedora 36-39 can use xdp
   - microsoft-rhel9.0-prod-yum
 - name: debug # debug mode will not actually upload and publish packages
   type: boolean
   default: false
-- name: ubuntu20repos
+- name: openssldebrepos
   type: object
   default:
   - microsoft-ubuntu-xenial-prod-apt
@@ -64,17 +55,25 @@ parameters:
   - microsoft-ubuntu-focal-prod-apt
   - microsoft-ubuntu-groovy-prod-apt
   - microsoft-ubuntu-hirsute-prod-apt
-- name: ubuntu22repos
+  - microsoft-debian-stretch-prod-apt
+  - microsoft-debian-buster-prod-apt
+  - microsoft-debian-bullseye-prod-apt
+- name: openssl3debrepos
   type: object
   default:
   - microsoft-ubuntu-jammy-prod-apt
   - microsoft-ubuntu-kinetic-prod-apt
   - microsoft-ubuntu-lunar-prod-apt
   - microsoft-ubuntu-mantic-prod-apt
-- name: ubuntu24repos
+  - microsoft-debian-bookworm-prod-apt # maybe debian 12 can use xdp
+- name: openssl3xdpdebrepos
   type: object
   default:
   - microsoft-ubuntu-noble-prod-apt
+- name: openssl3xdprpmrepos
+  - microsoft-fedora40-prod-yum
+- name: openssl3xdprpmcblrepos
+  - cbl-mariner-3.0-prod-Microsoft-x86_64-yum
 
 stages:
 - stage: UploadPackage_stage
@@ -98,7 +97,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
+          artifact: drop_package_linux_distribution_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -128,7 +127,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
+          artifact: drop_package_linux_distribution_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -158,7 +157,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
+          artifact: drop_package_linux_distribution_openssl
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -167,6 +166,36 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.opensslrpmcblrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl/cbl -r ${{ repo }} -n "*.rpm"
+          condition: eq(${{ parameters.debug }}, false)
+          displayName: ${{ repo }}
+          continueOnError: true
+  - job: UploadPackage_openssl3_xdp_rpms_cbl
+    displayName: Upload openSSL3 and XDP based RPM packages to CBL repos
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+    - group: MsQuicAADApp
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
+      - task: DownloadSecureFile@1
+        name:  pmcv4cert
+        displayName: 'Download cert for PMC v4'
+        inputs:
+          secureFile: 'auth.pem'
+      - ${{ each repo in parameters.openssl3xdprpmcblrepos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/cbl -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
@@ -188,7 +217,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
+          artifact: drop_package_linux_distribution_openssl3
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -200,8 +229,8 @@ stages:
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
-  - job: UploadPackage_ubuntu20
-    displayName: Upload Ubuntu 20 packages to repos
+  - job: UploadPackage_openssl3_xdp_debs
+    displayName: Upload openSSL3 and XDP based DEB packages to repos
     timeoutInMinutes: 120
     workspace:
       clean: all
@@ -218,75 +247,15 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2004_openssl
-          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2004_openssl
+          artifact: drop_package_linux_distribution_openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
       - task: DownloadSecureFile@1
         name:  pmcv4cert
         displayName: 'Download cert for PMC v4'
         inputs:
           secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu20repos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2004_openssl/gen -r ${{ repo }} -n "*.deb"
-          condition: eq(${{ parameters.debug }}, false)
-          displayName: ${{ repo }}
-          continueOnError: true
-  - job: UploadPackage_ubuntu22
-    displayName: Upload Ubuntu 22 packages to repos
-    timeoutInMinutes: 120
-    workspace:
-      clean: all
-    pool:
-      vmImage: 'ubuntu-latest'
-    variables:
-    - group: MsQuicAADApp
-    steps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          source: specific
-          project: $(resources.pipeline.onebranch.projectID)
-          pipeline: $(resources.pipeline.onebranch.pipelineID)
-          preferTriggeringPipeline: true
-          runVersion: specific
-          runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
-          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl3
-      - task: DownloadSecureFile@1
-        name:  pmcv4cert
-        displayName: 'Download cert for PMC v4'
-        inputs:
-          secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu22repos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2204_openssl3/gen -r ${{ repo }} -n "*.deb"
-          condition: eq(${{ parameters.debug }}, false)
-          displayName: ${{ repo }}
-          continueOnError: true
-  - job: UploadPackage_ubuntu24
-    displayName: Upload Ubuntu 24 packages to repos
-    timeoutInMinutes: 120
-    workspace:
-      clean: all
-    pool:
-      vmImage: 'ubuntu-latest'
-    variables:
-    - group: MsQuicAADApp
-    steps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          source: specific
-          project: $(resources.pipeline.onebranch.projectID)
-          pipeline: $(resources.pipeline.onebranch.pipelineID)
-          preferTriggeringPipeline: true
-          runVersion: specific
-          runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2404_openssl3
-          path: $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl3
-      - task: DownloadSecureFile@1
-        name:  pmcv4cert
-        displayName: 'Download cert for PMC v4'
-        inputs:
-          secureFile: 'auth.pem'
-      - ${{ each repo in parameters.ubuntu24repos }}:
-        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/ubuntu_2404_openssl3/gen -r ${{ repo }} -n "*.deb"
+      - ${{ each repo in parameters.openssl3xdpdebrepos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.deb"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true
@@ -308,7 +277,7 @@ stages:
           preferTriggeringPipeline: true
           runVersion: specific
           runId: $(resources.pipeline.onebranch.runID)
-          artifact: drop_package_linux_distribution_ubuntu_2204_openssl3
+          artifact: drop_package_linux_distribution_openssl3
           path: $(Build.SourcesDirectory)/artifacts/signed/openssl3
       - task: DownloadSecureFile@1
         name:  pmcv4cert
@@ -317,6 +286,36 @@ stages:
           secureFile: 'auth.pem'
       - ${{ each repo in parameters.openssl3rpmrepos }}:
         - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3/gen -r ${{ repo }} -n "*.rpm"
+          condition: eq(${{ parameters.debug }}, false)
+          displayName: ${{ repo }}
+          continueOnError: true
+  - job: UploadPackage_openssl3_xdp_rpms
+    displayName: Upload openSSL3 and XDP based RPM packages to repos
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+    - group: MsQuicAADApp
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          project: $(resources.pipeline.onebranch.projectID)
+          pipeline: $(resources.pipeline.onebranch.pipelineID)
+          preferTriggeringPipeline: true
+          runVersion: specific
+          runId: $(resources.pipeline.onebranch.runID)
+          artifact: drop_package_linux_distribution_openssl3_xdp
+          path: $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp
+      - task: DownloadSecureFile@1
+        name:  pmcv4cert
+        displayName: 'Download cert for PMC v4'
+        inputs:
+          secureFile: 'auth.pem'
+      - ${{ each repo in parameters.openssl3xdprpmrepos }}:
+        - script: bash scripts/upload-linux-packages.sh -i $(PMCv4ClientId) -c $(pmcv4cert.secureFilePath) -f $(Build.SourcesDirectory)/artifacts/signed/openssl3_xdp/gen -r ${{ repo }} -n "*.rpm"
           condition: eq(${{ parameters.debug }}, false)
           displayName: ${{ repo }}
           continueOnError: true

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -172,28 +172,33 @@ extends:
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
+          job_and_artifact_suffix: 'openssl_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
           os: ubuntu_2204
           tls: openssl3
+          job_and_artifact_suffix: 'openssl3_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
           os: ubuntu_2204
           tls: openssl3
+          job_and_artifact_suffix: 'openssl3_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
           os: ubuntu_2404
           tls: openssl3
           xdp: "-UseXdp"
+          job_and_artifact_suffix: 'openssl3_xdp_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
           os: ubuntu_2404
           tls: openssl3
           xdp: "-UseXdp"
+          job_and_artifact_suffix: 'openssl3_xdp_Debug'
 
     - stage: package_linux
       displayName: Package Linux

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -74,10 +74,10 @@ extends:
       - container: linux_build_container # Default container
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-20.04-cross'
         type: Linux
-      - container: ubuntu_2204_cross
+      - container: kernel5_15_cross
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-22.04-cross'
         type: Linux
-      - container: ubuntu_2404_cross
+      - container: kernel6_8_cross
         image: 'ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-24.04-cross'
         type: Linux
 
@@ -172,33 +172,28 @@ extends:
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          job_and_artifact_suffix: 'openssl_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
-          os: ubuntu_2204
+          kernel: "kernel5_15"
           tls: openssl3
-          job_and_artifact_suffix: 'openssl3_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          os: ubuntu_2204
+          kernel: "kernel5_15"
           tls: openssl3
-          job_and_artifact_suffix: 'openssl3_Debug'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Release
-          os: ubuntu_2404
+          kernel: "kernel6_8"
           tls: openssl3
           xdp: "-UseXdp"
-          job_and_artifact_suffix: 'openssl3_xdp_Release'
       - template: .azure/obtemplates/build-linux.yml@self
         parameters:
           config: Debug
-          os: ubuntu_2404
+          kernel: "kernel6_8"
           tls: openssl3
           xdp: "-UseXdp"
-          job_and_artifact_suffix: 'openssl3_xdp_Debug'
 
     - stage: package_linux
       displayName: Package Linux

--- a/.azure/obtemplates/build-distribution.yml
+++ b/.azure/obtemplates/build-distribution.yml
@@ -42,12 +42,14 @@ jobs:
       linuxos: ubuntu_2404
       config: Release
       tls: openssl3
+      xdp: -UseXdp
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
       linuxos: ubuntu_2404
       config: Debug
       tls: openssl3
+      xdp: -UseXdp
 
   - template: ./download-artifacts.yml
     parameters:

--- a/.azure/obtemplates/build-distribution.yml
+++ b/.azure/obtemplates/build-distribution.yml
@@ -42,14 +42,14 @@ jobs:
       linuxos: ubuntu_2404
       config: Release
       tls: openssl3
-      xdp: -UseXdp
+      xdp: _xdp
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
       linuxos: ubuntu_2404
       config: Debug
       tls: openssl3
-      xdp: -UseXdp
+      xdp: _xdp
 
   - template: ./download-artifacts.yml
     parameters:

--- a/.azure/obtemplates/build-distribution.yml
+++ b/.azure/obtemplates/build-distribution.yml
@@ -13,43 +13,41 @@ jobs:
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2004
+      kernel: kernel5_4
       config: Release
       tls: openssl
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2004
+      kernel: kernel5_4
       config: Debug
       tls: openssl
 
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2204
+      kernel: kernel5_15
       config: Release
       tls: openssl3
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2204
+      kernel: kernel5_15
       config: Debug
       tls: openssl3
 
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2404
+      kernel: kernel6_8
       config: Release
       tls: openssl3
-      xdp: _xdp
   - template: ./download-artifacts.yml
     parameters:
       platform: linux
-      linuxos: ubuntu_2404
+      kernel: kernel6_8
       config: Debug
       tls: openssl3
-      xdp: _xdp
 
   - template: ./download-artifacts.yml
     parameters:

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -46,15 +46,9 @@ jobs:
       find -name "*.tar" -exec tar -xvf '{}' \;
   - task: PowerShell@2
     displayName: Distribution
-    ${{ if not(eq(parameters.xdp, '')) }}:
-      inputs:
-        pwsh: false
-        filePath: scripts/package-distribution.ps1
-        arguments: -UseXdp
-    ${{ else }}:
-      inputs:
-        pwsh: false
-        filePath: scripts/package-distribution.ps1
+    inputs:
+      pwsh: false
+      filePath: scripts/package-distribution.ps1
   - script: | # prepare 2 sets of packages for signing with different keys (gen = general purpose, cbl = cbl-mariner)
       mkdir $(Build.SourcesDirectory)/artifacts/dist/gen
       find $(Build.SourcesDirectory)/artifacts/dist -type f -exec mv -t $(Build.SourcesDirectory)/artifacts/dist/gen/ {} +

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -7,22 +7,22 @@ jobs:
   strategy:
     matrix:
       ubuntu_2004:
-        os: ubuntu_2004
         tls: openssl
         xdp: ""
+        kernel: "kernel5_4"
       ubuntu_2204:
-        os: ubuntu_2204
         tls: openssl3
         xdp: ""
+        kernel: "kernel5_15"
       ubuntu_2404:
-        os: ubuntu_2404
         tls: openssl3
         xdp: "_xdp"
+        kernel: "kernel6_8"
   pool:
     type: linux
   variables:
     ob_outputDirectory: $(Build.SourcesDirectory)/artifacts/dist
-    ob_artifactSuffix: _$(tls)$(xdp)
+    ob_artifactSuffix: _$(kernel) # drop_package_linux_${{ jobname }}_${{ kernel }}
   steps:
   - task: PowerShell@2
     displayName: Prepare Build Machine
@@ -32,12 +32,12 @@ jobs:
       arguments: -ForContainerBuild
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: drop_build_linux_build_$(tls)$(xdp)_Debug
+      artifact: drop_build_linux_$(kernel)_Debug
       path: $(Build.SourcesDirectory)/artifacts/bin/linux
       pattern: '*.tar'
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: drop_build_linux_build_$(tls)$(xdp)_Release
+      artifact: drop_build_linux_$(kernel)_Release
       path: $(Build.SourcesDirectory)/artifacts/bin/linux
       pattern: '*.tar'
   - script: | # rebuild artifacts with correct permissions and symlink attributes.

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -46,7 +46,7 @@ jobs:
       find -name "*.tar" -exec tar -xvf '{}' \;
   - task: PowerShell@2
     displayName: Distribution
-    ${{ if eq(xdp, "_xdp") }}:
+    ${{ if not(eq(parameters.xdp, "")) }}:
       inputs:
         pwsh: false
         filePath: scripts/package-distribution.ps1

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -7,16 +7,10 @@ jobs:
   strategy:
     matrix:
       ubuntu_2004:
-        tls: openssl
-        xdp: ""
         kernel: "kernel5_4"
       ubuntu_2204:
-        tls: openssl3
-        xdp: ""
         kernel: "kernel5_15"
       ubuntu_2404:
-        tls: openssl3
-        xdp: "_xdp"
         kernel: "kernel6_8"
   pool:
     type: linux

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -9,17 +9,20 @@ jobs:
       ubuntu_2004:
         os: ubuntu_2004
         tls: openssl
+        xdp: ""
       ubuntu_2204:
         os: ubuntu_2204
         tls: openssl3
+        xdp: ""
       ubuntu_2404:
         os: ubuntu_2404
         tls: openssl3
+        xdp: "_xdp"
   pool:
     type: linux
   variables:
     ob_outputDirectory: $(Build.SourcesDirectory)/artifacts/dist
-    ob_artifactSuffix: _$(os)_$(tls)
+    ob_artifactSuffix: _$(tls)$(xdp)
   steps:
   - task: PowerShell@2
     displayName: Prepare Build Machine
@@ -29,12 +32,12 @@ jobs:
       arguments: -ForContainerBuild
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: drop_build_linux_build_$(os)_$(tls)_Debug
+      artifact: drop_build_linux_build_$(tls)$(xdp)_Debug
       path: $(Build.SourcesDirectory)/artifacts/bin/linux
       pattern: '*.tar'
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: drop_build_linux_build_$(os)_$(tls)_Release
+      artifact: drop_build_linux_build_$(tls)$(xdp)_Release
       path: $(Build.SourcesDirectory)/artifacts/bin/linux
       pattern: '*.tar'
   - script: | # rebuild artifacts with correct permissions and symlink attributes.
@@ -43,10 +46,15 @@ jobs:
       find -name "*.tar" -exec tar -xvf '{}' \;
   - task: PowerShell@2
     displayName: Distribution
-    inputs:
-      pwsh: false
-      filePath: scripts/package-distribution.ps1
-      arguments: -OS $(os)
+    ${{ if eq(xdp, "_xdp") }}:
+      inputs:
+        pwsh: false
+        filePath: scripts/package-distribution.ps1
+        arguments: -UseXdp
+    ${{ else }}:
+      inputs:
+        pwsh: false
+        filePath: scripts/package-distribution.ps1
   - script: | # prepare 2 sets of packages for signing with different keys (gen = general purpose, cbl = cbl-mariner)
       mkdir $(Build.SourcesDirectory)/artifacts/dist/gen
       find $(Build.SourcesDirectory)/artifacts/dist -type f -exec mv -t $(Build.SourcesDirectory)/artifacts/dist/gen/ {} +

--- a/.azure/obtemplates/build-linux-packages.yml
+++ b/.azure/obtemplates/build-linux-packages.yml
@@ -46,7 +46,7 @@ jobs:
       find -name "*.tar" -exec tar -xvf '{}' \;
   - task: PowerShell@2
     displayName: Distribution
-    ${{ if not(eq(parameters.xdp, "")) }}:
+    ${{ if not(eq(parameters.xdp, '')) }}:
       inputs:
         pwsh: false
         filePath: scripts/package-distribution.ps1

--- a/.azure/obtemplates/build-linux.yml
+++ b/.azure/obtemplates/build-linux.yml
@@ -4,10 +4,11 @@ parameters:
   platform: 'linux'
   os: 'ubuntu_2004'
   xdp: ''
+  job_and_artifact_suffix: 'openssl_Release'
 
 jobs:
-- job: build_${{ parameters.os }}_${{ parameters.tls }}_${{ parameters.config }}
-  displayName: ${{ parameters.os }} ${{ parameters.tls }} ${{ parameters.config }}
+- job: build_${{ parameters.job_and_artifact_suffix }}
+  displayName: ${{ parameters.platform }} ${{ parameters.tls }} ${{ parameters.config }}
   pool:
     type: linux
   variables:

--- a/.azure/obtemplates/build-linux.yml
+++ b/.azure/obtemplates/build-linux.yml
@@ -2,13 +2,12 @@ parameters:
   config: ''
   tls: 'openssl'
   platform: 'linux'
-  os: 'ubuntu_2004'
+  kernel: 'kernel5_4'
   xdp: ''
-  job_and_artifact_suffix: 'openssl_Release'
 
 jobs:
-- job: build_${{ parameters.job_and_artifact_suffix }}
-  displayName: ${{ parameters.platform }} ${{ parameters.tls }} ${{ parameters.config }}
+- job: ${{ parameters.kernel }}_${{ parameters.config }} # this job name becomes artifact suffix in the build pipeline
+  displayName: ${{ parameters.platform }} ${{ parameters.kernel }} ${{ parameters.tls }} ${{ parameters.config }}
   pool:
     type: linux
   variables:
@@ -18,48 +17,48 @@ jobs:
   steps:
   - task: PowerShell@2
     displayName: Prepare Build Machine
-    ${{ if eq(parameters.os, 'ubuntu_2004') }}:
+    ${{ if eq(parameters.kernel, 'kernel5_4') }}:
       target: linux_build_container
-    ${{ elseif eq(parameters.os, 'ubuntu_2204') }}:
-      target: ubuntu_2204_cross
+    ${{ elseif eq(parameters.kernel, 'kernel5_15') }}:
+      target:  kernel5_15_cross
     ${{ else }}:
-      target: ubuntu_2404_cross
+      target:  kernel6_8_cross
     inputs:
       pwsh: true
       filePath: scripts/prepare-machine.ps1
       arguments: -Tls ${{ parameters.tls }} -ForContainerBuild
   - task: PowerShell@2
     displayName: x64
-    ${{ if eq(parameters.os, 'ubuntu_2004') }}:
+    ${{ if eq(parameters.kernel, 'kernel5_4') }}:
       target: linux_build_container
-    ${{ elseif eq(parameters.os, 'ubuntu_2204') }}:
-      target: ubuntu_2204_cross
+    ${{ elseif eq(parameters.kernel, 'kernel5_15') }}:
+      target:  kernel5_15_cross
     ${{ else }}:
-      target: ubuntu_2404_cross
+      target:  kernel6_8_cross
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
       arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} ${{ parameters.xdp }} -Arch x64 -CI -UseSystemOpenSSLCrypto -OneBranch -OfficialRelease
   - task: PowerShell@2
     displayName: arm64
-    ${{ if eq(parameters.os, 'ubuntu_2004') }}:
+    ${{ if eq(parameters.kernel, 'kernel5_4') }}:
       target: linux_build_container
-    ${{ elseif eq(parameters.os, 'ubuntu_2204') }}:
-      target: ubuntu_2204_cross
+    ${{ elseif eq(parameters.kernel, 'kernel5_15') }}:
+      target:  kernel5_15_cross
     ${{ else }}:
-      target: ubuntu_2404_cross
+      target:  kernel6_8_cross
     inputs:
       pwsh: true
       filePath: scripts/build.ps1
       arguments: -Tls ${{ parameters.tls }} -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Arch arm64 -CI -UseSystemOpenSSLCrypto -OneBranch -OfficialRelease
   - task: PowerShell@2
     displayName: arm
-    ${{ if eq(parameters.os, 'ubuntu_2004') }}:
+    ${{ if eq(parameters.kernel, 'kernel5_4') }}:
       target: linux_build_container
-    ${{ elseif eq(parameters.os, 'ubuntu_2204') }}:
-      target: ubuntu_2204_cross
+    ${{ elseif eq(parameters.kernel, 'kernel5_15') }}:
+      target:  kernel5_15_cross
     ${{ else }}:
-      target: ubuntu_2404_cross
+      target:  kernel6_8_cross
     inputs:
       pwsh: true
       filePath: scripts/build.ps1

--- a/.azure/obtemplates/download-artifacts.yml
+++ b/.azure/obtemplates/download-artifacts.yml
@@ -5,6 +5,7 @@ parameters:
   linuxos: 'ubuntu_2004'
   tls: ''
   config: ''
+  xdp: ''
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -15,8 +16,8 @@ steps:
     preferTriggeringPipeline: true
     runVersion: specific
     runId: $(resources.pipeline.onebranch.runID)
-    ${{ if eq(parameters.platform, 'linux') }}:
-      artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.linuxos }}_${{ parameters.tls }}_${{ parameters.config }}
+    ${{ if eq(parameters.platform, 'linux') && ne(parameters.xdp, '')}}:
+      artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}_xdp_${{ parameters.config }}
     ${{ else }}:
       artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}_${{ parameters.config }}
     path: $(Build.SourcesDirectory)/artifacts/bin/${{ parameters.platform }}

--- a/.azure/obtemplates/download-artifacts.yml
+++ b/.azure/obtemplates/download-artifacts.yml
@@ -2,10 +2,9 @@
 
 parameters:
   platform: ''
-  linuxos: 'ubuntu_2004'
+  kernel: 'kernel5_4'
   tls: ''
   config: ''
-  xdp: ''
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -16,7 +15,10 @@ steps:
     preferTriggeringPipeline: true
     runVersion: specific
     runId: $(resources.pipeline.onebranch.runID)
-    artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}${{ parameters.xdp }}_${{ parameters.config }}
+    ${{ if eq(parameters.platform, 'linux') }}:
+      artifact: drop_build_${{ parameters.platform }}_${{ parameters.kernel }}_${{ parameters.config }}
+    ${{ else }}:
+      artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}_${{ parameters.config }}
     path: $(Build.SourcesDirectory)/artifacts/bin/${{ parameters.platform }}
 
 - task: PowerShell@2

--- a/.azure/obtemplates/download-artifacts.yml
+++ b/.azure/obtemplates/download-artifacts.yml
@@ -16,10 +16,7 @@ steps:
     preferTriggeringPipeline: true
     runVersion: specific
     runId: $(resources.pipeline.onebranch.runID)
-    ${{ if eq(parameters.platform, 'linux') && ne(parameters.xdp, '')}}:
-      artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}_xdp_${{ parameters.config }}
-    ${{ else }}:
-      artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}_${{ parameters.config }}
+    artifact: drop_build_${{ parameters.platform }}_build_${{ parameters.platform }}_${{ parameters.tls }}${{ parameters.xdp }}_${{ parameters.config }}
     path: $(Build.SourcesDirectory)/artifacts/bin/${{ parameters.platform }}
 
 - task: PowerShell@2

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -194,7 +194,7 @@ if [ "$OS" == "linux" ]; then
         --license MIT \
         --url https://github.com/microsoft/msquic \
         --log error \
-        ${FILES}
+        ${FILES} ${ARTIFACTS}/datapath_raw_xdp_kern.o=/usr/${LIBDIR}/datapath_raw_xdp_kern.o
     fi
   fi
 

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -151,25 +151,51 @@ if [ "$OS" == "linux" ]; then
     if [ "$PKGARCH" == 'aarch64' ] || [ "$PKGARCH" == 'x86_64' ]; then
       BITS='64bit'
     fi
-    fpm \
-      --force \
-      --input-type dir \
-      --output-type rpm \
-      --architecture ${PKGARCH} \
-      --name ${NAME} \
-      --provides ${NAME} \
-      --depends "libcrypto.so.${TLSVERSION}()(${BITS})" \
-      --depends "libnuma.so.1()(${BITS})" \
-      --conflicts ${CONFLICTS} \
-      --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
-      --description "${DESCRIPTION}" \
-      --vendor "${VENDOR}" \
-      --maintainer "${MAINTAINER}" \
-      --package "${OUTPUT}" \
-      --license MIT \
-      --url https://github.com/microsoft/msquic \
-      --log error \
-      ${FILES}
+    if [ "$XDP" == "True" ] && [[ "$ARCH" == x* ]]; then
+      echo "Building rpm package (XDP)"
+      fpm \
+        --force \
+        --input-type dir \
+        --output-type rpm \
+        --architecture ${PKGARCH} \
+        --name ${NAME} \
+        --provides ${NAME} \
+        --depends "libcrypto.so.${TLSVERSION}()(${BITS})" \
+        --depends "libnuma.so.1()(${BITS})" \
+        --depends "libxdp.so.1.4.0" \
+        --depends "libnl-route-3.so.200" \
+        --conflicts ${CONFLICTS} \
+        --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
+        --description "${DESCRIPTION}" \
+        --vendor "${VENDOR}" \
+        --maintainer "${MAINTAINER}" \
+        --package "${OUTPUT}" \
+        --license MIT \
+        --url https://github.com/microsoft/msquic \
+        --log error \
+        ${FILES}
+    else
+      echo "Building rpm package"
+      fpm \
+        --force \
+        --input-type dir \
+        --output-type rpm \
+        --architecture ${PKGARCH} \
+        --name ${NAME} \
+        --provides ${NAME} \
+        --depends "libcrypto.so.${TLSVERSION}()(${BITS})" \
+        --depends "libnuma.so.1()(${BITS})" \
+        --conflicts ${CONFLICTS} \
+        --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
+        --description "${DESCRIPTION}" \
+        --vendor "${VENDOR}" \
+        --maintainer "${MAINTAINER}" \
+        --package "${OUTPUT}" \
+        --license MIT \
+        --url https://github.com/microsoft/msquic \
+        --log error \
+        ${FILES}
+    fi
   fi
 
   # Debian/Ubuntu

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -173,7 +173,7 @@ if [ "$OS" == "linux" ]; then
         --license MIT \
         --url https://github.com/microsoft/msquic \
         --log error \
-        ${FILES}
+        ${FILES} ${ARTIFACTS}/datapath_raw_xdp_kern.o=/usr/${LIBDIR}/datapath_raw_xdp_kern.o
     else
       echo "Building rpm package"
       fpm \
@@ -194,7 +194,7 @@ if [ "$OS" == "linux" ]; then
         --license MIT \
         --url https://github.com/microsoft/msquic \
         --log error \
-        ${FILES} ${ARTIFACTS}/datapath_raw_xdp_kern.o=/usr/${LIBDIR}/datapath_raw_xdp_kern.o
+        ${FILES}
     fi
   fi
 

--- a/scripts/make-packages.sh
+++ b/scripts/make-packages.sh
@@ -141,7 +141,6 @@ mkdir -p ${OUTPUT}
 if [ "$OS" == "linux" ]; then
   # XDP is only validated on Ubuntu 24.04 and x64
   if [ "$XDP" == "False" ] || [[ "$ARCH" == arm* ]]; then
-    echo "Building rpm package"
     # RedHat/CentOS
     FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
     FILES="${FILES} ${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}"

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -6,16 +6,6 @@
 
 #>
 
-param (
-    [Parameter(Mandatory = $false)]
-    [switch]$UseXdp
-)
-
-$Time64Distro = $false
-if ($UseXdp) {
-    $Time64Distro = $true
-}
-
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
@@ -123,6 +113,17 @@ foreach ($Build in $AllBuilds) {
 
     if ($Platform -eq "windows" -or $Platform -eq "uwp" -or $Platform -eq "gamecore_console") {
         $Libraries += Join-Path $ArtifactsDir "msquic.lib"
+    }
+
+    # if datapath_raw_xdp_kern.o exists under $ArtifactsDir, $UseXdp to be true
+    $Time64Distro = $false
+    $UseXdp = $false
+    if ($Platform -eq "linux") {
+        $XdpBin = Join-Path $ArtifactsDir "datapath_raw_xdp_kern.o"
+        if (Test-Path $XdpBin) {
+            $UseXdp = $true
+            $Time64Distro = $true
+        }
     }
 
     # Copy items into temp folder that can be zipped in 1 command

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -8,14 +8,11 @@
 
 param (
     [Parameter(Mandatory = $false)]
-    [ValidateSet("ubuntu_2404", "ubuntu_2204", "ubuntu_2004", "")]
-    [string]$OS = ""
+    [switch]$UseXdp
 )
 
-$UseXdp = $false
 $Time64Distro = $false
-if ($OS -eq "ubuntu_2404") {
-    $UseXdp = $true
+if ($UseXdp) {
     $Time64Distro = $true
 }
 


### PR DESCRIPTION
## Description

- Add more distros. fedora39, 49, azure linux 3.0
- Correct openssl dependencies (e.g. fedora 37, debian 12)
- Refactoring
- Stop using ubuntu_2X04 keyword for differentiate builds. Use kernel version instead.

## Testing

Use internal pipeline

## Documentation

N/A
