### PR TITLE
Delete Prepare Machine and Checkout from Linux Package Testing

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -58,13 +58,6 @@ jobs:
         ]
     runs-on: ${{ matrix.vec.os }}
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      with:
-        fetch-depth: 0
-    - name: Prepare Machine
-      shell: pwsh
-      run: scripts/prepare-machine.ps1 -ForTest ${{ matrix.vec.xdp }}
     - name: Download Package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -73,7 +73,7 @@ jobs:
         sudo apt-add-repository ppa:lttng/stable-2.13
         sudo apt-get update
         sudo apt-get install -y lttng-tools
-        sudo find -name "*.deb" -exec dpkg -i {} \;
+        sudo find -name "*.deb" -exec sudo apt install -y ./{} \;
         rm artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}/libmsquic.so*
         ls artifacts/bin/linux/${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}
     - name: Test

--- a/.github/workflows/package-reuse-linux.yml
+++ b/.github/workflows/package-reuse-linux.yml
@@ -96,7 +96,7 @@ jobs:
         find -name "*.tar" -exec tar -xvf '{}' \;
     - name: Build Package
       shell: pwsh
-      run: scripts/package-distribution.ps1
+      run: scripts/package-distribution.ps1 -OS ${{ inputs.os }}
     - name: Upload build artifacts
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
       with:

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -8,7 +8,7 @@
 
 param (
     [Parameter(Mandatory = $false)]
-    [ValidateSet("ubuntu_2404", "ubuntu_2204", "ubuntu_2004", "")]
+    [ValidateSet("ubuntu_2404", "ubuntu_2204", "ubuntu_2004", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04", "")]
     [string]$OS = ""
 )
 

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -12,6 +12,19 @@ param (
     [string]$OS = ""
 )
 
+# Convert GH Actions OS names to our internal names
+if ($OS -eq "ubuntu-20.04") {
+    $OS = "ubuntu_2004"
+}
+
+if ($OS -eq "ubuntu-22.04") {
+    $OS = "ubuntu_2204"
+}
+
+if ($OS -eq "ubuntu-24.04") {
+    $OS = "ubuntu_2404"
+}
+
 $UseXdp = $false
 $Time64Distro = $false
 if ($OS -eq "ubuntu_2404") {


### PR DESCRIPTION
## Description

Linux packages should work without needing to prepare the machine or checkout msquic. This PR removes the unnecessary steps.

## Testing

CI tests should pass

## Documentation

No
