### PR TITLE
set include_dest value

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -250,6 +250,9 @@ elseif (CX_PLATFORM STREQUAL "darwin")
         PROPERTIES LINK_FLAGS "-exported_symbols_list \"${CMAKE_CURRENT_SOURCE_DIR}/darwin/exports.txt\"")
 endif()
 
+include(GNUInstallDirs)
+set(include_dest ${CMAKE_INSTALL_INCLUDEDIR})
+
 if(BUILD_SHARED_LIBS)
     target_include_directories(msquic PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc>


### PR DESCRIPTION
fix cmake install error:

```
cmake -S msquic -B msquic-build -DCMAKE_INSTALL_PREFIX=msquic-install
cmake --build msquic-build
cmake --install msquic-build
```
target_link_libraries(app msquic)
```
cmake -S app -B app-build -DCMAKE_PREFIX_PATH=msquic-install
cmake --build app-build
```

#include <msquic.h>: No such file or directory