### PR TITLE
Implement LowLat mode in TCP

### DIFF
--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -19,6 +19,10 @@ Supported Environments:
 
 #include <stddef.h>
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
 
 #define CXPLAT_MAX(a,b) (((a) > (b)) ? (a) : (b))
@@ -592,3 +596,7 @@ CxPlatFreeTestCert(
 #endif
 
 #endif // QUIC_TEST_APIS
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -199,7 +199,7 @@ TcpWorker::~TcpWorker()
     CxPlatEventUninitialize(WakeEvent);
 }
 
-bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
+bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t)
 {
     Engine = _Engine;
     CXPLAT_THREAD_CONFIG Config = { 0, 0, "TcpPerfWorker", WorkerThread, this };
@@ -208,10 +208,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
     this->ExecutionContext.Context = this;
     this->ExecutionContext.Ready = TRUE;
 
-    if (Engine->TcpExecutionProfile == TCP_EXECUTION_PROFILE_LOW_LATENCY) {
-        // The CxPlat worker thread should also handle any 'Perf' protocol work, instead of creating a new thread for it.
-        CxPlatAddExecutionContext(&this->ExecutionContext, AssignedCPU);
-    } else if (QUIC_FAILED(
+    if (QUIC_FAILED(
         CxPlatThreadCreate(
             &Config,
             &Thread))) {

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -206,10 +206,12 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
     ExecutionContext.Context = this;
     ExecutionContext.Ready = TRUE;
     ExecutionContext.NextTimeUs = 0; // TODO: Figure out why adding this line makes lowlat tcp work?
+    PartitionIndex = AssignedCPU;
 
     if (Engine->TcpExecutionProfile == TCP_EXECUTION_PROFILE_LOW_LATENCY) {
         CxPlatAddExecutionContext(&ExecutionContext, AssignedCPU);
         Initialized = true;
+        IsExternal = true;
         return true;
     }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -252,7 +252,7 @@ TcpWorker::DoWork(
 {
     TcpWorker* This = (TcpWorker*)Context;
     TcpConnection* Connection;
-    if (This->Engine->Shutdown) {
+    if (This == NULL || This->Engine->Shutdown) {
         return FALSE;
     }
     CxPlatDispatchLockAcquire(&This->Lock);

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -192,7 +192,7 @@ TcpWorker::TcpWorker()
 TcpWorker::~TcpWorker()
 {
     CXPLAT_FRE_ASSERT(!Connections);
-    if (Initialized) {
+    if (Initialized && !IsExternal) {
         CxPlatThreadDelete(&Thread);
     }
     CxPlatDispatchLockUninitialize(&Lock);
@@ -229,7 +229,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
 
 void TcpWorker::Shutdown()
 {
-    if (Initialized) {
+    if (Initialized && !IsExternal) {
         CxPlatEventSet(WakeEvent);
         CxPlatThreadWait(&Thread);
     }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -259,7 +259,7 @@ TcpWorker::DoWork(
         Connection->Release();
         This->ExecutionContext.Ready = TRUE; // We just did work, let's keep this thread hot.
     } else {
-        This->ExecutionContext.Ready = FALSE; // No work to do right now.
+        This->ExecutionContext.Ready = FALSE; 
     }
     return TRUE;
 }
@@ -267,12 +267,9 @@ TcpWorker::DoWork(
 CXPLAT_THREAD_CALLBACK(TcpWorker::WorkerThread, Context)
 {
     TcpWorker* This = (TcpWorker*)Context;
-    BOOLEAN MoreWorkIncoming = TRUE;
-
-    while (MoreWorkIncoming == TRUE) {
-        MoreWorkIncoming = DoWork(This, nullptr);
-        if (!This->ExecutionContext.Ready) { // No work for the moment, but more will come.
-            CxPlatEventWaitForever(This->WakeEvent); // Sleep until there is time to do more work.
+    while (DoWork(This, nullptr)) {
+        if (This->ExecutionContext.Ready == FALSE) { // No work for the moment, but more will come.
+            CxPlatEventWaitForever(This->WakeEvent);
         }
     }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -241,7 +241,7 @@ void TcpWorker::Shutdown()
 BOOLEAN
 TcpWorker::DoWork(
     _Inout_ void* Context,
-    _Inout_ CXPLAT_EXECUTION_STATE* State
+    _Inout_ CXPLAT_EXECUTION_STATE*
     )
 {
     TcpWorker* This = (TcpWorker*)Context;
@@ -266,7 +266,6 @@ TcpWorker::DoWork(
         Connection->Process();
         Connection->Release();
         This->ExecutionContext.Ready = TRUE; // We just did work, let's keep this thread hot.
-        State->NoWorkCount = 0; // TODO: Figure out why adding this line makes lowlat tcp work?
     }
     return TRUE;
 }
@@ -274,10 +273,7 @@ TcpWorker::DoWork(
 CXPLAT_THREAD_CALLBACK(TcpWorker::WorkerThread, Context)
 {
     TcpWorker* This = (TcpWorker*)Context;
-    CXPLAT_EXECUTION_STATE DummyState = {
-        0, CxPlatTimeUs64(), UINT32_MAX, 0, CxPlatCurThreadID()
-    };
-    while (DoWork(This, &DummyState)) {
+    while (DoWork(This, nullptr)) {
         if (This->ExecutionContext.Ready == FALSE) { // No work for the moment, but more will come.
             CxPlatEventWaitForever(This->WakeEvent);
         }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -257,7 +257,9 @@ TcpWorker::DoWork(
     if (Connection) {
         Connection->Process();
         Connection->Release();
-        This->ExecutionContext.Ready = TRUE; // Keep this thread hot.
+        This->ExecutionContext.Ready = TRUE; // We just did work, let's keep this thread hot.
+    } else {
+        This->ExecutionContext.Ready = FALSE; // No work to do right now.
     }
     return TRUE;
 }
@@ -272,7 +274,6 @@ CXPLAT_THREAD_CALLBACK(TcpWorker::WorkerThread, Context)
         if (!This->ExecutionContext.Ready) { // No work for the moment, but more will come.
             CxPlatEventWaitForever(This->WakeEvent); // Sleep until there is time to do more work.
         }
-        This->ExecutionContext.Ready = FALSE;
     }
 
     CXPLAT_THREAD_RETURN(0);

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -205,7 +205,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
     ExecutionContext.Callback = DoWork;
     ExecutionContext.Context = this;
     ExecutionContext.Ready = TRUE;
-    ExecutionContext.NextTimeUs = 0; // TODO: Figure out why adding this line makes lowlat tcp work?
+    ExecutionContext.NextTimeUs = 0;
     PartitionIndex = AssignedCPU;
 
     if (Engine->TcpExecutionProfile == TCP_EXECUTION_PROFILE_LOW_LATENCY) {
@@ -241,7 +241,7 @@ void TcpWorker::Shutdown()
 BOOLEAN
 TcpWorker::DoWork(
     _Inout_ void* Context,
-    _Inout_ CXPLAT_EXECUTION_STATE*
+    _Inout_ CXPLAT_EXECUTION_STATE* State
     )
 {
     TcpWorker* This = (TcpWorker*)Context;
@@ -266,6 +266,7 @@ TcpWorker::DoWork(
         Connection->Process();
         Connection->Release();
         This->ExecutionContext.Ready = TRUE; // We just did work, let's keep this thread hot.
+        State->NoWorkCount = 0;
     }
     return TRUE;
 }
@@ -273,7 +274,10 @@ TcpWorker::DoWork(
 CXPLAT_THREAD_CALLBACK(TcpWorker::WorkerThread, Context)
 {
     TcpWorker* This = (TcpWorker*)Context;
-    while (DoWork(This, nullptr)) {
+    CXPLAT_EXECUTION_STATE DummyState = {
+        0, CxPlatTimeUs64(), UINT32_MAX, 0, CxPlatCurThreadID()
+    };
+    while (DoWork(This, &DummyState)) {
         if (This->ExecutionContext.Ready == FALSE) { // No work for the moment, but more will come.
             CxPlatEventWaitForever(This->WakeEvent);
         }

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -204,9 +204,9 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t)
     Engine = _Engine;
     CXPLAT_THREAD_CONFIG Config = { 0, 0, "TcpPerfWorker", WorkerThread, this };
 
-    this->ExecutionContext.Callback = DoWork;
-    this->ExecutionContext.Context = this;
-    this->ExecutionContext.Ready = TRUE;
+    ExecutionContext.Callback = DoWork;
+    ExecutionContext.Context = this;
+    ExecutionContext.Ready = TRUE;
 
     if (QUIC_FAILED(
         CxPlatThreadCreate(

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -208,12 +208,14 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t AssignedCPU)
     ExecutionContext.NextTimeUs = 0;
     PartitionIndex = AssignedCPU;
 
+    #ifndef _KERNEL_MODE // Not supported on kernel mode
     if (Engine->TcpExecutionProfile == TCP_EXECUTION_PROFILE_LOW_LATENCY) {
         CxPlatAddExecutionContext(&ExecutionContext, AssignedCPU);
         Initialized = true;
         IsExternal = true;
         return true;
     }
+    #endif
 
     CXPLAT_THREAD_CONFIG Config = { 0, 0, "TcpPerfWorker", WorkerThread, this };
     if (QUIC_FAILED(

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -114,6 +114,8 @@ class TcpWorker {
     friend class TcpConnection;
     CXPLAT_EXECUTION_CONTEXT ExecutionContext;
     bool Initialized{false};
+    bool IsExternal{false};
+    uint16_t PartitionIndex{0};
     TcpEngine* Engine{nullptr};
     CXPLAT_THREAD Thread;
     CXPLAT_EVENT WakeEvent;

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -21,6 +21,7 @@ class TcpServer;
 class TcpConnection;
 struct TcpFrame;
 
+
 struct TcpSendData {
     TcpSendData* Next;
     uint32_t StreamId : 29;
@@ -112,6 +113,7 @@ public:
 class TcpWorker {
     friend class TcpEngine;
     friend class TcpConnection;
+    CXPLAT_EXECUTION_CONTEXT ExecutionContext;
     bool Initialized{false};
     TcpEngine* Engine{nullptr};
     CXPLAT_THREAD Thread;
@@ -125,6 +127,10 @@ class TcpWorker {
     void Shutdown();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);
     bool QueueConnection(TcpConnection* Connection);
+    static BOOLEAN WorkerLoop(
+        _Inout_ void* Context,
+        _Inout_ CXPLAT_EXECUTION_STATE* State
+    );
 };
 
 class TcpServer {

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -122,7 +122,7 @@ class TcpWorker {
     TcpConnection** ConnectionsTail{&Connections};
     TcpWorker();
     ~TcpWorker();
-    bool Initialize(TcpEngine* _Engine);
+    bool Initialize(TcpEngine* _Engine, uint16_t AssignedCPU);
     void Shutdown();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);
     bool QueueConnection(TcpConnection* Connection);

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -115,16 +115,16 @@ class TcpWorker {
     CXPLAT_EXECUTION_CONTEXT ExecutionContext;
     bool Initialized{false};
     bool IsExternal{false};
-    uint16_t PartitionIndex{0};
     TcpEngine* Engine{nullptr};
     CXPLAT_THREAD Thread;
     CXPLAT_EVENT WakeEvent;
+    CXPLAT_EVENT DoneEvent;
     CXPLAT_DISPATCH_LOCK Lock;
     TcpConnection* Connections{nullptr};
     TcpConnection** ConnectionsTail{&Connections};
     TcpWorker();
     ~TcpWorker();
-    bool Initialize(TcpEngine* _Engine, uint16_t AssignedCPU);
+    bool Initialize(TcpEngine* _Engine, uint16_t PartitionIndex);
     void Shutdown();
     void WakeWorkerThread();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -126,6 +126,7 @@ class TcpWorker {
     ~TcpWorker();
     bool Initialize(TcpEngine* _Engine, uint16_t AssignedCPU);
     void Shutdown();
+    void WakeWorkerThread();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);
     bool QueueConnection(TcpConnection* Connection);
     static BOOLEAN DoWork(

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -21,7 +21,6 @@ class TcpServer;
 class TcpConnection;
 struct TcpFrame;
 
-
 struct TcpSendData {
     TcpSendData* Next;
     uint32_t StreamId : 29;

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -127,7 +127,7 @@ class TcpWorker {
     void Shutdown();
     static CXPLAT_THREAD_CALLBACK(WorkerThread, Context);
     bool QueueConnection(TcpConnection* Connection);
-    static BOOLEAN WorkerLoop(
+    static BOOLEAN DoWork(
         _Inout_ void* Context,
         _Inout_ CXPLAT_EXECUTION_STATE* State
     );

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -4086,7 +4086,6 @@ CxPlatSocketSendInline(
         return QUIC_STATUS_PENDING;
     }
 
-    QUIC_STATUS Status;
     int Result;
     DWORD BytesSent;
     CXPLAT_DATAPATH* Datapath = SocketProc->Parent->Datapath;
@@ -4201,24 +4200,17 @@ CxPlatSocketSendInline(
                 NULL);
     }
 
-    int WsaError = NO_ERROR;
     if (Result == SOCKET_ERROR) {
-        WsaError = WSAGetLastError();
-        if (WsaError == WSA_IO_PENDING) {
-            return QUIC_STATUS_SUCCESS;
-        }
-        Status = HRESULT_FROM_WIN32(WsaError);
-    } else {
-        Status = QUIC_STATUS_SUCCESS;
+        return QUIC_STATUS_SUCCESS; // Always processed asynchronously
     }
 
     //
     // Completed synchronously, so process the completion inline.
     //
     CxPlatCancelDatapathIo(SocketProc, &SendData->Sqe);
-    CxPlatSendDataComplete(SendData, WsaError);
+    CxPlatSendDataComplete(SendData, NO_ERROR);
 
-    return Status;
+    return QUIC_STATUS_SUCCESS;
 }
 
 QUIC_STATUS


### PR DESCRIPTION
## Description

As of today, MsQuic has several execution modes, namely Max Throughput, and Low Latency.

We use the Secnetperf tool to measure this performance impact between the different modes.
However, with our Secnetperf TCP implementation, there is no such distinction between modes.

Meaning, we are artificially giving QUIC an advantage in performance when we run it in Lowlat mode to optimize thread / context switching, but we are not doing the same for TCP.

This PR implements the actual TCP lowlat execution context part.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
