### PR TITLE
Remove invalid characters from logfile names on non-Windows

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -381,6 +381,10 @@ function Start-TestCase([String]$Name, [int]$Trial = 1) {
 
     # Get a string of invalid chars for filenames
     $InvalidChars = [System.IO.Path]::GetInvalidFileNameChars() -join ''
+    if (!$IsWindows) {
+        # Add characters that Azure disallows in filenames, but aren't invalid on POSIX
+        $InvalidChars = $InvalidChars,'"', ":", "<", ">", "|", "*", "?", "`r", "`n" -join ''
+    }
     # Escape those chars for use in a regex and put them inside a regex set (the square brackets)
     $InvalidCharsToReplace = "[{0}]" -f [RegEx]::Escape($InvalidChars)
     $InstanceName = $Name -replace $InvalidCharsToReplace, "_"


### PR DESCRIPTION
## Description
Non-Windows platforms allow characters in filenames that are not allowed on Windows, or in Github's artifact storage.
This change removes the characters that Github claims are disallowed.

## Testing

Tested by CI and by manually testing against the string containing invalid characters that started this.

## Documentation

N/A.
