### PR TITLE
Socket Errors are Asynchronous

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -4086,7 +4086,6 @@ CxPlatSocketSendInline(
         return QUIC_STATUS_PENDING;
     }
 
-    QUIC_STATUS Status;
     int Result;
     DWORD BytesSent;
     CXPLAT_DATAPATH* Datapath = SocketProc->Parent->Datapath;
@@ -4201,24 +4200,17 @@ CxPlatSocketSendInline(
                 NULL);
     }
 
-    int WsaError = NO_ERROR;
     if (Result == SOCKET_ERROR) {
-        WsaError = WSAGetLastError();
-        if (WsaError == WSA_IO_PENDING) {
-            return QUIC_STATUS_SUCCESS;
-        }
-        Status = HRESULT_FROM_WIN32(WsaError);
-    } else {
-        Status = QUIC_STATUS_SUCCESS;
+        return QUIC_STATUS_SUCCESS; // Always processed asynchronously
     }
 
     //
     // Completed synchronously, so process the completion inline.
     //
+    CxPlatSendDataComplete(SendData, NO_ERROR);
     CxPlatCancelDatapathIo(SocketProc, &SendData->Sqe);
-    CxPlatSendDataComplete(SendData, WsaError);
 
-    return Status;
+    return QUIC_STATUS_SUCCESS;
 }
 
 QUIC_STATUS


### PR DESCRIPTION
## Description

The send path error processing logic assumed errors could/should be processed synchronously, and since we never see them for UDP, it wasn't a big deal. For TCP, though, we see them more often, and it results in a use-after-free because we incorrectly release the last ref inline, and later the completion fires after the object had been freed.

P.S. I wish there was a `FILE_SKIP_COMPLETION_PORT_ON_ERROR` so that only PENDING results completed async. Errors should be processed inline too.

## Testing

Locally via secnetperf

## Documentation

N/A
