### PR TITLE
Do not exit gracefully in error cases

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -257,7 +257,7 @@ $allTests = [System.Collections.Specialized.OrderedDictionary]::new()
 $allTests["tput-up"] = "-exec:maxtput -up:12s -ptput:1"
 $allTests["tput-down"] = "-exec:maxtput -down:12s -ptput:1"
 $allTests["hps-conns-100"] = "-exec:maxtput -rconn:1 -share:1 -conns:100 -run:12s -prate:1"
-$allTests["rps-up-512-down-4000"] = "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:20s -plat:1"
+$allTests["rps-up-512-down-4000"] = "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:20s -plat:1 -abortOnFailure"
 
 $hasFailures = $false
 $json["run_args"] = $allTests

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -257,7 +257,7 @@ $allTests = [System.Collections.Specialized.OrderedDictionary]::new()
 $allTests["tput-up"] = "-exec:maxtput -up:12s -ptput:1"
 $allTests["tput-down"] = "-exec:maxtput -down:12s -ptput:1"
 $allTests["hps-conns-100"] = "-exec:maxtput -rconn:1 -share:1 -conns:100 -run:12s -prate:1"
-$allTests["rps-up-512-down-4000"] = "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:20s -plat:1 -abortOnFailure"
+$allTests["rps-up-512-down-4000"] = "-exec:lowlat -rstream:1 -up:512 -down:4000 -run:20s -plat:1"
 
 $hasFailures = $false
 $json["run_args"] = $allTests

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -99,6 +99,7 @@ QuicUserMain(
     ) {
     CxPlatEvent StopEvent {true};
     auto SimpleOutput = GetFlag(argc, argv, "trimout");
+    auto AbortOnFailure = GetFlag(argc, argv, "abortOnFailure");
     QUIC_STATUS Status = QuicMainStart(argc, argv, &StopEvent.Handle, SelfSignedCredConfig);
     if (QUIC_FAILED(Status)) {
         goto Exit;
@@ -124,6 +125,10 @@ Exit:
     QuicMainFree();
     if (!SimpleOutput) {
         printf("App Main returning status %d\n", Status);
+    }
+    if (!QUIC_SUCCEEDED(Status) && AbortOnFailure) {
+        printf("AbortOnFailure: non zero exit code: %d, Aborting to generate core dump. \n", Status);
+        abort();
     }
     return Status;
 }
@@ -335,11 +340,6 @@ Exit:
 
     CxPlatUninitialize();
     CxPlatSystemUnload();
-
-    if (!QUIC_SUCCEEDED(Status)) {
-        printf("Error: non zero exit code: %d, Aborting to generate core dump. \n", Status);
-        abort();
-    }
 
     return Status;
 }

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -108,7 +108,10 @@ QuicUserMain(
         printf("Started!\n\n");
     }
     fflush(stdout);
-    QuicMainWaitForCompletion();
+    Status = QuicMainWaitForCompletion();
+    if (QUIC_FAILED(Status)) {
+        goto Exit;
+    }
 
     if (const uint32_t DataLength = QuicMainGetExtraDataLength(); DataLength) {
         auto Buffer = UniquePtr<uint8_t[]>(new (std::nothrow) uint8_t[DataLength]);

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -336,5 +336,10 @@ Exit:
     CxPlatUninitialize();
     CxPlatSystemUnload();
 
+    if (!QUIC_SUCCEEDED(Status)) {
+        printf("Error: non zero exit code: %d, Aborting to generate core dump. \n", Status);
+        abort();
+    }
+
     return Status;
 }

--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -127,8 +127,7 @@ Exit:
         printf("App Main returning status %d\n", Status);
     }
     if (!QUIC_SUCCEEDED(Status) && AbortOnFailure) {
-        printf("AbortOnFailure: non zero exit code: %d, Aborting to generate core dump. \n", Status);
-        abort();
+        CXPLAT_FRE_ASSERTMSG(FALSE, "AbortOnFailure: Non zero exit code detected. Abort to generate core dump.");
     }
     return Status;
 }

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -388,6 +388,8 @@ PerfClient::Wait(
             WriteOutput("No connections or streams completed!\n");
         }
     }
+
+    return QUIC_STATUS_SUCCESS;
 }
 
 uint32_t

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -337,7 +337,7 @@ PerfClient::Start(
     return QUIC_STATUS_SUCCESS;
 }
 
-void
+QUIC_STATUS
 PerfClient::Wait(
     _In_ int Timeout
     ) {
@@ -360,7 +360,7 @@ PerfClient::Wait(
 
     if (GetConnectedConnections() == 0) {
         WriteOutput("Error: No Successful Connections!\n");
-        return;
+        return QUIC_STATUS_CONNECTION_REFUSED;
     }
 
     unsigned long long CompletedConnections = GetConnectionsCompleted();

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -139,7 +139,7 @@ struct PerfClient {
         _In_reads_(argc) _Null_terminated_ char* argv[],
         _In_z_ const char* target);
     QUIC_STATUS Start(_In_ CXPLAT_EVENT* StopEvent);
-    void Wait(_In_ int Timeout);
+    QUIC_STATUS Wait(_In_ int Timeout);
     uint32_t GetExtraDataLength();
     void GetExtraData(_Out_writes_bytes_(Length) uint8_t* Data, _In_ uint32_t Length);
 

--- a/src/perf/lib/PerfServer.cpp
+++ b/src/perf/lib/PerfServer.cpp
@@ -102,7 +102,7 @@ PerfServer::Start(
     return Listener.Start(PERF_ALPN, &LocalAddr);
 }
 
-void
+QUIC_STATUS
 PerfServer::Wait(
     _In_ int Timeout
     ) {
@@ -112,6 +112,7 @@ PerfServer::Wait(
         CxPlatEventWaitForever(*StopEvent);
     }
     Registration.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
+    return QUIC_STATUS_SUCCESS;
 }
 
 void

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -42,7 +42,7 @@ public:
         _In_reads_(argc) _Null_terminated_ char* argv[]
         );
     QUIC_STATUS Start(_In_ CXPLAT_EVENT* StopEvent);
-    void Wait(int Timeout);
+    QUIC_STATUS Wait(int Timeout);
 
     static CXPLAT_DATAPATH_RECEIVE_CALLBACK DatapathReceive;
     static void DatapathUnreachable(_In_ CXPLAT_SOCKET*, _In_ void*, _In_ const QUIC_ADDR*) { }

--- a/src/perf/lib/SecNetPerf.h
+++ b/src/perf/lib/SecNetPerf.h
@@ -65,7 +65,7 @@ QuicMainStart(
     );
 
 extern
-void
+QUIC_STATUS
 QuicMainWaitForCompletion(
     );
 

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -259,7 +259,7 @@ QuicMainStart(
 QUIC_STATUS
 QuicMainWaitForCompletion(
     ) {
-    Client ? Client->Wait((int)MaxRuntime) : Server->Wait((int)MaxRuntime);
+    return Client ? Client->Wait((int)MaxRuntime) : Server->Wait((int)MaxRuntime);
 }
 
 void

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -256,7 +256,7 @@ QuicMainStart(
     return Status; // QuicMainFree is called on failure
 }
 
-void
+QUIC_STATUS
 QuicMainWaitForCompletion(
     ) {
     Client ? Client->Wait((int)MaxRuntime) : Server->Wait((int)MaxRuntime);


### PR DESCRIPTION
## Description

In the Secnet tool, 

when something is wrong or supposed to crash, exiting gracefully leads to quiet errors and a massive pain while debugging.

This PR makes it so it will actually crash and a core dump gets generated.

## Testing

Netperf CI

## Documentation

N/A