### PR TITLE
Use Rundown Protection for TCP Send Completions

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -3987,7 +3987,7 @@ CxPlatSendDataComplete(
     _In_ ULONG IoResult
     )
 {
-    const CXPLAT_SOCKET_PROC* SocketProc = SendData->SocketProc;
+    CXPLAT_SOCKET_PROC* SocketProc = SendData->SocketProc;
 
     if (IoResult != QUIC_STATUS_SUCCESS) {
         QuicTraceEvent(


### PR DESCRIPTION
## Description

Finally fixes the real reason we were seeing secnetperf crash.

## Testing

Local. CI/CD

## Documentation

N/A
