### PR TITLE
Make GetParam return INVALID_STATE error when TLS has been cleaned up

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1667,8 +1667,10 @@ QuicLibraryGetParam(
 
     case QUIC_PARAM_PREFIX_TLS:
     case QUIC_PARAM_PREFIX_TLS_SCHANNEL:
-        if (Connection == NULL || Connection->Crypto.TLS == NULL) {
+        if (Connection == NULL) {
             Status = QUIC_STATUS_INVALID_PARAMETER;
+        } else if (Connection->Crypto.TLS == NULL) {
+            Status = QUIC_STATUS_INVALID_STATE;
         } else {
             Status = CxPlatTlsParamGet(Connection->Crypto.TLS, Param, BufferLength, Buffer);
         }

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4607,7 +4607,7 @@ void QuicTestTlsParam()
                 CxPlatEventInitialize(&ServerContext.Event, FALSE, FALSE);
                 Listener.Context = &ServerContext;
 
-                QuicAddr ServerLocalAddr;
+                QuicAddr ServerLocalAddr(QUIC_ADDRESS_FAMILY_INET);
                 TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
                 TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
@@ -4617,7 +4617,7 @@ void QuicTestTlsParam()
                     Client.Start(
                         ClientConfiguration,
                         QUIC_ADDRESS_FAMILY_INET,
-                        "localhost",
+                        QUIC_LOCALHOST_FOR_AF(QUIC_ADDRESS_FAMILY_INET),
                         ServerLocalAddr.GetPort()));
 
                 TEST_TRUE(Client.WaitForConnectionComplete());
@@ -4672,7 +4672,7 @@ void QuicTestTlsParam()
                 CxPlatEventInitialize(&ServerContext.Event, FALSE, FALSE);
                 Listener.Context = &ServerContext;
 
-                QuicAddr ServerLocalAddr;
+                QuicAddr ServerLocalAddr(QUIC_ADDRESS_FAMILY_INET);
                 TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
                 TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
@@ -4682,7 +4682,7 @@ void QuicTestTlsParam()
                     Client.Start(
                         ClientConfiguration,
                         QUIC_ADDRESS_FAMILY_INET,
-                        "localhost",
+                        QUIC_LOCALHOST_FOR_AF(QUIC_ADDRESS_FAMILY_INET),
                         ServerLocalAddr.GetPort()));
 
                 TEST_TRUE(Client.WaitForConnectionComplete());

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4484,6 +4484,39 @@ void QuicTestConnectionParam()
     QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(Registration, ClientConfiguration);
 }
 
+struct TestTlsParamServerContext {
+    MsQuicConnection** Server;
+    CXPLAT_EVENT Event;
+    QUIC_STATUS GetParamStatus;
+};
+
+bool
+TestTlsParamListenerCallback(
+    _In_ TestListener* Listener,
+    _In_ HQUIC ConnectionHandle)
+{
+    TestTlsParamServerContext* Context = (TestTlsParamServerContext*)Listener->Context;
+    *Context->Server = new(std::nothrow) MsQuicConnection(
+        ConnectionHandle,
+        CleanUpManual,
+        [](MsQuicConnection* Connection, void* Context, QUIC_CONNECTION_EVENT* Event) {
+            if (Event->Type == QUIC_CONNECTION_EVENT_CONNECTED) {
+                QUIC_HANDSHAKE_INFO Info = {};
+                uint32_t Length = sizeof(Info);
+                ((TestTlsParamServerContext*)Context)->GetParamStatus =
+                    MsQuic->GetParam(
+                        *Connection,
+                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                        &Length,
+                        &Info);
+                CxPlatEventSet(((TestTlsParamServerContext*)Context)->Event);
+            }
+            return QUIC_STATUS_SUCCESS;
+        },
+        Context);
+    return true;
+}
+
 //
 // This test uses TEST_NOT_EQUAL(XXX, QUIC_STATUS_SUCCESS) to cover both
 // OpenSSL and Schannel which return different error code.
@@ -4555,6 +4588,136 @@ void QuicTestTlsParam()
                         &Length,
                         &Info
                 ), QUIC_STATUS_SUCCESS);
+            }
+
+            //
+            // After handshake, no resumption
+            //
+            {
+                TestScopeLogger LogScope2("After handshake - no resumption");
+                MsQuicConfiguration ServerConfiguration(Registration, Alpn, ServerSelfSignedCredConfig);
+                TEST_TRUE(ServerConfiguration.IsValid());
+                TestListener Listener(
+                    Registration,
+                    TestTlsParamListenerCallback,
+                    ServerConfiguration);
+                TEST_QUIC_SUCCEEDED(Listener.IsValid());
+                UniquePtr<MsQuicConnection> Server;
+                TestTlsParamServerContext ServerContext = { (MsQuicConnection**)&Server, {}, QUIC_STATUS_SUCCESS };
+                CxPlatEventInitialize(&ServerContext.Event, FALSE, FALSE);
+                Listener.Context = &ServerContext;
+
+                QuicAddr ServerLocalAddr;
+                TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+                TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+                TestConnection Client(Registration);
+                TEST_TRUE(Client.IsValid());
+                TEST_QUIC_SUCCEEDED(
+                    Client.Start(
+                        ClientConfiguration,
+                        QUIC_ADDRESS_FAMILY_INET,
+                        "localhost",
+                        ServerLocalAddr.GetPort()));
+
+                TEST_TRUE(Client.WaitForConnectionComplete());
+                TEST_TRUE(Server);
+                CxPlatEventWaitForever(ServerContext.Event);
+
+                //
+                // Validate the GetParam succeeded in the CONNECTED callback.
+                //
+                TEST_QUIC_SUCCEEDED(ServerContext.GetParamStatus);
+
+                QUIC_HANDSHAKE_INFO Info = {};
+                Length = sizeof(Info);
+                TEST_QUIC_SUCCEEDED(
+                    MsQuic->GetParam(
+                        Client.GetConnection(),
+                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                        &Length,
+                        &Info
+                ));
+
+                //
+                // The server should have freed the TLS state by now, so this
+                // should fail.
+                //
+                Length = sizeof(Info);
+                TEST_EQUAL(
+                    MsQuic->GetParam(
+                        *Server,
+                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                        &Length,
+                        &Info),
+                    QUIC_STATUS_INVALID_STATE);
+            }
+
+            //
+            // After handshake, with resumption
+            //
+            {
+                TestScopeLogger LogScope2("After handshake - with resumption");
+                MsQuicSettings Settings;
+                Settings.SetServerResumptionLevel(QUIC_SERVER_RESUME_ONLY);
+                MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, ServerSelfSignedCredConfig);
+                TEST_TRUE(ServerConfiguration.IsValid());
+                TestListener Listener(
+                    Registration,
+                    TestTlsParamListenerCallback,
+                    ServerConfiguration);
+                TEST_QUIC_SUCCEEDED(Listener.IsValid());
+                UniquePtr<MsQuicConnection> Server;
+                TestTlsParamServerContext ServerContext = { (MsQuicConnection**)&Server, {}, QUIC_STATUS_SUCCESS };
+                CxPlatEventInitialize(&ServerContext.Event, FALSE, FALSE);
+                Listener.Context = &ServerContext;
+
+                QuicAddr ServerLocalAddr;
+                TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+                TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+                TestConnection Client(Registration);
+                TEST_TRUE(Client.IsValid());
+                TEST_QUIC_SUCCEEDED(
+                    Client.Start(
+                        ClientConfiguration,
+                        QUIC_ADDRESS_FAMILY_INET,
+                        "localhost",
+                        ServerLocalAddr.GetPort()));
+
+                TEST_TRUE(Client.WaitForConnectionComplete());
+                TEST_TRUE(Server);
+                CxPlatEventWaitForever(ServerContext.Event);
+
+                //
+                // Validate the GetParam succeeded in the CONNECTED callback.
+                //
+                TEST_QUIC_SUCCEEDED(ServerContext.GetParamStatus);
+
+                //
+                // Validate the client always can call GetParam after handshake.
+                //
+                QUIC_HANDSHAKE_INFO Info = {};
+                Length = sizeof(Info);
+                TEST_QUIC_SUCCEEDED(
+                    MsQuic->GetParam(
+                        Client.GetConnection(),
+                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                        &Length,
+                        &Info
+                ));
+
+                //
+                // The server should NOT have freed the TLS state, so this
+                // should succeed.
+                //
+                TEST_EQUAL(
+                    MsQuic->GetParam(
+                        *Server,
+                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                        &Length,
+                        &Info),
+                    QUIC_STATUS_SUCCESS);
             }
 
             {


### PR DESCRIPTION
## Description

One the server-side, QUIC cleans up the TLS state once the connection handshake is complete. This means that the last time `QUIC_PARAM_TLS_HANDSHAKE_INFO` can be queried on a server is in the `QUIC_CONNECTION_EVENT_CONNECTED` event.
Once cleaned up, attempting to query this state returned `QUIC_STATUS_INVALID_PARAMETER`, as pointed out in #4457, this is confusing. This change updates it so that `QUIC_STATUS_INVALID_STATE` is returned once the TLS state has been cleaned up to more clearly indicate that internal state has changed.

## Testing

Tested by CI

## Documentation

This behavior isn't documented, so no new documentation is needed. However, maybe the limitation of this GetParam needs to be documented better for the difference between client and server behavior.
