### PR TITLE
Fix test failures from #4518

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,7 @@ jobs:
     - name: Test
       shell: pwsh
       timeout-minutes: 90
-      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*
+      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*
     - name: Upload on Failure
       uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a
       if: failure()

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -50,7 +50,7 @@ void QuicTestRegistrationParam();
 void QuicTestConfigurationParam();
 void QuicTestListenerParam();
 void QuicTestConnectionParam();
-void QuicTestTlsParam();
+void QuicTestTlsParam(_In_ bool SkipHandshakeTest);
 void QuicTestStreamParam();
 void QuicTestGetPerfCounters();
 void QuicTestVersionSettings();
@@ -1213,6 +1213,7 @@ typedef struct {
 
 #define IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM \
     QUIC_CTL_CODE(96, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // BOOLEAN - SkipHandshakeTest
 
 #define IOCTL_QUIC_RUN_VALIDATE_STREAM_PARAM \
     QUIC_CTL_CODE(97, METHOD_BUFFERED, FILE_WRITE_DATA)

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -50,7 +50,8 @@ void QuicTestRegistrationParam();
 void QuicTestConfigurationParam();
 void QuicTestListenerParam();
 void QuicTestConnectionParam();
-void QuicTestTlsParam(_In_ bool SkipHandshakeTest);
+void QuicTestTlsParam();
+void QuicTestTlsHandshakeInfo(_In_ bool EnableResumption);
 void QuicTestStreamParam();
 void QuicTestGetPerfCounters();
 void QuicTestVersionSettings();
@@ -1213,7 +1214,6 @@ typedef struct {
 
 #define IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM \
     QUIC_CTL_CODE(96, METHOD_BUFFERED, FILE_WRITE_DATA)
-    // BOOLEAN - SkipHandshakeTest
 
 #define IOCTL_QUIC_RUN_VALIDATE_STREAM_PARAM \
     QUIC_CTL_CODE(97, METHOD_BUFFERED, FILE_WRITE_DATA)
@@ -1326,4 +1326,8 @@ typedef struct {
 #define IOCTL_QUIC_RUN_STREAM_MULTI_RECEIVE \
     QUIC_CTL_CODE(124, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 124
+#define IOCTL_QUIC_RUN_VALIDATE_TLS_HANDSHAKE_INFO \
+    QUIC_CTL_CODE(125, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // BOOLEAN - EnableResumption
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 125

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -289,7 +289,8 @@ TEST(ParameterValidation, ValidateConnectionParam) {
 TEST(ParameterValidation, ValidateTlsParam) {
     TestLogger Logger("QuicTestValidateTlsParam");
     if (TestingKernelMode) {
-        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM, (BOOLEAN)(IsWindows2022() || IsWindows2019())));
+        BOOLEAN SkipHandshakeTest = IsWindows2022() || IsWindows2019();
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM, SkipHandshakeTest));
     } else {
         QuicTestTlsParam(FALSE);
     }

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -289,9 +289,9 @@ TEST(ParameterValidation, ValidateConnectionParam) {
 TEST(ParameterValidation, ValidateTlsParam) {
     TestLogger Logger("QuicTestValidateTlsParam");
     if (TestingKernelMode) {
-        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM));
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM, (BOOLEAN)(IsWindows2022() || IsWindows2019())));
     } else {
-        QuicTestTlsParam();
+        QuicTestTlsParam(FALSE);
     }
 }
 

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -289,10 +289,20 @@ TEST(ParameterValidation, ValidateConnectionParam) {
 TEST(ParameterValidation, ValidateTlsParam) {
     TestLogger Logger("QuicTestValidateTlsParam");
     if (TestingKernelMode) {
-        BOOLEAN SkipHandshakeTest = IsWindows2022() || IsWindows2019();
-        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM, SkipHandshakeTest));
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM));
     } else {
-        QuicTestTlsParam(FALSE);
+        QuicTestTlsParam();
+    }
+}
+
+TEST_P(WithBool, ValidateTlsHandshakeInfo) {
+    TestLoggerT<ParamType> Logger("QuicTestValidateTlsHandshakeInfo", GetParam());
+    if (TestingKernelMode) {
+        if (IsWindows2022() || IsWindows2019()) GTEST_SKIP(); // Not supported on WS2019 or WS2022
+        uint8_t EnableResumption = (uint8_t)GetParam();
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_VALIDATE_TLS_HANDSHAKE_INFO, EnableResumption));
+    } else {
+        QuicTestTlsHandshakeInfo(GetParam());
     }
 }
 

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -494,7 +494,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
-    0,
+    sizeof(BOOLEAN),
     0,
     0,
     0,
@@ -563,6 +563,7 @@ typedef union {
     QUIC_RUN_FEATURE_NEGOTIATION FeatureNegotiationParams;
     QUIC_HANDSHAKE_LOSS_PARAMS HandshakeLossParams;
     BOOLEAN ClientShutdown;
+    BOOLEAN SkipHandshakeTest;
 } QUIC_IOCTL_PARAMS;
 
 #define QuicTestCtlRun(X) \
@@ -1320,7 +1321,8 @@ QuicTestCtlEvtIoDeviceControl(
         break;
 
     case IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM:
-        QuicTestCtlRun(QuicTestTlsParam());
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(QuicTestTlsParam(Params->SkipHandshakeTest));
         break;
 
     case IOCTL_QUIC_RUN_VALIDATE_STREAM_PARAM:

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -494,7 +494,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
-    sizeof(BOOLEAN),
+    0,
     0,
     0,
     0,
@@ -523,6 +523,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     0,
     0,
+    sizeof(BOOLEAN),
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -563,7 +564,7 @@ typedef union {
     QUIC_RUN_FEATURE_NEGOTIATION FeatureNegotiationParams;
     QUIC_HANDSHAKE_LOSS_PARAMS HandshakeLossParams;
     BOOLEAN ClientShutdown;
-    BOOLEAN SkipHandshakeTest;
+    BOOLEAN EnableResumption;
 } QUIC_IOCTL_PARAMS;
 
 #define QuicTestCtlRun(X) \
@@ -1321,8 +1322,7 @@ QuicTestCtlEvtIoDeviceControl(
         break;
 
     case IOCTL_QUIC_RUN_VALIDATE_TLS_PARAM:
-        CXPLAT_FRE_ASSERT(Params != nullptr);
-        QuicTestCtlRun(QuicTestTlsParam(Params->SkipHandshakeTest));
+        QuicTestCtlRun(QuicTestTlsParam());
         break;
 
     case IOCTL_QUIC_RUN_VALIDATE_STREAM_PARAM:
@@ -1476,6 +1476,11 @@ QuicTestCtlEvtIoDeviceControl(
 
     case IOCTL_QUIC_RUN_CONNECTION_PRIORITY:
         QuicTestCtlRun(QuicTestConnectionPriority());
+        break;
+
+    case IOCTL_QUIC_RUN_VALIDATE_TLS_HANDSHAKE_INFO:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(QuicTestTlsHandshakeInfo(Params->EnableResumption != 0));
         break;
 
     default:

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4533,6 +4533,13 @@ void QuicTestTlsParam()
         //
         {
             TestScopeLogger LogScope1("GetParam");
+            TEST_QUIC_STATUS(
+                QUIC_STATUS_INVALID_PARAMETER,
+                Connection.GetParam(
+                    QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                    nullptr,
+                    nullptr));
+
             uint32_t Length = 0;
             TEST_QUIC_STATUS(
                 QUIC_STATUS_BUFFER_TOO_SMALL,
@@ -4753,7 +4760,8 @@ TestTlsHandshakeInfoListenerCallback(
     return QUIC_STATUS_SUCCESS;
 }
 
-void QuicTestTlsHandshakeInfo(
+void
+QuicTestTlsHandshakeInfo(
     _In_ bool EnableResumption
     )
 {

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4606,7 +4606,7 @@ void QuicTestTlsParam()
                     CleanUpManual,
                     TestTlsParamListenerCallback,
                     &ServerContext);
-                TEST_QUIC_SUCCEEDED(Listener.IsValid());
+                TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
                 UniquePtr<MsQuicConnection> Server;
                 ServerContext.Server = (MsQuicConnection**)&Server;
                 Listener.Context = &ServerContext;
@@ -4679,7 +4679,7 @@ void QuicTestTlsParam()
                     CleanUpManual,
                     TestTlsParamListenerCallback,
                     &ServerContext);
-                TEST_QUIC_SUCCEEDED(Listener.IsValid());
+                TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
                 UniquePtr<MsQuicConnection> Server;
                 ServerContext.Server = (MsQuicConnection**)&Server;
                 Listener.Context = &ServerContext;

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4526,7 +4526,9 @@ TestTlsParamListenerCallback(
 // This need to be fixed in the future.
 // see src/platform/tsl_schannel.c about the TODO
 //
-void QuicTestTlsParam()
+void QuicTestTlsParam(
+    _In_ bool SkipHandshakeTest
+    )
 {
     MsQuicRegistration Registration;
     TEST_TRUE(Registration.IsValid());
@@ -4596,6 +4598,7 @@ void QuicTestTlsParam()
             //
             // After handshake, no resumption
             //
+            if (!SkipHandshakeTest)
             {
                 TestScopeLogger LogScope2("After handshake - no resumption");
                 MsQuicConfiguration ServerConfiguration(Registration, Alpn, ServerSelfSignedCredConfig);
@@ -4667,6 +4670,7 @@ void QuicTestTlsParam()
             //
             // After handshake, with resumption
             //
+            if (!SkipHandshakeTest)
             {
                 TestScopeLogger LogScope2("After handshake - with resumption");
                 MsQuicSettings Settings;

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4484,51 +4484,13 @@ void QuicTestConnectionParam()
     QuicTest_QUIC_PARAM_CONN_ORIG_DEST_CID(Registration, ClientConfiguration);
 }
 
-struct TestTlsParamServerContext {
-    MsQuicConnection** Server;
-    MsQuicConfiguration* ServerConfiguration;
-    QUIC_STATUS GetParamStatus;
-};
-
-QUIC_STATUS
-TestTlsParamListenerCallback(
-    _In_ MsQuicListener* /*Listener*/,
-    _In_opt_ void* ListenerContext,
-    _Inout_ QUIC_LISTENER_EVENT* Event)
-{
-    TestTlsParamServerContext* Context = (TestTlsParamServerContext*)ListenerContext;
-    if (Event->Type == QUIC_LISTENER_EVENT_NEW_CONNECTION) {
-        *Context->Server = new(std::nothrow) MsQuicConnection(
-            Event->NEW_CONNECTION.Connection,
-            CleanUpManual,
-            [](MsQuicConnection* Connection, void* Context, QUIC_CONNECTION_EVENT* Event) {
-                if (Event->Type == QUIC_CONNECTION_EVENT_CONNECTED) {
-                    QUIC_HANDSHAKE_INFO Info = {};
-                    uint32_t Length = sizeof(Info);
-                    ((TestTlsParamServerContext*)Context)->GetParamStatus =
-                        MsQuic->GetParam(
-                            *Connection,
-                            QUIC_PARAM_TLS_HANDSHAKE_INFO,
-                            &Length,
-                            &Info);
-                }
-                return QUIC_STATUS_SUCCESS;
-            },
-            Context);
-        (*Context->Server)->SetConfiguration(*Context->ServerConfiguration);
-    }
-    return QUIC_STATUS_SUCCESS;
-}
-
 //
 // This test uses TEST_NOT_EQUAL(XXX, QUIC_STATUS_SUCCESS) to cover both
 // OpenSSL and Schannel which return different error code.
 // This need to be fixed in the future.
 // see src/platform/tsl_schannel.c about the TODO
 //
-void QuicTestTlsParam(
-    _In_ bool SkipHandshakeTest
-    )
+void QuicTestTlsParam()
 {
     MsQuicRegistration Registration;
     TEST_TRUE(Registration.IsValid());
@@ -4593,153 +4555,6 @@ void QuicTestTlsParam(
                         &Length,
                         &Info
                 ), QUIC_STATUS_SUCCESS);
-            }
-
-            //
-            // After handshake, no resumption
-            //
-            if (!SkipHandshakeTest)
-            {
-                TestScopeLogger LogScope2("After handshake - no resumption");
-                MsQuicConfiguration ServerConfiguration(Registration, Alpn, ServerSelfSignedCredConfig);
-                TEST_TRUE(ServerConfiguration.IsValid());
-                TestTlsParamServerContext ServerContext = { nullptr, &ServerConfiguration, QUIC_STATUS_SUCCESS };
-                MsQuicListener Listener(
-                    Registration,
-                    CleanUpManual,
-                    TestTlsParamListenerCallback,
-                    &ServerContext);
-                TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
-                UniquePtr<MsQuicConnection> Server;
-                ServerContext.Server = (MsQuicConnection**)&Server;
-                Listener.Context = &ServerContext;
-
-                QuicAddr ServerLocalAddr(QUIC_ADDRESS_FAMILY_INET);
-                TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, ServerLocalAddr));
-                TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
-
-                MsQuicConnection Client(Registration);
-                TEST_QUIC_SUCCEEDED(Client.GetInitStatus());
-
-                if (UseDuoNic) {
-                    QuicAddr RemoteAddr{QuicAddrGetFamily(ServerLocalAddr), ServerLocalAddr.GetPort()};
-                    QuicAddrSetToDuoNic(&RemoteAddr.SockAddr);
-                    TEST_QUIC_SUCCEEDED(Client.SetRemoteAddr(RemoteAddr));
-                }
-
-                TEST_QUIC_SUCCEEDED(
-                    Client.Start(
-                        ClientConfiguration,
-                        QUIC_ADDRESS_FAMILY_INET,
-                        QUIC_LOCALHOST_FOR_AF(QUIC_ADDRESS_FAMILY_INET),
-                        ServerLocalAddr.GetPort()));
-
-                Client.HandshakeCompleteEvent.WaitForever();
-                TEST_TRUE(Client.HandshakeComplete);
-                TEST_TRUE(Server);
-                Server->HandshakeCompleteEvent.WaitForever();
-                TEST_TRUE(Server->HandshakeComplete);
-
-                //
-                // Validate the GetParam succeeded in the CONNECTED callback.
-                //
-                TEST_QUIC_SUCCEEDED(ServerContext.GetParamStatus);
-
-                QUIC_HANDSHAKE_INFO Info = {};
-                Length = sizeof(Info);
-                TEST_QUIC_SUCCEEDED(
-                    Client.GetParam(
-                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
-                        &Length,
-                        &Info
-                ));
-
-                //
-                // The server should have freed the TLS state by now, so this
-                // should fail.
-                //
-                Length = sizeof(Info);
-                TEST_EQUAL(
-                    Server->GetParam(
-                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
-                        &Length,
-                        &Info),
-                    QUIC_STATUS_INVALID_STATE);
-            }
-
-            //
-            // After handshake, with resumption
-            //
-            if (!SkipHandshakeTest)
-            {
-                TestScopeLogger LogScope2("After handshake - with resumption");
-                MsQuicSettings Settings;
-                Settings.SetServerResumptionLevel(QUIC_SERVER_RESUME_ONLY);
-                MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, ServerSelfSignedCredConfig);
-                TEST_TRUE(ServerConfiguration.IsValid());
-                TestTlsParamServerContext ServerContext = { nullptr, &ServerConfiguration, QUIC_STATUS_SUCCESS };
-                MsQuicListener Listener(
-                    Registration,
-                    CleanUpManual,
-                    TestTlsParamListenerCallback,
-                    &ServerContext);
-                TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
-                UniquePtr<MsQuicConnection> Server;
-                ServerContext.Server = (MsQuicConnection**)&Server;
-                Listener.Context = &ServerContext;
-
-                QuicAddr ServerLocalAddr(QUIC_ADDRESS_FAMILY_INET);
-                TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, ServerLocalAddr));
-                TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
-
-                MsQuicConnection Client(Registration);
-                TEST_QUIC_SUCCEEDED(Client.GetInitStatus());
-
-                if (UseDuoNic) {
-                    QuicAddr RemoteAddr{QuicAddrGetFamily(ServerLocalAddr), ServerLocalAddr.GetPort()};
-                    QuicAddrSetToDuoNic(&RemoteAddr.SockAddr);
-                    TEST_QUIC_SUCCEEDED(Client.SetRemoteAddr(RemoteAddr));
-                }
-
-                TEST_QUIC_SUCCEEDED(
-                    Client.Start(
-                        ClientConfiguration,
-                        QUIC_ADDRESS_FAMILY_INET,
-                        QUIC_LOCALHOST_FOR_AF(QUIC_ADDRESS_FAMILY_INET),
-                        ServerLocalAddr.GetPort()));
-
-                Client.HandshakeCompleteEvent.WaitForever();
-                TEST_TRUE(Client.HandshakeComplete);
-                TEST_TRUE(Server);
-                Server->HandshakeCompleteEvent.WaitForever();
-                TEST_TRUE(Server->HandshakeComplete);
-
-                //
-                // Validate the GetParam succeeded in the CONNECTED callback.
-                //
-                TEST_QUIC_SUCCEEDED(ServerContext.GetParamStatus);
-
-                //
-                // Validate the client always can call GetParam after handshake.
-                //
-                QUIC_HANDSHAKE_INFO Info = {};
-                Length = sizeof(Info);
-                TEST_QUIC_SUCCEEDED(
-                    Client.GetParam(
-                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
-                        &Length,
-                        &Info
-                ));
-
-                //
-                // The server should NOT have freed the TLS state, so this
-                // should succeed.
-                //
-                TEST_QUIC_SUCCEEDED(
-                    Server->GetParam(
-                        QUIC_PARAM_TLS_HANDSHAKE_INFO,
-                        &Length,
-                        &Info));
             }
 
             {
@@ -4900,6 +4715,140 @@ void QuicTestTlsParam(
         }
     }
 #endif
+}
+
+struct TestTlsHandshakeInfoServerContext {
+    MsQuicConnection** Server;
+    MsQuicConfiguration* ServerConfiguration;
+    QUIC_STATUS GetParamStatus;
+};
+
+QUIC_STATUS
+TestTlsHandshakeInfoListenerCallback(
+    _In_ MsQuicListener* /*Listener*/,
+    _In_opt_ void* ListenerContext,
+    _Inout_ QUIC_LISTENER_EVENT* Event)
+{
+    TestTlsHandshakeInfoServerContext* Context = (TestTlsHandshakeInfoServerContext*)ListenerContext;
+    if (Event->Type == QUIC_LISTENER_EVENT_NEW_CONNECTION) {
+        *Context->Server = new(std::nothrow) MsQuicConnection(
+            Event->NEW_CONNECTION.Connection,
+            CleanUpManual,
+            [](MsQuicConnection* Connection, void* Context, QUIC_CONNECTION_EVENT* Event) {
+                if (Event->Type == QUIC_CONNECTION_EVENT_CONNECTED) {
+                    QUIC_HANDSHAKE_INFO Info = {};
+                    uint32_t Length = sizeof(Info);
+                    ((TestTlsHandshakeInfoServerContext*)Context)->GetParamStatus =
+                        MsQuic->GetParam(
+                            *Connection,
+                            QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                            &Length,
+                            &Info);
+                }
+                return QUIC_STATUS_SUCCESS;
+            },
+            Context);
+        (*Context->Server)->SetConfiguration(*Context->ServerConfiguration);
+    }
+    return QUIC_STATUS_SUCCESS;
+}
+
+void QuicTestTlsHandshakeInfo(
+    _In_ bool EnableResumption
+    )
+{
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicCredentialConfig ClientCredConfig;
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, ClientCertCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    MsQuicSettings Settings;
+    if (EnableResumption) {
+        Settings.SetServerResumptionLevel(QUIC_SERVER_RESUME_ONLY);
+    }
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    TestTlsHandshakeInfoServerContext ServerContext = { nullptr, &ServerConfiguration, QUIC_STATUS_SUCCESS };
+
+    MsQuicListener Listener(
+        Registration,
+        CleanUpManual,
+        TestTlsHandshakeInfoListenerCallback,
+        &ServerContext);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+
+    UniquePtr<MsQuicConnection> Server;
+    ServerContext.Server = (MsQuicConnection**)&Server;
+    Listener.Context = &ServerContext;
+
+    QuicAddr ServerLocalAddr(QUIC_ADDRESS_FAMILY_INET);
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, ServerLocalAddr));
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Client(Registration);
+    TEST_QUIC_SUCCEEDED(Client.GetInitStatus());
+
+    if (UseDuoNic) {
+        QuicAddr RemoteAddr{QuicAddrGetFamily(ServerLocalAddr), ServerLocalAddr.GetPort()};
+        QuicAddrSetToDuoNic(&RemoteAddr.SockAddr);
+        TEST_QUIC_SUCCEEDED(Client.SetRemoteAddr(RemoteAddr));
+    }
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_INET,
+            QUIC_LOCALHOST_FOR_AF(QUIC_ADDRESS_FAMILY_INET),
+            ServerLocalAddr.GetPort()));
+
+    Client.HandshakeCompleteEvent.WaitForever();
+    TEST_TRUE(Client.HandshakeComplete);
+    TEST_TRUE(Server);
+    Server->HandshakeCompleteEvent.WaitForever();
+    TEST_TRUE(Server->HandshakeComplete);
+
+    //
+    // Validate the GetParam succeeded in the CONNECTED callback.
+    //
+    TEST_QUIC_SUCCEEDED(ServerContext.GetParamStatus);
+
+    QUIC_HANDSHAKE_INFO Info = {};
+    uint32_t Length = sizeof(Info);
+    TEST_QUIC_SUCCEEDED(
+        Client.GetParam(
+            QUIC_PARAM_TLS_HANDSHAKE_INFO,
+            &Length,
+            &Info
+    ));
+
+    if (EnableResumption) {
+        //
+        // The server should NOT have freed the TLS state, so this
+        // should succeed.
+        //
+        TEST_QUIC_SUCCEEDED(
+            Server->GetParam(
+                QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                &Length,
+                &Info));
+    } else {
+        //
+        // The server should have freed the TLS state by now, so this
+        // should fail.
+        //
+        TEST_EQUAL(
+            Server->GetParam(
+                QUIC_PARAM_TLS_HANDSHAKE_INFO,
+                &Length,
+                &Info),
+            QUIC_STATUS_INVALID_STATE);
+    }
 }
 
 void QuicTestStreamParam()


### PR DESCRIPTION
## Description

#4518 Was completed with some tests still failing, so this PR attempts to fix the test failures introduced in that PR.

## Testing

Fix the ApiTests for TLS parameters to run on XDP and not run test cases unsupported by kernel mode.

## Documentation

N/A
