### PR TITLE
Correctly set output in_pktinfo on unix platforms

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2333,7 +2333,7 @@ CxPlatSendDataPopulateAncillaryData(
             CMsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
             struct in_pktinfo *PktInfo = (struct in_pktinfo*)CMSG_DATA(CMsg);
             PktInfo->ipi_ifindex = SendData->LocalAddress.Ipv6.sin6_scope_id;
-            PktInfo->ipi_spec_dst.s_addr = 0;
+            PktInfo->ipi_spec_dst = SendData->LocalAddress.Ipv4.sin_addr;
             PktInfo->ipi_addr = SendData->LocalAddress.Ipv4.sin_addr;
         } else {
             Mhdr->msg_controllen += CMSG_SPACE(sizeof(struct in6_pktinfo));

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2002,6 +2002,7 @@ CxPlatSocketSendInternal(
             PktInfo = (struct in_pktinfo*) CMSG_DATA(CMsg);
             // TODO: Use Ipv4 instead of Ipv6.
             PktInfo->ipi_ifindex = LocalAddress->Ipv6.sin6_scope_id;
+            PktInfo->ipi_spec_dst = LocalAddress.Ipv4.sin_addr;
             PktInfo->ipi_addr = LocalAddress->Ipv4.sin_addr;
         } else {
             CMsg->cmsg_level = IPPROTO_IPV6;


### PR DESCRIPTION
## Description

Unix platforms have a 3rd field in in_pktinfo. ipi_spec_dst specifies the local address, whereas ipi_addr specifies what is put in the header. According to the docs, ipi_spec_dst  should be overwritten if ipi_ifindex is set. However, I seem to have a platform (Raspberry Pi 5 Raspbian) where that is not the case.

I'm running a setup where I'm connected to both WiFi and Ethernet to the same network. As the code sits, if I tried connecting to the WiFi address, the server to client packets would never send properly. Doing some testing, setting ipi_spec_dst to the IPV4 local address solves this issue, and packets get through properly on both NICs.

According to the docs, this shouldn't be necessary, as we pass the ifindex, but it does. It doesn't seem to break anything else.

## Testing

All the datapath tests will test this. The only other way to fully test this would be to have 2 nics with paths back to the same client, which is difficult in a CI environment

## Documentation

N/A
