### PR TITLE
Fix kqueue CSPLAT_SQE Type

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -1125,7 +1125,7 @@ CxPlatCqeUserData(
 #include <fcntl.h>
 
 typedef int CXPLAT_EVENTQ;
-#define CXPLAT_SQE int
+#define CXPLAT_SQE uintptr_t
 #define CXPLAT_SQE_DEFAULT 0
 typedef struct kevent CXPLAT_CQE;
 
@@ -1193,7 +1193,7 @@ CxPlatEventQReturn(
 
 #define CXPLAT_SQE_INIT 1
 
-extern long CxPlatCurrentSqe;
+extern uintptr_t CxPlatCurrentSqe;
 
 inline
 BOOLEAN
@@ -1205,7 +1205,7 @@ CxPlatSqeInitialize(
 {
     UNREFERENCED_PARAMETER(queue);
     UNREFERENCED_PARAMETER(user_data);
-    *sqe = (CXPLAT_SQE)InterlockedIncrement(&CxPlatCurrentSqe);
+    *sqe = __sync_add_and_fetch(&CxPlatCurrentSqe, 1);
     return TRUE;
 }
 

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -245,6 +245,8 @@ CxPlatInitialize(
         return Status;
     }
 
+    CxPlatWorkersInit();
+
     CxPlatTotalMemory = CGroupGetMemoryLimit();
 
     QuicTraceLogInfo(
@@ -260,6 +262,7 @@ CxPlatUninitialize(
     void
     )
 {
+    CxPlatWorkersUninit();
     CxPlatCryptUninitialize();
     close(RandomFd);
     QuicTraceLogInfo(

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -56,7 +56,7 @@ uint32_t CxPlatProcessorCount;
 uint64_t CxPlatTotalMemory;
 
 #if __APPLE__ || __FreeBSD__
-long CxPlatCurrentSqe = 0x80000000;
+uintptr_t CxPlatCurrentSqe = 0x80000000;
 #endif
 
 #ifdef __clang__
@@ -245,8 +245,6 @@ CxPlatInitialize(
         return Status;
     }
 
-    CxPlatWorkersInit();
-
     CxPlatTotalMemory = CGroupGetMemoryLimit();
 
     QuicTraceLogInfo(
@@ -262,7 +260,6 @@ CxPlatUninitialize(
     void
     )
 {
-    CxPlatWorkersUninit();
     CxPlatCryptUninitialize();
     close(RandomFd);
     QuicTraceLogInfo(


### PR DESCRIPTION
## Description

`kevent.ident` is a `uintptr_t`, not an `int`. C didn't really care, but if C++ included quic_platform.h, an error would occur as narrowing from signed to unsigned in a designated initializer is an error in C++. Could be solved either by adding an explicit cast, or changing the type to be correct. Changing the type seemed like the better option.

## Testing

Existing tests will cover it.

## Documentation

N/A
