### PR TITLE
Disable port sharing mechanisms when running in single processor mode

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -901,7 +901,8 @@ CxPlatSocketContextInitialize(
         // Only set SO_REUSEPORT on a server socket, otherwise the client could be
         // assigned a server port (unless it's forcing sharing).
         //
-        if (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) {
+        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) && 
+            SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.
             //

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -1252,7 +1252,7 @@ SocketCreateUdp(
             goto Error;
         }
 
-        if (Config->RemoteAddress == NULL) {
+        if (Config->RemoteAddress == NULL && Datapath->PartitionCount > 1) {
             uint16_t Processor = i; // API only supports 16-bit proc index.
             Result =
                 WSAIoctl(


### PR DESCRIPTION
## Description

On linux, server sockets always enable SO_REUSEPORT. This has a side affect of not blocking other processes from accessing the port. If running in a single core execution context, we don't need to set SO_REUSEPORT, which allows that port blocking to work.

On windows, server sockets always are enabled with processor affinity. On single proc, this is likely not wanted, and similar behavior to client sockets are likely wanted.

Mac is already treated as single core, so no changes required.

Note that single core systems themselves are extremely rare nowadays, so this behavior is generally explicitly requested.

## Testing

New test added to verify this behavior.

## Documentation
