### PR TITLE
CxPlatTimespecToUs:Microsecond time conversion overflow on 32-bit unix platforms

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -438,7 +438,7 @@ CxPlatTimespecToUs(
     _In_ const struct timespec *Time
     )
 {
-    return (Time->tv_sec * CXPLAT_MICROSEC_PER_SEC) + (Time->tv_nsec / CXPLAT_NANOSEC_PER_MICROSEC);
+    return ((uint64_t)Time->tv_sec * CXPLAT_MICROSEC_PER_SEC) + ((uint64_t)Time->tv_nsec / CXPLAT_NANOSEC_PER_MICROSEC);
 }
 
 uint64_t


### PR DESCRIPTION
CxPlatTimespecToUs:Microsecond time conversion overflow on 32-bit unix platforms

## Description

_Describe the purpose of and changes within this Pull Request._
The timespec structure is defined as follows
struct timespec
{
    time_t tv_sec;  // Seconds - >= 0
    long   tv_nsec; // Nanoseconds - [0, 999999999]
};
On a 32-bit platform, time_t t is usually defined as a 32-bit signed integer (int or long) .
Therefore, byte overflow occurs in the following calculation:
#define CXPLAT_MICROSEC_PER_SEC     (1000000)
Time->tv_sec * CXPLAT_MICROSEC_PER_SEC
This will cause the calculated microsecond time to be discontinuous, and the time obtained after overflow is smaller than the last time obtained
## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
