### PR TITLE
Fix ETW Manifest Typo

### DIFF
--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -4993,7 +4993,7 @@
             />
         <string
             id="Etw.ConnStatsV2"
-            value="[conn][%1] STATS: SRtt=%2 CongestionCount=%3 PersistentCongestionCount=%4 SendTotalBytes=%5 RecvTotalBytes=%6 CongestionWindow=%7 Cc=%8 EcnCongestionCount=%8"
+            value="[conn][%1] STATS: SRtt=%2 CongestionCount=%3 PersistentCongestionCount=%4 SendTotalBytes=%5 RecvTotalBytes=%6 CongestionWindow=%7 Cc=%8 EcnCongestionCount=%9"
             />
         <string
             id="Etw.DatapathSendTcpControl"


### PR DESCRIPTION
## Description

Noticed this while looking at a log. Example:
```
[8]0004.0E28::2024/09/03-16:13:49.692808900 [Microsoft-Quic][conn][0xFFFFEF82DA6DE100] STATS: SRtt=26359 CongestionCount=19 PersistentCongestionCount=0 SendTotalBytes=48827769 RecvTotalBytes=2731188 CongestionWindow=385840 Cc=Cubic EcnCongestionCount=Cubic
```

## Testing

N/A

## Documentation

N/A
