### PR TITLE
Add global internal param to get default datapath worker pool

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1422,10 +1422,10 @@ QuicLibraryGetGlobalParam(
         Status = QUIC_STATUS_SUCCESS;
         break;
 
-    case QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL:
+    case QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL:
 
-        if (*BufferLength != sizeof(CXPLAT_WORKER_POOL**)) {
-            *BufferLength = sizeof(CXPLAT_WORKER_POOL**);
+        if (*BufferLength != sizeof(CXPLAT_WORKER_POOL*)) {
+            *BufferLength = sizeof(CXPLAT_WORKER_POOL*);
             Status = QUIC_STATUS_BUFFER_TOO_SMALL;
             break;
         }

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1422,6 +1422,24 @@ QuicLibraryGetGlobalParam(
         Status = QUIC_STATUS_SUCCESS;
         break;
 
+    case QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL:
+
+        if (*BufferLength != sizeof(CXPLAT_WORKER_POOL**)) {
+            *BufferLength = sizeof(CXPLAT_WORKER_POOL**);
+            Status = QUIC_STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+
+        if (Buffer == NULL) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            break;
+        }
+
+        *(CXPLAT_WORKER_POOL**)Buffer = &MsQuicLib.WorkerPool;
+
+        Status = QUIC_STATUS_SUCCESS;
+        break;
+
     default:
         Status = QUIC_STATUS_INVALID_PARAMETER;
         break;

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -116,6 +116,7 @@ typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
 #endif
 #define QUIC_PARAM_GLOBAL_IN_USE                        0x81000004  // BOOLEAN
 #define QUIC_PARAM_GLOBAL_DATAPATH_FEATURES             0x81000005  // uint32_t
+#define QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL      0x81000006  // CXPLAT_WORKER_POOL**
 
 //
 // The different private parameters for Configuration.

--- a/src/inc/msquicp.h
+++ b/src/inc/msquicp.h
@@ -116,7 +116,7 @@ typedef struct QUIC_PRIVATE_TRANSPORT_PARAMETER {
 #endif
 #define QUIC_PARAM_GLOBAL_IN_USE                        0x81000004  // BOOLEAN
 #define QUIC_PARAM_GLOBAL_DATAPATH_FEATURES             0x81000005  // uint32_t
-#define QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL      0x81000006  // CXPLAT_WORKER_POOL**
+#define QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL          0x81000006  // CXPLAT_WORKER_POOL*
 
 //
 // The different private parameters for Configuration.

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2681,6 +2681,7 @@ void QuicTestGlobalParam()
         }
     }
 
+#if DEBUG
     //
     // QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL
     //
@@ -2724,6 +2725,7 @@ void QuicTestGlobalParam()
                     &WorkerPool));
         }
     }
+#endif
 
     //
     // Invalid parameter

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2714,10 +2714,10 @@ void QuicTestGlobalParam()
                     QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL,
                     &Length,
                     nullptr));
-            TEST_EQUAL(Length, sizeof(CXPLAT_WORKER_POOL**));
+            TEST_EQUAL(Length, sizeof(CXPLAT_WORKER_POOL*));
 
             CXPLAT_WORKER_POOL* WorkerPool = 0;
-            TEST_QUIC_STATUS(QUIC_STATUS_INVALID_STATE,
+            TEST_QUIC_SUCCEEDED(
                 MsQuic->GetParam(
                     nullptr,
                     QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL,

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2682,6 +2682,50 @@ void QuicTestGlobalParam()
     }
 
     //
+    // QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL
+    //
+    {
+        TestScopeLogger LogScope0("QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL");
+        {
+            TestScopeLogger LogScope1("SetParam");
+            //
+            // Invalid features
+            //
+            {
+                TestScopeLogger LogScope2("SetParam is not allowed");
+                TEST_QUIC_STATUS(
+                    QUIC_STATUS_INVALID_PARAMETER,
+                    MsQuic->SetParam(
+                        nullptr,
+                        QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                        0,
+                        nullptr));
+            }
+        }
+
+        {
+            TestScopeLogger LogScope2("GetParam. Failed by missing MsQuicLib.WorkerPool");
+            uint32_t Length = 0;
+            TEST_QUIC_STATUS(
+                QUIC_STATUS_BUFFER_TOO_SMALL,
+                MsQuic->GetParam(
+                    nullptr,
+                    QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                    &Length,
+                    nullptr));
+            TEST_EQUAL(Length, sizeof(CXPLAT_WORKER_POOL**));
+
+            CXPLAT_WORKER_POOL* WorkerPool = 0;
+            TEST_QUIC_STATUS(QUIC_STATUS_INVALID_STATE,
+                MsQuic->GetParam(
+                    nullptr,
+                    QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                    &Length,
+                    &WorkerPool));
+        }
+    }
+
+    //
     // Invalid parameter
     //
     {

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2682,10 +2682,10 @@ void QuicTestGlobalParam()
     }
 
     //
-    // QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL
+    // QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL
     //
     {
-        TestScopeLogger LogScope0("QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL");
+        TestScopeLogger LogScope0("QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL");
         {
             TestScopeLogger LogScope1("SetParam");
             //
@@ -2697,7 +2697,7 @@ void QuicTestGlobalParam()
                     QUIC_STATUS_INVALID_PARAMETER,
                     MsQuic->SetParam(
                         nullptr,
-                        QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                        QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL,
                         0,
                         nullptr));
             }
@@ -2710,7 +2710,7 @@ void QuicTestGlobalParam()
                 QUIC_STATUS_BUFFER_TOO_SMALL,
                 MsQuic->GetParam(
                     nullptr,
-                    QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                    QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL,
                     &Length,
                     nullptr));
             TEST_EQUAL(Length, sizeof(CXPLAT_WORKER_POOL**));
@@ -2719,7 +2719,7 @@ void QuicTestGlobalParam()
             TEST_QUIC_STATUS(QUIC_STATUS_INVALID_STATE,
                 MsQuic->GetParam(
                     nullptr,
-                    QUIC_PARAM_GLOBAL_GET_DATAPATH_WORKER_POOL,
+                    QUIC_PARAM_GLOBAL_PLATFORM_WORKER_POOL,
                     &Length,
                     &WorkerPool));
         }


### PR DESCRIPTION
## Description

Before #4492, it was possible for apps statically linking to MsQuic and CxPLat to get the default worker pool used by Quic. After that PR, the default worker pool is no longer accessible. Add a new global param getter to make that accessable.

## Testing

Added test to cover the new parameter.

## Documentation

Internal, so not documented.
