### PR TITLE
Fill out remote and local addresses on TCP server connection

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1554,11 +1554,12 @@ CxPlatSocketContextAcceptCompletion(
         goto Error;
     }
 
+    socklen_t AssignedLocalAddressLength = sizeof(SocketContext->AcceptSocket->LocalAddress);
     int Result =
         getsockname(
             SocketContext->AcceptSocket->SocketContexts[0].SocketFd,
-            &SocketContext->AcceptSocket->LocalAddress,
-            sizeof(SocketContext->AcceptSocket->LocalAddress));
+            (struct sockaddr*)&SocketContext->AcceptSocket->LocalAddress,
+            &AssignedLocalAddressLength);
     if (Result == SOCKET_ERROR) {
         QuicTraceEvent(
             DatapathErrorStatus,

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1538,11 +1538,12 @@ CxPlatSocketContextAcceptCompletion(
         goto Error;
     }
 
+    socklen_t AssignedRemoteAddressLength = sizeof(SocketContext->AcceptSocket->RemoteAddress);
     SocketContext->AcceptSocket->SocketContexts[0].SocketFd =
         accept(
             SocketContext->SocketFd,
-            &SocketContext->AcceptSocket->RemoteAddress,
-            sizeof(SocketContext->AcceptSocket->RemoteAddress));
+            (struct sockaddr*)&SocketContext->AcceptSocket->RemoteAddress,
+            &AssignedRemoteAddressLength);
     if (SocketContext->AcceptSocket->SocketContexts[0].SocketFd == INVALID_SOCKET) {
         Status = errno;
         QuicTraceEvent(

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1541,8 +1541,8 @@ CxPlatSocketContextAcceptCompletion(
     SocketContext->AcceptSocket->SocketContexts[0].SocketFd =
         accept(
             SocketContext->SocketFd,
-            &SocketContext->AcceptSocket.RemoteAddress,
-            sizeof(SocketContext->AcceptSocket.RemoteAddress));
+            &SocketContext->AcceptSocket->RemoteAddress,
+            sizeof(SocketContext->AcceptSocket->RemoteAddress));
     if (SocketContext->AcceptSocket->SocketContexts[0].SocketFd == INVALID_SOCKET) {
         Status = errno;
         QuicTraceEvent(
@@ -1557,8 +1557,8 @@ CxPlatSocketContextAcceptCompletion(
     int Result =
         getsockname(
             SocketContext->AcceptSocket->SocketContexts[0].SocketFd,
-            &SocketContext->AcceptSocket.LocalAddress,
-            sizeof(SocketContext->AcceptSocket.LocalAddress));
+            &SocketContext->AcceptSocket->LocalAddress,
+            sizeof(SocketContext->AcceptSocket->LocalAddress));
     if (Result == SOCKET_ERROR) {
         QuicTraceEvent(
             DatapathErrorStatus,

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2601,6 +2601,17 @@ CxPlatDataPathSocketProcessAcceptCompletion(
         SOCKET_PROCESSOR_AFFINITY RssAffinity = { 0 };
         uint16_t PartitionIndex = 0;
 
+        ListenerSocketProc->AcceptSocket->LocalAddress =
+            *(const QUIC_ADDR*)ListenerSocketProc->AcceptAddrSpace;
+        ListenerSocketProc->AcceptSocket->RemoteAddress =
+            *(const QUIC_ADDR*)(ListenerSocketProc->AcceptAddrSpace + (sizeof(SOCKADDR_INET) + 16));
+        CxPlatConvertFromMappedV6(
+            &ListenerSocketProc->AcceptSocket->LocalAddress,
+            &ListenerSocketProc->AcceptSocket->LocalAddress);
+        CxPlatConvertFromMappedV6(
+            &ListenerSocketProc->AcceptSocket->RemoteAddress,
+            &ListenerSocketProc->AcceptSocket->RemoteAddress);
+
         QuicTraceEvent(
             DatapathErrorStatus,
             "[data][%p] ERROR, %u, %s.",

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -1071,6 +1071,13 @@ TEST_P(DataPathTest, TcpConnect)
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ClientContext.ConnectEvent, 500));
     ASSERT_TRUE(CxPlatEventWaitWithTimeout(ListenerContext.AcceptEvent, 500));
     ASSERT_NE(nullptr, ListenerContext.Server);
+    QUIC_ADDR ServerRemote = {};
+    CxPlatSocketGetRemoteAddress(ListenerContext.Server, &ServerRemote);
+    QUIC_ADDR ServerLocal = {};
+    CxPlatSocketGetLocalAddress(ListenerContext.Server, &ServerLocal);
+    ASSERT_NE(ServerRemote.Ipv4.sin_port, (uint16_t)0);
+    ASSERT_NE(ServerLocal.Ipv4.sin_port, (uint16_t)0);
+    ASSERT_EQ(ServerRemote.Ipv4.sin_port, Client.GetLocalAddress().Ipv4.sin_port);
 
     ListenerContext.DeleteSocket();
 


### PR DESCRIPTION
## Description

TCP accepted connections did not have a filled out remote or local address. Fill them out.

## Testing

Update the connect test to assert things are valid.

## Documentation

N/A
