### PR TITLE
Fix Linux Send Complete Status

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2287,7 +2287,8 @@ SocketSend(
     //
     // Go ahead and try to send on the socket.
     //
-    if (CxPlatSendDataSend(SendData) == QUIC_STATUS_PENDING) {
+    QUIC_STATUS Status = CxPlatSendDataSend(SendData);
+    if (Status == QUIC_STATUS_PENDING) {
         //
         // Couldn't send right now, so queue up the send and wait for send
         // (EPOLLOUT) to be ready.
@@ -2301,7 +2302,7 @@ SocketSend(
             SocketContext->Binding->Datapath->TcpHandlers.SendComplete(
                 SocketContext->Binding,
                 SocketContext->Binding->ClientContext,
-                errno,
+                Status,
                 SendData->TotalSize);
         }
         CxPlatSendDataFree(SendData);
@@ -2598,7 +2599,8 @@ CxPlatSocketContextFlushTxQueue(
     CxPlatLockRelease(&SocketContext->TxQueueLock);
 
     while (SendData != NULL) {
-        if (CxPlatSendDataSend(SendData) == QUIC_STATUS_PENDING) {
+        QUIC_STATUS Status = CxPlatSendDataSend(SendData);
+        if (Status == QUIC_STATUS_PENDING) {
             if (!SendAlreadyPending) {
                 //
                 // Add the EPOLLOUT event since we have more pending sends.
@@ -2614,7 +2616,7 @@ CxPlatSocketContextFlushTxQueue(
             SocketContext->Binding->Datapath->TcpHandlers.SendComplete(
                 SocketContext->Binding,
                 SocketContext->Binding->ClientContext,
-                errno,
+                Status,
                 SendData->TotalSize);
         }
         CxPlatSendDataFree(SendData);


### PR DESCRIPTION
## Description

Linux TCP was recently broken when secnetperf was updated to handle send completion errors. This exposed a bug in the platform layer that was always passing up `errno` incorrectly.

This PR updates the platform abstraction to return the proper status.

## Testing

Verified locally on Linux GitHub Codespaces. CI/CD

## Documentation

N/A
