### PR TITLE
Don't set EPOLLOUT when creating TCP sockets

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1393,7 +1393,7 @@ CxPlatSocketCreateTcpInternal(
     //
     *NewBinding = Binding;
 
-    CxPlatSocketContextSetEvents(SocketContext, EPOLL_CTL_ADD, EPOLLIN | EPOLLOUT);
+    CxPlatSocketContextSetEvents(SocketContext, EPOLL_CTL_ADD, EPOLLIN);
     SocketContext->IoStarted = TRUE;
 
     Binding = NULL;


### PR DESCRIPTION
## Description

Epollout shouldn't be set until a pending send is available.

## Testing

Not easy to test because there isn't really a failure case, but the UDP side explicitly adds epollout only when needed. 

## Documentation

N/A
