### PR TITLE
Use Private Nuget Feed for OneBranch

### DIFF
--- a/.azure/nuget.config
+++ b/.azure/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="msquic_PublicPackages" value="https://mscodehub.visualstudio.com/msquic/_artifacts/feed/msquic_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/.azure/nuget.config
+++ b/.azure/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="msquic_PublicPackages" value="https://mscodehub.visualstudio.com/msquic/_artifacts/feed/msquic_PublicPackages/nuget/v3/index.json" />
+    <add key="msquic_PublicPackages" value="https://pkgs.dev.azure.com/mscodehub/msquic/_packaging/msquic_PublicPackages/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/.azure/obtemplates/build-winkernel.yml
+++ b/.azure/obtemplates/build-winkernel.yml
@@ -20,7 +20,7 @@ jobs:
       command: 'restore'
       restoreSolution: msquic.kernel.sln
       feedsToUse: 'config'
-      nugetConfigPath: .\azure\nuget.config
+      nugetConfigPath: .\.azure\nuget.config
   - script: scripts\onebranch-build-kernel.cmd ${{ parameters.config }} x64
     displayName: x64
     target: windows_build_container2

--- a/.azure/obtemplates/build-winkernel.yml
+++ b/.azure/obtemplates/build-winkernel.yml
@@ -13,6 +13,14 @@ jobs:
     ob_sdl_codeSignValidation_excludes: -|**\*.sys # Disable signing requirements for KM builds
     ob_spgo_enabled: true # Enable SPGO
   steps:
+  - task: NuGetCommand@2
+    displayName: Nuget Restore
+    target: windows_build_container2
+    inputs:
+      command: 'restore'
+      restoreSolution: msquic.kernel.sln
+      feedsToUse: 'config'
+      nugetConfigPath: .\azure\nuget.config
   - script: scripts\onebranch-build-kernel.cmd ${{ parameters.config }} x64
     displayName: x64
     target: windows_build_container2

--- a/scripts/onebranch-build-kernel.cmd
+++ b/scripts/onebranch-build-kernel.cmd
@@ -1,3 +1,2 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat
-msbuild msquic.kernel.sln -t:restore -p:RestorePackagesConfig=true /p:Configuration=%1 /p:Platform=%2
 msbuild msquic.kernel.sln -p:ONEBRANCH_BUILD=true /p:Configuration=%1 /p:Platform=%2 /p:QUIC_VER_SUFFIX=-official /p:QUIC_VER_BUILD_ID=%BUILD_BUILDID% /p:QUIC_VER_GIT_HASH=%BUILD_SOURCEVERSION%


### PR DESCRIPTION
## Description

Updates internal builds to use nuget.config to use internal mirror instead of nuget.org directly.

## Testing

Created internal draft PR to trigger pipeline: https://mscodehub.visualstudio.com/msquic/_build/results?buildId=531354&view=logs&j=4e010f65-6a42-5318-8120-b81b51c2abd2&t=abd3eb9e-9a6d-521e-c133-9e198ddfd123

## Documentation

N/A
