### PR TITLE
Don't Access Volatile Variables Directly

### DIFF
--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -199,7 +199,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t PartitionIndex)
     Engine = _Engine;
     ExecutionContext.Callback = DoWork;
     ExecutionContext.Context = this;
-    InterlockedFetchAndSetBoolean(&ExecutionContext.Ready);
+    WriteBooleanNoFence(&ExecutionContext.Ready, TRUE);
     ExecutionContext.NextTimeUs = UINT64_MAX;
 
     #ifndef _KERNEL_MODE // Not supported on kernel mode
@@ -282,7 +282,7 @@ TcpWorker::DoWork(
     if (Connection) {
         Connection->Process();
         Connection->Release();
-        InterlockedFetchAndSetBoolean(&This->ExecutionContext.Ready); // We just did work, let's keep this thread hot.
+        WriteBooleanNoFence(&This->ExecutionContext.Ready, TRUE); // We just did work, let's keep this thread hot.
         State->NoWorkCount = 0;
     }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -199,7 +199,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t PartitionIndex)
     Engine = _Engine;
     ExecutionContext.Callback = DoWork;
     ExecutionContext.Context = this;
-    ExecutionContext.Ready = TRUE;
+    InterlockedFetchAndSetBoolean(&ExecutionContext.Ready);
     ExecutionContext.NextTimeUs = UINT64_MAX;
 
     #ifndef _KERNEL_MODE // Not supported on kernel mode
@@ -282,7 +282,7 @@ TcpWorker::DoWork(
     if (Connection) {
         Connection->Process();
         Connection->Release();
-        This->ExecutionContext.Ready = TRUE; // We just did work, let's keep this thread hot.
+        InterlockedFetchAndSetBoolean(&This->ExecutionContext.Ready); // We just did work, let's keep this thread hot.
         State->NoWorkCount = 0;
     }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -199,7 +199,7 @@ bool TcpWorker::Initialize(TcpEngine* _Engine, uint16_t PartitionIndex)
     Engine = _Engine;
     ExecutionContext.Callback = DoWork;
     ExecutionContext.Context = this;
-    WriteBooleanNoFence(&ExecutionContext.Ready, TRUE);
+    InterlockedFetchAndSetBoolean(&ExecutionContext.Ready); // TODO - Use WriteBooleanNoFence equivalent instead?
     ExecutionContext.NextTimeUs = UINT64_MAX;
 
     #ifndef _KERNEL_MODE // Not supported on kernel mode
@@ -282,7 +282,7 @@ TcpWorker::DoWork(
     if (Connection) {
         Connection->Process();
         Connection->Release();
-        WriteBooleanNoFence(&This->ExecutionContext.Ready, TRUE); // We just did work, let's keep this thread hot.
+        InterlockedFetchAndSetBoolean(&This->ExecutionContext.Ready); // We just did work, let's keep this thread hot.
         State->NoWorkCount = 0;
     }
 


### PR DESCRIPTION
## Description

We were getting arm64 build errors when we accessed volatile variables directly in C++ code. Remove those.

## Testing

CI/CD

## Documentation

N/A