### PR TITLE
Add prereqs to publishing alpine package docs

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -104,7 +104,10 @@ When testing the pipeline, please make sure to comment out the PMC cli commands 
 
 ### Publishing MsQuic for Alpine
 
-1. Run `generate-alpine-packaging-file.ps1` script to create `APKBUILD` file for the release. (This script can run on any Linux distro.)
+Prerequisites:
+- Docker
+
+1. Run `generate-alpine-packaging-file.ps1` script on host computer to create `APKBUILD` file for the release. (This script can run on any Linux distro, and this script will create a docker alpine container to calculate hash keys in APKBUILD file)
 1. If you don't have account for [AlpineLinux GitLab](https://gitlab.alpinelinux.org). Create an account and [configure your SSH](https://docs.gitlab.com/ee/user/ssh.html).
 1. If you didn't fork `aports` repository yet, Fork `https://gitlab.alpinelinux.org/alpine/aports`.
 1. Clone `https://gitlab.alpinelinux.org/<your_username>/aports` repository.


### PR DESCRIPTION
## Description

Add prereqs to publishing alpine package docs

## Testing

No test is needed

## Documentation

Release doc
