### PR TITLE
add barrier missing between producer submit and needpoke check

### DIFF
--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1697,9 +1697,8 @@ CxPlatXdpTx(
         ProdCount++;
     }
 
-    if (ProdCount > 0 ||
+    if ((ProdCount > 0 && (XskRingProducerSubmit(&Queue->TxRing, ProdCount), TRUE)) ||
         (CompCount > 0 && XskRingProducerReserve(&Queue->TxRing, MAXUINT32, &TxIndex) != Queue->TxRing.Size)) {
-        XskRingProducerSubmit(&Queue->TxRing, ProdCount);
         MemoryBarrier();
         if (Xdp->TxAlwaysPoke || XskRingProducerNeedPoke(&Queue->TxRing)) {
             XSK_NOTIFY_RESULT_FLAGS OutFlags;

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1700,6 +1700,7 @@ CxPlatXdpTx(
     if (ProdCount > 0 ||
         (CompCount > 0 && XskRingProducerReserve(&Queue->TxRing, MAXUINT32, &TxIndex) != Queue->TxRing.Size)) {
         XskRingProducerSubmit(&Queue->TxRing, ProdCount);
+        MemoryBarrier();
         if (Xdp->TxAlwaysPoke || XskRingProducerNeedPoke(&Queue->TxRing)) {
             XSK_NOTIFY_RESULT_FLAGS OutFlags;
             QUIC_STATUS Status = Xdp->XdpApi->XskNotifySocket(Queue->TxXsk, XSK_NOTIFY_FLAG_POKE_TX, 0, &OutFlags);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I noticed MsQuic is missing the mandatory (on x64) barrier between submitting TX producer entries and checking the TX ring for the NeedPoke flag. If these operations get reordered, pokes could be missed.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.
