### PR TITLE
Update Alpine Release Docs

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -111,10 +111,10 @@ Prerequisites:
 1. If you don't have account for [AlpineLinux GitLab](https://gitlab.alpinelinux.org). Create an account and [configure your SSH](https://docs.gitlab.com/ee/user/ssh.html).
 1. If you didn't fork `aports` repository yet, Fork `https://gitlab.alpinelinux.org/alpine/aports`.
 1. Clone `https://gitlab.alpinelinux.org/<your_username>/aports` repository.
-1. Navigate to `aports/testing/libmsquic` folder.
+1. Navigate to `aports/community/libmsquic` folder.
 1. Replace the `APKBUILD` file with newly created `APKBUILD` file.
-1. Create a commit using `testing/libmsquic: upgrade to <version_number>` (version_number e.g. 2.5.0 or 2.4.4).
-1. Create a merge request using `testing/libmsquic: upgrade to <version_number>` (version_number e.g. 2.5.0 or 2.4.4).
+1. Create a commit using `community/libmsquic: upgrade to <version_number>` (version_number e.g. 2.5.0 or 2.4.4).
+1. Create a merge request using `community/libmsquic: upgrade to <version_number>` (version_number e.g. 2.5.0 or 2.4.4).
 1. Owners of the `aports` repository will respond to the PR or merge it in couple of days/hours.
 
 For future reference: [Official documentation](https://wiki.alpinelinux.org/wiki/Creating_an_Alpine_package)


### PR DESCRIPTION
## Description

Since we've moved alpine package from `testing` repository to `community` repository, let's update this in doc as well.

## Testing

No needed

## Documentation

Updating release doc
