### PR TITLE
Fix crash issue on Samsung phone A217M when send big payload size

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2257,6 +2257,7 @@ CxPlatSendDataFinalizeSendBuffer(
         IoVec->iov_base = SendData->ClientBuffer.Buffer;
         IoVec->iov_len = SendData->ClientBuffer.Length;
         if (SendData->TotalSize + SendData->SegmentSize > sizeof(SendData->Buffer) ||
+            SendData->TotalSize + SendData->ClientBuffer.Length > sizeof(SendData->Buffer) ||
             SendData->BufferCount == SendData->SocketContext->DatapathPartition->Datapath->SendIoVecCount) {
             SendData->ClientBuffer.Buffer = NULL;
         } else {
@@ -2447,7 +2448,7 @@ CxPlatSendDataPopulateAncillaryData(
     }
 
 #ifdef UDP_SEGMENT
-    if (SendData->SegmentationSupported && SendData->SegmentSize > 0) {
+    if (SendData->SegmentationSupported && SendData->SegmentSize > 0 && Mhdr->msg_iov->iov_len > SendData->SegmentSize) {
         Mhdr->msg_controllen += CMSG_SPACE(sizeof(uint16_t));
         CMsg = CXPLAT_CMSG_NXTHDR(CMsg);
         CMsg->cmsg_level = SOL_UDP;


### PR DESCRIPTION
## Description

My phone: Samsung A217M (Android 12)
After I upgraded MsQuic to v2.3.6, crash occurs when sending big payload size. I have tried the releases both v.2.3.4 and v.2.3.5, also failed on my phone.
With MsQuic v2.2.4, it's ok. 
Please see the discussion here:
https://github.com/microsoft/msquic/issues/4144

## Testing

No need to add new test case. The gtest "WithSendArgs2.SendLarge" in guic_gtest.cpp already covers this issue.

## Documentation


