### PR TITLE
freeing pIfTable later for potential memory leak

### DIFF
--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1086,7 +1086,6 @@ CxPlatDpRawInitialize(
             "CxPlatThreadCreate");
         goto Error;
     }
-    FreeMibTable(pIfTable);
 
     if (CxPlatListIsEmpty(&Xdp->Interfaces)) {
         QuicTraceEvent(
@@ -1152,6 +1151,9 @@ CxPlatDpRawInitialize(
     Status = QUIC_STATUS_SUCCESS;
 
 Error:
+    if (pIfTable != NULL) {
+        FreeMibTable(pIfTable);
+    }
 
     if (QUIC_FAILED(Status)) {
         while (!CxPlatListIsEmpty(&Xdp->Interfaces)) {


### PR DESCRIPTION
## Description

Potential memory leak when CXPLAT_ALLOC_NONPAGED or GetAdaptersAddresses fails

## Testing

CI

## Documentation

N/A
