### PR TITLE
Modifications in PR (4607) should not touch Core library

### DIFF
--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -17,6 +17,7 @@ on:
     - src/core/**
     - src/platform/**
     - src/perf/**
+    - src/inc/**
     - submodules/openssl/**
     - submodules/openssl3/**
     - submodules/xdp-for-windows/**
@@ -35,6 +36,7 @@ on:
     - src/core/**
     - src/platform/**
     - src/perf/**
+    - src/inc/**
     - submodules/openssl/**
     - submodules/openssl3/**
     - submodules/xdp-for-windows/**

--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -304,7 +304,7 @@ IsValue(
     _In_z_ const char* toTestAgainst
     )
 {
-    return _strnicmp(name, toTestAgainst, strlen(toTestAgainst)) == 0;
+    return _strnicmp(name, toTestAgainst, CXPLAT_MIN(strlen(name), strlen(toTestAgainst))) == 0;
 }
 
 inline


### PR DESCRIPTION
## Description

Reverts the changes to msquichelper.h in PR https://github.com/microsoft/msquic/pull/4607/files#diff-8c815f8709f890481f7dca98690cabe22460b384b7e90da85d2cc0a42ee72cc1

because it wasn't clear why that change was made when the PR was about refactoring the Secnet tool.

## Testing

CI

## Documentation

N/A
