### PR TITLE
reduce overhead of rps-multi

### DIFF
--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -132,20 +132,20 @@ PerfClient::Init(
             Download = 4000;
             ConnectionCount = 16 * CxPlatProcCount();
             StreamCount = 100;
-            RunTime = S_TO_US(20); // 20 seconds
+            RunTime = S_TO_US(5); // 5 seconds
             RepeatStreams = TRUE;
             PrintLatency = TRUE;
         } else if (IsValue(ScenarioStr, "rps")) {
             Upload = 512;
             Download = 4000;
             StreamCount = 100;
-            RunTime = S_TO_US(20); // 20 seconds
+            RunTime = S_TO_US(5); // 5 seconds
             RepeatStreams = TRUE;
             PrintLatency = TRUE;
         } else if (IsValue(ScenarioStr, "latency")) {
             Upload = 512;
             Download = 4000;
-            RunTime = S_TO_US(20); // 20 seconds
+            RunTime = S_TO_US(5); // 5 seconds
             RepeatStreams = TRUE;
             PrintLatency = TRUE;
         } else {


### PR DESCRIPTION
## Description

Recently we've been seeing azure runners in iocp "crashing" (losing connection to the Github Backend).

One possible cause is that we are starving the CPU and that fails some heartbeat check on Github's side.

Let's try reducing this constraint.
## Testing

CI

## Documentation

N/A