### PR TITLE
Add publishing support for fedora 41

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -27,7 +27,7 @@ parameters:
     type: object
     default:
     - name: RPM
-      destinations:
+      destination:
         - microsoft-sles12-prod-yum     # 12 3.12
         - microsoft-sles15-prod-yum     # 15 4.12
         - microsoft-centos7-prod-yum    # 7 3.10
@@ -41,7 +41,7 @@ parameters:
         - microsoft-rhel8.0-prod-yum    # 8.0 4.18
         - microsoft-rhel8.1-prod-yum    # 8.1 4.18
     - name: DEB
-      destinations:
+      destination:
         - microsoft-ubuntu-xenial-prod-apt   # 16.04 4.4
         - microsoft-ubuntu-bionic-prod-apt   # 18.04 4.15
         - microsoft-ubuntu-focal-prod-apt    # 20.04 5.4
@@ -51,7 +51,7 @@ parameters:
         - microsoft-debian-buster-prod-apt   # 10 4.19
         - microsoft-debian-bullseye-prod-apt # 11 5.10
     - name: CBL
-      destinations:
+      destination:
         - cbl-mariner-1.0-prod-Microsoft-x86_64-rpms-yum
         - cbl-mariner-2.0-prod-Microsoft-x86_64-yum
         - cbl-mariner-2.0-prod-Microsoft-aarch64-yum
@@ -60,14 +60,14 @@ parameters:
     type: object
     default:
     - name: RPM
-      destinations:
+      destination:
         - microsoft-fedora36-prod-yum   # 36 5.17
         - microsoft-fedora37-prod-yum   # 37 6.0
         - microsoft-fedora38-prod-yum   # 38 6.2
         - microsoft-fedora39-prod-yum   # 39 6.5
         - microsoft-rhel9.0-prod-yum    # 9.0 5.14
     - name: DEB
-      destinations:
+      destination:
         - microsoft-ubuntu-jammy-prod-apt    # 22.04 5.15
         - microsoft-ubuntu-kinetic-prod-apt  # 22.10 5.19
         - microsoft-ubuntu-lunar-prod-apt    # 23.04 6.2
@@ -78,13 +78,14 @@ parameters:
     type: object
     default:
     - name: RPM
-      destionations:
+      destionation:
         - microsoft-fedora40-prod-yum           # 40 6.8
+        - microsoft-fedora41-prod-yum           # 41 6.11
     - name: DEB
-      destinations:
+      destination:
         - microsoft-ubuntu-noble-prod-apt       # 24.04 6.8
     - name: CBL
-      destinations:
+      destination:
         - azurelinux-3.0-prod-ms-oss-x86_64-yum  # 3.0 6.6
         - azurelinux-3.0-prod-ms-oss-aarch64-yum # 3.0 6.6
 


### PR DESCRIPTION
## Description

Modify the `OneBranch.publish` file to include fedora 41

References issue #4682 

## Testing

I can't invoke your publish process, which is what this changed, so I can't really test it.

## Documentation

Not that I can find.