### PR TITLE
Publish packages for Fedora 41

### DIFF
--- a/.azure/OneBranch.Publish.yml
+++ b/.azure/OneBranch.Publish.yml
@@ -78,8 +78,9 @@ parameters:
     type: object
     default:
     - name: RPM
-      destionations:
+      destinations:
         - microsoft-fedora40-prod-yum           # 40 6.8
+        - microsoft-fedora41-prod-yum           # 41 6.11
     - name: DEB
       destinations:
         - microsoft-ubuntu-noble-prod-apt       # 24.04 6.8


### PR DESCRIPTION
Modifications to .azure/OneBranch.publish to instruct things to publish fedora 41.

See #4682 for details

This is a replacement for a PR I deleted due to a lot of miscommunication and a lot of incorrect work.