### PR TITLE
Fix OneBranch Build of msquictest

### DIFF
--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -89,7 +89,11 @@ public:
             ASSERT_TRUE(DriverService.Start());
             ASSERT_TRUE(DriverClient.Initialize(&CertParams, DriverName));
 
-            Config.Flags |= UseDuoNic ? QUIC_EXECUTION_CONFIG_FLAG_XDP : QUIC_EXECUTION_CONFIG_FLAG_NONE;
+#if defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+            if (UseDuoNic) {
+                Config.Flags |= QUIC_EXECUTION_CONFIG_FLAG_XDP;
+            }
+#endif
             QUIC_TEST_CONFIGURATION_PARAMS Params {
                 UseDuoNic,
                 Config,


### PR DESCRIPTION
## Description

Fixes the following OneBranch build error of Windows user mode:
```
C:\__w\1\s\src\test\bin\quic_gtest.cpp(92,41): error C2065: 'QUIC_EXECUTION_CONFIG_FLAG_XDP': undeclared identifier [C:\__w\1\s\build\windows\x64_schannel\src\test\bin\msquictest.vcxproj]
```
This happens because internally we don't build test code with preview features enabled.

## Testing

Need to run through the CI.

## Documentation

N/A
