### PR TITLE
Restrict MaxOperationsPerDrain to Greater Than Zero

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -431,6 +431,9 @@ QuicSettingApply(
         Destination->IsSet.DatagramReceiveEnabled = TRUE;
     }
     if (Source->IsSet.MaxOperationsPerDrain && (!Destination->IsSet.MaxOperationsPerDrain || OverWrite)) {
+        if (Source->MaxOperationsPerDrain == 0) {
+            return FALSE;
+        }
         Destination->MaxOperationsPerDrain = Source->MaxOperationsPerDrain;
         Destination->IsSet.MaxOperationsPerDrain = TRUE;
     }
@@ -795,7 +798,7 @@ QuicSettingsLoad(
             QUIC_SETTING_MAX_OPERATIONS_PER_DRAIN,
             (uint8_t*)&Value,
             &ValueLen);
-        if (Value <= UINT8_MAX) {
+        if (Value > 0 && Value <= UINT8_MAX) {
             Settings->MaxOperationsPerDrain = (uint8_t)Value;
         }
     }

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2090,6 +2090,32 @@ void SettingApplyTests(HQUIC Handle, uint32_t Param, bool AllowMtuEcnChanges = t
                 sizeof(QUIC_SETTINGS),
                 &Settings));
     }
+
+    //
+    // MaxOperationsPerDrain
+    //
+    {
+        QUIC_SETTINGS Settings{0};
+        Settings.IsSet.MaxOperationsPerDrain = TRUE;
+
+        Settings.MaxOperationsPerDrain = 0; // Not allowed
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_INVALID_PARAMETER,
+            MsQuic->SetParam(
+                Handle,
+                Param,
+                sizeof(QUIC_SETTINGS),
+                &Settings));
+
+        Settings.MaxOperationsPerDrain = 255; // Max allowed
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_SUCCESS,
+            MsQuic->SetParam(
+                Handle,
+                Param,
+                sizeof(QUIC_SETTINGS),
+                &Settings));
+    }
 }
 
 void QuicTestStatefulGlobalSetParam()


### PR DESCRIPTION
## Description

Fixes #4705 by disallowing the app to set a value of zero.

## Testing

Added

## Documentation

N/A