### PR TITLE
Add conversion method for Addr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,4 @@ bitfield = "0.17.0"
 libc = "0.2.0"
 c-types = "4.0.0"
 serde = { version = "1.0.117", features = ["derive"] }
+socket2 = "0.5.8"


### PR DESCRIPTION
## Description
This pull request includes significant changes to the `src/lib.rs` file and updates to the `Cargo.toml` file to improve the handling of socket addresses and address families. The most important changes include the addition of new dependencies, the removal of redundant structures, and the introduction of new methods for address conversion and retrieval.

### Dependency Updates:
* Added `socket2` crate to `Cargo.toml` for enhanced socket address handling.

### Code Refactoring and Improvements:
* Replaced our own `sockaddr_in` and `sockaddr_in6` structures with `c_types::sockaddr_in` and `c_types::sockaddr_in6` .
* Added methods to the `Addr` union for converting to and from `std::net::SocketAddr`, and for retrieving port numbers.
* Implemented `get_local_addr` and `get_remote_addr` methods in the `Connection` struct to retrieve local and remote addresses.

### Event Handling Enhancements:
* Updated the `test_conn_callback` function to print local and remote addresses upon connection.

## Testing

cargo test

## Documentation

TBD