### PR TITLE
fix(epoll): buffer overflow when GSO off

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2154,7 +2154,8 @@ CxPlatSendDataFinalizeSendBuffer(
         struct iovec* IoVec = &SendData->Iovs[SendData->BufferCount - 1];
         IoVec->iov_base = SendData->ClientBuffer.Buffer;
         IoVec->iov_len = SendData->ClientBuffer.Length;
-        if (SendData->TotalSize + SendData->SegmentSize > sizeof(SendData->Buffer) ||
+        if (SendData->SegmentSize == 0 ||
+            SendData->TotalSize + SendData->SegmentSize > sizeof(SendData->Buffer) ||
             SendData->BufferCount == SendData->SocketContext->DatapathPartition->Datapath->SendIoVecCount) {
             SendData->ClientBuffer.Buffer = NULL;
         } else {


### PR DESCRIPTION
## Description

Fix buffer overflow that SendData buffer size could not be checked correctly in `CxPlatSendDataFinalizeSendBuffer` when `SendData->SegmentSize` is 0.

This issue was found in a env where GSO is off, mtu size 1400 and sending large payload (size: 780038)  + Linux epoll.
It is hard to reproduce in other env. 

this is a quick fix and hurt performance,  I think for long term the `CxPlatSendDataFinalizeSendBuffer` should be aware of the allocating buffer size. 

## Testing
_

## Documentation

_