### PR TITLE
Export msquic include install dir

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 if(BUILD_SHARED_LIBS)
     add_library(msquic SHARED ${SOURCES})
+    target_include_directories(msquic PUBLIC $<INSTALL_INTERFACE:include>)
     target_link_libraries(msquic PRIVATE core msquic_platform inc warnings logging base_link main_binary_link_args)
     set_target_properties(msquic PROPERTIES OUTPUT_NAME ${QUIC_LIBRARY_NAME})
     if (NOT WIN32)


### PR DESCRIPTION
## Description

This PR ensures that the exported CMake target carries the include directories property which is necessary for accessing the installed headers.
The location corresponds to the destination in 
https://github.com/microsoft/msquic/blob/10f248775a5e32f1c0935ab794c0fb4c3e2f9c18/src/bin/CMakeLists.txt#L270

## Testing

This is backported from the vcpkg port of msquic. In vcpkg, the exported config is consumed by port msh3.

## Documentation

No impact AFAICT. CMake usage is not covered at all.

FTR vcpkg's (tested) usage notice is:
~~~
msquic provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(msquic CONFIG REQUIRED)
  target_link_libraries(main PRIVATE msquic::msquic)
~~~
which is pretty much what is expected for Modern CMake. (But the vcpkg port comes with more patches.)