### PR TITLE
CMake: Force openssl QUIC_TLS on non-Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ enable_testing()
 if (WIN32)
     set(QUIC_TLS "schannel" CACHE STRING "TLS Library to use")
 else()
-    set(QUIC_TLS "openssl" CACHE STRING "TLS Library to use")
+    set(QUIC_TLS "openssl" CACHE INTERNAL "TLS Library to use")
 endif()
 
 option(QUIC_BUILD_TOOLS "Builds the tools code" OFF)


### PR DESCRIPTION
## Description

On Windows, `QUIC_TLS` can be "schannel" or "openssl". For non-Windows targets, `openssl` is the only valid value. By marking the cache variable as `INTERNAL`, this value is [enforced](https://cmake.org/cmake/help/v3.20/command/set.html#set-cache-entry) (regardless of user input), and a false impression of choice is avoided.

## Testing

No change.

## Documentation

No change.  
Related: https://github.com/microsoft/msquic/blob/main/docs/Platforms.md.
