### PR TITLE
Simplify cmake config chainloading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,6 @@ elseif (UNIX)
 endif()
 message(STATUS "QUIC Platform: ${CX_PLATFORM}")
 
-set(FILENAME_DEP_REPLACE "get_filename_component(SELF_DIR \"$\{CMAKE_CURRENT_LIST_FILE\}\" PATH)")
-set(SELF_DIR "$\{SELF_DIR\}")
-
 enable_testing()
 
 # Set the default TLS method for each platform.

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -269,7 +269,7 @@ else()
 endif()
 install(FILES ${PUBLIC_HEADERS} DESTINATION include)
 
-configure_file(msquic-config.cmake.in ${CMAKE_BINARY_DIR}/msquic-config.cmake)
+configure_file(msquic-config.cmake.in ${CMAKE_BINARY_DIR}/msquic-config.cmake @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/msquic-config.cmake DESTINATION share/msquic)
 

--- a/src/bin/msquic-config-unix.cmake.in
+++ b/src/bin/msquic-config-unix.cmake.in
@@ -1,5 +1,0 @@
-include(CMakeFindDependencyMacro)
-@FILENAME_DEP_REPLACE@
-
-include(${SELF_DIR}/msquic.cmake)
-include(${SELF_DIR}/msquictraceprovider.cmake)

--- a/src/bin/msquic-config.cmake.in
+++ b/src/bin/msquic-config.cmake.in
@@ -1,7 +1,6 @@
 include(CMakeFindDependencyMacro)
-@FILENAME_DEP_REPLACE@
 
-include(${SELF_DIR}/msquic.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/msquic.cmake")
 
 foreach(_t IN ITEMS msquic msquic_platform)
     if(TARGET msquic::${_t} AND NOT TARGET ${_t})


### PR DESCRIPTION
## Description

Removes an ununsed config template.
Adopts the common configuration template pattern of only substituting `@VAR@` references, allowing to use a literal `${CMAKE_CURRENT_LIST_DIR}` expression for evaluation when the condig is used.

## Testing

Covered by `find_package(msquic REQUIRED)` in `src/platform/unittest/external/CMakeLists.txt`.

## Documentation

No change.
