### PR TITLE
Refactor lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1262,26 +1262,36 @@ pub struct Api {
 pub struct Registration {
     handle: Handle,
 }
+unsafe impl Sync for Registration {}
+unsafe impl Send for Registration {}
 
 /// Specifies how to configure a connection.
 pub struct Configuration {
     handle: Handle,
 }
+unsafe impl Sync for Configuration {}
+unsafe impl Send for Configuration {}
 
 /// A single QUIC connection.
 pub struct Connection {
     handle: Handle,
 }
+unsafe impl Sync for Connection {}
+unsafe impl Send for Connection {}
 
 /// A single server listener
 pub struct Listener {
     handle: Handle,
 }
+unsafe impl Sync for Listener {}
+unsafe impl Send for Listener {}
 
 /// A single QUIC stream on a parent connection.
 pub struct Stream {
     handle: Handle,
 }
+unsafe impl Sync for Stream {}
+unsafe impl Send for Stream {}
 
 impl From<&str> for Buffer {
     fn from(data: &str) -> Buffer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1771,7 +1771,6 @@ impl Listener {
         if Status::failed(status) {
             return Err(status);
         }
-
         Ok(())
     }
 
@@ -1789,7 +1788,6 @@ impl Listener {
         if Status::failed(status) {
             return Err(status);
         }
-
         Ok(())
     }
 
@@ -1813,7 +1811,6 @@ impl Listener {
         if Status::failed(status) {
             return Err(status);
         }
-
         Ok(unsafe { *(addr_buffer.as_ptr() as *const c_void as *const Addr) })
     }
 
@@ -1871,6 +1868,14 @@ impl Stream {
         Ok(())
     }
 
+    pub fn shutdown(&self, flags: StreamShutdownFlags, error_code: u62) -> Result<(), u32> {
+        let status = unsafe { ((*APITABLE).stream_shutdown)(self.handle, flags, error_code) };
+        if Status::failed(status) {
+            return Err(status);
+        }
+        Ok(())
+    }
+
     pub fn close(&self) {
         unsafe {
             ((*APITABLE).stream_close)(self.handle);
@@ -1903,6 +1908,27 @@ impl Stream {
         unsafe {
             ((*APITABLE).set_callback_handler)(self.handle, handler as *const c_void, context)
         };
+    }
+
+    pub fn get_param(
+        &self,
+        param: u32,
+        buffer_length: *mut u32,
+        buffer: *const c_void,
+    ) -> Result<(), u32> {
+        let status = unsafe { ((*APITABLE).get_param)(self.handle, param, buffer_length, buffer) };
+        if Status::failed(status) {
+            return Err(status);
+        }
+        Ok(())
+    }
+
+    pub fn receive_complete(&self, buffer_length: u64) -> Result<(), u32> {
+        let status = unsafe { ((*APITABLE).stream_receive_complete)(self.handle, buffer_length) };
+        if Status::failed(status) {
+            return Err(status);
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description
This pull request includes several changes to the `src/lib.rs` file, focusing on enhancing the `Listener` and `Stream` structs, as well as ensuring thread safety for multiple structs. The most important changes include implementing `Sync` and `Send` traits for various structs, adding new methods to the `Listener` and `Stream` structs, and modifying existing methods for better functionality.

Thread safety improvements:
* Implemented `Sync` and `Send` traits for `Registration`, `Configuration`, `Connection`, `Listener`, and `Stream` structs to ensure they can be safely shared across threads.

Enhancements to `Listener` struct:
* Added a `Default` implementation for the `Listener` struct to provide a default instance.
* Separated the `new` method of the `Listener` struct into `new` and `open` to allow us to pass itself as callback's context.
* Added new methods `stop` and `get_local_addr` to the `Listener` struct to provide additional functionalities for stopping the listener and retrieving the local address.

Enhancements to `Stream` struct:
* Added a `shutdown` method to the `Stream` struct to allow shutting down the stream with specific flags and error codes.
* Added new methods `get_param` and `receive_complete` to the `Stream` struct to retrieve parameters and mark the completion of data reception.

## Testing

NA

## Documentation

TBD