### PR TITLE
Fix Path Classifiers in CodeQL YML

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -2,13 +2,14 @@
 # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
 # (Access restricted to Microsoft employees only.)
 
-# The following paths are explicitly classified which indicates they should no
+# The following paths are explicitly classified which indicates they should not
 # be analyzed by CodeQL and generate alerts.
 path_classifiers:
   docs:
     - docs
   generated:
+    - build
     - src/cs
     - src/generated
   submodules:
-    - subodules
+    - submodules


### PR DESCRIPTION
## Description

Fixes up the CodeQL path classifiers to restrict which paths should be analyzed.

## Testing

This will have to be merged and go through the OneBranch build to be validated.

## Documentation

N/A
