### PR TITLE
Add schannel feature

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -17,7 +17,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-xlarge]
-        features: ["", "--features static"]
+        features: ["", "--features static", "--features schannel", "--features schannel,static"]
+        exclude:
+          - os: ubuntu-latest
+            features: "--features schannel"
+          - os: ubuntu-latest
+            features: "--features schannel,static"
+          - os: macos-latest
+            features: "--features schannel"
+          - os: macos-latest
+            features: "--features schannel,static"
+          - os: macos-latest-xlarge
+            features: "--features schannel"
+          - os: macos-latest-xlarge
+            features: "--features schannel,static"
     runs-on: ${{ matrix.os }}
     name: Cargo
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ include = [
 
 [features]
 default = []
+schannel = []
 static = []
 preview-api = []
 

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -21,8 +21,12 @@ fn main() {
     let mut config = Config::new(".");
     config
         .define("QUIC_ENABLE_LOGGING", logging_enabled)
-        .define("QUIC_TLS", "openssl")
         .define("QUIC_OUTPUT_DIR", quic_output_dir.to_str().unwrap());
+    if cfg!(feature = "schannel") {
+        config.define("QUIC_TLS", "schannel");
+    } else {
+        config.define("QUIC_TLS", "openssl");
+    }
     if cfg!(feature = "static") {
         config.define("QUIC_BUILD_SHARED", "off");
     }


### PR DESCRIPTION
## Description
This pull request introduces support for the `schannel` feature and updates the build configuration accordingly. The most important changes include modifying the GitHub Actions workflow, updating the `Cargo.toml` file, and adjusting the build script to conditionally define the TLS library.

### Support for `schannel` feature:

* [`.github/workflows/cargo.yml`](diffhunk://#diff-c405e4afd304c7295273c10a937f4a1e3d7853ff71b4066c487e1f3c8291b690L20-R33): Expanded the `features` matrix to include `--features schannel` and `--features schannel,static`, and excluded incompatible combinations for certain operating systems.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R49): Added a new feature named `schannel` to the features list.

### Build configuration adjustments:

* [`scripts/build.rs`](diffhunk://#diff-f40a4fef0c5d05259954fdb422c0f519d90ca9db0c9a5e071243676dd39ed49dL24-R29): Modified the build script to conditionally define the `QUIC_TLS` library based on the presence of the `schannel` feature, defaulting to `openssl` if not specified.
## Testing

- `cargo build --features schannel`
- `cargo build --features schannel,static`

## Documentation

TBD