### PR TITLE
Add OpenSSL 3 feature support to CI and configuration

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-xlarge]
-        features: ["", "--features static", "--features schannel", "--features schannel,static"]
+        features: ["", "--features static", "--features schannel", "--features schannel,static", "--features openssl3", "--features openssl3,static"]
         exclude:
           - os: ubuntu-latest
             features: "--features schannel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ include = [
 [features]
 default = []
 schannel = []
+openssl3 = []
 static = []
 preview-api = []
 

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -24,6 +24,8 @@ fn main() {
         .define("QUIC_OUTPUT_DIR", quic_output_dir.to_str().unwrap());
     if cfg!(feature = "schannel") {
         config.define("QUIC_TLS", "schannel");
+    } else if cfg!(feature = "openssl3") {
+        config.define("QUIC_TLS", "openssl3");
     } else {
         config.define("QUIC_TLS", "openssl");
     }


### PR DESCRIPTION
## Description
This pull request introduces support for the `openssl3` feature across multiple files. The most important changes include updates to the workflow configuration, the feature list in `Cargo.toml`, and the build script to accommodate the new feature.

Support for `openssl3` feature:

* [`.github/workflows/cargo.yml`](diffhunk://#diff-c405e4afd304c7295273c10a937f4a1e3d7853ff71b4066c487e1f3c8291b690L20-R20): Added `--features openssl3` and `--features openssl3,static` to the matrix of features.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R50): Added `openssl3` to the list of features.
* [`scripts/build.rs`](diffhunk://#diff-f40a4fef0c5d05259954fdb422c0f519d90ca9db0c9a5e071243676dd39ed49dR27-R28): Updated the build script to define `QUIC_TLS` as `openssl3` when the `openssl3` feature is enabled.

## Testing

- `cargo test --features openssl3`
- `cargo test --features openssl3,static`

## Documentation

TBD