### PR TITLE
Provide namespaced CMake targets

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 if(BUILD_SHARED_LIBS)
     add_library(msquic SHARED ${SOURCES})
+    add_library(msquic::msquic ALIAS msquic)
     target_include_directories(msquic PUBLIC $<INSTALL_INTERFACE:include>)
     target_link_libraries(msquic PRIVATE core msquic_platform inc warnings logging base_link main_binary_link_args)
     set_target_properties(msquic PROPERTIES OUTPUT_NAME ${QUIC_LIBRARY_NAME})

--- a/src/bin/msquic-config.cmake.in
+++ b/src/bin/msquic-config.cmake.in
@@ -2,8 +2,10 @@ include(CMakeFindDependencyMacro)
 
 include("${CMAKE_CURRENT_LIST_DIR}/msquic.cmake")
 
-foreach(_t IN ITEMS msquic msquic_platform)
-    if(TARGET msquic::${_t} AND NOT TARGET ${_t})
-        add_library(${_t} ALIAS msquic::${_t})
-    endif()
-endforeach()
+# Legacy names
+if(NOT TARGET msquic)
+    add_library(msquic ALIAS msquic::msquic)
+endif()
+if(NOT TARGET msquic_platform)
+    add_library(msquic_platform ALIAS msquic::platform)
+endif()

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_features(inc INTERFACE cxx_std_17)
 target_compile_features(inc INTERFACE c_std_11)
 
 add_library(base_link INTERFACE)
+add_library(msquic::base_link ALIAS base_link)
 
 if (HAS_GUARDCF)
     target_link_options(base_link INTERFACE /guard:cf /DYNAMICBASE)

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 endif()
 
 add_library(msquic_platform STATIC ${SOURCES})
+set_target_properties(msquic_platform PROPERTIES EXPORT_NAME platform)
 
 if("${CX_PLATFORM}" STREQUAL "windows")
     target_link_libraries(

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 endif()
 
 add_library(msquic_platform STATIC ${SOURCES})
+add_library(msquic::platform ALIAS msquic_platform)
 set_target_properties(msquic_platform PROPERTIES EXPORT_NAME platform)
 
 if("${CX_PLATFORM}" STREQUAL "windows")

--- a/src/platform/unittest/external/CMakeLists.txt
+++ b/src/platform/unittest/external/CMakeLists.txt
@@ -32,5 +32,5 @@ set_target_properties(msquic::inc PROPERTIES  INTERFACE_COMPILE_DEFINITIONS "${d
 
 add_executable(msquicplatformtest ${SOURCES})
 target_include_directories(msquicplatformtest PRIVATE ${CMAKE_INSTALL_PREFIX}/include)
-target_link_libraries(msquicplatformtest PRIVATE gtest msquic::msquic msquic::msquic_platform ws2_32 ntdll ncrypt crypt32 iphlpapi)
+target_link_libraries(msquicplatformtest PRIVATE gtest msquic::msquic msquic::platform ws2_32 ntdll ncrypt crypt32 iphlpapi)
 target_compile_definitions(msquicplatformtest PRIVATE QUIC_EVENTS_STUB QUIC_LOGS_STUB _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)


### PR DESCRIPTION
## Description

Projects (e.g. msh3) that use CMake targets from dependencies (here: msquic) should use namespaced target names from those dependencies. This enables CMake to recognize the intention to use a target, not a library name. CMake can report a missing target definition early (at generation time), instead of creating linker instruction which may fail at build time.

msquic already added namespace `msquic::` to the exported CMake config. However, this should be complemented with `msquic::` `ALIAS` targets inside the build, for reverse dependencies which integrate msquic via `add_subdirectory`. This PR adds the missing targets.

In addition the PR shortens the exported name of `msquic_platform` to `msquic::platform`.

The `msquic::base_link` alias is added for use in msh3. (This nicely illustrate how the namespace clarifies the origin of `base_link`.)

## Testing

Covered by src/platform/unittest/external/CMakeLists.txt.

~The msquic/msh3 integration with namespaced targets is tested in https://github.com/microsoft/vcpkg/pull/43018/files, with a DLL build of msquic passed to msh3 via CMake config.~(Blocked.)

## Documentation

No change due to lack of specific CMake usage documentation.
(vcpkg prints an generated hint which will need to be reduced to linking `msquic::msquic`.)
