### PR TITLE
[Expose TTL Follow up PR] move version logic to platform_xyz instead of datapath

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -190,8 +190,8 @@ typedef struct CXPLAT_SEND_DATA {
 
 typedef struct CXPLAT_RECV_MSG_CONTROL_BUFFER {
     char Data[CMSG_SPACE(sizeof(struct in6_pktinfo)) + // IP_PKTINFO
-              2 * CMSG_SPACE(sizeof(int)) // TOS
-              + CMSG_SPACE(sizeof(int))]; // IP_TTL
+              3 * CMSG_SPACE(sizeof(int))]; // TOS + IP_TTL
+
 } CXPLAT_RECV_MSG_CONTROL_BUFFER;
 
 #ifdef DEBUG
@@ -205,7 +205,7 @@ typedef struct CXPLAT_RECV_MSG_CONTROL_BUFFER {
 #else
 #define CXPLAT_DBG_ASSERT_CMSG(CMsg, type)
 #endif
-    
+
 CXPLAT_EVENT_COMPLETION CxPlatSocketContextUninitializeEventComplete;
 CXPLAT_EVENT_COMPLETION CxPlatSocketContextFlushTxEventComplete;
 CXPLAT_EVENT_COMPLETION CxPlatSocketContextIoEventComplete;
@@ -339,9 +339,6 @@ Error:
     }
 
     Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TCP;
-    //
-    // TTL should always be available / enabled on Linux.
-    //
     Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
 }
 
@@ -848,10 +845,6 @@ CxPlatSocketContextInitialize(
                 "setsockopt(IP_RECVTOS) failed");
             goto Exit;
         }
-
-        //
-        // TTL should always be available / enabled on Linux.
-        //
 
         //
         // On Linux, IP_HOPLIMIT does not exist. So we will use IP_RECVTTL, IPV6_RECVHOPLIMIT instead.
@@ -1895,9 +1888,6 @@ CxPlatSocketContextRecvComplete(
 
         CXPLAT_FRE_ASSERT(FoundLocalAddr);
         CXPLAT_FRE_ASSERT(FoundTOS);
-        //
-        // TTL should always be available/enabled on Linux.
-        //
         CXPLAT_FRE_ASSERT(FoundTTL);
 
         QuicTraceEvent(

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -376,7 +376,7 @@ typedef struct CXPLAT_DATAPATH {
     CXPLAT_DATAPATH_PARTITION Partitions[];
 
 } CXPLAT_DATAPATH;
-    
+
 CXPLAT_EVENT_COMPLETION CxPlatSocketContextUninitializeEventComplete;
 CXPLAT_EVENT_COMPLETION CxPlatSocketContextIoEventComplete;
 
@@ -567,9 +567,6 @@ CxPlatDataPathGetSupportedFeatures(
     _In_ CXPLAT_DATAPATH* Datapath
     )
 {
-    //
-    // Intentionally not enabling Feature_TTL on MacOS for now.
-    //
     return Datapath->Features;
 }
 

--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -150,9 +150,6 @@ RawDataPathGetSupportedFeatures(
     )
 {
     UNREFERENCED_PARAMETER(Datapath);
-    //
-    // TTL should always be available / enabled for XDP.
-    //
     return CXPLAT_DATAPATH_FEATURE_RAW | CXPLAT_DATAPATH_FEATURE_TTL;
 }
 

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -600,24 +600,9 @@ CxPlatDataPathQuerySockoptSupport(
 
     } while (FALSE);
 
-    do {
-        RTL_OSVERSIONINFOW osInfo;
-        RtlZeroMemory(&osInfo, sizeof(osInfo));
-        osInfo.dwOSVersionInfoSize = sizeof(osInfo);
-        NTSTATUS status = RtlGetVersion(&osInfo);
-        if (NT_SUCCESS(status)) {
-            DWORD BuildNumber = osInfo.dwBuildNumber;
-            //
-            // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
-            //
-            if (BuildNumber == 20348) {
-                break;
-            }
-        } else {
-            break;
-        }
+    if (CxPlatform.dwBuildNumber != 20348)
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
-    } while (FALSE);
+    }
 
 Error:
 

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -600,6 +600,9 @@ CxPlatDataPathQuerySockoptSupport(
 
     } while (FALSE);
 
+    //
+    // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
+    //
     if (CxPlatform.dwBuildNumber != 20348) {
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
     }

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -600,7 +600,7 @@ CxPlatDataPathQuerySockoptSupport(
 
     } while (FALSE);
 
-    if (CxPlatform.dwBuildNumber != 20348)
+    if (CxPlatform.dwBuildNumber != 20348) {
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
     }
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -700,6 +700,10 @@ CxPlatDataPathQuerySockoptSupport(
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_RECV_COALESCING;
     }
 }
+
+    //
+    // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
+    //
     if (CxPlatform.dwBuildNumber != 20348) {
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
     }
@@ -819,6 +823,9 @@ DataPathInitialize(
     // Check for port reservation support.
     //
 #ifndef QUIC_UWP_BUILD
+    //
+    // Only RS5 and newer can use the port reservation feature safely.
+    //
     if (CxPlatform.dwBuildNumber >= 17763) {
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_PORT_RESERVATIONS;
     }

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -294,7 +294,7 @@ void
 SocketDelete(
     _In_ CXPLAT_SOCKET* Socket
     );
-    
+
 CXPLAT_EVENT_COMPLETION CxPlatIoRecvEventComplete;
 CXPLAT_EVENT_COMPLETION CxPlatIoRecvFailureEventComplete;
 CXPLAT_EVENT_COMPLETION CxPlatIoSendEventComplete;
@@ -524,12 +524,6 @@ Error:
     }
 }
 
-//
-// To determine the OS version, we are going to use RtlGetVersion API
-// since GetVersion call can be shimmed on Win8.1+.
-//
-typedef LONG (WINAPI *FuncRtlGetVersion)(RTL_OSVERSIONINFOW *);
-
 QUIC_STATUS
 CxPlatDataPathQuerySockoptSupport(
     _Inout_ CXPLAT_DATAPATH* Datapath
@@ -706,27 +700,8 @@ CxPlatDataPathQuerySockoptSupport(
         Datapath->Features |= CXPLAT_DATAPATH_FEATURE_RECV_COALESCING;
     }
 }
-    //
-    // TODO: This "TTL_FEATURE check" code works, and mirrors the approach for Kernel mode.
-    //       However, it is considered a "hack" and we should determine whether or not
-    //       the current release story fits this current workaround.
-    //
-    HMODULE NtDllHandle = LoadLibraryA("ntdll.dll");
-    if (NtDllHandle) {
-        FuncRtlGetVersion VersionFunc = (FuncRtlGetVersion)GetProcAddress(NtDllHandle, "RtlGetVersion");
-        if (VersionFunc) {
-            RTL_OSVERSIONINFOW VersionInfo = {0};
-            VersionInfo.dwOSVersionInfoSize = sizeof(VersionInfo);
-            if ((*VersionFunc)(&VersionInfo) == 0) {
-                //
-                // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
-                //
-                if (VersionInfo.dwBuildNumber != 20348) {
-                    Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
-                }
-            }
-        }
-        FreeLibrary(NtDllHandle);
+    if (CxPlatform.dwBuildNumber != 20348) {
+        Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
     }
 
     Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TCP;
@@ -844,22 +819,8 @@ DataPathInitialize(
     // Check for port reservation support.
     //
 #ifndef QUIC_UWP_BUILD
-    HMODULE NtDllHandle = LoadLibraryA("ntdll.dll");
-    if (NtDllHandle) {
-        FuncRtlGetVersion VersionFunc = (FuncRtlGetVersion)GetProcAddress(NtDllHandle, "RtlGetVersion");
-        if (VersionFunc) {
-            RTL_OSVERSIONINFOW VersionInfo = {0};
-            VersionInfo.dwOSVersionInfoSize = sizeof(VersionInfo);
-            if ((*VersionFunc)(&VersionInfo) == 0) {
-                //
-                // Only RS5 and newer can use the port reservation feature safely.
-                //
-                if (VersionInfo.dwBuildNumber >= 17763) {
-                    Datapath->Features |= CXPLAT_DATAPATH_FEATURE_PORT_RESERVATIONS;
-                }
-            }
-        }
-        FreeLibrary(NtDllHandle);
+    if (CxPlatform.dwBuildNumber >= 17763) {
+        Datapath->Features |= CXPLAT_DATAPATH_FEATURE_PORT_RESERVATIONS;
     }
 #endif
 

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -138,6 +138,11 @@ typedef struct CX_PLATFORM {
     //
     BCRYPT_ALG_HANDLE RngAlgorithm;
 
+    //
+    // Current Windows build number
+    //
+    DWORD dwBuildNumber;
+
 #ifdef DEBUG
     //
     // 1/Denominator of allocations to fail.
@@ -304,6 +309,11 @@ typedef struct CX_PLATFORM {
     // Heap used for all allocations.
     //
     HANDLE Heap;
+
+    //
+    // Current Windows build number
+    //
+    DWORD dwBuildNumber;
 
 #ifdef DEBUG
     //
@@ -747,7 +757,7 @@ CxPlatCryptUninitialize(
 
 //
 // Platform Worker APIs
-// 
+//
 
 BOOLEAN
 CxPlatWorkerPoolLazyStart(

--- a/src/platform/platform_winkernel.c
+++ b/src/platform/platform_winkernel.c
@@ -128,7 +128,7 @@ CxPlatInitialize(
         DWORD BuildNumber = osInfo.dwBuildNumber;
         CxPlatform.dwBuildNumber = BuildNumber;
     } else {
-        CXPLAT_DBG_ASSERT(FALSE); // TODO: Is the assert here enough or is there an appropritae QUIC_STATUS we return?
+        CXPLAT_DBG_ASSERT(FALSE); // TODO: Is the assert here enough or is there an appropriate QUIC_STATUS we return?
     }
 
     QUIC_STATUS Status =

--- a/src/platform/platform_winkernel.c
+++ b/src/platform/platform_winkernel.c
@@ -120,6 +120,17 @@ CxPlatInitialize(
     CxPlatProcessorCount =
         (uint32_t)KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
 
+    RTL_OSVERSIONINFOW osInfo;
+    RtlZeroMemory(&osInfo, sizeof(osInfo));
+    osInfo.dwOSVersionInfoSize = sizeof(osInfo);
+    NTSTATUS status = RtlGetVersion(&osInfo);
+    if (NT_SUCCESS(status)) {
+        DWORD BuildNumber = osInfo.dwBuildNumber;
+        CxPlatform.dwBuildNumber = BuildNumber;
+    } else {
+        CXPLAT_DBG_ASSERT(FALSE); // TODO: Is the assert here enough or is there an appropritae QUIC_STATUS we return?
+    }
+
     QUIC_STATUS Status =
         BCryptOpenAlgorithmProvider(
             &CxPlatform.RngAlgorithm,

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -30,6 +30,12 @@ TIMECAPS CxPlatTimerCapabilities;
 #endif // TIMERR_NOERROR
 QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
+//
+// To determine the OS version, we are going to use RtlGetVersion API
+// since GetVersion call can be shimmed on Win8.1+.
+//
+typedef LONG (WINAPI *FuncRtlGetVersion)(RTL_OSVERSIONINFOW *);
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 CxPlatSystemLoad(
@@ -241,6 +247,22 @@ CxPlatInitialize(
         Status = QUIC_STATUS_OUT_OF_MEMORY;
         goto Error;
     }
+
+    BOOLEAN SuccessfullySetVersion = FALSE;
+    HMODULE NtDllHandle = LoadLibraryA("ntdll.dll");
+    if (NtDllHandle) {
+        FuncRtlGetVersion VersionFunc = (FuncRtlGetVersion)GetProcAddress(NtDllHandle, "RtlGetVersion");
+        if (VersionFunc) {
+            RTL_OSVERSIONINFOW VersionInfo = {0};
+            VersionInfo.dwOSVersionInfoSize = sizeof(VersionInfo);
+            if ((*VersionFunc)(&VersionInfo) == 0) {
+                CxPlatform.dwBuildNumber = VersionInfo.dwBuildNumber;
+                SuccessfullySetVersion = TRUE;
+            }
+        }
+        FreeLibrary(NtDllHandle);
+    }
+    CXPLAT_DBG_ASSERT(SuccessfullySetVersion); // TODO: Is the assert here enough or is there an appropritae QUIC_STATUS we return?
 
     if (QUIC_FAILED(Status = CxPlatProcessorInfoInit())) {
         QuicTraceEvent(

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -262,7 +262,7 @@ CxPlatInitialize(
         }
         FreeLibrary(NtDllHandle);
     }
-    CXPLAT_DBG_ASSERT(SuccessfullySetVersion); // TODO: Is the assert here enough or is there an appropritae QUIC_STATUS we return?
+    CXPLAT_DBG_ASSERT(SuccessfullySetVersion); // TODO: Is the assert here enough or is there an appropriate QUIC_STATUS we return?
 
     if (QUIC_FAILED(Status = CxPlatProcessorInfoInit())) {
         QuicTraceEvent(


### PR DESCRIPTION
## Description

There was some additional feedback from https://github.com/microsoft/msquic/pull/4602

The biggest one being that we have the version fetching logic in a bunch of different places, let's instead standardize it in the CX_PLATFORM global object so subroutines can just reference it.

## Testing

CI

## Documentation

No.
