### PR TITLE
Rust: Migrate to use ffi QUIC_API_TABLE

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -18,3 +18,9 @@ include!("linux_bindings.rs");
 pub type ADDRESS_FAMILY = u16;
 #[cfg(target_os = "windows")]
 include!("win_bindings.rs");
+
+/// Temp type for casting manual ffi flags. To be removed eventually.
+#[cfg(not(target_os = "windows"))]
+pub type QuicFlag = u32;
+#[cfg(target_os = "windows")]
+pub type QuicFlag = i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1532,7 +1532,7 @@ impl Connection {
         }
     }
 
-    pub fn get_stats(&self) -> QuicStatistics {
+    pub fn get_stats(&self) -> Result<QuicStatistics, Error> {
         let mut stat_buffer: [u8; std::mem::size_of::<QuicStatistics>()] =
             [0; std::mem::size_of::<QuicStatistics>()];
         let stat_size_mut = std::mem::size_of::<QuicStatistics>();
@@ -1543,12 +1543,11 @@ impl Connection {
                 (&stat_size_mut) as *const usize as *const u32 as *mut u32,
                 stat_buffer.as_mut_ptr() as *mut c_void,
             )
-        }
-        .expect("fail to get stats");
-        unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatistics) }
+        }?;
+        Ok(unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatistics) })
     }
 
-    pub fn get_stats_v2(&self) -> QuicStatisticsV2 {
+    pub fn get_stats_v2(&self) -> Result<QuicStatisticsV2, Error> {
         let mut stat_buffer: [u8; std::mem::size_of::<QuicStatisticsV2>()] =
             [0; std::mem::size_of::<QuicStatisticsV2>()];
         let stat_size_mut = std::mem::size_of::<QuicStatisticsV2>();
@@ -1559,10 +1558,8 @@ impl Connection {
                 (&stat_size_mut) as *const usize as *const u32 as *mut u32,
                 stat_buffer.as_mut_ptr() as *mut c_void,
             )
-        }
-        .expect("fail to get stats v2");
-
-        unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatisticsV2) }
+        }?;
+        Ok(unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatisticsV2) })
     }
 
     pub fn set_configuration(&self, configuration: &Configuration) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1524,7 +1524,11 @@ impl Connection {
 
     pub fn shutdown(&self, flags: ConnectionShutdownFlags, error_code: u62) {
         unsafe {
-            Api::ffi_ref().ConnectionShutdown.unwrap()(self.handle, flags as i32, error_code);
+            Api::ffi_ref().ConnectionShutdown.unwrap()(
+                self.handle,
+                flags as crate::ffi::QuicFlag,
+                error_code,
+            );
         }
     }
 
@@ -1610,7 +1614,7 @@ impl Connection {
                 self.handle,
                 buffer as *const Buffer as *const QUIC_BUFFER,
                 buffer_count,
-                flags as i32,
+                flags as crate::ffi::QuicFlag,
                 client_send_context as *mut c_void,
             )
         };
@@ -1634,7 +1638,7 @@ impl Connection {
         let status = unsafe {
             Api::ffi_ref()
                 .ConnectionCertificateValidationComplete
-                .unwrap()(self.handle, result, tls_alert as i32)
+                .unwrap()(self.handle, result, tls_alert as crate::ffi::QuicFlag)
         };
         Error::ok_from_raw(status)
     }
@@ -1771,7 +1775,7 @@ impl Stream {
         let status = unsafe {
             Api::ffi_ref().StreamOpen.unwrap()(
                 connection.handle,
-                flags as i32,
+                flags as crate::ffi::QuicFlag,
                 Some(std::mem::transmute(handler)),
                 context as *mut c_void,
                 std::ptr::addr_of_mut!(self.handle),
@@ -1781,13 +1785,19 @@ impl Stream {
     }
 
     pub fn start(&self, flags: StreamStartFlags) -> Result<(), Error> {
-        let status = unsafe { Api::ffi_ref().StreamStart.unwrap()(self.handle, flags as i32) };
+        let status = unsafe {
+            Api::ffi_ref().StreamStart.unwrap()(self.handle, flags as crate::ffi::QuicFlag)
+        };
         Error::ok_from_raw(status)
     }
 
     pub fn shutdown(&self, flags: StreamShutdownFlags, error_code: u62) -> Result<(), Error> {
         let status = unsafe {
-            Api::ffi_ref().StreamShutdown.unwrap()(self.handle, flags as i32, error_code)
+            Api::ffi_ref().StreamShutdown.unwrap()(
+                self.handle,
+                flags as crate::ffi::QuicFlag,
+                error_code,
+            )
         };
         Error::ok_from_raw(status)
     }
@@ -1812,7 +1822,7 @@ impl Stream {
                 self.handle,
                 buffer as *const Buffer as *const QUIC_BUFFER,
                 buffer_count,
-                flags as i32,
+                flags as crate::ffi::QuicFlag,
                 client_send_context as *mut c_void, //(self as *const Stream) as *const c_void,
             )
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@ use c_types::AF_INET6;
 #[allow(unused_imports)]
 use c_types::AF_UNSPEC;
 use c_types::{sa_family_t, sockaddr_in, sockaddr_in6, socklen_t};
+use ffi::{HQUIC, QUIC_API_TABLE, QUIC_BUFFER, QUIC_CREDENTIAL_CONFIG, QUIC_ERROR, QUIC_SETTINGS};
 use libc::c_void;
 use serde::{Deserialize, Serialize};
 use socket2::SockAddr;
 use std::convert::TryInto;
 use std::fmt;
 use std::io;
-use std::marker::PhantomData;
 use std::mem;
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::option::Option;
@@ -30,9 +30,6 @@ pub use error::{Error, ErrorCode};
 //
 // The following starts the C interop layer of MsQuic API.
 //
-
-/// Opaque handle to a MsQuic object.
-pub type Handle = *const libc::c_void;
 
 /// Unsigned 62-bit integer.
 #[allow(non_camel_case_types)]
@@ -273,7 +270,7 @@ pub struct RegistrationConfig {
 
 /// Completion callback for a async creation of a new credential.
 pub type CredentialLoadComplete =
-    extern "C" fn(configuration: Handle, context: *const c_void, status: u64);
+    extern "C" fn(configuration: HQUIC, context: *const c_void, status: u64);
 
 /// The 20-byte hash/thumbprint of a certificate.
 #[repr(C)]
@@ -773,7 +770,7 @@ pub const LISTENER_EVENT_STOP_COMPLETE: ListenerEventType = 1;
 #[derive(Debug, Copy, Clone)]
 pub struct ListenerEventNewConnection {
     pub info: *const NewConnectionInfo,
-    pub connection: Handle,
+    pub connection: HQUIC,
 }
 
 bitfield! {
@@ -804,9 +801,6 @@ pub struct ListenerEvent {
     pub event_type: ListenerEventType,
     pub payload: ListenerEventPayload,
 }
-
-pub type ListenerEventHandler =
-    extern "C" fn(listener: Handle, context: *mut c_void, event: &ListenerEvent) -> u32;
 
 pub type ConnectionEventType = u32;
 pub const CONNECTION_EVENT_CONNECTED: ConnectionEventType = 0;
@@ -879,7 +873,7 @@ pub struct ConnectionEventPeerAddressChanged {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ConnectionEventPeerStreamStarted {
-    pub stream: Handle,
+    pub stream: HQUIC,
     pub flags: StreamOpenFlags,
 }
 
@@ -974,9 +968,6 @@ pub struct ConnectionEvent {
     pub event_type: ConnectionEventType,
     pub payload: ConnectionEventPayload,
 }
-
-pub type ConnectionEventHandler =
-    extern "C" fn(connection: Handle, context: *mut c_void, event: &ConnectionEvent) -> u32;
 
 pub type StreamEventType = u32;
 pub const STREAM_EVENT_START_COMPLETE: StreamEventType = 0;
@@ -1096,112 +1087,12 @@ pub struct StreamEvent {
 }
 
 pub type StreamEventHandler =
-    extern "C" fn(stream: Handle, context: *mut c_void, event: &StreamEvent) -> u32;
-
-#[repr(C)]
-struct ApiTable {
-    set_context: extern "C" fn(handle: Handle, context: *const c_void),
-    get_context: extern "C" fn(handle: Handle) -> *mut c_void,
-    set_callback_handler:
-        extern "C" fn(handle: Handle, handler: *const c_void, context: *const c_void),
-    set_param:
-        extern "C" fn(handle: Handle, param: u32, buffer_length: u32, buffer: *const c_void) -> u32,
-    get_param: extern "C" fn(
-        handle: Handle,
-        param: u32,
-        buffer_length: *mut u32,
-        buffer: *const c_void,
-    ) -> u32,
-    registration_open:
-        extern "C" fn(config: *const RegistrationConfig, registration: &Handle) -> u32,
-    registration_close: extern "C" fn(registration: Handle),
-    registration_shutdown: extern "C" fn(registration: Handle),
-    configuration_open: extern "C" fn(
-        registration: Handle,
-        alpn_buffers: *const Buffer,
-        alpn_buffer_cout: u32,
-        settings: *const Settings,
-        settings_size: u32,
-        context: *const c_void,
-        configuration: &*const c_void,
-    ) -> u32,
-    configuration_close: extern "C" fn(configuration: Handle),
-    configuration_load_credential:
-        extern "C" fn(configuration: Handle, cred_config: *const CredentialConfig) -> u32,
-    listener_open: extern "C" fn(
-        registration: Handle,
-        handler: ListenerEventHandler,
-        context: *const c_void,
-        listener: &Handle,
-    ) -> u32,
-    listener_close: extern "C" fn(listener: Handle),
-    listener_start: extern "C" fn(
-        listener: Handle,
-        alpn_buffers: *const Buffer,
-        alpn_buffer_cout: u32,
-        local_address: *const Addr,
-    ) -> u32,
-    listener_stop: extern "C" fn(listener: Handle),
-    connection_open: extern "C" fn(
-        registration: Handle,
-        handler: ConnectionEventHandler,
-        context: *const c_void,
-        connection: &Handle,
-    ) -> u32,
-    connection_close: extern "C" fn(connection: Handle),
-    connection_shutdown:
-        extern "C" fn(connection: Handle, flags: ConnectionShutdownFlags, error_code: u62),
-    connection_start: extern "C" fn(
-        connection: Handle,
-        configuration: Handle,
-        family: AddressFamily,
-        server_name: *const i8,
-        server_port: u16,
-    ) -> u32,
-    connection_set_configuration: extern "C" fn(connection: Handle, configuration: Handle) -> u32,
-    connection_send_resumption_ticket: extern "C" fn(
-        connection: Handle,
-        flags: SendResumptionFlags,
-        data_length: u16,
-        resumption_data: *const u8,
-    ) -> u32,
-    stream_open: extern "C" fn(
-        connection: Handle,
-        flags: StreamOpenFlags,
-        handler: StreamEventHandler,
-        context: *const c_void,
-        stream: &Handle,
-    ) -> u32,
-    stream_close: extern "C" fn(stream: Handle),
-    stream_start: extern "C" fn(stream: Handle, flags: StreamStartFlags) -> u32,
-    stream_shutdown:
-        extern "C" fn(stream: Handle, flags: StreamShutdownFlags, error_code: u62) -> u32,
-    stream_send: extern "C" fn(
-        stream: Handle,
-        buffers: *const Buffer,
-        buffer_count: u32,
-        flags: SendFlags,
-        client_send_context: *const c_void,
-    ) -> u32,
-    stream_receive_complete: extern "C" fn(stream: Handle, buffer_length: u64) -> u32,
-    stream_receive_set_enabled: extern "C" fn(stream: Handle, is_enabled: BOOLEAN) -> u32,
-    datagram_send: extern "C" fn(
-        connection: Handle,
-        buffers: *const Buffer,
-        buffer_count: u32,
-        flags: SendFlags,
-        client_send_context: *const c_void,
-    ) -> u32,
-    resumption_ticket_validation_complete:
-        extern "C" fn(connection: Handle, result: BOOLEAN) -> u32,
-    certificate_validation_complete:
-        extern "C" fn(connection: Handle, result: BOOLEAN, tls_alert: TlsAlertCode) -> u32,
-}
+    extern "C" fn(stream: HQUIC, context: *mut c_void, event: &StreamEvent) -> u32;
 
 #[link(name = "msquic")]
-extern "C" {
-    fn MsQuicOpenVersion(version: u32, api: &*const ApiTable) -> u32;
-    fn MsQuicClose(api: *const ApiTable);
+unsafe extern "C" {
+    unsafe fn MsQuicOpenVersion(version: u32, api: *mut *const QUIC_API_TABLE) -> u32;
+    unsafe fn MsQuicClose(api: *const QUIC_API_TABLE);
 }
 
 //
@@ -1211,45 +1102,78 @@ extern "C" {
 //
 // APITABLE will be initialized via MsQuicOpenVersion() when we first initialize Api or Registration.
 //
-static mut APITABLE: *const ApiTable = ptr::null();
+static mut APITABLE: *const QUIC_API_TABLE = ptr::null();
 static START_MSQUIC: Once = Once::new();
 
 /// Entry point for some global MsQuic APIs.
-pub struct Api {
-    marker: PhantomData<()>,
+pub struct Api {}
+
+impl Api {
+    /// Get the ffi api table internally.
+    /// Assumes global has been initialized.
+    /// i.e. get_ffi() has been called at least once before.
+    #[inline]
+    fn ffi_ref() -> &'static crate::ffi::QUIC_API_TABLE {
+        unsafe { APITABLE.as_ref().unwrap() }
+    }
+
+    /// Returns the global ffi api table.
+    /// Initialize it if called the first time.
+    /// Allows user to use the unsafe api table for functions not yet
+    /// supported in the wrappers.
+    pub fn get_ffi() -> &'static crate::ffi::QUIC_API_TABLE {
+        Api::once_init_api();
+        Api::ffi_ref()
+    }
+
+    /// Initializes the global static api table.
+    /// This is used in registration creation, or in user getting raw ffi.
+    fn once_init_api() {
+        // initialization is done exactly once.
+        unsafe {
+            START_MSQUIC.call_once(|| {
+                let mut table: *const QUIC_API_TABLE = ptr::null();
+                let status = MsQuicOpenVersion(2, std::ptr::addr_of_mut!(table));
+                if let Err(err) = Error::ok_from_raw(status as QUIC_ERROR) {
+                    panic!("Failed to open MsQuic: {}", err);
+                }
+                APITABLE = table;
+            });
+        }
+    }
 }
 
 /// The execution context for processing connections on the application's behalf.
 pub struct Registration {
-    handle: Handle,
+    handle: HQUIC,
 }
 unsafe impl Sync for Registration {}
 unsafe impl Send for Registration {}
 
 /// Specifies how to configure a connection.
 pub struct Configuration {
-    handle: Handle,
+    handle: HQUIC,
 }
 unsafe impl Sync for Configuration {}
 unsafe impl Send for Configuration {}
 
 /// A single QUIC connection.
 pub struct Connection {
-    handle: Handle,
+    handle: HQUIC,
 }
 unsafe impl Sync for Connection {}
 unsafe impl Send for Connection {}
 
 /// A single server listener
 pub struct Listener {
-    handle: Handle,
+    handle: HQUIC,
 }
 unsafe impl Sync for Listener {}
 unsafe impl Send for Listener {}
 
 /// A single QUIC stream on a parent connection.
 pub struct Stream {
-    handle: Handle,
+    handle: HQUIC,
 }
 unsafe impl Sync for Stream {}
 unsafe impl Send for Stream {}
@@ -1345,69 +1269,64 @@ impl CredentialConfig {
     }
 }
 
-impl Default for Api {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Api {
-    pub fn new() -> Self {
-        // We initialize APITABLE at only once.
-        unsafe {
-            START_MSQUIC.call_once(|| {
-                let table: *const ApiTable = ptr::null();
-                let status = MsQuicOpenVersion(2, &table);
-                if let Err(err) = Error::from_u32(status).ok() {
-                    panic!("Failed to open MsQuic: {}", err);
-                }
-                APITABLE = table;
-            });
-        }
-        Self {
-            marker: PhantomData,
-        }
+    /// # Safety
+    /// Buffer needs to be valid
+    pub unsafe fn get_param(
+        handle: HQUIC,
+        param: u32,
+        buffer_length: *const u32,
+        buffer: *mut c_void,
+    ) -> Result<(), Error> {
+        let status = unsafe {
+            Api::ffi_ref().GetParam.unwrap()(handle, param, buffer_length as *mut u32, buffer)
+        };
+        Error::ok_from_raw(status)
     }
 
-    pub fn close_listener(&self, listener: Handle) {
-        unsafe {
-            ((*APITABLE).listener_close)(listener);
-        }
-    }
-    pub fn close_connection(&self, connection: Handle) {
-        unsafe {
-            ((*APITABLE).connection_close)(connection);
-        }
-    }
-    pub fn close_stream(&self, stream: Handle) {
-        unsafe {
-            ((*APITABLE).stream_close)(stream);
-        }
+    /// # Safety
+    /// buffer needs to be valid.
+    pub unsafe fn set_param(
+        handle: HQUIC,
+        param: u32,
+        buffer_length: u32,
+        buffer: *const c_void,
+    ) -> Result<(), Error> {
+        let status =
+            unsafe { Api::ffi_ref().SetParam.unwrap()(handle, param, buffer_length, buffer) };
+        Error::ok_from_raw(status)
     }
 
-    pub fn get_perf(&self) -> QuicPerformance {
+    pub fn get_perf(&self) -> Result<QuicPerformance, Error> {
         let mut perf = QuicPerformance {
             counters: [0; PERF_COUNTER_MAX as usize],
         };
         let perf_length = std::mem::size_of::<[i64; PERF_COUNTER_MAX as usize]>() as u32;
         unsafe {
-            ((*APITABLE).get_param)(
-                std::ptr::null(),
+            Api::get_param(
+                std::ptr::null_mut(),
                 PARAM_GLOBAL_PERF_COUNTERS,
-                (&perf_length) as *const u32 as *mut u32,
-                perf.counters.as_mut_ptr() as *const c_void,
-            )
+                std::ptr::addr_of!(perf_length),
+                perf.counters.as_mut_ptr() as *mut c_void,
+            )?
         };
-        perf
+        Ok(perf)
     }
 
-    pub fn set_callback_handler(
-        &self,
-        handle: Handle,
+    /// # Safety
+    /// handler and context must be valid.
+    pub unsafe fn set_callback_handler(
+        handle: HQUIC,
         handler: *const c_void,
         context: *const c_void,
     ) {
-        unsafe { ((*APITABLE).set_callback_handler)(handle, handler, context) }
+        unsafe {
+            Api::ffi_ref().SetCallbackHandler.unwrap()(
+                handle,
+                handler as *mut c_void,
+                context as *mut c_void,
+            )
+        };
     }
 }
 
@@ -1421,37 +1340,75 @@ fn close_msquic() {
     }
 }
 
+/// macro to define common functionalities for quic handle,
+/// including conversion from raw HQUIC and Drop trait.
+macro_rules! define_quic_handle_impl {
+    ($handle_name:ident) => {
+        /// Raw quic handle apis.
+        impl $handle_name {
+            /// Takes ownership of raw handle.
+            /// # Safety
+            /// handle must be valid
+            pub unsafe fn from_raw(h: HQUIC) -> Self {
+                Self { handle: h }
+            }
+
+            /// Returns the raw handle.
+            /// # Safety
+            /// caller should not close handle.
+            pub unsafe fn as_raw(&self) -> HQUIC {
+                self.handle
+            }
+
+            /// Returns the raw handle.
+            /// # Safety
+            /// caller is responsible for cleanups
+            pub unsafe fn into_raw(mut self) -> HQUIC {
+                let h = self.handle;
+                self.handle = std::ptr::null_mut();
+                h
+            }
+        }
+
+        /// drop the handle. Requires close() to be implemented.
+        impl Drop for $handle_name {
+            fn drop(&mut self) {
+                self.close();
+            }
+        }
+    };
+}
+
 impl Registration {
     pub fn new(config: *const RegistrationConfig) -> Result<Registration, Error> {
-        // We initialize APITABLE at only once.
-        unsafe {
-            START_MSQUIC.call_once(|| {
-                let table: *const ApiTable = ptr::null();
-                let status = MsQuicOpenVersion(2, &table);
-                if let Err(err) = Error::from_u32(status).ok() {
-                    panic!("Failed to open MsQuic: {}", err);
-                }
-                APITABLE = table;
-            });
-        }
-        let new_registration: Handle = ptr::null();
-        let status = unsafe { ((*APITABLE).registration_open)(config, &new_registration) };
-        Error::from_u32(status).ok()?;
-        Ok(Registration {
-            handle: new_registration,
-        })
+        // Initialize the global api table.
+        // Registration is the first created in all msquic apps.
+        let api = Api::get_ffi();
+        let mut h = std::ptr::null_mut();
+        let status = unsafe {
+            api.RegistrationOpen.unwrap()(
+                config as *const crate::ffi::QUIC_REGISTRATION_CONFIG,
+                std::ptr::addr_of_mut!(h),
+            )
+        };
+
+        Error::ok_from_raw(status)?;
+        Ok(Registration { handle: h })
     }
 
     pub fn shutdown(&self) {
-        unsafe { ((*APITABLE).registration_shutdown)(self.handle) }
+        unsafe { Api::ffi_ref().RegistrationShutdown.unwrap()(self.handle, 0, 0) }
+    }
+
+    pub fn close(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { Api::ffi_ref().RegistrationClose.unwrap()(self.handle) }
+            self.handle = std::ptr::null_mut();
+        }
     }
 }
 
-impl Drop for Registration {
-    fn drop(&mut self) {
-        unsafe { ((*APITABLE).registration_close)(self.handle) };
-    }
-}
+define_quic_handle_impl!(Registration);
 
 impl Configuration {
     pub fn new(
@@ -1459,41 +1416,49 @@ impl Configuration {
         alpn: &[Buffer],
         settings: *const Settings,
     ) -> Result<Configuration, Error> {
-        let context: *const c_void = ptr::null();
-        let new_configuration: Handle = ptr::null();
+        let context: *mut c_void = ptr::null_mut();
+        let mut new_configuration: HQUIC = ptr::null_mut();
         let mut settings_size: u32 = 0;
         if !settings.is_null() {
             settings_size = ::std::mem::size_of::<Settings>() as u32;
         }
+
         let status = unsafe {
-            ((*APITABLE).configuration_open)(
-                registration.handle,
-                alpn.as_ptr(),
+            Api::ffi_ref().ConfigurationOpen.unwrap()(
+                registration.as_raw(),
+                alpn.as_ptr() as *const QUIC_BUFFER,
                 alpn.len() as u32,
-                settings,
+                settings as *const QUIC_SETTINGS,
                 settings_size,
                 context,
-                &new_configuration,
+                std::ptr::addr_of_mut!(new_configuration),
             )
         };
-        Error::from_u32(status).ok()?;
+        Error::ok_from_raw(status)?;
         Ok(Configuration {
             handle: new_configuration,
         })
     }
 
     pub fn load_credential(&self, cred_config: &CredentialConfig) -> Result<(), Error> {
-        let status =
-            unsafe { ((*APITABLE).configuration_load_credential)(self.handle, cred_config) };
-        Error::from_u32(status).ok()
+        let status = unsafe {
+            Api::ffi_ref().ConfigurationLoadCredential.unwrap()(
+                self.handle,
+                cred_config as *const CredentialConfig as *const QUIC_CREDENTIAL_CONFIG,
+            )
+        };
+        Error::ok_from_raw(status)
+    }
+
+    pub fn close(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { Api::ffi_ref().ConfigurationClose.unwrap()(self.handle) };
+            self.handle = std::ptr::null_mut();
+        }
     }
 }
 
-impl Drop for Configuration {
-    fn drop(&mut self) {
-        unsafe { ((*APITABLE).configuration_close)(self.handle) };
-    }
-}
+define_quic_handle_impl!(Configuration);
 
 impl Default for Connection {
     fn default() -> Self {
@@ -1504,24 +1469,27 @@ impl Default for Connection {
 impl Connection {
     pub fn new() -> Connection {
         Connection {
-            handle: ptr::null(),
+            handle: ptr::null_mut(),
         }
     }
 
-    pub fn from_parts(handle: Handle) -> Connection {
-        Connection { handle }
-    }
-
+    /// TODO: The handler type should eventually be changed to Fn type.
+    /// ffi type and the context ptr makes this function unsafe.
     pub fn open(
-        &self,
+        &mut self,
         registration: &Registration,
-        handler: ConnectionEventHandler,
+        handler: ffi::QUIC_CONNECTION_CALLBACK_HANDLER,
         context: *const c_void,
     ) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).connection_open)(registration.handle, handler, context, &self.handle)
+            Api::ffi_ref().ConnectionOpen.unwrap()(
+                registration.handle,
+                handler,
+                context as *mut c_void,
+                std::ptr::addr_of_mut!(self.handle),
+            )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn start(
@@ -1532,7 +1500,7 @@ impl Connection {
     ) -> Result<(), Error> {
         let server_name_safe = std::ffi::CString::new(server_name).unwrap();
         let status = unsafe {
-            ((*APITABLE).connection_start)(
+            Api::ffi_ref().ConnectionStart.unwrap()(
                 self.handle,
                 configuration.handle,
                 0,
@@ -1540,29 +1508,29 @@ impl Connection {
                 server_port,
             )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
-    pub fn close(&self) {
-        unsafe {
-            ((*APITABLE).connection_close)(self.handle);
+    pub fn close(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                Api::ffi_ref().ConnectionClose.unwrap()(self.handle);
+            }
+            self.handle = std::ptr::null_mut();
         }
     }
 
     pub fn shutdown(&self, flags: ConnectionShutdownFlags, error_code: u62) {
         unsafe {
-            ((*APITABLE).connection_shutdown)(self.handle, flags, error_code);
+            Api::ffi_ref().ConnectionShutdown.unwrap()(self.handle, flags as i32, error_code);
         }
     }
 
-    pub fn set_param(&self, param: u32, buffer_length: u32, buffer: *const c_void) -> Error {
-        let status = unsafe { ((*APITABLE).set_param)(self.handle, param, buffer_length, buffer) };
-        Error::from_u32(status)
-    }
-
-    pub fn stream_close(&self, stream: Handle) {
+    /// # Safety
+    /// Raw handle must be valid.
+    pub unsafe fn stream_close(&self, stream: HQUIC) {
         unsafe {
-            ((*APITABLE).stream_close)(stream);
+            Api::ffi_ref().StreamClose.unwrap()(stream);
         }
     }
 
@@ -1571,14 +1539,14 @@ impl Connection {
             [0; std::mem::size_of::<QuicStatistics>()];
         let stat_size_mut = std::mem::size_of::<QuicStatistics>();
         unsafe {
-            ((*APITABLE).get_param)(
+            Api::get_param(
                 self.handle,
                 PARAM_CONN_STATISTICS,
                 (&stat_size_mut) as *const usize as *const u32 as *mut u32,
-                stat_buffer.as_mut_ptr() as *const c_void,
+                stat_buffer.as_mut_ptr() as *mut c_void,
             )
-        };
-
+        }
+        .expect("fail to get stats");
         unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatistics) }
     }
 
@@ -1587,39 +1555,53 @@ impl Connection {
             [0; std::mem::size_of::<QuicStatisticsV2>()];
         let stat_size_mut = std::mem::size_of::<QuicStatisticsV2>();
         unsafe {
-            ((*APITABLE).get_param)(
+            Api::get_param(
                 self.handle,
                 PARAM_CONN_STATISTICS_V2,
                 (&stat_size_mut) as *const usize as *const u32 as *mut u32,
-                stat_buffer.as_mut_ptr() as *const c_void,
+                stat_buffer.as_mut_ptr() as *mut c_void,
             )
-        };
+        }
+        .expect("fail to get stats v2");
 
         unsafe { *(stat_buffer.as_ptr() as *const c_void as *const QuicStatisticsV2) }
     }
 
     pub fn set_configuration(&self, configuration: &Configuration) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).connection_set_configuration)(self.handle, configuration.handle)
+            Api::ffi_ref().ConnectionSetConfiguration.unwrap()(self.handle, configuration.handle)
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
-    pub fn set_callback_handler(&self, handler: ConnectionEventHandler, context: *const c_void) {
-        unsafe {
-            ((*APITABLE).set_callback_handler)(self.handle, handler as *const c_void, context)
-        };
-    }
-
-    pub fn set_stream_callback_handler(
+    /// # Safety
+    /// handler and context must be valid
+    pub unsafe fn set_callback_handler(
         &self,
-        stream_handle: Handle,
-        handler: StreamEventHandler,
+        handler: ffi::QUIC_CONNECTION_CALLBACK_HANDLER,
         context: *const c_void,
     ) {
         unsafe {
-            ((*APITABLE).set_callback_handler)(stream_handle, handler as *const c_void, context)
+            Api::set_callback_handler(
+                self.handle,
+                std::mem::transmute::<ffi::QUIC_CONNECTION_CALLBACK_HANDLER, *const c_void>(
+                    handler,
+                ),
+                context,
+            )
         };
+    }
+
+    /// # Safety
+    /// handler and context must be valid
+    /// TODO: handler needs to be Fn type.
+    pub unsafe fn set_stream_callback_handler(
+        &self,
+        stream_handle: HQUIC,
+        handler: StreamEventHandler,
+        context: *const c_void,
+    ) {
+        unsafe { Api::set_callback_handler(stream_handle, handler as *const c_void, context) };
     }
 
     pub fn datagram_send(
@@ -1630,21 +1612,24 @@ impl Connection {
         client_send_context: *const c_void,
     ) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).datagram_send)(
+            Api::ffi_ref().DatagramSend.unwrap()(
                 self.handle,
-                buffer,
+                buffer as *const Buffer as *const QUIC_BUFFER,
                 buffer_count,
-                flags,
-                client_send_context,
+                flags as i32,
+                client_send_context as *mut c_void,
             )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn resumption_ticket_validation_complete(&self, result: BOOLEAN) -> Result<(), Error> {
-        let status =
-            unsafe { ((*APITABLE).resumption_ticket_validation_complete)(self.handle, result) };
-        Error::from_u32(status).ok()
+        let status = unsafe {
+            Api::ffi_ref()
+                .ConnectionResumptionTicketValidationComplete
+                .unwrap()(self.handle, result)
+        };
+        Error::ok_from_raw(status)
     }
 
     pub fn certificate_validation_complete(
@@ -1653,47 +1638,43 @@ impl Connection {
         tls_alert: TlsAlertCode,
     ) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).certificate_validation_complete)(self.handle, result, tls_alert)
+            Api::ffi_ref()
+                .ConnectionCertificateValidationComplete
+                .unwrap()(self.handle, result, tls_alert as i32)
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn get_local_addr(&self) -> Result<Addr, Error> {
         let mut addr_buffer: [u8; mem::size_of::<Addr>()] = [0; mem::size_of::<Addr>()];
         let addr_size_mut = mem::size_of::<Addr>();
-        let status = unsafe {
-            ((*APITABLE).get_param)(
+        unsafe {
+            Api::get_param(
                 self.handle,
                 PARAM_CONN_LOCAL_ADDRESS,
                 (&addr_size_mut) as *const usize as *const u32 as *mut u32,
-                addr_buffer.as_mut_ptr() as *const c_void,
-            )
+                addr_buffer.as_mut_ptr() as *mut c_void,
+            )?
         };
-        Error::from_u32(status).ok()?;
         Ok(unsafe { *(addr_buffer.as_ptr() as *const c_void as *const Addr) })
     }
 
     pub fn get_remote_addr(&self) -> Result<Addr, Error> {
         let mut addr_buffer: [u8; mem::size_of::<Addr>()] = [0; mem::size_of::<Addr>()];
         let addr_size_mut = mem::size_of::<Addr>();
-        let status = unsafe {
-            ((*APITABLE).get_param)(
+        unsafe {
+            Api::get_param(
                 self.handle,
                 PARAM_CONN_REMOTE_ADDRESS,
                 (&addr_size_mut) as *const usize as *const u32 as *mut u32,
-                addr_buffer.as_mut_ptr() as *const c_void,
-            )
+                addr_buffer.as_mut_ptr() as *mut c_void,
+            )?
         };
-        Error::from_u32(status).ok()?;
         Ok(unsafe { *(addr_buffer.as_ptr() as *const c_void as *const Addr) })
     }
 }
 
-impl Drop for Connection {
-    fn drop(&mut self) {
-        unsafe { ((*APITABLE).connection_close)(self.handle) };
-    }
-}
+define_quic_handle_impl!(Connection);
 
 impl Default for Listener {
     fn default() -> Self {
@@ -1704,69 +1685,73 @@ impl Default for Listener {
 impl Listener {
     pub fn new() -> Listener {
         Listener {
-            handle: ptr::null(),
+            handle: ptr::null_mut(),
         }
     }
 
+    /// TODO: handler should be changed to Fn type.
     pub fn open(
-        &self,
+        &mut self,
         registration: &Registration,
-        handler: ListenerEventHandler,
+        handler: ffi::QUIC_LISTENER_CALLBACK_HANDLER,
         context: *const c_void,
     ) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).listener_open)(registration.handle, handler, context, &self.handle)
+            Api::ffi_ref().ListenerOpen.unwrap()(
+                registration.handle,
+                handler,
+                context as *mut c_void,
+                std::ptr::addr_of_mut!(self.handle),
+            )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn start(&self, alpn: &[Buffer], local_address: Option<&Addr>) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).listener_start)(
+            Api::ffi_ref().ListenerStart.unwrap()(
                 self.handle,
-                alpn.as_ptr(),
+                alpn.as_ptr() as *const QUIC_BUFFER,
                 alpn.len() as u32,
                 local_address
-                    .map(|addr| addr as *const _)
+                    .map(|addr| addr as *const Addr as *const _)
                     .unwrap_or(ptr::null()),
             )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn stop(&self) {
         unsafe {
-            ((*APITABLE).listener_stop)(self.handle);
+            Api::ffi_ref().ListenerStop.unwrap()(self.handle);
         }
     }
 
     pub fn get_local_addr(&self) -> Result<Addr, Error> {
         let mut addr_buffer: [u8; mem::size_of::<Addr>()] = [0; mem::size_of::<Addr>()];
         let addr_size_mut = mem::size_of::<Addr>();
-        let status = unsafe {
-            ((*APITABLE).get_param)(
+        unsafe {
+            Api::get_param(
                 self.handle,
                 PARAM_LISTENER_LOCAL_ADDRESS,
                 (&addr_size_mut) as *const usize as *const u32 as *mut u32,
-                addr_buffer.as_mut_ptr() as *const c_void,
-            )
+                addr_buffer.as_mut_ptr() as *mut c_void,
+            )?
         };
-        Error::from_u32(status).ok()?;
         Ok(unsafe { *(addr_buffer.as_ptr() as *const c_void as *const Addr) })
     }
 
-    pub fn close(&self) {
-        unsafe {
-            ((*APITABLE).listener_close)(self.handle);
+    pub fn close(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                Api::ffi_ref().ListenerClose.unwrap()(self.handle);
+                self.handle = std::ptr::null_mut();
+            }
         }
     }
 }
 
-impl Drop for Listener {
-    fn drop(&mut self) {
-        unsafe { ((*APITABLE).listener_close)(self.handle) };
-    }
-}
+define_quic_handle_impl!(Listener);
 
 impl Default for Stream {
     fn default() -> Self {
@@ -1777,40 +1762,49 @@ impl Default for Stream {
 impl Stream {
     pub fn new() -> Stream {
         Stream {
-            handle: ptr::null(),
+            handle: ptr::null_mut(),
         }
     }
 
-    pub fn from_parts(handle: Handle) -> Stream {
-        Stream { handle }
-    }
-
     pub fn open(
-        &self,
+        &mut self,
         connection: &Connection,
         flags: StreamOpenFlags,
         handler: StreamEventHandler,
         context: *const c_void,
     ) -> Result<(), Error> {
+        // TODO: remove transmute.
+        #[allow(clippy::missing_transmute_annotations)]
         let status = unsafe {
-            ((*APITABLE).stream_open)(connection.handle, flags, handler, context, &self.handle)
+            Api::ffi_ref().StreamOpen.unwrap()(
+                connection.handle,
+                flags as i32,
+                Some(std::mem::transmute(handler)),
+                context as *mut c_void,
+                std::ptr::addr_of_mut!(self.handle),
+            )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
     pub fn start(&self, flags: StreamStartFlags) -> Result<(), Error> {
-        let status = unsafe { ((*APITABLE).stream_start)(self.handle, flags) };
-        Error::from_u32(status).ok()
+        let status = unsafe { Api::ffi_ref().StreamStart.unwrap()(self.handle, flags as i32) };
+        Error::ok_from_raw(status)
     }
 
     pub fn shutdown(&self, flags: StreamShutdownFlags, error_code: u62) -> Result<(), Error> {
-        let status = unsafe { ((*APITABLE).stream_shutdown)(self.handle, flags, error_code) };
-        Error::from_u32(status).ok()
+        let status = unsafe {
+            Api::ffi_ref().StreamShutdown.unwrap()(self.handle, flags as i32, error_code)
+        };
+        Error::ok_from_raw(status)
     }
 
-    pub fn close(&self) {
-        unsafe {
-            ((*APITABLE).stream_close)(self.handle);
+    pub fn close(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                Api::ffi_ref().StreamClose.unwrap()(self.handle);
+            }
+            self.handle = std::ptr::null_mut();
         }
     }
 
@@ -1822,172 +1816,175 @@ impl Stream {
         client_send_context: *const c_void,
     ) -> Result<(), Error> {
         let status = unsafe {
-            ((*APITABLE).stream_send)(
+            Api::ffi_ref().StreamSend.unwrap()(
                 self.handle,
-                buffer,
+                buffer as *const Buffer as *const QUIC_BUFFER,
                 buffer_count,
-                flags,
-                client_send_context, //(self as *const Stream) as *const c_void,
+                flags as i32,
+                client_send_context as *mut c_void, //(self as *const Stream) as *const c_void,
             )
         };
-        Error::from_u32(status).ok()
+        Error::ok_from_raw(status)
     }
 
-    pub fn set_callback_handler(&self, handler: StreamEventHandler, context: *const c_void) {
-        unsafe {
-            ((*APITABLE).set_callback_handler)(self.handle, handler as *const c_void, context)
-        };
+    /// # Safety
+    /// handler and context must be valid.
+    pub unsafe fn set_callback_handler(&self, handler: StreamEventHandler, context: *const c_void) {
+        unsafe { Api::set_callback_handler(self.handle, handler as *const c_void, context) };
     }
 
-    pub fn get_param(
-        &self,
-        param: u32,
-        buffer_length: *mut u32,
-        buffer: *const c_void,
-    ) -> Result<(), Error> {
-        let status = unsafe { ((*APITABLE).get_param)(self.handle, param, buffer_length, buffer) };
-        Error::from_u32(status).ok()
-    }
-
-    pub fn receive_complete(&self, buffer_length: u64) -> Result<(), Error> {
-        let status = unsafe { ((*APITABLE).stream_receive_complete)(self.handle, buffer_length) };
-        Error::from_u32(status).ok()
+    pub fn receive_complete(&self, buffer_length: u64) {
+        unsafe { Api::ffi_ref().StreamReceiveComplete.unwrap()(self.handle, buffer_length) }
     }
 }
 
-impl Drop for Stream {
-    fn drop(&mut self) {
-        unsafe { ((*APITABLE).stream_close)(self.handle) };
+define_quic_handle_impl!(Stream);
+
+#[cfg(test)]
+mod tests {
+
+    //
+    // The following defines some simple test code.
+    //
+
+    use std::ffi::c_void;
+    use std::ptr;
+
+    use crate::ffi::{HQUIC, QUIC_ERROR};
+    use crate::{
+        ffi, Buffer, Configuration, Connection, ConnectionEvent, CredentialConfig, Registration,
+        Settings, StreamEvent,
+    };
+
+    extern "C" fn test_conn_callback(
+        _connection: HQUIC,
+        context: *mut c_void,
+        event: *mut ffi::QUIC_CONNECTION_EVENT,
+    ) -> QUIC_ERROR {
+        let connection = unsafe { &*(context as *const Connection) };
+        let event = unsafe { (event as *const ConnectionEvent).as_ref().unwrap() };
+        match event.event_type {
+            crate::CONNECTION_EVENT_CONNECTED => {
+                let local_addr = connection.get_local_addr().unwrap().as_socket().unwrap();
+                let remote_addr = connection.get_remote_addr().unwrap().as_socket().unwrap();
+                println!("Connected({}, {})", local_addr, remote_addr);
+            }
+            crate::CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT => {
+                println!("Transport shutdown 0x{:x}", unsafe {
+                    event.payload.shutdown_initiated_by_transport.status
+                })
+            }
+            crate::CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER => {
+                println!("App shutdown {}", unsafe {
+                    event.payload.shutdown_initiated_by_peer.error_code
+                })
+            }
+            crate::CONNECTION_EVENT_SHUTDOWN_COMPLETE => println!("Shutdown complete"),
+            crate::CONNECTION_EVENT_PEER_STREAM_STARTED => {
+                println!("Peer stream started");
+                unsafe {
+                    connection.set_stream_callback_handler(
+                        event.payload.peer_stream_started.stream as HQUIC,
+                        test_stream_callback,
+                        context,
+                    );
+                }
+            }
+            _ => println!("Other callback {}", event.event_type),
+        }
+        0
     }
-}
 
-//
-// The following defines some simple test code.
-//
-
-#[allow(dead_code)] // Used in test code
-extern "C" fn test_conn_callback(
-    _connection: Handle,
-    context: *mut c_void,
-    event: &ConnectionEvent,
-) -> u32 {
-    let connection = unsafe { &*(context as *const Connection) };
-    match event.event_type {
-        CONNECTION_EVENT_CONNECTED => {
-            let local_addr = connection.get_local_addr().unwrap().as_socket().unwrap();
-            let remote_addr = connection.get_remote_addr().unwrap().as_socket().unwrap();
-            println!("Connected({}, {})", local_addr, remote_addr);
+    extern "C" fn test_stream_callback(
+        stream: HQUIC,
+        context: *mut c_void,
+        event: &StreamEvent,
+    ) -> u32 {
+        let connection = unsafe { &*(context as *const Connection) };
+        match event.event_type {
+            crate::STREAM_EVENT_START_COMPLETE => {
+                println!("Stream start complete 0x{:x}", unsafe {
+                    event.payload.start_complete.status
+                })
+            }
+            crate::STREAM_EVENT_RECEIVE => println!("Receive {} bytes", unsafe {
+                event.payload.receive.total_buffer_length
+            }),
+            crate::STREAM_EVENT_SEND_COMPLETE => println!("Send complete"),
+            crate::STREAM_EVENT_PEER_SEND_SHUTDOWN => println!("Peer send shutdown"),
+            crate::STREAM_EVENT_PEER_SEND_ABORTED => println!("Peer send aborted"),
+            crate::STREAM_EVENT_PEER_RECEIVE_ABORTED => println!("Peer receive aborted"),
+            crate::STREAM_EVENT_SEND_SHUTDOWN_COMPLETE => println!("Peer receive aborted"),
+            crate::STREAM_EVENT_SHUTDOWN_COMPLETE => {
+                println!("Stream shutdown complete");
+                unsafe { connection.stream_close(stream) };
+            }
+            crate::STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE => println!("Ideal send buffer size"),
+            crate::STREAM_EVENT_PEER_ACCEPTED => println!("Peer accepted"),
+            _ => println!("Other callback {}", event.event_type),
         }
-        CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT => {
-            println!("Transport shutdown 0x{:x}", unsafe {
-                event.payload.shutdown_initiated_by_transport.status
-            })
-        }
-        CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER => println!("App shutdown {}", unsafe {
-            event.payload.shutdown_initiated_by_peer.error_code
-        }),
-        CONNECTION_EVENT_SHUTDOWN_COMPLETE => println!("Shutdown complete"),
-        CONNECTION_EVENT_PEER_STREAM_STARTED => {
-            println!("Peer stream started");
-            connection.set_stream_callback_handler(
-                unsafe { event.payload.peer_stream_started.stream },
-                test_stream_callback,
-                context,
-            );
-        }
-        _ => println!("Other callback {}", event.event_type),
+        0
     }
-    0
-}
 
-#[allow(dead_code)] // Used in test code
-extern "C" fn test_stream_callback(
-    stream: Handle,
-    context: *mut c_void,
-    event: &StreamEvent,
-) -> u32 {
-    let connection = unsafe { &*(context as *const Connection) };
-    match event.event_type {
-        STREAM_EVENT_START_COMPLETE => println!("Stream start complete 0x{:x}", unsafe {
-            event.payload.start_complete.status
-        }),
-        STREAM_EVENT_RECEIVE => println!("Receive {} bytes", unsafe {
-            event.payload.receive.total_buffer_length
-        }),
-        STREAM_EVENT_SEND_COMPLETE => println!("Send complete"),
-        STREAM_EVENT_PEER_SEND_SHUTDOWN => println!("Peer send shutdown"),
-        STREAM_EVENT_PEER_SEND_ABORTED => println!("Peer send aborted"),
-        STREAM_EVENT_PEER_RECEIVE_ABORTED => println!("Peer receive aborted"),
-        STREAM_EVENT_SEND_SHUTDOWN_COMPLETE => println!("Peer receive aborted"),
-        STREAM_EVENT_SHUTDOWN_COMPLETE => {
-            println!("Stream shutdown complete");
-            connection.stream_close(stream);
-        }
-        STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE => println!("Ideal send buffer size"),
-        STREAM_EVENT_PEER_ACCEPTED => println!("Peer accepted"),
-        _ => println!("Other callback {}", event.event_type),
+    #[test]
+    fn test_module() {
+        let res = Registration::new(ptr::null());
+        assert!(
+            res.is_ok(),
+            "Failed to open registration: {}",
+            res.err().unwrap()
+        );
+        let registration = res.unwrap();
+
+        let alpn = [Buffer::from("h3")];
+        let res = Configuration::new(
+            &registration,
+            &alpn,
+            #[cfg(feature = "preview-api")]
+            Settings::new()
+                .set_peer_bidi_stream_count(100)
+                .set_peer_unidi_stream_count(3)
+                .set_stream_multi_receive_enabled(true),
+            #[cfg(not(feature = "preview-api"))]
+            Settings::new()
+                .set_peer_bidi_stream_count(100)
+                .set_peer_unidi_stream_count(3),
+        );
+        assert!(
+            res.is_ok(),
+            "Failed to open configuration: {}",
+            res.err().unwrap()
+        );
+        let configuration = res.unwrap();
+
+        let cred_config = CredentialConfig::new_client();
+        let res = configuration.load_credential(&cred_config);
+        assert!(
+            res.is_ok(),
+            "Failed to load credential: {}",
+            res.err().unwrap()
+        );
+
+        let mut connection = Connection::new();
+        let res = connection.open(
+            &registration,
+            Some(test_conn_callback),
+            &connection as *const Connection as *const c_void,
+        );
+        assert!(
+            res.is_ok(),
+            "Failed to open connection: {}",
+            res.err().unwrap()
+        );
+
+        let res = connection.start(&configuration, "www.cloudflare.com", 443);
+        assert!(
+            res.is_ok(),
+            "Failed to start connection: {}",
+            res.err().unwrap()
+        );
+
+        let duration = std::time::Duration::from_millis(1000);
+        std::thread::sleep(duration);
     }
-    0
-}
-
-#[test]
-fn test_module() {
-    let res = Registration::new(ptr::null());
-    assert!(
-        res.is_ok(),
-        "Failed to open registration: {}",
-        res.err().unwrap()
-    );
-    let registration = res.unwrap();
-
-    let alpn = [Buffer::from("h3")];
-    let res = Configuration::new(
-        &registration,
-        &alpn,
-        #[cfg(feature = "preview-api")]
-        Settings::new()
-            .set_peer_bidi_stream_count(100)
-            .set_peer_unidi_stream_count(3)
-            .set_stream_multi_receive_enabled(true),
-        #[cfg(not(feature = "preview-api"))]
-        Settings::new()
-            .set_peer_bidi_stream_count(100)
-            .set_peer_unidi_stream_count(3),
-    );
-    assert!(
-        res.is_ok(),
-        "Failed to open configuration: {}",
-        res.err().unwrap()
-    );
-    let configuration = res.unwrap();
-
-    let cred_config = CredentialConfig::new_client();
-    let res = configuration.load_credential(&cred_config);
-    assert!(
-        res.is_ok(),
-        "Failed to load credential: {}",
-        res.err().unwrap()
-    );
-
-    let connection = Connection::new();
-    let res = connection.open(
-        &registration,
-        test_conn_callback,
-        &connection as *const Connection as *const c_void,
-    );
-    assert!(
-        res.is_ok(),
-        "Failed to open connection: {}",
-        res.err().unwrap()
-    );
-
-    let res = connection.start(&configuration, "www.cloudflare.com", 443);
-    assert!(
-        res.is_ok(),
-        "Failed to start connection: {}",
-        res.err().unwrap()
-    );
-
-    let duration = std::time::Duration::from_millis(1000);
-    std::thread::sleep(duration);
 }


### PR DESCRIPTION
## Description
This is the beginning of a series of PRs to migrate from manually written code to use auto generated Rust ffi bindings, and make Rust APIs safe in default, and handles ffi internally in the crate.

This PR changes the following:
* Migrate to use ffi QUIC_API_TABLE from manually written ApiTable.
* Change Error::from_u32 and Error::ok to Error::ok_from_raw for dedicated error conversion from ffi function returns.
* Reorganize apis like get_param, set_param and simplify other apis built on top of them.
* Refactor the static api table initialization.
* Add unified raw handle functions for all wrapper handle types. All wrappers support from_raw(HQUIC), into_raw()->HQUIC, as_raw()->HQUIC, close() and Drop. This allows user to use unsafe ffi apis directly.
* Refactored the test code into test mod under test cfg section.
* Removed types that are no longer needed or replaced by ffi mod.

The migration process will break the compatibility of the APIs but this is ok as msquic rust crate is experimental.

## Testing
Existing rust test.
More tests will be added once we establish the Rust safe APIs.

## Documentation
NA
