### PR TITLE
Added support for using UCRT nuget package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 message(STATUS "CMAKE Version: ${CMAKE_VERSION}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
+set_property(TARGET GLOBAL PROPERTY UseInternalMSUniCrtPackage TRUE)
+ 
 message(STATUS "Source Dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "Host System name: ${CMAKE_HOST_SYSTEM_NAME}")
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 message(STATUS "CMAKE Version: ${CMAKE_VERSION}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set_property(TARGET GLOBAL PROPERTY UseInternalMSUniCrtPackage TRUE)
+set(CMAKE_VS_GLOBALS "UseInternalMSUniCrtPackage=true")
  
 message(STATUS "Source Dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "Host System name: ${CMAKE_HOST_SYSTEM_NAME}")


### PR DESCRIPTION
## Description
The Microsoft Internal Undocked UCRT Nuget package cannot be used by the undock repo for building through OneBranch. This makes sure the flag is true and we can build using the undock repo.
_Describe the purpose of and changes within this Pull Request._

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
