### PR TITLE
Delete .NET 8.0 from pipeline

### DIFF
--- a/.github/workflows/package-alpine-linux.yml
+++ b/.github/workflows/package-alpine-linux.yml
@@ -28,9 +28,6 @@ jobs:
       matrix:
         vec: [
           { friendlyName: "Alpine-3.20-x64", config: "Release", arch: "x64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20-amd64" },
-          { friendlyName: "Alpine-3.20-ARM64", config: "Release", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20-arm64v8" },
-          # .NET is not working properly for ARM32 Alpine with QEMU, so keep it disabled for now.
-          # { friendlyName: "Alpine-3.20-ARM32", config: "Release", arch: "arm", tls: "openssl3", image: "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20-arm32v7" },
         ]
     runs-on: ubuntu-latest
     steps:
@@ -63,9 +60,6 @@ jobs:
       matrix:
         vec: [
           { friendlyName: "Alpine-3.20-x64", config: "Release", arch: "x64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-alpine3.20-amd64", dotnetVersion: "9.0" },
-          { friendlyName: "Alpine-3.20-ARM64", config: "Release", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-alpine3.20-arm64v8", dotnetVersion: "9.0" },
-          # .NET is not working properly for ARM32 Alpine with QEMU, so keep it disabled for now.
-          # { friendlyName: "Alpine-3.20-ARM32", config: "Release", arch: "arm", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-alpine3.20-arm32v7", dotnetVersion: "9.0" },
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -92,10 +92,6 @@ jobs:
           { friendlyName: "Ubuntu 24.04 x64", config: "Release", os: "ubuntu-24.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-amd64", xdp: "-UseXdp", dotnetVersion: "9.0" },
           { friendlyName: "Ubuntu 24.04 ARM32", config: "Release", os: "ubuntu-24.04", arch: "arm",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-arm32v7", dotnetVersion: "9.0" },
           { friendlyName: "Ubuntu 24.04 ARM64", config: "Release", os: "ubuntu-24.04", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-arm64v8", dotnetVersion: "9.0" },
-          # Ubuntu 22.04
-          { friendlyName: "Ubuntu 22.04 x64", config: "Release", os: "ubuntu-22.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:8.0-jammy-amd64", dotnetVersion: "8.0" },
-          { friendlyName: "Ubuntu 22.04 ARM32", config: "Release", os: "ubuntu-22.04", arch: "arm", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:8.0-jammy-arm32v7", dotnetVersion: "8.0" },
-          { friendlyName: "Ubuntu 22.04 ARM64", config: "Release", os: "ubuntu-22.04", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:8.0-jammy-arm64v8", dotnetVersion: "8.0" },
           # Ubuntu 20.04
           { friendlyName: "Ubuntu 20.04 x64", config: "Release", os: "ubuntu-20.04", arch: "x64",   tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64", dotnetVersion: "9.0" },
           { friendlyName: "Ubuntu 20.04 ARM64", config: "Release", os: "ubuntu-20.04", arch: "arm64", tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8", dotnetVersion: "9.0" },
@@ -103,9 +99,6 @@ jobs:
           { friendlyName: "Debian 12 x64", config: "Release", os: "ubuntu-22.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim-amd64", dotnetVersion: "9.0" },
           { friendlyName: "Debian 12 ARM32", config: "Release", os: "ubuntu-22.04", arch: "arm",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim-arm32v7", dotnetVersion: "9.0" },
           { friendlyName: "Debian 12 ARM64", config: "Release", os: "ubuntu-22.04", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim-arm64v8", dotnetVersion: "9.0" },
-          # CBL-Mariner 2.0
-          { friendlyName: "CBL-Mariner 2.0 x64", config: "Release", os: "ubuntu-20.04", arch: "x64",   tls: "openssl", image: "mcr.microsoft.com/dotnet/runtime:8.0-cbl-mariner2.0-amd64", dotnetVersion: "8.0" },
-          { friendlyName: "CBL-Mariner 2.0 ARM64", config: "Release", os: "ubuntu-20.04", arch: "arm64",   tls: "openssl", image: "mcr.microsoft.com/dotnet/runtime:8.0-cbl-mariner2.0-arm64v8", dotnetVersion: "8.0" },
           # Azure Linux 3.0
           { friendlyName: "AzureLinux 3.0 x64", config: "Release", os: "ubuntu-24.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-azurelinux3.0-amd64", dotnetVersion: "9.0", xdp: "-UseXdp" },
           { friendlyName: "AzureLinux 3.0 ARM64", config: "Release", os: "ubuntu-24.04", arch: "arm64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-azurelinux3.0-arm64v8", dotnetVersion: "9.0" },

--- a/src/cs/QuicSimpleTest/QuicHello.net8.0.csproj
+++ b/src/cs/QuicSimpleTest/QuicHello.net8.0.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-	</PropertyGroup>
-</Project>


### PR DESCRIPTION
## Description

.NET 9.0 is out, and we don't need 8.0 testing anymore. Most likely, we need to back port this change to older branches

## Testing

CI

## Documentation

No