### PR TITLE
Fix wrong instruction in sample.md

### DIFF
--- a/docs/Sample.md
+++ b/docs/Sample.md
@@ -30,7 +30,7 @@ By default, the server listens on port 4567.
 Start the client providing the IP address for the server. Here 127.0.0.1 is used as an example.
 
 ```Powershell
-quicsample.exe -client -unsecure -target:{127.0.0.1}
+quicsample.exe -client -unsecure -target:127.0.0.1
 ```
 
 ## Troubleshooting with Wireshark 


### PR DESCRIPTION
Delete the "{}" which makes the ip unable to identified

## Description

`-target:{127.0.0.1}` will result in error.

## Testing

None

## Documentation

Modified the sample.md
