### PR TITLE
Correctly initialize the ip address when setting QUIC_ADDR to the loopback address

### DIFF
--- a/src/inc/msquic_winkernel.h
+++ b/src/inc/msquic_winkernel.h
@@ -254,9 +254,11 @@ QuicAddrSetToLoopback(
     )
 {
     if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET) {
+        Addr->Ipv4.sin_addr.s_addr = 0UL;
         Addr->Ipv4.sin_addr.S_un.S_un_b.s_b1 = 127;
         Addr->Ipv4.sin_addr.S_un.S_un_b.s_b4 = 1;
     } else {
+        memset(&Addr->Ipv6.sin6_addr, 0, sizeof(Addr->Ipv6.sin6_addr));
         Addr->Ipv6.sin6_addr.u.Byte[15] = 1;
     }
 }

--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -259,9 +259,11 @@ QuicAddrSetToLoopback(
     )
 {
     if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET) {
+        Addr->Ipv4.sin_addr.s_addr = 0UL;
         Addr->Ipv4.sin_addr.S_un.S_un_b.s_b1 = 127;
         Addr->Ipv4.sin_addr.S_un.S_un_b.s_b4 = 1;
     } else {
+        memset(&Addr->Ipv6.sin6_addr, 0, sizeof(Addr->Ipv6.sin6_addr));
         Addr->Ipv6.sin6_addr.u.Byte[15] = 1;
     }
 }

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -781,11 +781,6 @@ typedef struct {
     QUIC_CTL_CODE(15, METHOD_BUFFERED, FILE_WRITE_DATA)
     // int - Family
 
-#define IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS \
-    QUIC_CTL_CODE(16, METHOD_BUFFERED, FILE_WRITE_DATA)
-    // int - Family
-
-
 #pragma pack(push)
 #pragma pack(1)
 
@@ -1346,4 +1341,8 @@ typedef struct {
     QUIC_CTL_CODE(126, METHOD_BUFFERED, FILE_WRITE_DATA)
     // int - Family
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 126
+#define IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS \
+    QUIC_CTL_CODE(127, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // int - Family
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 127

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -97,6 +97,7 @@ void QuicTestCreateConnection();
 void QuicTestBindConnectionImplicit(_In_ int Family);
 void QuicTestBindConnectionExplicit(_In_ int Family);
 void QuicTestConnectionCloseFromCallback();
+void QuicTestAddrFunctions(_In_ int Family);
 
 //
 // MTU tests
@@ -779,6 +780,11 @@ typedef struct {
 #define IOCTL_QUIC_RUN_BIND_CONNECTION_EXPLICIT \
     QUIC_CTL_CODE(15, METHOD_BUFFERED, FILE_WRITE_DATA)
     // int - Family
+
+#define IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS \
+    QUIC_CTL_CODE(16, METHOD_BUFFERED, FILE_WRITE_DATA)
+    // int - Family
+
 
 #pragma pack(push)
 #pragma pack(1)

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -708,7 +708,7 @@ TEST_P(WithFamilyArgs, TestAddrFunctions) {
         ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS, GetParam().Family));
     }
     else {
-        QuicTestBindConnectionExplicit(GetParam().Family);
+        QuicTestAddrFunctions(GetParam().Family);
     }
 }
 

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -702,6 +702,16 @@ TEST_P(WithFamilyArgs, BindConnectionExplicit) {
     }
 }
 
+TEST_P(WithFamilyArgs, TestAddrFunctions) {
+    TestLoggerT<ParamType> Logger("QuicTestAddrFunctions", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS, GetParam().Family));
+    }
+    else {
+        QuicTestBindConnectionExplicit(GetParam().Family);
+    }
+}
+
 TEST_P(WithHandshakeArgs1, Connect) {
     TestLoggerT<ParamType> Logger("QuicTestConnect-Connect", GetParam());
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -773,6 +773,10 @@ QuicTestCtlEvtIoDeviceControl(
         CXPLAT_FRE_ASSERT(Params != nullptr);
         QuicTestCtlRun(QuicTestBindConnectionExplicit(Params->Family));
         break;
+    case IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS:
+        CXPLAT_FRE_ASSERT(Params != nullptr);
+        QuicTestCtlRun(QuicTestAddrFunctions(Params->Family));
+        break;
 
     case IOCTL_QUIC_RUN_CONNECT:
         CXPLAT_FRE_ASSERT(Params != nullptr);

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -525,6 +525,7 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     0,
     sizeof(BOOLEAN),
     sizeof(INT32),
+    sizeof(INT32),                           // IOCTL_QUIC_RUN_TEST_ADDR_FUNCTIONS
 };
 
 CXPLAT_STATIC_ASSERT(

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -284,8 +284,8 @@ void QuicTestAddrFunctions(_In_ int Family)
         TEST_TRUE((SockAddr.Ipv4.sin_addr.s_addr & 0x00FFFF00UL) == 0);
     } else {
         memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
-        for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.u.Byte) - 1; i++) {
-            TEST_TRUE(SockAddr.Ipv6.sin6_addr.u.Byte[i] == 0);
+        for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.s6_addr) - 1; i++) {
+            TEST_TRUE(SockAddr.Ipv6.sin6_addr.s6_addr[i] == 0);
         }
     }
 

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -281,8 +281,8 @@ void QuicTestAddrFunctions(_In_ int Family)
     if (QuicAddrFamily == QUIC_ADDRESS_FAMILY_INET) {
         SockAddr.Ipv4.sin_addr.s_addr = 0x00FFFF00UL;
         QuicAddrSetToLoopback(&SockAddr);
-        TEST_TRUE(SockAddr.Ipv4.sin_addr.S_un.S_un_b.s_b2 == 0);
-        TEST_TRUE(SockAddr.Ipv4.sin_addr.S_un.S_un_b.s_b3 == 0);
+        TEST_TRUE(SockAddr.Ipv4.sin_addr.s_host == 0);
+        TEST_TRUE(SockAddr.Ipv4.sin_addr.s_lh == 0);
     }
     else {
         memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -287,7 +287,7 @@ void QuicTestAddrFunctions(_In_ int Family)
     if (QuicAddrFamily == QUIC_ADDRESS_FAMILY_INET) {
         TEST_TRUE((SockAddr.Ipv4.sin_addr.s_addr & 0x00FFFF00UL) == 0);
     } else {
-        for (unsigned long i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr._S6_un) - 1; i++) {
+        for (unsigned long i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr) - 1; i++) {
             TEST_TRUE(SockAddr.Ipv6.sin6_addr.s6_addr[i] == 0);
         }
     }

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -283,8 +283,7 @@ void QuicTestAddrFunctions(_In_ int Family)
         QuicAddrSetToLoopback(&SockAddr);
         TEST_TRUE(SockAddr.Ipv4.sin_addr.s_host == 0);
         TEST_TRUE(SockAddr.Ipv4.sin_addr.s_lh == 0);
-    }
-    else {
+    } else {
         memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
         for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.u.Byte) - 1; i++) {
             TEST_TRUE(SockAddr.Ipv6.sin6_addr.u.Byte[i] == 0);

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -273,18 +273,21 @@ void QuicTestBindConnectionExplicit(_In_ int Family)
 
 void QuicTestAddrFunctions(_In_ int Family)
 {
-    QUIC_ADDR SockAddr = {};
+    QUIC_ADDR SockAddr;
     QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
+
+    // initialize the struct to 0xFF to ensure any code issues are caught by the following tests
+    memset(&SockAddr, 0xFF, sizeof(SockAddr));
+
     QuicAddrSetFamily(&SockAddr, QuicAddrFamily);
     TEST_TRUE(QuicAddrGetFamily(&SockAddr) == QuicAddrFamily);
 
+    QuicAddrSetToLoopback(&SockAddr);
+
     if (QuicAddrFamily == QUIC_ADDRESS_FAMILY_INET) {
-        SockAddr.Ipv4.sin_addr.s_addr = 0x00FFFF00UL;
-        QuicAddrSetToLoopback(&SockAddr);
         TEST_TRUE((SockAddr.Ipv4.sin_addr.s_addr & 0x00FFFF00UL) == 0);
     } else {
-        memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
-        for (unsigned long i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.s6_addr) - 1; i++) {
+        for (unsigned long i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr._S6_un) - 1; i++) {
             TEST_TRUE(SockAddr.Ipv6.sin6_addr.s6_addr[i] == 0);
         }
     }

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -281,8 +281,7 @@ void QuicTestAddrFunctions(_In_ int Family)
     if (QuicAddrFamily == QUIC_ADDRESS_FAMILY_INET) {
         SockAddr.Ipv4.sin_addr.s_addr = 0x00FFFF00UL;
         QuicAddrSetToLoopback(&SockAddr);
-        TEST_TRUE(SockAddr.Ipv4.sin_addr.s_host == 0);
-        TEST_TRUE(SockAddr.Ipv4.sin_addr.s_lh == 0);
+        TEST_TRUE((SockAddr.Ipv4.sin_addr.s_addr & 0x00FFFF00UL) == 0);
     } else {
         memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
         for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.u.Byte) - 1; i++) {

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -270,3 +270,26 @@ void QuicTestBindConnectionExplicit(_In_ int Family)
         TEST_QUIC_SUCCEEDED(Status);
     }
 }
+
+void QuicTestAddrFunctions(_In_ int Family)
+{
+    QUIC_ADDR SockAddr = {};
+    QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
+    QuicAddrSetFamily(&SockAddr, QuicAddrFamily);
+    TEST_TRUE(QuicAddrGetFamily(&SockAddr) == QuicAddrFamily);
+
+    if (QuicAddrFamily == QUIC_ADDRESS_FAMILY_INET) {
+        SockAddr.Ipv4.sin_addr.s_addr = 0x00FFFF00UL;
+        QuicAddrSetToLoopback(&SockAddr);
+        TEST_TRUE(SockAddr.Ipv4.sin_addr.S_un.S_un_b.s_b2 == 0);
+        TEST_TRUE(SockAddr.Ipv4.sin_addr.S_un.S_un_b.s_b3 == 0);
+    }
+    else {
+        memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
+        for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.u.Byte) - 1; i++) {
+            TEST_TRUE(SockAddr.Ipv6.sin6_addr.u.Byte[i] == 0);
+        }
+    }
+
+    TEST_TRUE(QuicAddrGetFamily(&SockAddr) == QuicAddrFamily);
+}

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -284,7 +284,7 @@ void QuicTestAddrFunctions(_In_ int Family)
         TEST_TRUE((SockAddr.Ipv4.sin_addr.s_addr & 0x00FFFF00UL) == 0);
     } else {
         memset(&SockAddr.Ipv6.sin6_addr, 0XFF, sizeof(SockAddr.Ipv6.sin6_addr));
-        for (int i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.s6_addr) - 1; i++) {
+        for (unsigned long i = 0; i < sizeof(SockAddr.Ipv6.sin6_addr.s6_addr) - 1; i++) {
             TEST_TRUE(SockAddr.Ipv6.sin6_addr.s6_addr[i] == 0);
         }
     }


### PR DESCRIPTION
## Description

Fixes #3969.

- Initialize address field when setting given QUIC_ADDR to loopback address
- Basic tests for several QuicAddr* API

## Testing

Some existing tests hit this code path and new tests have been added for specific checks.

## Documentation

No
