### PR TITLE
Remove ubuntu-20.04 from GitHub Actions

### DIFF
--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -32,9 +32,8 @@ on:
       os:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-22.04'
         # options:
-        #   - ubuntu-20.04
         #   - ubuntu-22.04
         #   - ubuntu-24.04
         #   - macos-13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [linux]
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
         arch: [arm, arm64]
         tls: [openssl, openssl3]
         static: ['', '-Static']
@@ -105,7 +105,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [linux, android]
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
         arch: [x86, x64]
         tls: [openssl, openssl3]
         systemcrypto: ['', '-UseSystemOpenSSLCrypto']
@@ -123,10 +123,6 @@ jobs:
         # TODO: android to support ubuntu-24.04
         - plat: android
           os: 'ubuntu-24.04'
-        # No openssl3 system crypto on ubuntu-20.04
-        - plat: linux
-          os: 'ubuntu-20.04'
-          tls: 'openssl3'
           systemcrypto: '-UseSystemOpenSSLCrypto'
         # No openssl system crypto on ubuntu-22.04
         - plat: linux
@@ -140,8 +136,6 @@ jobs:
           systemcrypto: '-UseSystemOpenSSLCrypto'
         # linux xdp is for ubuntu24.04 only for now
         - plat: android
-          xdp: "-UseXdp"
-        - os: 'ubuntu-20.04'
           xdp: "-UseXdp"
         - os: 'ubuntu-22.04'
           xdp: "-UseXdp"

--- a/.github/workflows/docker-publish-xcomp.yml
+++ b/.github/workflows/docker-publish-xcomp.yml
@@ -5,14 +5,12 @@ on:
     branches: [ main ]
     paths:
     - .github/workflows/docker-publish-xcomp.yml
-    - .docker/ubuntu-20.04/*
     - .docker/ubuntu-22.04/*
     - .docker/ubuntu-24.04/*
   pull_request:
     branches: [ main ]
     paths:
     - .github/workflows/docker-publish-xcomp.yml
-    - .docker/ubuntu-20.04/*
     - .docker/ubuntu-22.04/*
     - .docker/ubuntu-24.04/*
 
@@ -29,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['20.04', '22.04', '24.04']
+        version: ['22.04', '24.04']
         target: ['cross']
 
     name: Build

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       config: 'Debug'
       repo: ${{ github.repository }}
-  
+
   build-linux:
     name: Ubuntu
     needs: []
@@ -34,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp" },
         ]
@@ -66,7 +65,7 @@ jobs:
       arch: ${{ matrix.vec.arch }}
       tls: ${{ matrix.vec.tls }}
       repo: ${{ github.repository }}
-    
+
   dotnet-test:
     name: DotNet Test
     needs: [build-windows, build-linux, build-darwin-frameworks]
@@ -76,7 +75,6 @@ jobs:
         vec: [
           { plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl" },
           { plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl3" },
-          { plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp" },
           { plat: "macos", os: "macos-13", arch: "universal", tls: "openssl" },

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -27,9 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Release", os: "ubuntu-20.04", arch: "arm", tls: "openssl" },
-          { config: "Release", os: "ubuntu-20.04", arch: "arm64", tls: "openssl" },
-          { config: "Release", os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { config: "Release", os: "ubuntu-22.04", arch: "arm", tls: "openssl3" },
           { config: "Release", os: "ubuntu-22.04", arch: "arm64", tls: "openssl3" },
           { config: "Release", os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
@@ -53,7 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Release", os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { config: "Release", os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { config: "Release", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", xdp: "-UseXdp" },
         ]
@@ -92,9 +88,6 @@ jobs:
           { friendlyName: "Ubuntu 24.04 x64", config: "Release", os: "ubuntu-24.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-amd64", xdp: "-UseXdp", dotnetVersion: "9.0" },
           { friendlyName: "Ubuntu 24.04 ARM32", config: "Release", os: "ubuntu-24.04", arch: "arm",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-arm32v7", dotnetVersion: "9.0" },
           { friendlyName: "Ubuntu 24.04 ARM64", config: "Release", os: "ubuntu-24.04", arch: "arm64", tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-noble-arm64v8", dotnetVersion: "9.0" },
-          # Ubuntu 20.04
-          { friendlyName: "Ubuntu 20.04 x64", config: "Release", os: "ubuntu-20.04", arch: "x64",   tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64", dotnetVersion: "9.0" },
-          { friendlyName: "Ubuntu 20.04 ARM64", config: "Release", os: "ubuntu-20.04", arch: "arm64", tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8", dotnetVersion: "9.0" },
           # Debian 12
           { friendlyName: "Debian 12 x64", config: "Release", os: "ubuntu-22.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim-amd64", dotnetVersion: "9.0" },
           { friendlyName: "Debian 12 ARM32", config: "Release", os: "ubuntu-22.04", arch: "arm",   tls: "openssl3", image: "mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim-arm32v7", dotnetVersion: "9.0" },
@@ -108,7 +101,7 @@ jobs:
           { friendlyName: "Fedora 39 x64", config: "Release", os: "ubuntu-22.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39", dotnetVersion: "9.0" },
           { friendlyName: "Fedora 40 x64", config: "Release", os: "ubuntu-22.04", arch: "x64",   tls: "openssl3", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40", dotnetVersion: "9.0" },
           # OpenSuse 15.4
-          { friendlyName: "OpenSuse 15.4 x64", config: "Release", os: "ubuntu-20.04", arch: "x64",   tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-15.4-helix-amd64", dotnetVersion: "9.0" },
+          #{ friendlyName: "OpenSuse 15.4 x64", config: "Release", os: "ubuntu-20.04", arch: "x64",   tls: "openssl", image: "mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-15.4-helix-amd64", dotnetVersion: "9.0" },
           # RHEL 8 - 9
           # { config: "Release", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", image: "redhat/ubi8-minimal:latest" },
           # { config: "Release", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", image: "redhat/ubi9-minimal:latest" },

--- a/.github/workflows/package-reuse-linux.yml
+++ b/.github/workflows/package-reuse-linux.yml
@@ -16,10 +16,10 @@ on:
       os:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-22.04'
         # options:
-        #   - ubuntu-20.04
         #   - ubuntu-22.04
+        #   - ubuntu-24.04
       arch:
         required: false
         default: 'x64'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -50,8 +50,6 @@ jobs:
         vec: [
           { config: "Debug", plat: "macos", os: "macos-13", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "macos", os: "macos-13", arch: "x64", tls: "openssl3", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", build: "-Test", xdp: "-UseXdp" },
@@ -76,8 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "openssl3", build: "-Test", xdp: "-UseXdp"  },

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -25,19 +25,16 @@ jobs:
       matrix:
         vec: [
           # v2.2
-          { release: "2.2.6",  os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { release: "2.2.6",  os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { release: "2.2.6",  os: "windows-2022", arch: "x64", tls: "schannel" },
           { release: "2.2.6",  os: "windows-2022", arch: "x64", tls: "openssl" },
           { release: "2.2.6",  os: "windows-2022", arch: "x64", tls: "openssl3" },
           # v2.3
-          { release: "2.3.8",  os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { release: "2.3.8",  os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { release: "2.3.8",  os: "windows-2022", arch: "x64", tls: "schannel" },
           { release: "2.3.8",  os: "windows-2022", arch: "x64", tls: "openssl" },
           { release: "2.3.8",  os: "windows-2022", arch: "x64", tls: "openssl3" },
           # v2.4
-          { release: "2.4.7",  os: "ubuntu-20.04", arch: "x64", tls: "openssl" },
           { release: "2.4.7",  os: "ubuntu-22.04", arch: "x64", tls: "openssl3" },
           { release: "2.4.7",  os: "windows-2022", arch: "x64", tls: "schannel" },
           { release: "2.4.7",  os: "windows-2022", arch: "x64", tls: "openssl" },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test" },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test" },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test" },
@@ -105,9 +102,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test"  },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test"  },
-          { config: "Debug", plat: "linux", os: "ubuntu-20.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", sanitize: "-Sanitize", build: "-Test"  },
           { config: "Debug", plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl3", systemcrypto: "-UseSystemOpenSSLCrypto", sanitize: "-Sanitize", build: "-Test"  },

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -14,7 +14,7 @@ This script assumes the latest MsQuic commit is built and downloaded as artifact
     The platform (linux or windows) this test is running on.
 
 .PARAMETER os
-    The full OS name and version being tested (i.e., ubuntu-20.04).
+    The full OS name and version being tested (i.e., ubuntu-22.04).
 
 .PARAMETER arch
     The architecture being tested (i.e., x64).


### PR DESCRIPTION
## Description

GitHub is removing support for ubuntu-20.04 builds soon. Fixes #4809.

## Testing

CI/CD

## Documentation

N/A
