### PR TITLE
Require powershell 7.2 for scripts susceptible to be run manually

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -113,6 +113,8 @@ This script provides helpers for building msquic.
 
 #>
 
+#Requires -Version 7.2
+
 param (
     [Parameter(Mandatory = $false)]
     [ValidateSet("Debug", "Release")]

--- a/scripts/generate-dotnet.ps1
+++ b/scripts/generate-dotnet.ps1
@@ -6,6 +6,8 @@
 
 #>
 
+#Requires -Version 7.2
+
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -30,6 +30,8 @@ on the provided configuration.
 
 #>
 
+#Requires -Version 7.2
+
 param (
     [Parameter(Mandatory = $false)]
     [string]$Tls = "",

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -92,6 +92,8 @@ This script runs the MsQuic tests.
     test.ps1 -Filter ParameterValidation* -NumIterations 10
 #>
 
+#Requires -Version 7.2
+
 param (
     [Parameter(Mandatory = $false)]
     [ValidateSet("Debug", "Release")]

--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -5,6 +5,8 @@ This regenerates the CLOG sidecar file.
 
 #>
 
+#Requires -Version 7.2
+
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 


### PR DESCRIPTION
## Description

It is easy to miss / forget about the powershell 7 requirement for running scripts, especially when Windows still ship with version 5.
This makes the script failure clearly indicate that the powershell version is the reason for the failures (versus the current undefined variables errors).

Resolves #4810 

## Testing

CI

## Documentation

N/A
