### PR TITLE
Fix Release-Build Failure on Debian Bookworm

### DIFF
--- a/src/inc/msquichelper.h
+++ b/src/inc/msquichelper.h
@@ -257,7 +257,7 @@ DecodeHexBuffer(
     return HexBufferLen;
 }
 
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__GNUC__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
@@ -277,7 +277,7 @@ EncodeHexBuffer(
     }
 }
 
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__GNUC__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
## Description

Debian Bookworm uses gcc version 12.2.0 (Debian 12.2.0-14) by default. It generates errors if `#pragma GCC diagnostic ignored "-Wstringop-overflow"` is not set. Lowering the minimum GCC version from 13 to 12 therefore fixes this problem.

## Testing

To my knowledge, no existing tests cover this change. The only way to properly test this would be to add a Debian build to the CI/CD workflow.

## Documentation

There is no documentation impact for this change.