### PR TITLE
Rust: BufferRef type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@ mod error;
 pub mod ffi;
 pub use error::{Status, StatusCode};
 mod types;
-pub use types::{ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent};
+pub use types::{
+    BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent, VecBuffers,
+};
 
 //
 // The following starts the C interop layer of MsQuic API.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ use ffi::{HQUIC, QUIC_API_TABLE, QUIC_BUFFER, QUIC_CREDENTIAL_CONFIG, QUIC_SETTI
 use libc::c_void;
 use serde::{Deserialize, Serialize};
 use socket2::SockAddr;
-use std::convert::TryInto;
 use std::fmt;
 use std::io;
 use std::mem;
@@ -27,9 +26,7 @@ mod error;
 pub mod ffi;
 pub use error::{Status, StatusCode};
 mod types;
-pub use types::{
-    BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent, VecBuffers,
-};
+pub use types::{BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent};
 
 //
 // The following starts the C interop layer of MsQuic API.
@@ -356,14 +353,6 @@ pub struct TicketKeyConfig {
     pub id: [u8; 16usize],
     pub material: [u8; 64usize],
     pub material_length: u8,
-}
-
-/// A generic wrapper for contiguous buffer.
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Buffer {
-    pub length: u32,
-    pub buffer: *mut u8,
 }
 
 pub type TlsProtocolVersion = u32;
@@ -844,43 +833,6 @@ unsafe impl Send for Stream {}
 /// should not be closed by default.
 pub struct StreamRef(Stream);
 
-impl From<&str> for Buffer {
-    fn from(data: &str) -> Buffer {
-        Buffer {
-            length: data.len() as u32,
-            buffer: data.as_ptr() as *mut u8,
-        }
-    }
-}
-
-impl From<&Vec<u8>> for Buffer {
-    fn from(data: &Vec<u8>) -> Buffer {
-        Buffer {
-            length: data.len() as u32,
-            buffer: data.as_ptr() as *mut u8,
-        }
-    }
-}
-
-impl From<&[u8]> for Buffer {
-    fn from(data: &[u8]) -> Buffer {
-        Buffer {
-            length: data.len() as u32,
-            buffer: data.as_ptr() as *mut u8,
-        }
-    }
-}
-
-impl From<Buffer> for Vec<u8> {
-    fn from(data: Buffer) -> Vec<u8> {
-        let mut vec = vec![0; data.length.try_into().unwrap()];
-        for index in 0..data.length - 1 {
-            vec[index as usize] = unsafe { *data.buffer.offset(index as isize) };
-        }
-        vec
-    }
-}
-
 impl QuicPerformance {
     pub fn counter(&self, counter: PerformanceCounter) -> i64 {
         self.counters[counter as usize]
@@ -1083,7 +1035,7 @@ define_quic_handle_impl!(Registration);
 impl Configuration {
     pub fn new(
         registration: &Registration,
-        alpn: &[Buffer],
+        alpn: &[BufferRef],
         settings: *const Settings,
     ) -> Result<Configuration, Status> {
         let context: *mut c_void = ptr::null_mut();
@@ -1253,18 +1205,23 @@ impl Connection {
         };
     }
 
-    pub fn datagram_send(
+    /// # Safety
+    /// buffers memory needs to be valid until callback
+    /// [ConnectionEvent::DatagramSendStateChanged]
+    /// is delivered.
+    /// One can optionally pass client_send_context along
+    /// and get it back in the callback.
+    pub unsafe fn datagram_send(
         &self,
-        buffer: &Buffer,
-        buffer_count: u32,
+        buffers: &[BufferRef],
         flags: SendFlags,
         client_send_context: *const c_void,
     ) -> Result<(), Status> {
         let status = unsafe {
             Api::ffi_ref().DatagramSend.unwrap()(
                 self.handle,
-                buffer as *const Buffer as *const QUIC_BUFFER,
-                buffer_count,
+                buffers.as_ptr() as *const QUIC_BUFFER,
+                buffers.len() as u32,
                 flags as crate::ffi::QuicFlag,
                 client_send_context as *mut c_void,
             )
@@ -1356,7 +1313,7 @@ impl Listener {
         Status::ok_from_raw(status)
     }
 
-    pub fn start(&self, alpn: &[Buffer], local_address: Option<&Addr>) -> Result<(), Status> {
+    pub fn start(&self, alpn: &[BufferRef], local_address: Option<&Addr>) -> Result<(), Status> {
         let status = unsafe {
             Api::ffi_ref().ListenerStart.unwrap()(
                 self.handle,
@@ -1459,20 +1416,25 @@ impl Stream {
         }
     }
 
-    pub fn send(
+    /// # Safety
+    /// buffers memory needs to be valid until callback
+    /// [StreamEvent::SendComplete]
+    /// is delivered.
+    /// One can optionally pass client_send_context along
+    /// and get it back in the callback.
+    pub unsafe fn send(
         &self,
-        buffer: &Buffer,
-        buffer_count: u32,
+        buffers: &[BufferRef],
         flags: SendFlags,
         client_send_context: *const c_void,
     ) -> Result<(), Status> {
         let status = unsafe {
             Api::ffi_ref().StreamSend.unwrap()(
                 self.handle,
-                buffer as *const Buffer as *const QUIC_BUFFER,
-                buffer_count,
+                buffers.as_ptr() as *const QUIC_BUFFER,
+                buffers.len() as u32,
                 flags as crate::ffi::QuicFlag,
-                client_send_context as *mut c_void, //(self as *const Stream) as *const c_void,
+                client_send_context as *mut c_void,
             )
         };
         Status::ok_from_raw(status)
@@ -1536,7 +1498,7 @@ mod tests {
 
     use crate::ffi::{HQUIC, QUIC_STATUS};
     use crate::{
-        ffi, Buffer, Configuration, Connection, ConnectionEvent, CredentialConfig, Registration,
+        ffi, BufferRef, Configuration, Connection, ConnectionEvent, CredentialConfig, Registration,
         Settings, StatusCode, Stream, StreamEvent,
     };
 
@@ -1673,7 +1635,7 @@ mod tests {
         );
         let registration = res.unwrap();
 
-        let alpn = [Buffer::from("h3")];
+        let alpn = [BufferRef::from("h3")];
         let res = Configuration::new(
             &registration,
             &alpn,

--- a/src/types.rs
+++ b/src/types.rs
@@ -303,7 +303,7 @@ impl<'b> From<&'b mut crate::ffi::QUIC_STREAM_EVENT> for StreamEvent<'b> {
                     absolute_offset: ev.AbsoluteOffset,
                     total_buffer_length: &mut ev.TotalBufferLength,
                     buffers: unsafe {
-                        BufferRef::from_ffi_slice_ref(slice_conv(
+                        BufferRef::slice_from_ffi_ref(slice_conv(
                             ev.Buffers,
                             ev.BufferCount as usize,
                         ))
@@ -373,7 +373,11 @@ impl<'b> From<&'b mut crate::ffi::QUIC_STREAM_EVENT> for StreamEvent<'b> {
 }
 
 /// Buffer with same abi as ffi type.
-/// It has no ownership of the memory chunk.
+/// # Safety
+/// It has no ownership of the memory chunk,
+/// and user needs to ensure that this ref has
+/// the same lifetime as the original buffer
+/// location.
 #[repr(transparent)]
 pub struct BufferRef(pub QUIC_BUFFER);
 
@@ -384,52 +388,38 @@ impl BufferRef {
     }
 
     /// Cast from the ffi type.
-    /// # Safety
-    /// Raw buffer lifetime needs to be manually ensured.
-    pub unsafe fn from_ffi_ref(raw: &QUIC_BUFFER) -> &Self {
-        (raw as *const QUIC_BUFFER as *const Self).as_ref().unwrap()
+    /// This achieves zero copy.
+    pub fn from_ffi_ref(raw: &QUIC_BUFFER) -> &Self {
+        unsafe { (raw as *const QUIC_BUFFER as *const Self).as_ref().unwrap() }
     }
 
-    /// Cast from ffi slice type
-    /// # Safety
-    /// Raw buffer lifetime needs to be manually ensured.
-    pub unsafe fn from_ffi_slice_ref(raw: &[QUIC_BUFFER]) -> &[Self] {
-        (raw as *const [QUIC_BUFFER] as *const [Self])
-            .as_ref()
-            .unwrap()
-    }
-}
-
-/// Buffers backed by vectors.
-/// T is the buffer type that can convert to slice, typically Vec<u8> or array
-/// are used.
-/// TODO: this impl is unstable.
-pub struct VecBuffers<T: AsRef<[u8]>> {
-    /// buffers. Each chunk T is heap allocated via Vec,
-    _data: Vec<T>,
-    meta: Vec<QUIC_BUFFER>,
-}
-
-impl<T: AsRef<[u8]>> VecBuffers<T> {
-    pub fn as_ffi(&self) -> &[QUIC_BUFFER] {
-        self.meta.as_slice()
+    /// Cast from ffi slice type.
+    /// This achieves zero copy.
+    pub fn slice_from_ffi_ref(raw: &[QUIC_BUFFER]) -> &[Self] {
+        unsafe {
+            (raw as *const [QUIC_BUFFER] as *const [Self])
+                .as_ref()
+                .unwrap()
+        }
     }
 }
 
-impl<T: AsRef<[u8]>> VecBuffers<T> {
-    pub fn new(data: Vec<T>) -> Self {
-        let meta = data
-            .iter()
-            .by_ref()
-            .map(|b| {
-                let buf_ref = b.as_ref();
-                QUIC_BUFFER {
-                    Buffer: buf_ref.as_ptr() as *mut u8,
-                    Length: buf_ref.len() as u32,
-                }
-            })
-            .collect();
-        Self { _data: data, meta }
+// Convert from various common buffer types
+impl From<&str> for BufferRef {
+    fn from(value: &str) -> Self {
+        Self(QUIC_BUFFER {
+            Length: value.len() as u32,
+            Buffer: value.as_ptr() as *mut u8,
+        })
+    }
+}
+
+impl From<&[u8]> for BufferRef {
+    fn from(value: &[u8]) -> Self {
+        Self(QUIC_BUFFER {
+            Length: value.len() as u32,
+            Buffer: value.as_ptr() as *mut u8,
+        })
     }
 }
 
@@ -445,11 +435,8 @@ unsafe fn slice_conv<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
 }
 
 #[cfg(test)]
-mod tests {
+mod buff_tests {
     use crate::{ffi::QUIC_BUFFER, types::slice_conv, BufferRef};
-
-    use super::VecBuffers;
-
     #[test]
     fn slice_conv_test() {
         {
@@ -466,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_ref_test() {
+    fn buffer_ref_raw_test() {
         let first = Box::new(b"first");
         let second = b"second";
         let buffers = Box::new([
@@ -479,8 +466,9 @@ mod tests {
                 Length: second.len() as u32,
             },
         ]);
-        let buffs = unsafe { BufferRef::from_ffi_slice_ref(buffers.as_ref()) };
-        // In callback events, BufferSlice buffs is the given type and memory is from C,
+        let buffer_refs = BufferRef::slice_from_ffi_ref(buffers.as_ref());
+        let buffs = buffer_refs;
+        // In callback events, buffers has memory from C,
         // and it has the right lifetime.
         // In this test, `buffers` variable emulates the memory from C.
 
@@ -497,33 +485,66 @@ mod tests {
         assert_eq!(second, second1.as_bytes());
     }
 
-    const FIRST: &[u8; 5] = b"aaaaa";
-    const SECOND: &[u8; 5] = b"bbbbb";
-
+    /// This test shows how to construct simple
+    /// buffers to call msquic.
     #[test]
-    fn buffer_write_test_vec() {
-        let buffers = VecBuffers::new(vec![FIRST.to_vec(), SECOND.to_vec()]);
-        buffer_write_test(buffers);
+    fn buffer_ref_conv_test() {
+        let b1 = b"11";
+        let b2 = b"22".to_vec();
+        let b3 = "33";
+
+        let buffer_refs = [
+            BufferRef::from(b1.as_slice()),
+            BufferRef::from(b2.as_slice()),
+            BufferRef::from(b3),
+        ];
+        // One can call msquic api here using the slice.
+
+        assert_eq!(buffer_refs[0].as_bytes(), b1);
+        assert_eq!(buffer_refs[1].as_bytes(), b2);
+        assert_eq!(buffer_refs[2].as_bytes(), b3.as_bytes());
     }
 
     #[test]
-    fn buffer_write_test_array() {
-        let buffers = VecBuffers::new(vec![FIRST.to_owned(), SECOND.to_owned()]);
-        buffer_write_test(buffers);
+    fn buffer_ref_detach_test() {
+        let data = b"data".to_vec().into_boxed_slice();
+        let buff_refs = [BufferRef::from(data.as_ref())];
+
+        // Detach the data as raw ptr.
+        // raw ptr can be pass to msquic as client context.
+        let raw = Box::into_raw(data);
+
+        // MsQuic takes ownership of the buff and can inspect it.
+        assert_eq!(buff_refs[0].as_bytes(), b"data");
+
+        // Attach back the ownership
+        // Usually used when msquic gives back the client context
+        // in the callback event.
+        let _ = unsafe { Box::from_raw(raw) };
     }
 
-    fn buffer_write_test<T: AsRef<[u8]>>(buffers: VecBuffers<T>) {
-        let refs = unsafe { BufferRef::from_ffi_slice_ref(buffers.as_ffi()) };
-        // try read it
-        assert_eq!(refs[0].as_bytes(), FIRST);
-        assert_eq!(refs[1].as_bytes(), SECOND);
+    #[test]
+    fn multi_buffer_ref_detach_test() {
+        let data = b"data".to_vec();
+        let data2 = Box::new("data2");
+        let buff_refs = [
+            BufferRef::from(data.as_slice()),
+            BufferRef::from(data2.as_bytes()),
+        ];
 
-        // TODO: implement detach attach.
-        // // detach and reattach and check content
-        // let raw = buffers.into_raw();
-        // let buffers2 = unsafe { BoxedBuffersOwned::<T>::from_raw(raw) }.into_inner();
-        // let refs2 = BufferRefSlice(buffers2.as_ffi());
-        // assert_eq!(refs2.as_slice()[0].as_bytes(), FIRST);
-        // assert_eq!(refs2.as_slice()[1].as_bytes(), SECOND);
+        let ctx = Box::new((data, data2));
+
+        // Detach the data as raw ptr.
+        // raw ptr can be pass to msquic as client context.
+        let raw = Box::into_raw(ctx);
+
+        // MsQuic takes ownership of the buff and can inspect it.
+        assert_eq!(buff_refs[0].as_bytes(), b"data");
+        assert_eq!(buff_refs[1].as_bytes(), b"data2");
+
+        // Attach back the ownership
+        // Usually used when msquic gives back the client context
+        // in the callback event.
+        let _ = unsafe { Box::from_raw(raw) };
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::ffi::QUIC_CONNECTION_EVENT;
+use crate::ffi::{QUIC_BUFFER, QUIC_CONNECTION_EVENT};
 use std::ffi::c_void;
 
 /// Listener event converted from ffi type.
@@ -123,9 +123,8 @@ pub enum ConnectionEvent<'a> {
         send_enabled: bool,
         max_send_length: u16,
     },
-    // TODO: buffer needs to be safely converted.
     DatagramReceived {
-        buffer: &'a crate::ffi::QUIC_BUFFER,
+        buffer: &'a BufferRef,
         // TODO: provide safe wrapper.
         flags: crate::ffi::QUIC_RECEIVE_FLAGS,
     },
@@ -209,7 +208,7 @@ impl<'a> From<&'a QUIC_CONNECTION_EVENT> for ConnectionEvent<'a> {
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_DATAGRAM_RECEIVED => {
               let ev = unsafe { value.__bindgen_anon_1.DATAGRAM_RECEIVED };
-              Self::DatagramReceived { buffer: unsafe { ev.Buffer.as_ref().unwrap() }, flags: ev.Flags }
+              Self::DatagramReceived { buffer: unsafe { BufferRef::from_ffi_ref(ev.Buffer.as_ref().unwrap()) }, flags: ev.Flags }
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED => {
               let ev = unsafe { value.__bindgen_anon_1.DATAGRAM_SEND_STATE_CHANGED };
@@ -252,8 +251,8 @@ pub enum StreamEvent<'a> {
     },
     Receive {
         absolute_offset: u64,
-        total_buffer_length: &'a mut u64,       // inout parameter
-        buffers: &'a [crate::ffi::QUIC_BUFFER], // TODO: impl buffer wrapper types
+        total_buffer_length: &'a mut u64, // inout parameter
+        buffers: &'a [BufferRef],
         flags: crate::ffi::QUIC_RECEIVE_FLAGS,
     },
     SendComplete {
@@ -303,7 +302,12 @@ impl<'b> From<&'b mut crate::ffi::QUIC_STREAM_EVENT> for StreamEvent<'b> {
                 Self::Receive {
                     absolute_offset: ev.AbsoluteOffset,
                     total_buffer_length: &mut ev.TotalBufferLength,
-                    buffers: unsafe { slice_conv(ev.Buffers, ev.BufferCount as usize) },
+                    buffers: unsafe {
+                        BufferRef::from_ffi_slice_ref(slice_conv(
+                            ev.Buffers,
+                            ev.BufferCount as usize,
+                        ))
+                    },
                     flags: ev.Flags,
                 }
             }
@@ -368,6 +372,67 @@ impl<'b> From<&'b mut crate::ffi::QUIC_STREAM_EVENT> for StreamEvent<'b> {
     }
 }
 
+/// Buffer with same abi as ffi type.
+/// It has no ownership of the memory chunk.
+#[repr(transparent)]
+pub struct BufferRef(pub QUIC_BUFFER);
+
+impl BufferRef {
+    /// Get the bytes of the buffer.
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { slice_conv(self.0.Buffer, self.0.Length as usize) }
+    }
+
+    /// Cast from the ffi type.
+    /// # Safety
+    /// Raw buffer lifetime needs to be manually ensured.
+    pub unsafe fn from_ffi_ref(raw: &QUIC_BUFFER) -> &Self {
+        (raw as *const QUIC_BUFFER as *const Self).as_ref().unwrap()
+    }
+
+    /// Cast from ffi slice type
+    /// # Safety
+    /// Raw buffer lifetime needs to be manually ensured.
+    pub unsafe fn from_ffi_slice_ref(raw: &[QUIC_BUFFER]) -> &[Self] {
+        (raw as *const [QUIC_BUFFER] as *const [Self])
+            .as_ref()
+            .unwrap()
+    }
+}
+
+/// Buffers backed by vectors.
+/// T is the buffer type that can convert to slice, typically Vec<u8> or array
+/// are used.
+/// TODO: this impl is unstable.
+pub struct VecBuffers<T: AsRef<[u8]>> {
+    /// buffers. Each chunk T is heap allocated via Vec,
+    _data: Vec<T>,
+    meta: Vec<QUIC_BUFFER>,
+}
+
+impl<T: AsRef<[u8]>> VecBuffers<T> {
+    pub fn as_ffi(&self) -> &[QUIC_BUFFER] {
+        self.meta.as_slice()
+    }
+}
+
+impl<T: AsRef<[u8]>> VecBuffers<T> {
+    pub fn new(data: Vec<T>) -> Self {
+        let meta = data
+            .iter()
+            .by_ref()
+            .map(|b| {
+                let buf_ref = b.as_ref();
+                QUIC_BUFFER {
+                    Buffer: buf_ref.as_ptr() as *mut u8,
+                    Length: buf_ref.len() as u32,
+                }
+            })
+            .collect();
+        Self { _data: data, meta }
+    }
+}
+
 /// Convert array pointer to slice.
 /// Allows empty buffer. slice::from_raw_parts does not allow empty buffer.
 #[inline]
@@ -376,5 +441,89 @@ unsafe fn slice_conv<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
         &[]
     } else {
         std::slice::from_raw_parts(ptr, len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ffi::QUIC_BUFFER, types::slice_conv, BufferRef};
+
+    use super::VecBuffers;
+
+    #[test]
+    fn slice_conv_test() {
+        {
+            let ptr = std::ptr::null::<u8>();
+            let len = 0;
+            let buff = unsafe { slice_conv(ptr, len) };
+            assert_eq!(buff.len(), 0)
+        }
+        {
+            let original = b"hello";
+            let buff = unsafe { slice_conv(original.as_ptr(), original.len()) };
+            assert_eq!(buff, original.as_slice())
+        }
+    }
+
+    #[test]
+    fn buffer_ref_test() {
+        let first = Box::new(b"first");
+        let second = b"second";
+        let buffers = Box::new([
+            QUIC_BUFFER {
+                Buffer: first.as_ptr() as *mut u8,
+                Length: first.len() as u32,
+            },
+            QUIC_BUFFER {
+                Buffer: second.as_ptr() as *mut u8,
+                Length: second.len() as u32,
+            },
+        ]);
+        let buffs = unsafe { BufferRef::from_ffi_slice_ref(buffers.as_ref()) };
+        // In callback events, BufferSlice buffs is the given type and memory is from C,
+        // and it has the right lifetime.
+        // In this test, `buffers` variable emulates the memory from C.
+
+        let first1 = &buffs[0];
+        // If we drop buffers here on this line, compiler can catch the first1's lifetime is violated.
+        // This shows that the BufferSlice wrapper captures the right lifetime of the buffers.
+        // However there is no way to carry the lifetime of the var `first` into var `buffers` because the C style
+        // api raw pointer boundary has been crossed.
+        // TODO: msquic has feature to hold on to buffers even after callback have returned. This is
+        // is not supported safely in rust. (event if we support this, buffs reference's lifetime is still only valid
+        // at the end of the callback function. However, the lifetime of content of the buffer, i.e. &[u8], can be extended.)
+        let second1 = &buffs[1];
+        assert_eq!(first.as_slice(), first1.as_bytes());
+        assert_eq!(second, second1.as_bytes());
+    }
+
+    const FIRST: &[u8; 5] = b"aaaaa";
+    const SECOND: &[u8; 5] = b"bbbbb";
+
+    #[test]
+    fn buffer_write_test_vec() {
+        let buffers = VecBuffers::new(vec![FIRST.to_vec(), SECOND.to_vec()]);
+        buffer_write_test(buffers);
+    }
+
+    #[test]
+    fn buffer_write_test_array() {
+        let buffers = VecBuffers::new(vec![FIRST.to_owned(), SECOND.to_owned()]);
+        buffer_write_test(buffers);
+    }
+
+    fn buffer_write_test<T: AsRef<[u8]>>(buffers: VecBuffers<T>) {
+        let refs = unsafe { BufferRef::from_ffi_slice_ref(buffers.as_ffi()) };
+        // try read it
+        assert_eq!(refs[0].as_bytes(), FIRST);
+        assert_eq!(refs[1].as_bytes(), SECOND);
+
+        // TODO: implement detach attach.
+        // // detach and reattach and check content
+        // let raw = buffers.into_raw();
+        // let buffers2 = unsafe { BoxedBuffersOwned::<T>::from_raw(raw) }.into_inner();
+        // let refs2 = BufferRefSlice(buffers2.as_ffi());
+        // assert_eq!(refs2.as_slice()[0].as_bytes(), FIRST);
+        // assert_eq!(refs2.as_slice()[1].as_bytes(), SECOND);
     }
 }


### PR DESCRIPTION
## Description
Introduce BufferRef type to wrap ffi QUIC_BUFFER type. 
BufferRef has the same abi as QUIC_BUFFER, and it has slice accessor functionality. 
* Apis having arguments using &QUIC_BUFFER and length are converted to use &[BufferRef].
* Callbacks with &[QUIC_BUFFER] fields are converted to use &[BufferRef].

This brings us closer to have a full server client example with relatively safe Apis.

## Testing
Added tests to demonstrate how to use BufferRef to call msquic Apis and how to pass client context to ensure lifetime of buffer memories on heap.

## Documentation
NA
