### PR TITLE
Rust: Settings type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod ffi;
 pub use error::{Status, StatusCode};
 mod types;
 pub use types::{BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent};
+mod settings;
+pub use settings::Settings;
 
 //
 // The following starts the C interop layer of MsQuic API.
@@ -452,41 +454,6 @@ pub struct QuicTlsSecrets {
     pub server_traffic_secret0: [u8; QUIC_TLS_SECRETS_MAX_SECRET_LEN],
 }
 
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-pub struct Settings {
-    pub is_set_flags: u64,
-    pub max_bytes_per_key: u64,
-    pub handshake_idle_timeout_ms: u64,
-    pub idle_timeout_ms: u64,
-    pub mtu_discovery_search_complete_timeout_us: u64,
-    pub tls_client_max_send_buffer: u32,
-    pub tls_server_max_send_buffer: u32,
-    pub stream_recv_window_default: u32,
-    pub stream_recv_buffer_default: u32,
-    pub conn_flow_control_window: u32,
-    pub max_worker_queue_delay_us: u32,
-    pub max_stateless_operations: u32,
-    pub initial_window_packets: u32,
-    pub send_idle_timeout_ms: u32,
-    pub initiall_rtt_ms: u32,
-    pub max_ack_delay_ms: u32,
-    pub disconnect_timeout_ms: u32,
-    pub keep_alive_interval_ms: u32,
-    pub congestion_control_algorithm: u16,
-    pub peer_bidi_stream_count: u16,
-    pub peer_unidi_stream_count: u16,
-    pub max_binding_stateless_operations: u16,
-    pub stateless_operation_expiration_ms: u16,
-    pub minimum_mtu: u16,
-    pub maximum_mtu: u16,
-    pub other_flags: u8,
-    pub mtu_operations_per_drain: u8,
-    pub mtu_discovery_missing_probe_count: u8,
-    pub dest_cid_update_idle_timeout_ms: u32,
-    pub other2_flags: u64,
-}
-
 pub const PARAM_GLOBAL_RETRY_MEMORY_PERCENT: u32 = 0x01000000;
 pub const PARAM_GLOBAL_SUPPORTED_VERSIONS: u32 = 0x01000001;
 pub const PARAM_GLOBAL_LOAD_BALACING_MODE: u32 = 0x01000002;
@@ -742,38 +709,6 @@ impl From<QuicPerformanceCountersParam> for QuicPerformanceCounters {
     }
 }
 
-impl Settings {
-    pub fn new() -> Self {
-        Self::default()
-    }
-    pub fn set_peer_bidi_stream_count(&mut self, value: u16) -> &mut Settings {
-        self.is_set_flags |= 0x40000;
-        self.peer_bidi_stream_count = value;
-        self
-    }
-    pub fn set_peer_unidi_stream_count(&mut self, value: u16) -> &mut Settings {
-        self.is_set_flags |= 0x80000;
-        self.peer_unidi_stream_count = value;
-        self
-    }
-    pub fn set_idle_timeout_ms(&mut self, value: u64) -> &mut Settings {
-        self.is_set_flags |= 0x4;
-        self.idle_timeout_ms = value;
-        self
-    }
-    pub fn set_datagram_receive_enabled(&mut self, value: bool) -> &mut Settings {
-        self.is_set_flags |= 1 << 27;
-        self.other_flags |= (value as u8) << 3;
-        self
-    }
-    #[cfg(feature = "preview-api")]
-    pub fn set_stream_multi_receive_enabled(&mut self, value: bool) -> &mut Settings {
-        self.is_set_flags |= 1 << 42;
-        self.other2_flags |= (value as u64) << 5;
-        self
-    }
-}
-
 impl CredentialConfig {
     pub fn new_client() -> CredentialConfig {
         CredentialConfig {
@@ -961,21 +896,24 @@ impl Configuration {
     pub fn new(
         registration: &Registration,
         alpn: &[BufferRef],
-        settings: *const Settings,
+        settings: Option<&Settings>,
     ) -> Result<Configuration, Status> {
         let context: *mut c_void = ptr::null_mut();
         let mut new_configuration: HQUIC = ptr::null_mut();
-        let mut settings_size: u32 = 0;
-        if !settings.is_null() {
-            settings_size = ::std::mem::size_of::<Settings>() as u32;
-        }
+        let (settings_ptr, settings_size) = match settings {
+            Some(s) => (
+                s.as_ffi_ref() as *const QUIC_SETTINGS,
+                ::std::mem::size_of::<QUIC_SETTINGS>() as u32,
+            ),
+            None => (std::ptr::null(), 0),
+        };
 
         let status = unsafe {
             Api::ffi_ref().ConfigurationOpen.unwrap()(
                 registration.as_raw(),
                 alpn.as_ptr() as *const QUIC_BUFFER,
                 alpn.len() as u32,
-                settings as *const QUIC_SETTINGS,
+                settings_ptr,
                 settings_size,
                 context,
                 std::ptr::addr_of_mut!(new_configuration),
@@ -1519,19 +1457,10 @@ mod tests {
         }
 
         let alpn = [BufferRef::from("h3")];
-        let res = Configuration::new(
-            &registration,
-            &alpn,
-            #[cfg(feature = "preview-api")]
-            Settings::new()
-                .set_peer_bidi_stream_count(100)
-                .set_peer_unidi_stream_count(3)
-                .set_stream_multi_receive_enabled(true),
-            #[cfg(not(feature = "preview-api"))]
-            Settings::new()
-                .set_peer_bidi_stream_count(100)
-                .set_peer_unidi_stream_count(3),
-        );
+        let settings = Settings::new()
+            .set_PeerBidiStreamCount(100)
+            .set_PeerUnidiStreamCount(3);
+        let res = Configuration::new(&registration, &alpn, Some(&settings));
         assert!(
             res.is_ok(),
             "Failed to open configuration: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1460,6 +1460,8 @@ mod tests {
         let settings = Settings::new()
             .set_PeerBidiStreamCount(100)
             .set_PeerUnidiStreamCount(3);
+        #[cfg(feature = "preview-api")]
+        let settings = settings.set_StreamMultiReceiveEnabled();
         let res = Configuration::new(&registration, &alpn, Some(&settings));
         assert!(
             res.is_ok(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -42,6 +42,18 @@ macro_rules! define_settings_entry_bitflag {
     };
 }
 
+/// Macro to define function to set a bit flag in a substruct.
+/// It sets the IsSet bitflag for the entry and set the bit flage value.
+macro_rules! define_settings_entry_bitflag2 {
+    ( $fn_name:ident) => {
+        pub fn $fn_name(mut self) -> Self {
+            unsafe { self.inner.__bindgen_anon_1.IsSet.$fn_name(1) };
+            unsafe { self.inner.__bindgen_anon_2.__bindgen_anon_1.$fn_name(1) };
+            self
+        }
+    };
+}
+
 impl Settings {
     pub fn new() -> Self {
         Self::default()
@@ -115,17 +127,20 @@ impl Settings {
     define_settings_entry_bitflag!(set_GreaseQuicBitEnabled);
     define_settings_entry_bitflag!(set_EcnEnabled);
 
-    // TODO: add preview feature.
-    pub fn set_HyStartEnabled(&mut self) -> &mut Self {
-        unsafe { self.inner.__bindgen_anon_1.IsSet.set_HyStartEnabled(1) };
-        unsafe {
-            self.inner
-                .__bindgen_anon_2
-                .__bindgen_anon_1
-                .set_HyStartEnabled(1)
-        };
-        self
-    }
+    define_settings_entry_bitflag2!(set_HyStartEnabled);
+
+    // preview features
+
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_EncryptionOffloadAllowed);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_ReliableResetEnabled);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_OneWayDelayEnabled);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_NetStatsEventEnabled);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_StreamMultiReceiveEnabled);
 
     define_settings_entry!(
         set_StreamRecvWindowBidiLocalDefault,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ffi::QUIC_SETTINGS;
+
+/// Settings for MsQuic
+/// Wrapping QUIC_SETTINGS ffi type.
+pub struct Settings {
+    inner: QUIC_SETTINGS,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            inner: unsafe { std::mem::zeroed::<QUIC_SETTINGS>() },
+        }
+    }
+}
+
+/// Macro to define function to set the setting entry in ffi type.
+/// It sets the IsSet bitflag for the entry, and set the value.
+/// Arguments are: function name, settings field name, settings field type.
+macro_rules! define_settings_entry {
+    ( $fn_name:ident, $field_name:ident, $tp:ty ) => {
+        pub fn $fn_name(mut self, value: $tp) -> Self {
+            unsafe { self.inner.__bindgen_anon_1.IsSet.$fn_name(1) };
+            self.inner.$field_name = value;
+            self
+        }
+    };
+}
+
+/// Macro to define function to set a bit flag in ffi type.
+/// It sets the IsSet bitflag for the entry and set the bit flage value.
+macro_rules! define_settings_entry_bitflag {
+    ( $fn_name:ident) => {
+        pub fn $fn_name(mut self) -> Self {
+            unsafe { self.inner.__bindgen_anon_1.IsSet.$fn_name(1) };
+            self.inner.$fn_name(1);
+            self
+        }
+    };
+}
+
+impl Settings {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn as_ffi_ref(&self) -> &QUIC_SETTINGS {
+        &self.inner
+    }
+}
+
+// Defines the setters for each setting.
+// Keep the casing as the ffi function for easy of using macro.
+#[allow(non_snake_case)]
+impl Settings {
+    define_settings_entry!(set_MaxBytesPerKey, MaxBytesPerKey, u64);
+    define_settings_entry!(set_HandshakeIdleTimeoutMs, HandshakeIdleTimeoutMs, u64);
+    define_settings_entry!(set_IdleTimeoutMs, IdleTimeoutMs, u64);
+    define_settings_entry!(
+        set_MtuDiscoverySearchCompleteTimeoutUs,
+        MtuDiscoverySearchCompleteTimeoutUs,
+        u64
+    );
+    define_settings_entry!(set_TlsClientMaxSendBuffer, TlsClientMaxSendBuffer, u32);
+    define_settings_entry!(set_TlsServerMaxSendBuffer, TlsServerMaxSendBuffer, u32);
+    define_settings_entry!(set_StreamRecvWindowDefault, StreamRecvWindowDefault, u32);
+    define_settings_entry!(set_StreamRecvBufferDefault, StreamRecvBufferDefault, u32);
+    define_settings_entry!(set_ConnFlowControlWindow, ConnFlowControlWindow, u32);
+    define_settings_entry!(set_MaxWorkerQueueDelayUs, MaxWorkerQueueDelayUs, u32);
+    define_settings_entry!(set_MaxStatelessOperations, MaxStatelessOperations, u32);
+    define_settings_entry!(set_InitialWindowPackets, InitialWindowPackets, u32);
+    define_settings_entry!(set_SendIdleTimeoutMs, SendIdleTimeoutMs, u32);
+    define_settings_entry!(set_InitialRttMs, InitialRttMs, u32);
+    define_settings_entry!(set_MaxAckDelayMs, MaxAckDelayMs, u32);
+    define_settings_entry!(set_DisconnectTimeoutMs, DisconnectTimeoutMs, u32);
+    define_settings_entry!(set_KeepAliveIntervalMs, KeepAliveIntervalMs, u32);
+    define_settings_entry!(
+        set_CongestionControlAlgorithm,
+        CongestionControlAlgorithm,
+        u16
+    );
+    define_settings_entry!(set_PeerBidiStreamCount, PeerBidiStreamCount, u16);
+    define_settings_entry!(set_PeerUnidiStreamCount, PeerUnidiStreamCount, u16);
+    define_settings_entry!(
+        set_MaxBindingStatelessOperations,
+        MaxBindingStatelessOperations,
+        u16
+    );
+    define_settings_entry!(
+        set_StatelessOperationExpirationMs,
+        StatelessOperationExpirationMs,
+        u16
+    );
+    define_settings_entry!(set_MinimumMtu, MinimumMtu, u16);
+    define_settings_entry!(set_MaximumMtu, MaximumMtu, u16);
+    define_settings_entry_bitflag!(set_SendBufferingEnabled);
+    define_settings_entry_bitflag!(set_PacingEnabled);
+    define_settings_entry_bitflag!(set_MigrationEnabled);
+    define_settings_entry_bitflag!(set_DatagramReceiveEnabled);
+    define_settings_entry_bitflag!(set_ServerResumptionLevel);
+    define_settings_entry!(set_MaxOperationsPerDrain, MaxOperationsPerDrain, u8);
+    define_settings_entry!(
+        set_MtuDiscoveryMissingProbeCount,
+        MtuDiscoveryMissingProbeCount,
+        u8
+    );
+    define_settings_entry!(
+        set_DestCidUpdateIdleTimeoutMs,
+        DestCidUpdateIdleTimeoutMs,
+        u32
+    );
+    define_settings_entry_bitflag!(set_GreaseQuicBitEnabled);
+    define_settings_entry_bitflag!(set_EcnEnabled);
+
+    // TODO: add preview feature.
+    pub fn set_HyStartEnabled(&mut self) -> &mut Self {
+        unsafe { self.inner.__bindgen_anon_1.IsSet.set_HyStartEnabled(1) };
+        unsafe {
+            self.inner
+                .__bindgen_anon_2
+                .__bindgen_anon_1
+                .set_HyStartEnabled(1)
+        };
+        self
+    }
+
+    define_settings_entry!(
+        set_StreamRecvWindowBidiLocalDefault,
+        StreamRecvWindowBidiLocalDefault,
+        u32
+    );
+    define_settings_entry!(
+        set_StreamRecvWindowBidiRemoteDefault,
+        StreamRecvWindowBidiRemoteDefault,
+        u32
+    );
+    define_settings_entry!(
+        set_StreamRecvWindowUnidiDefault,
+        StreamRecvWindowUnidiDefault,
+        u32
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Settings;
+
+    #[test]
+    fn test_bit_field() {
+        let s = Settings::new()
+            .set_PeerBidiStreamCount(3)
+            .set_PeerUnidiStreamCount(4);
+        assert_eq!(3, s.as_ffi_ref().PeerBidiStreamCount);
+        assert_eq!(4, s.as_ffi_ref().PeerUnidiStreamCount);
+    }
+}


### PR DESCRIPTION
## Description
Add safe wrapper for QUIC_SETTINGS ffi type.
Add setters for each setting entry using macro.
Changed Configuration new() to use new Settings type and removed the manual ffi type.

MISC:
Preview settings is removed/regressed because the auto generated bindings do not have preview apis yet.
Rust code files are accumulated in src dir. We should add a dedicated dir inside src to keep all rust code together. Will do it in a separate PR.

## Testing
Added simple test to set settings using setters, and get the settings using ffi type to verify they match.

## Documentation
NA
