### PR TITLE
Remove Extra Keep Alive set in ConnectionStart

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1919,13 +1919,6 @@ QuicConnStart(
         goto Exit;
     }
 
-    if (Connection->Settings.KeepAliveIntervalMs != 0) {
-        QuicConnTimerSet(
-            Connection,
-            QUIC_CONN_TIMER_KEEP_ALIVE,
-            MS_TO_US(Connection->Settings.KeepAliveIntervalMs));
-    }
-
 Exit:
 
     if (ServerName != NULL) {


### PR DESCRIPTION
## Description

`QuicConnStart` sets the keep alive timer, when a client creates a new connection. However, this timer set is unnecessary because `QuicConnDrainOperations` will update the keep alive timer every time, for example, when the initial packet is set. 

## Testing

Keep alives are already tested, so no new tests are needed.

## Documentation

Nope.
