### PR TITLE
Optimize QuicStreamSetUpdateMaxStreams

### DIFF
--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -204,7 +204,7 @@ QuicStreamFree(
     CXPLAT_DBG_ASSERT(Connection->State.ClosedLocally || Stream->Flags.ShutdownComplete);
     CXPLAT_DBG_ASSERT(Connection->State.ClosedLocally || Stream->Flags.HandleClosed);
     CXPLAT_DBG_ASSERT(!Stream->Flags.InStreamTable);
-    CXPLAT_DBG_ASSERT(Stream->WaitingForIdFlowControlLink.Flink == NULL);
+    CXPLAT_DBG_ASSERT(!Stream->Flags.InWaitingList);
     CXPLAT_DBG_ASSERT(Stream->ClosedLink.Flink == NULL);
     CXPLAT_DBG_ASSERT(Stream->SendLink.Flink == NULL);
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -204,6 +204,7 @@ QuicStreamFree(
     CXPLAT_DBG_ASSERT(Connection->State.ClosedLocally || Stream->Flags.ShutdownComplete);
     CXPLAT_DBG_ASSERT(Connection->State.ClosedLocally || Stream->Flags.HandleClosed);
     CXPLAT_DBG_ASSERT(!Stream->Flags.InStreamTable);
+    CXPLAT_DBG_ASSERT(Stream->WaitingForIdFlowControlLink.Flink == NULL);
     CXPLAT_DBG_ASSERT(Stream->ClosedLink.Flink == NULL);
     CXPLAT_DBG_ASSERT(Stream->SendLink.Flink == NULL);
 

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -158,6 +158,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
         BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
+        BOOLEAN InWaitingList           : 1;    // The stream is currently in the waiting list for stream id FC.
         BOOLEAN DelayIdFcUpdate         : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;
@@ -236,17 +237,16 @@ typedef struct QUIC_STREAM {
         CXPLAT_HASHTABLE_ENTRY TableEntry;
 
         //
+        // The entry in the connection's list of streams waiting on stream
+        // id flow control.
+        //
+        CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
+
+        //
         // The entry in the connection's list of closed streams to clean up.
         //
         CXPLAT_LIST_ENTRY ClosedLink;
     };
-
-    //
-    // TODO guhetier: Check if can be moved in the union or if need to be in hashtable + this at the same time.
-    // The entry in the connection's list of streams waiting on stream
-    // id flow control.
-    //
-    CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
 
     //
     // The list entry in the output module's send list.

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -237,17 +237,16 @@ typedef struct QUIC_STREAM {
         CXPLAT_HASHTABLE_ENTRY TableEntry;
 
         //
+        // The entry in the connection's list of streams waiting on stream
+        // id flow control.
+        //
+        CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
+
+        //
         // The entry in the connection's list of closed streams to clean up.
         //
         CXPLAT_LIST_ENTRY ClosedLink;
     };
-
-    //
-    // TODO guhetier: Check if can be moved in the union or if need to be in hashtable + this at the same time.
-    // The entry in the connection's list of streams waiting on stream
-    // id flow control.
-    //
-    CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
 
     //
     // The list entry in the output module's send list.

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -237,16 +237,17 @@ typedef struct QUIC_STREAM {
         CXPLAT_HASHTABLE_ENTRY TableEntry;
 
         //
-        // The entry in the connection's list of streams waiting on stream
-        // id flow control.
-        //
-        CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
-
-        //
         // The entry in the connection's list of closed streams to clean up.
         //
         CXPLAT_LIST_ENTRY ClosedLink;
     };
+
+    //
+    // TODO guhetier: Check if can be moved in the union or if need to be in hashtable + this at the same time.
+    // The entry in the connection's list of streams waiting on stream
+    // id flow control.
+    //
+    CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
 
     //
     // The list entry in the output module's send list.

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -242,6 +242,13 @@ typedef struct QUIC_STREAM {
     };
 
     //
+    // TODO guhetier: Check if can be moved in the union or if need to be in hashtable + this at the same time.
+    // The entry in the connection's list of streams waiting on stream
+    // id flow control.
+    //
+    CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
+
+    //
     // The list entry in the output module's send list.
     //
     CXPLAT_LIST_ENTRY SendLink;

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -230,20 +230,23 @@ typedef struct QUIC_STREAM {
     //
     uint32_t OutstandingSentMetadata;
 
+    //
+    // Linkage in the stream set
+    //
     union {
         //
-        // The entry in the connection's hashtable of streams.
+        // Link in the hash-table when the stream is open.
         //
         CXPLAT_HASHTABLE_ENTRY TableEntry;
 
         //
-        // The entry in the connection's list of streams waiting on stream
+        // Link in the waiting list when the stream if waiting for stream
         // id flow control.
         //
-        CXPLAT_LIST_ENTRY WaitingForIdFlowControlLink;
+        CXPLAT_LIST_ENTRY WaitingLink;
 
         //
-        // The entry in the connection's list of closed streams to clean up.
+        // Link in the closed list when closed and waiting for clean up.
         //
         CXPLAT_LIST_ENTRY ClosedLink;
     };

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -39,7 +39,7 @@ QuicStreamSetValidate(
         CxPlatHashtableEnumerateEnd(StreamSet->StreamTable, &Enumerator);
     }
 
-    for (CXPLAT_LIST_ENTRY *Link = StreamSet->WaitingStreams.Flink;
+    for (CXPLAT_LIST_ENTRY* Link = StreamSet->WaitingStreams.Flink;
          Link != &StreamSet->WaitingStreams;
          Link = Link->Flink) {
         QUIC_STREAM* Stream =

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -380,13 +380,6 @@ QuicStreamSetInitializeTransportParameters(
 
         CXPLAT_DBG_ASSERT(Stream->OutFlowBlockedReasons & QUIC_FLOW_BLOCKED_STREAM_ID_FLOW_CONTROL);
 
-        if (StreamIndex >= BidiStreamCount && StreamIndex >= UnidiStreamCount) {
-            //
-            // All streams left in the (ordered) list are not allowed yet
-            //
-            break;
-        }
-
         uint8_t FlowBlockedFlagsToRemove = 0;
         if (StreamIndex < Info->MaxTotalStreamCount) {
             FlowBlockedFlagsToRemove |= QUIC_FLOW_BLOCKED_STREAM_ID_FLOW_CONTROL;

--- a/src/core/stream_set.c
+++ b/src/core/stream_set.c
@@ -122,7 +122,10 @@ QuicStreamSetTraceRundown(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != FALSE)
 BOOLEAN
-QuicStreamSetLazyInitStreamTable(_Inout_ QUIC_STREAM_SET* StreamSet) {
+QuicStreamSetLazyInitStreamTable(
+    _Inout_ QUIC_STREAM_SET* StreamSet
+    )
+{
     if (StreamSet->StreamTable == NULL) {
         //
         // Lazily initialize the hash table.

--- a/src/core/stream_set.h
+++ b/src/core/stream_set.h
@@ -47,6 +47,11 @@ typedef struct QUIC_STREAM_SET {
     CXPLAT_HASHTABLE* StreamTable;
 
     //
+    // The list of streams that are waiting for stream id flow control.
+    //
+    CXPLAT_LIST_ENTRY WaitingStreams;
+
+    //
     // The list of streams that are completely closed and need to be released.
     //
     CXPLAT_LIST_ENTRY ClosedStreams;

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -302,6 +302,21 @@ CxPlatListInsertTail(
 }
 
 FORCEINLINE
+void
+CxPlatListInsertAfter(
+    _Inout_ CXPLAT_LIST_ENTRY* ListEntry,
+    _Inout_ __drv_aliasesMem CXPLAT_LIST_ENTRY* NewEntry
+    )
+{
+    QuicListEntryValidate(ListEntry);
+    CXPLAT_LIST_ENTRY* Flink = ListEntry->Flink;
+    ListEntry->Flink = NewEntry;
+    NewEntry->Flink = Flink;
+    NewEntry->Blink = ListEntry;
+    Flink->Blink = NewEntry;
+}
+
+FORCEINLINE
 CXPLAT_LIST_ENTRY*
 CxPlatListRemoveHead(
     _Inout_ CXPLAT_LIST_ENTRY* ListHead

--- a/src/platform/inline.c
+++ b/src/platform/inline.c
@@ -89,6 +89,12 @@ CxPlatListInsertTail(
     _Inout_ __drv_aliasesMem CXPLAT_LIST_ENTRY* Entry
     );
 
+void
+CxPlatListInsertAfter(
+    _Inout_ CXPLAT_LIST_ENTRY* ListEntry,
+    _Inout_ __drv_aliasesMem CXPLAT_LIST_ENTRY* NewEntry
+    );
+
 CXPLAT_LIST_ENTRY*
 CxPlatListRemoveHead(
     _Inout_ CXPLAT_LIST_ENTRY* ListHead

--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -79,6 +79,7 @@ typedef union QUIC_STREAM_FLAGS {
         BOOLEAN Freed                   : 1;    // Freed after last ref count released. Used for Debugging.
 
         BOOLEAN InStreamTable           : 1;    // The stream is currently in the connection's table.
+        BOOLEAN InWaitingList           : 1;    // The stream is currently in the waiting list for stream id FC.
         BOOLEAN DelayIdFcUpdate         : 1;    // Delay stream ID FC updates to StreamClose.
     };
 } QUIC_STREAM_FLAGS;


### PR DESCRIPTION
## Description

Store new streams that are blocked by Stream Id flow control in a sorted list (instead of the hash table containing all streams) to improve the performances of `QuicStreamSetUpdateMaxStreams`.

It will now be enough to iterate over a subset of this list instead of iterating over the entirety of opened streams when receiving a "MAX_STREAMS" frame increasing the limit.

Closes #3538

## Testing

Already covered by existing tests.

## Documentation

In code documentation added.
