### PR TITLE
Bind XDP directly to VF if available

### DIFF
--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1031,7 +1031,6 @@ CxPlatDpRawInitialize(
 
                 // Look for VF which associated with Adapter
                 // It has same MAC address. and empirically these flags
-                /* TODO - Currently causes issues some times
                 for (int i = 0; i < (int) pIfTable->NumEntries; i++) {
                     MIB_IF_ROW2* pIfRow = &pIfTable->Table[i];
                     if (!pIfRow->InterfaceAndOperStatusFlags.FilterInterface &&
@@ -1049,7 +1048,7 @@ CxPlatDpRawInitialize(
                             Interface->ActualIfIndex);
                         break; // assuming there is 1:1 matching
                     }
-                }*/
+                }
 
                 QuicTraceLogVerbose(
                     XdpInterfaceInitialize,


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

- [x] Bind XDP directly to the virtual function (VF) driver for SR-IOV adapters.
- [ ] Configure XDP to use all available CPUs for RSS indications on the VF.
- [ ] Add knobs to make the above behavior(s) opt-in.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
