### PR TITLE
Pad final GSO segment for CPU efficiency

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -752,11 +752,13 @@ QuicPacketBuilderFinalize(
 
         FinalQuicPacket = TRUE;
 
-        if (!FlushBatchedDatagrams && CxPlatDataPathIsPaddingPreferred(MsQuicLib.Datapath, Builder->SendData)) {
+        if (CxPlatDataPathIsPaddingPreferred(MsQuicLib.Datapath, Builder->SendData)) {
             //
             // When buffering multiple datagrams in a single contiguous buffer
             // (at the datapath layer), all but the last datagram needs to be
-            // fully padded.
+            // fully padded. In practice, some NICs could benefit from the
+            // final packet also being padded on the send and/or receive path,
+            // so optimistically pad that, too. This will reduce goodput.
             //
             Builder->MinimumDatagramLength = (uint16_t)Builder->Datagram->Length;
         }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Reduce goodput to potentially increase CPU efficiency by padding all GSO segments, including the final segment.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.