### PR TITLE
Update windbg and etw plugins

### DIFF
--- a/src/plugins/dbg/quictypes.h
+++ b/src/plugins/dbg/quictypes.h
@@ -565,9 +565,35 @@ struct SendRequest : Struct {
     }
 };
 
+typedef enum QUIC_RECV_BUF_MODE {
+    QUIC_RECV_BUF_MODE_SINGLE,      // Only one receive with a single contiguous buffer at a time.
+    QUIC_RECV_BUF_MODE_CIRCULAR,    // Only one receive that may indicate two contiguous buffers at a time.
+    QUIC_RECV_BUF_MODE_MULTIPLE,    // Multiple independent receives that may indicate up to two contiguous buffers at a time.
+    QUIC_RECV_BUF_MODE_APP_OWNED    // Uses memory buffers provided by the app. Only one receive at a time,
+                                    //   that may indicate up to the number of provided buffers.
+} QUIC_RECV_BUF_MODE;
+
 struct RecvBuffer : Struct {
 
     RecvBuffer(ULONG64 Addr) : Struct("msquic!QUIC_RECV_BUFFER", Addr) { }
+
+
+    PSTR ModeStr() {
+        const auto Mode = ReadType<QUIC_RECV_BUF_MODE>("RecvMode");
+            
+        switch (Mode) {
+        case QUIC_RECV_BUF_MODE_SINGLE:
+            return "Single";
+        case QUIC_RECV_BUF_MODE_CIRCULAR:
+            return "Circular";
+        case QUIC_RECV_BUF_MODE_MULTIPLE:
+            return "Multiple";
+        case QUIC_RECV_BUF_MODE_APP_OWNED:
+            return "App Owned";
+        default:
+            return "Unknown";
+        }
+    }
 
     ULONG64 Buffer() {
         return ReadPointer("Buffer");
@@ -996,6 +1022,7 @@ typedef enum QUIC_API_TYPE {
     QUIC_API_TYPE_STRM_SEND,
     QUIC_API_TYPE_STRM_RECV_COMPLETE,
     QUIC_API_TYPE_STRM_RECV_SET_ENABLED,
+    QUIC_API_TYPE_STRM_PROVIDE_RECV_BUFFERS,
 
     QUIC_API_TYPE_SET_PARAM,
     QUIC_API_TYPE_GET_PARAM,
@@ -1038,6 +1065,8 @@ struct ApiCall : Struct {
             return "API_TYPE_STRM_RECV_COMPLETE";
         case QUIC_API_TYPE_STRM_RECV_SET_ENABLED:
             return "API_TYPE_STRM_RECV_SET_ENABLED";
+        case QUIC_API_TYPE_STRM_PROVIDE_RECV_BUFFERS:
+            return "API_TYPE_STRM_PROVIDE_RECV_BUFFERS";
         case QUIC_API_TYPE_SET_PARAM:
             return "API_SET_PARAM";
         case QUIC_API_TYPE_GET_PARAM:

--- a/src/plugins/dbg/stream.cpp
+++ b/src/plugins/dbg/stream.cpp
@@ -126,14 +126,14 @@ EXT_COMMAND(
         "\tMax Offset (FC)      %I64u\n"
         "\t0-RTT Length         %I64u\n"
         "\n"
-        "\tRecv Win Size        %I64u (Alloc %I64u)\n"
+        "\tRecv Buffer Mode     %s\n"
+        "\tRecv Win Size        %I64u\n"
         "\tRecv Win Start       %I64u\n",
         Strm.RecvStateStr(),
         Strm.MaxAllowedRecvOffset(),
         Strm.RecvMax0RttLength(),
         RecvBuf.ModeStr(),
         RecvBuf.VirtualBufferLength(),
-        RecvBuf.AllocBufferLength(),
         RecvBuf.BaseOffset());
 
     Dml("\n");

--- a/src/plugins/dbg/stream.cpp
+++ b/src/plugins/dbg/stream.cpp
@@ -131,6 +131,7 @@ EXT_COMMAND(
         Strm.RecvStateStr(),
         Strm.MaxAllowedRecvOffset(),
         Strm.RecvMax0RttLength(),
+        RecvBuf.ModeStr(),
         RecvBuf.VirtualBufferLength(),
         RecvBuf.AllocBufferLength(),
         RecvBuf.BaseOffset());

--- a/src/plugins/trace/dll/DataModel/QuicEvents.cs
+++ b/src/plugins/trace/dll/DataModel/QuicEvents.cs
@@ -39,6 +39,7 @@ namespace QuicTrace.DataModel
         StreamSend,
         StreamReceiveComplete,
         StreamReceiveSetEnabled,
+        StreamProvideReceiveBuffers,
         StreamDatagramSend,
         ConnectionCompleteResumptionTicketValidation,
         ConnectionCompleteCertificateValidation


### PR DESCRIPTION
## Description

Closes #4747 

Update the windbg and etw/wpa plugings with the updated enum definition + add the receive buffer mode to the stream description.

## Testing

Local validation of the output when running tests

## Documentation

N/A
