### PR TITLE
Rust: Safe Api for callbacks

### DIFF
--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -623,11 +623,6 @@ pub struct Stream {
 unsafe impl Sync for Stream {}
 unsafe impl Send for Stream {}
 
-/// Same as Stream but does not own the handle.
-/// Only used in callback wrapping where handle
-/// should not be closed by default.
-pub struct StreamRef(Stream);
-
 impl From<QuicPerformanceCountersParam> for QuicPerformanceCounters {
     fn from(value: QuicPerformanceCountersParam) -> Self {
         Self {
@@ -862,6 +857,68 @@ macro_rules! define_quic_handle_impl {
     };
 }
 
+/// defines the common code for the handle to manage handle context
+macro_rules! define_quic_handle_ctx_fn {
+    ($handle_name:ident, $callback_type:ident) => {
+        impl $handle_name {
+            pub fn get_context(&self) -> *mut c_void {
+                unsafe { Api::ffi_ref().GetContext.unwrap()(self.handle) }
+            }
+
+            /// # Safety
+            /// Previous context needs to be cleaned up before set a new one.
+            pub unsafe fn set_context(&self, ctx: *mut c_void) {
+                unsafe { Api::ffi_ref().SetContext.unwrap()(self.handle, ctx) }
+            }
+
+            /// clear ctx if it is present.
+            fn clear_ctx_if_present(&self) {
+                // Clean up context only if handle is present. (it is not a handle ref.)
+                // If there is a ctx, drop it.
+                let ctx = self.get_context();
+                if !ctx.is_null() {
+                    unsafe { self.set_context(std::ptr::null_mut()) };
+                    let _ = unsafe { Box::from_raw(ctx as *mut Box<$callback_type>) };
+                }
+            }
+        }
+    };
+}
+
+/// Defines the Ref type for the handle that does not cleanup
+/// the handle on drop.
+macro_rules! define_quic_handle_ref {
+    ($handle_name:ident, $handle_ref_name:ident) => {
+        /// Same as the owned type but does not own the handle.
+        /// Only used in callback wrapping where handle
+        /// should not be closed by default.
+        pub struct $handle_ref_name($handle_name);
+
+        impl $handle_ref_name {
+            /// For internal use only.
+            pub(crate) unsafe fn from_raw(handle: HQUIC) -> Self {
+                Self($handle_name { handle })
+            }
+        }
+
+        impl Drop for $handle_ref_name {
+            fn drop(&mut self) {
+                // clear the handle to prevent auto close.
+                self.0.handle = std::ptr::null_mut()
+            }
+        }
+
+        /// Make inner handle accessile
+        impl std::ops::Deref for $handle_ref_name {
+            type Target = $handle_name;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}
+
 impl Registration {
     pub fn new(config: *const RegistrationConfig) -> Result<Registration, Status> {
         // Initialize the global api table.
@@ -950,6 +1007,31 @@ impl Default for Connection {
     }
 }
 
+/// Connection callback type.
+/// Callback function or closure is set to connection msquic context of type `*mut Box<ConnectionCallback>>`.
+/// We cannot use type `*mut ConnectionCallback` because dyn trait cannot be converted to a pointer directly.
+/// The context is cleaned up when connection is dropped or when new callback is set.
+/// msquic never invokes the connection callback in parallel, so use FnMut to allow mutation.
+type ConnectionCallback = dyn FnMut(ConnectionRef, ConnectionEvent) -> Result<(), Status> + 'static;
+
+extern "C" fn raw_conn_callback(
+    connection: HQUIC,
+    context: *mut c_void,
+    event: *mut ffi::QUIC_CONNECTION_EVENT,
+) -> QUIC_STATUS {
+    let conn = unsafe { ConnectionRef::from_raw(connection) };
+    let f = unsafe {
+        (context as *mut Box<ConnectionCallback>)
+            .as_mut() // allow mutation
+            .expect("cannot get ConnectionCallback from ctx")
+    };
+    let event = ConnectionEvent::from(unsafe { event.as_ref().unwrap() });
+    match f(conn, event) {
+        Ok(_) => StatusCode::QUIC_STATUS_SUCCESS.into(),
+        Err(e) => e.0,
+    }
+}
+
 impl Connection {
     pub fn new() -> Connection {
         Connection {
@@ -957,23 +1039,26 @@ impl Connection {
         }
     }
 
-    /// TODO: The handler type should eventually be changed to Fn type.
-    /// ffi type and the context ptr makes this function unsafe.
-    pub fn open(
-        &mut self,
-        registration: &Registration,
-        handler: ffi::QUIC_CONNECTION_CALLBACK_HANDLER,
-        context: *const c_void,
-    ) -> Result<(), Status> {
+    pub fn open<F>(&mut self, registration: &Registration, handler: F) -> Result<(), Status>
+    where
+        F: FnMut(ConnectionRef, ConnectionEvent) -> Result<(), Status> + 'static,
+    {
+        // double boxing to allow Box dyn fat pointer
+        let b: Box<Box<ConnectionCallback>> = Box::new(Box::new(handler));
+        let ctx = Box::into_raw(b);
+        self.clear_ctx_if_present();
         let status = unsafe {
             Api::ffi_ref().ConnectionOpen.unwrap()(
                 registration.handle,
-                handler,
-                context as *mut c_void,
+                Some(raw_conn_callback),
+                ctx as *mut c_void,
                 std::ptr::addr_of_mut!(self.handle),
             )
         };
-        Status::ok_from_raw(status)
+        Status::ok_from_raw(status).inspect_err(|_| {
+            // attach memory back on failure
+            let _ = unsafe { Box::from_raw(ctx) };
+        })
     }
 
     pub fn start(
@@ -1000,6 +1085,7 @@ impl Connection {
             unsafe {
                 Api::ffi_ref().ConnectionClose.unwrap()(self.handle);
             }
+            self.clear_ctx_if_present();
         }
     }
 
@@ -1030,22 +1116,21 @@ impl Connection {
         Status::ok_from_raw(status)
     }
 
-    /// # Safety
-    /// handler and context must be valid
-    pub unsafe fn set_callback_handler(
-        &self,
-        handler: ffi::QUIC_CONNECTION_CALLBACK_HANDLER,
-        context: *const c_void,
-    ) {
+    pub fn set_callback_handler<F>(&self, handler: F)
+    where
+        F: FnMut(ConnectionRef, ConnectionEvent) -> Result<(), Status> + 'static,
+    {
+        let b: Box<Box<ConnectionCallback>> = Box::new(Box::new(handler));
+        let ctx = Box::into_raw(b);
+        // clear previous ctx before setting it.
+        self.clear_ctx_if_present();
         unsafe {
             Api::set_callback_handler(
                 self.handle,
-                std::mem::transmute::<ffi::QUIC_CONNECTION_CALLBACK_HANDLER, *const c_void>(
-                    handler,
-                ),
-                context,
+                raw_conn_callback as *const c_void,
+                ctx as *mut c_void,
             )
-        };
+        }
     }
 
     /// # Safety
@@ -1104,10 +1189,35 @@ impl Connection {
 }
 
 define_quic_handle_impl!(Connection);
+define_quic_handle_ref!(Connection, ConnectionRef);
+define_quic_handle_ctx_fn!(Connection, ConnectionCallback);
 
 impl Default for Listener {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Listener callback.
+/// msquic may execute listener callback on the same stream in parallel,
+/// so Fn is used for immutability.
+pub type ListenerCallback = dyn Fn(ListenerRef, ListenerEvent) -> Result<(), Status> + 'static;
+
+extern "C" fn raw_listener_callback(
+    listener: HQUIC,
+    context: *mut c_void,
+    event: *mut ffi::QUIC_LISTENER_EVENT,
+) -> QUIC_STATUS {
+    let listner_ref = unsafe { ListenerRef::from_raw(listener) };
+    let event = ListenerEvent::from(unsafe { event.as_ref().expect("fail to get listener event") });
+    let f = unsafe {
+        (context as *mut Box<ListenerCallback>)
+            .as_ref() // allow mutation
+            .expect("cannot get ListenerCallback from ctx")
+    };
+    match f(listner_ref, event) {
+        Ok(_) => StatusCode::QUIC_STATUS_SUCCESS.into(),
+        Err(e) => e.0,
     }
 }
 
@@ -1118,22 +1228,25 @@ impl Listener {
         }
     }
 
-    /// TODO: handler should be changed to Fn type.
-    pub fn open(
-        &mut self,
-        registration: &Registration,
-        handler: ffi::QUIC_LISTENER_CALLBACK_HANDLER,
-        context: *const c_void,
-    ) -> Result<(), Status> {
+    pub fn open<F>(&mut self, registration: &Registration, handler: F) -> Result<(), Status>
+    where
+        F: Fn(ListenerRef, ListenerEvent) -> Result<(), Status> + 'static,
+    {
+        // double boxing to allow Box dyn fat pointer
+        let b: Box<Box<ListenerCallback>> = Box::new(Box::new(handler));
+        let ctx = Box::into_raw(b);
+        self.clear_ctx_if_present();
         let status = unsafe {
             Api::ffi_ref().ListenerOpen.unwrap()(
                 registration.handle,
-                handler,
-                context as *mut c_void,
+                Some(raw_listener_callback),
+                ctx as *mut c_void,
                 std::ptr::addr_of_mut!(self.handle),
             )
         };
-        Status::ok_from_raw(status)
+        Status::ok_from_raw(status).inspect_err(|_| {
+            let _ = unsafe { Box::from_raw(ctx) };
+        })
     }
 
     pub fn start(&self, alpn: &[BufferRef], local_address: Option<&Addr>) -> Result<(), Status> {
@@ -1165,15 +1278,40 @@ impl Listener {
             unsafe {
                 Api::ffi_ref().ListenerClose.unwrap()(self.handle);
             }
+            self.clear_ctx_if_present();
         }
     }
 }
 
 define_quic_handle_impl!(Listener);
+define_quic_handle_ref!(Listener, ListenerRef);
+define_quic_handle_ctx_fn!(Listener, ListenerCallback);
 
 impl Default for Stream {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Stream callback.
+/// msquic never executes stream callback on the same stream in parallel.
+pub type StreamCallback = dyn FnMut(StreamRef, StreamEvent) -> Result<(), Status> + 'static;
+
+extern "C" fn raw_stream_callback(
+    stream: HQUIC,
+    context: *mut c_void,
+    event: *mut ffi::QUIC_STREAM_EVENT,
+) -> QUIC_STATUS {
+    let f = unsafe {
+        (context as *mut Box<StreamCallback>)
+            .as_mut() // allow mutation
+            .expect("cannot get ConnectionCallback from ctx")
+    };
+    let stream_ref = unsafe { StreamRef::from_raw(stream) };
+    let event = StreamEvent::from(unsafe { event.as_mut().expect("cannot get event ref") });
+    match f(stream_ref, event) {
+        Ok(_) => StatusCode::QUIC_STATUS_SUCCESS.into(),
+        Err(e) => e.0,
     }
 }
 
@@ -1184,23 +1322,30 @@ impl Stream {
         }
     }
 
-    pub fn open(
+    pub fn open<F>(
         &mut self,
         connection: &Connection,
         flags: StreamOpenFlags,
-        handler: ffi::QUIC_STREAM_CALLBACK_HANDLER,
-        context: *const c_void,
-    ) -> Result<(), Status> {
+        handler: F,
+    ) -> Result<(), Status>
+    where
+        F: FnMut(StreamRef, StreamEvent) -> Result<(), Status> + 'static,
+    {
+        let b: Box<Box<StreamCallback>> = Box::new(Box::new(handler));
+        let ctx = Box::into_raw(b);
+        self.clear_ctx_if_present();
         let status = unsafe {
             Api::ffi_ref().StreamOpen.unwrap()(
                 connection.handle,
                 flags as crate::ffi::QuicFlag,
-                handler,
-                context as *mut c_void,
+                Some(raw_stream_callback),
+                ctx as *mut c_void,
                 std::ptr::addr_of_mut!(self.handle),
             )
         };
-        Status::ok_from_raw(status)
+        Status::ok_from_raw(status).inspect_err(|_| {
+            let _ = unsafe { Box::from_raw(ctx) };
+        })
     }
 
     pub fn start(&self, flags: StreamStartFlags) -> Result<(), Status> {
@@ -1226,6 +1371,7 @@ impl Stream {
             unsafe {
                 Api::ffi_ref().StreamClose.unwrap()(self.handle);
             }
+            self.clear_ctx_if_present();
         }
     }
 
@@ -1253,18 +1399,19 @@ impl Stream {
         Status::ok_from_raw(status)
     }
 
-    /// # Safety
-    /// handler and context must be valid.
-    pub unsafe fn set_callback_handler(
-        &self,
-        handler: ffi::QUIC_STREAM_CALLBACK_HANDLER,
-        context: *const c_void,
-    ) {
+    pub fn set_callback_handler<F>(&self, handler: F)
+    where
+        F: FnMut(StreamRef, StreamEvent) -> Result<(), Status> + 'static,
+    {
+        let b: Box<Box<StreamCallback>> = Box::new(Box::new(handler));
+        let ctx = Box::into_raw(b);
+        // clear previous ctx before setting it.
+        self.clear_ctx_if_present();
         unsafe {
             Api::set_callback_handler(
                 self.handle,
-                std::mem::transmute::<ffi::QUIC_STREAM_CALLBACK_HANDLER, *const c_void>(handler),
-                context,
+                raw_stream_callback as *const c_void,
+                ctx as *mut c_void,
             )
         };
     }
@@ -1275,29 +1422,8 @@ impl Stream {
 }
 
 define_quic_handle_impl!(Stream);
-
-impl StreamRef {
-    /// For internal use only.
-    pub(crate) unsafe fn from_raw(handle: HQUIC) -> Self {
-        Self(Stream { handle })
-    }
-}
-
-impl Drop for StreamRef {
-    fn drop(&mut self) {
-        // clear the handle to prevent auto close.
-        self.0.handle = std::ptr::null_mut()
-    }
-}
-
-/// Make inner stream accessile
-impl std::ops::Deref for StreamRef {
-    type Target = Stream;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+define_quic_handle_ref!(Stream, StreamRef);
+define_quic_handle_ctx_fn!(Stream, StreamCallback);
 
 #[cfg(test)]
 mod tests {
@@ -1306,23 +1432,14 @@ mod tests {
     // The following defines some simple test code.
     //
 
-    use std::ffi::c_void;
     use std::ptr;
 
-    use crate::ffi::{HQUIC, QUIC_STATUS};
     use crate::{
-        ffi, BufferRef, Configuration, Connection, ConnectionEvent, CredentialConfig, Registration,
-        Settings, StatusCode, Stream, StreamEvent,
+        BufferRef, Configuration, Connection, ConnectionEvent, ConnectionRef, CredentialConfig,
+        Registration, Settings, Status, Stream, StreamEvent, StreamRef,
     };
 
-    extern "C" fn test_conn_callback(
-        _connection: HQUIC,
-        context: *mut c_void,
-        event: *mut ffi::QUIC_CONNECTION_EVENT,
-    ) -> QUIC_STATUS {
-        let connection = unsafe { &*(context as *const Connection) };
-        let ev_ref = unsafe { event.as_ref().unwrap() };
-        let event = ConnectionEvent::from(ev_ref);
+    fn test_conn_callback(connection: ConnectionRef, event: ConnectionEvent) -> Result<(), Status> {
         match event {
             ConnectionEvent::Connected {
                 session_resumed,
@@ -1354,7 +1471,7 @@ mod tests {
             }
             ConnectionEvent::PeerStreamStarted { stream, flags } => {
                 println!("Peer stream started: flags: {flags}");
-                unsafe { stream.set_callback_handler(Some(test_stream_callback), context) };
+                stream.set_callback_handler(test_stream_callback)
             }
             ConnectionEvent::StreamsAvailable {
                 bidirectional_count,
@@ -1367,18 +1484,12 @@ mod tests {
             ConnectionEvent::PeerNeedsStreams { bidirectional } => {
                 println!("Peer needs streams: bi: {bidirectional}");
             }
-            _ => println!("Connection other callback {}", ev_ref.Type),
+            _ => println!("Connection other callback ?",),
         }
-        StatusCode::QUIC_STATUS_SUCCESS.into()
+        Ok(())
     }
 
-    extern "C" fn test_stream_callback(
-        stream: HQUIC,
-        _context: *mut c_void,
-        event: *mut ffi::QUIC_STREAM_EVENT,
-    ) -> QUIC_STATUS {
-        let event_ref = unsafe { event.as_mut().unwrap() };
-        let event = StreamEvent::from(event_ref);
+    fn test_stream_callback(stream: StreamRef, event: StreamEvent) -> Result<(), Status> {
         match event {
             StreamEvent::StartComplete {
                 status,
@@ -1423,7 +1534,7 @@ mod tests {
             } => {
                 println!("Stream shutdown complete: {connection_shutdown} {app_close_in_progress} {connection_shutdown_by_app} {connection_closed_remotely} {connection_error_code} {connection_close_status}");
                 // Attach to stream for auto close handle.
-                unsafe { Stream::from_raw(stream) };
+                unsafe { Stream::from_raw(stream.as_raw()) };
             }
             StreamEvent::IdealSendBufferSize { byte_count } => {
                 println!("Stream ideal send buffer size: {byte_count}");
@@ -1435,7 +1546,7 @@ mod tests {
                 println!("Stream cancel on loss: {error_code}");
             }
         }
-        StatusCode::QUIC_STATUS_SUCCESS.into()
+        Ok(())
     }
 
     #[test]
@@ -1479,11 +1590,7 @@ mod tests {
         );
 
         let mut connection = Connection::new();
-        let res = connection.open(
-            &registration,
-            Some(test_conn_callback),
-            &connection as *const Connection as *const c_void,
-        );
+        let res = connection.open(&registration, test_conn_callback);
         assert!(
             res.is_ok(),
             "Failed to open connection: {}",

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -1007,10 +1007,16 @@ impl Default for Connection {
     }
 }
 
+// Remarks on Rust callback in general:
+// Callback function or closure is set to msquic handle context of type `*mut Box<TCallback>>`.
+// We cannot use type `*mut TCallback` because dyn trait cannot be converted to a pointer directly.
+// In the ffi function passed to msquic, the TCallback is extracted from msquic callback context
+// and invoked.
+// The context is cleaned up when connection is dropped or when new callback is set.
+// TCallback type is either Fn or FnMut type, so user can capture variables in them without worrying
+// about lifetime and how to set or cleanup msquic callback context.
+
 /// Connection callback type.
-/// Callback function or closure is set to connection msquic context of type `*mut Box<ConnectionCallback>>`.
-/// We cannot use type `*mut ConnectionCallback` because dyn trait cannot be converted to a pointer directly.
-/// The context is cleaned up when connection is dropped or when new callback is set.
 /// msquic never invokes the connection callback in parallel, so use FnMut to allow mutation.
 type ConnectionCallback = dyn FnMut(ConnectionRef, ConnectionEvent) -> Result<(), Status> + 'static;
 
@@ -1199,7 +1205,7 @@ impl Default for Listener {
 }
 
 /// Listener callback.
-/// msquic may execute listener callback on the same stream in parallel,
+/// msquic may execute listener callback in parallel,
 /// so Fn is used for immutability.
 pub type ListenerCallback = dyn Fn(ListenerRef, ListenerEvent) -> Result<(), Status> + 'static;
 

--- a/src/rs/types.rs
+++ b/src/rs/types.rs
@@ -103,6 +103,10 @@ pub enum ConnectionEvent<'a> {
     PeerAddressChanged {
         address: &'a crate::Addr,
     },
+    /// Stream ownership and cleanup is on user app.
+    /// App needs to set the stream callback handler before
+    /// returning from connection callback.
+    // TODO: may need to change StreamRef to Stream for better safety.
     PeerStreamStarted {
         stream: crate::StreamRef,
         // TODO: provide safe wrapper.

--- a/src/rs/types.rs
+++ b/src/rs/types.rs
@@ -8,7 +8,11 @@ use std::ffi::c_void;
 pub enum ListenerEvent<'a> {
     NewConnection {
         info: NewConnectionInfo<'a>,
-        connection: crate::Connection,
+        /// User app needs to take ownership of this new connection.
+        /// User app needs to set configuration for this connection
+        /// before returning from the callback.
+        /// TODO: Make this Connection type.
+        connection: crate::ConnectionRef,
     },
     StopComplete {
         app_close_in_progress: bool,
@@ -61,7 +65,7 @@ impl<'a> From<&'a crate::ffi::QUIC_LISTENER_EVENT> for ListenerEvent<'a> {
                 let ev = unsafe { &value.__bindgen_anon_1.NEW_CONNECTION };
                 Self::NewConnection {
                     info: NewConnectionInfo::from(unsafe { ev.Info.as_ref().unwrap() }),
-                    connection: unsafe { crate::Connection::from_raw(ev.Connection) },
+                    connection: unsafe { crate::ConnectionRef::from_raw(ev.Connection) },
                 }
             }
             crate::ffi::QUIC_LISTENER_EVENT_TYPE_QUIC_LISTENER_EVENT_STOP_COMPLETE => {


### PR DESCRIPTION
## Description
Use Rust Fn and FnMut for user callback function or closure, so user no longer need to use unsafe extern C function and managing callback context ptr.
Added macro to define common HandleRef type, and set get context functions to reduce code duplication.

## Testing
Modified the existing test callbacks to use the new APIs.

## Documentation
NA
