### PR TITLE
Wait for Dumps

### DIFF
--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -384,9 +384,9 @@ function Wait-Executable($Exe) {
         }
         # Wait up to 30 seconds for files to appear in $LogDir if $AZP is set.
         if ($AZP) {
-            $Timeout = 30
             $Elapsed = 0
-            while ($Elapsed -lt $Timeout -and (Get-ChildItem -Path $LogDir).Count -eq 0) {
+            $Timeout = 30
+            while ($Elapsed -lt $Timeout -and (Get-ChildItem -Path $LogDir | Measure-Object).Count -eq 0) {
                 Start-Sleep -Seconds 1
                 $Elapsed++
             }
@@ -472,7 +472,7 @@ function Wait-Executable($Exe) {
             }
 
             Log "Output available at $LogDir"
-            if ($AZP) { dir }
+            if ($AZP) { dir $LogDir }
 
         } else {
             if ($LogProfile -ne "None") {

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -386,7 +386,7 @@ function Wait-Executable($Exe) {
         if ($AZP) {
             $Timeout = 30
             $Elapsed = 0
-            while ($Elapsed -lt $Timeout -and (Get-ChildItem -Path $directoryPath).Count -eq 0) {
+            while ($Elapsed -lt $Timeout -and (Get-ChildItem -Path $LogDir).Count -eq 0) {
                 Start-Sleep -Seconds 1
                 $Elapsed++
             }

--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -382,6 +382,15 @@ function Wait-Executable($Exe) {
             LogErr "Process had nonzero exit code: $($Exe.Process.ExitCode)"
             $KeepOutput = $true
         }
+        # Wait up to 30 seconds for files to appear in $LogDir if $AZP is set.
+        if ($AZP) {
+            $Timeout = 30
+            $Elapsed = 0
+            while ($Elapsed -lt $Timeout -and (Get-ChildItem -Path $directoryPath).Count -eq 0) {
+                Start-Sleep -Seconds 1
+                $Elapsed++
+            }
+        }
         $DumpFiles = (Get-ChildItem $LogDir) | Where-Object { $_.Extension -eq ".dmp" }
         if ($DumpFiles) {
             LogErr "Dump file(s) generated"
@@ -462,7 +471,8 @@ function Wait-Executable($Exe) {
                 Remove-Item $LogDir -Recurse -Force | Out-Null
             }
 
-            Log "Output available at $($LogDir)"
+            Log "Output available at $LogDir"
+            if ($AZP) { dir }
 
         } else {
             if ($LogProfile -ne "None") {


### PR DESCRIPTION
## Description

Often we're not actually seeing a dump file when a stress test crashes. Try adding a wait in there for up to 30 seconds.

## Testing

CI/CD

## Documentation

N/A
