### PR TITLE
Upload logs on cancellation as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,9 +221,9 @@ jobs:
       shell: pwsh
       timeout-minutes: 90
       run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*
-    - name: Upload on Failure
+    - name: Upload on Failure or Cancellation
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
-      if: failure()
+      if: failure() || cancelled()
       with:
         name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
         path: artifacts


### PR DESCRIPTION
## Description

Often times devs can see a workflow is failing a lot of tests, and would like to triage the issue from the logs.
The problem is, logs are only uploaded on "failure" and sometimes it takes 1-2 hours to finish running the entire test suite.
We should allow uploading logs when you cancel the workflow to skip the waiting.

## Testing

CI
## Documentation

N/A