### PR TITLE
Add support for MsQuic Logging on Azure Netperf

### DIFF
--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -116,9 +116,6 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     $artifactName = $Command.Split(";")[1]
     # if artifacts don't exist, make it
     New-Item -ItemType Directory "artifacts/logs/$artifactName/server" -ErrorAction Ignore | Out-Null
-    ls
-    Write-Host "inspecting artifacts/logs"
-    ls artifacts/logs
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } else {
     throw "Invalid command: $Command"

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -114,6 +114,8 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     .\scripts\log.ps1 -Start -Profile $LogProfile
 } elseif ($Command.Contains("Stop_Server_Msquic_Logging")) {
     $artifactName = $Command.Split(";")[1]
+    # if artifacts don't exist, make it
+    New-Item -ItemType Directory "artifacts/logs/$artifactName/server" -ErrorAction Ignore | Out-Null
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } else {
     throw "Invalid command: $Command"

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -116,6 +116,7 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     $artifactName = $Command.Split(";")[1]
     # if artifacts don't exist, make it
     New-Item -ItemType Directory "artifacts/logs/$artifactName/server" -ErrorAction Ignore | Out-Null
+    ls
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } else {
     throw "Invalid command: $Command"

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -131,6 +131,12 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
         Write-Host "Listing directory: "
         ls
     }
+} elseif ($Command.Contains("Start_Server_Msquic_Logging")) {
+    $LogProfile = $Command.Split(";")[1]
+    .\scripts\log.ps1 -Start -Profile $LogProfile
+} elseif ($Command.Contains("Stop_Server_Msquic_Logging")) {
+    $artifactName = $Command.Split(";")[1]
+    .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } else {
     throw "Invalid command: $Command"
 }

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -109,28 +109,6 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     Write-Host "(SERVER) Installing Kernel driver. Path: $localSysPath"
     sc.exe create "msquicpriv" type= kernel binpath= $localSysPath start= demand | Out-Null
     net.exe start msquicpriv
-} elseif ($Command.Contains("Start_Server_CPU_Tracing")) {
-    if ($IsWindows) {
-        Write-Host "Starting CPU tracing with WPR on windows!"
-        wpr -start CPU
-    } else {
-        Write-Host "Preprending the command with 'perf record' to start CPU tracing on linux!"
-        $filename = $Command.Split(";")[1]
-        $write_this_string_to_disk = "perf record -o server-cpu-traces-$filename -- "
-        # now write the string to disk
-        Set-Content -Path "perf_command.txt" -Value $write_this_string_to_disk
-        ls
-    }
-} elseif ($Command.Contains("Stop_Server_CPU_Tracing")) {
-    if ($IsWindows) {
-        Write-Host "Stopping CPU tracing with WPR on windows!"
-        $filename = $Command.Split(";")[1]
-        wpr -stop "server-cpu-traces-$filename"
-    } else {
-        Write-Host "Nothing to do on Linux. 'perf' should have stopped recording."
-        Write-Host "Listing directory: "
-        ls
-    }
 } elseif ($Command.Contains("Start_Server_Msquic_Logging")) {
     $LogProfile = $Command.Split(";")[1]
     .\scripts\log.ps1 -Start -Profile $LogProfile

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -117,6 +117,8 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     # if artifacts don't exist, make it
     New-Item -ItemType Directory "artifacts/logs/$artifactName/server" -ErrorAction Ignore | Out-Null
     ls
+    Write-Host "inspecting artifacts/logs"
+    ls artifacts/logs
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } else {
     throw "Invalid command: $Command"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -15,7 +15,6 @@ if ($psVersion.Major -lt 7) {
 
 # Path to the WER registry key used for collecting dumps on Windows.
 $WerDumpRegPath = "HKLM:\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\secnetperf.exe"
-$env:linux_perf_prefix = ""
 
 # Write a GitHub error message to the console.
 function Write-GHError($msg) {
@@ -337,7 +336,7 @@ function Wait-StartRemoteServerPassive {
     for ($i = 0; $i -lt 30; $i++) {
         Start-Sleep -Seconds 5 | Out-Null
         Write-Host "Attempt $i to start the remote server, command: $FullPath -target:$RemoteName"
-        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir $UseSudo ""
+        $Process = Start-LocalTest $FullPath "-target:$RemoteName" $OutputDir $UseSudo
         $ConsoleOutput = Wait-LocalTest $Process $OutputDir $false 30000 $true
         Write-Host "Wait-StartRemoteServerPassive: $ConsoleOutput"
         $DidMatch = $ConsoleOutput -match "Completed" # Look for the special string to indicate success.
@@ -351,8 +350,7 @@ function Wait-StartRemoteServerPassive {
 
 # Creates a new local process to asynchronously run the test.
 function Start-LocalTest {
-    param ($FullPath, $FullArgs, $OutputDir, $UseSudo, $LinuxPerfPrefix)
-    Write-Host "Starting Localtest with LinuxPerfPrefix: $LinuxPerfPrefix"
+    param ($FullPath, $FullArgs, $OutputDir, $UseSudo)
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if ($isWindows) {
         $pinfo.FileName = $FullPath
@@ -360,7 +358,7 @@ function Start-LocalTest {
     } else {
         # We use bash to execute the test so we can collect core dumps.
         $NOFILE = Invoke-Expression "bash -c 'ulimit -n'"
-        $CommonCommand = "ulimit -n $NOFILE && ulimit -c unlimited && LD_LIBRARY_PATH=$(Split-Path $FullPath -Parent) LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $LinuxPerfPrefix$FullPath $FullArgs && echo ''"
+        $CommonCommand = "ulimit -n $NOFILE && ulimit -c unlimited && LD_LIBRARY_PATH=$(Split-Path $FullPath -Parent) LSAN_OPTIONS=report_objects=1 ASAN_OPTIONS=disable_coredump=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 $FullPath $FullArgs && echo ''"
         if ($UseSudo) {
             $pinfo.FileName = "/usr/bin/sudo"
             $pinfo.Arguments = "/usr/bin/bash -c `"$CommonCommand`""
@@ -637,31 +635,10 @@ function Invoke-Secnetperf {
         $StateDir = "/etc/_state"
     }
     if ($Session -eq "NOT_SUPPORTED") {
-        if ($env:collect_cpu_traces) {
-            if ($IsWindows) {
-                wpr -start CPU
-            } else {
-                $env:linux_perf_prefix = "perf record -o cpu-traces-$scenario-$io-istcp-$tcp.data -- "
-            }
-            NetperfSendCommand "Start_Server_CPU_Tracing;$scenario-$io-istcp-$tcp.data"
-            NetperfWaitServerFinishExecution
-        }
         NetperfSendCommand "$RemoteDir/$SecNetPerfPath $serverArgs"
         Wait-StartRemoteServerPassive "$clientPath" $RemoteName $artifactDir $useSudo
-
     } else {
-        if ($env:collect_cpu_traces) {
-            if ($IsWindows) {
-                wpr -start CPU
-                Invoke-Command -Session $Session -ScriptBlock { wpr -start CPU }
-                $job = Start-RemoteServer $Session "$RemoteDir/$SecNetPerfPath" $serverArgs $useSudo
-            } else {
-                $env:linux_perf_prefix = "perf record -o cpu-traces-$scenario-$io-istcp-$tcp.data -- "
-                $job = Start-RemoteServer $Session "perf record -o server-cpu-traces-$scenario-$io-istcp-$tcp.data -- $RemoteDir/$SecNetPerfPath" $serverArgs $useSudo
-            }
-        } else {
-            $job = Start-RemoteServer $Session "$RemoteDir/$SecNetPerfPath" $serverArgs $useSudo
-        }
+        $job = Start-RemoteServer $Session "$RemoteDir/$SecNetPerfPath" $serverArgs $useSudo
     }
 
     # Run the test multiple times, failing (for now) only if all tries fail.
@@ -672,8 +649,7 @@ function Invoke-Secnetperf {
         Write-Host "==============================`nRUN $($try+1):"
         "> secnetperf $clientArgs" | Add-Content $clientOut
         try {
-            Write-Host "About to start localtest with linux_perf_prefix: $env:linux_perf_prefix"
-            $process = Start-LocalTest "$clientPath" $clientArgs $artifactDir $useSudo $env:linux_perf_prefix
+            $process = Start-LocalTest "$clientPath" $clientArgs $artifactDir $useSudo
             $rawOutput = Wait-LocalTest $process $artifactDir ($io -eq "wsk") 30000
             Write-Host $rawOutput
             $values[$tcp] += Get-TestOutput $rawOutput $metric
@@ -712,24 +688,8 @@ function Invoke-Secnetperf {
                 $Socket.Send($BytesToSend, $BytesToSend.Length, $RemoteName, 9999) | Out-Null
                 Write-Host "Sent special UDP packet to tell the server to die."
             }
-            if ($env:collect_cpu_traces) {
-                if ($IsWindows) {
-                    wpr -stop "cpu-traces-$scenario-$io-istcp-$tcp.etl"
-                }
-                NetperfSendCommand "Stop_Server_CPU_Tracing;$scenario-$io-istcp-$tcp.etl"
-                NetperfWaitServerFinishExecution
-            }
         } else {
             try { Stop-RemoteServer $job $RemoteName | Add-Content $serverOut } catch { }
-            if ($env:collect_cpu_traces) {
-                if ($IsWindows) {
-                    wpr -stop "cpu-traces-$scenario-$io-istcp-$tcp.etl"
-                    Invoke-Command -Session $Session -ScriptBlock { wpr -stop "server-cpu-traces-$Using:scenario-$Using:io-istcp-$Using:tcp.etl" }
-                    Copy-Item -FromSession $Session "C:\Users\Administrator\Documents\server-cpu-traces-$scenario-$io-istcp-$tcp.etl" .
-                } else {
-                    Copy-Item -FromSession $Session "/home/secnetperf/server-cpu-traces-$scenario-$io-istcp-$tcp.data" .
-                }
-            }
         }
 
         # Stop any logging and copy the logs to the artifacts folder.


### PR DESCRIPTION
## Description

Expand the "Collect CPU traces" feature that was previously merged where `wpr.exe` was directly invoked to utilize the more established logging power-shell scripts in MsQuic.

Closes https://github.com/microsoft/netperf/issues/532

## Testing

From this CI run on Netperf:
https://github.com/microsoft/netperf/actions/runs/13820352608/job/38666893105
WPR etl Logs were accumulated with "Basic.Lignt" configuration.

## Documentation

N/A
