### PR TITLE
Enable Android on 24.04 with openssl3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,9 +120,6 @@ jobs:
         # Android doesn't use system crypto
         - plat: android
           systemcrypto: '-UseSystemOpenSSLCrypto'
-        # TODO: Fix android on ubuntu-24.04
-        - plat: android
-          os: 'ubuntu-24.04'
         # No openssl system crypto on ubuntu-22.04
         - plat: linux
           os: 'ubuntu-22.04'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -507,16 +507,22 @@ function CMake-Generate {
         $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
-        $NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '25.2.9519653' # Temporary work around. Use RegEx to replace newer version.
+        $NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '28.0.13004108' # Temporary work around. Use RegEx to replace newer version.
         $env:PATH = "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
+        $env:ANDROID_NDK_HOME = $NDK
+        $env:ANDROID_NDK_ROOT = $NDK  # Set ANDROID_NDK_ROOT to ensure consistency
+        Write-Host "Set ANDROID_NDK_HOME: $env:ANDROID_NDK_HOME"
+        Write-Host "Set ANDROID_NDK_ROOT: $env:ANDROID_NDK_ROOT"
+
         switch ($Arch) {
             "x86"   { $Arguments += " -DANDROID_ABI=x86"}
             "x64"   { $Arguments += " -DANDROID_ABI=x86_64" }
             "arm"   { $Arguments += " -DANDROID_ABI=armeabi-v7a" }
             "arm64" { $Arguments += " -DANDROID_ABI=arm64-v8a" }
         }
+        $env:CC = "x86_64-linux-android29-clang"
+        $env:CXX = "x86_64-linux-android29-clang++"
         $Arguments += " -DANDROID_PLATFORM=android-29"
-        $env:ANDROID_NDK_HOME = $NDK
         $NdkToolchainFile = "$NDK/build/cmake/android.toolchain.cmake"
         $Arguments += " -DANDROID_NDK=""$NDK"""
         $Arguments += " -DCMAKE_TOOLCHAIN_FILE=""$NdkToolchainFile"""

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -507,12 +507,14 @@ function CMake-Generate {
         $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
-        $NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '28.0.13004108' # Temporary work around. Use RegEx to replace newer version.
+        #$NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '28.0.13004108' # Temporary work around. Use RegEx to replace newer version.
+        $NDK = $env:ANDROID_NDK_LATEST_HOME
         $env:PATH = "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
         $env:ANDROID_NDK_HOME = $NDK
         $env:ANDROID_NDK_ROOT = $NDK  # Set ANDROID_NDK_ROOT to ensure consistency
         Write-Host "Set ANDROID_NDK_HOME: $env:ANDROID_NDK_HOME"
         Write-Host "Set ANDROID_NDK_ROOT: $env:ANDROID_NDK_ROOT"
+        Write-Host "Set ANDROID_NDK_LATEST_HOME: $env:ANDROID_NDK_LATEST_HOME"
 
         switch ($Arch) {
             "x86"   { $Arguments += " -DANDROID_ABI=x86"}

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -520,8 +520,6 @@ function CMake-Generate {
             "arm"   { $Arguments += " -DANDROID_ABI=armeabi-v7a" }
             "arm64" { $Arguments += " -DANDROID_ABI=arm64-v8a" }
         }
-        $env:CC = "x86_64-linux-android29-clang"
-        $env:CXX = "x86_64-linux-android29-clang++"
         $Arguments += " -DANDROID_PLATFORM=android-29"
         $NdkToolchainFile = "$NDK/build/cmake/android.toolchain.cmake"
         $Arguments += " -DANDROID_NDK=""$NDK"""

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -507,7 +507,6 @@ function CMake-Generate {
         $Arguments += " -DQUIC_HIGH_RES_TIMERS=on"
     }
     if ($Platform -eq "android") {
-        #$NDK = $env:ANDROID_NDK_LATEST_HOME -replace '26\.\d+\.\d+', '28.0.13004108' # Temporary work around. Use RegEx to replace newer version.
         $NDK = $env:ANDROID_NDK_LATEST_HOME
         $env:PATH = "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$env:PATH"
         $env:ANDROID_NDK_HOME = $NDK

--- a/src/tools/forwarder/forwarder.cpp
+++ b/src/tools/forwarder/forwarder.cpp
@@ -234,6 +234,6 @@ int QUIC_MAIN_EXPORT main(int argc, char **argv) {
     CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(Listener.Start(Alpn, QuicAddr(QUIC_ADDRESS_FAMILY_UNSPEC, FrontEndPort))));
 
     printf("Press Enter to exit.\n\n");
-    getchar();
+    (void)getchar();
     return 0;
 }

--- a/src/tools/interopserver/InteropServer.cpp
+++ b/src/tools/interopserver/InteropServer.cpp
@@ -134,7 +134,7 @@ main(
         HttpServer Server(Registration, SupportedALPNs, ARRAYSIZE(SupportedALPNs), &ListenAddr, SslKeyLogFileParam);
         if (!GetFlag(argc, argv, "noexit")) {
             printf("Press Enter to exit.\n\n");
-            getchar();
+            (void)getchar();
         } else {
             CXPLAT_EVENT Event;
             CxPlatEventInitialize(&Event, TRUE, FALSE);

--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -182,7 +182,7 @@ RunServer(
     }
 
     printf("Press Enter to exit.\n\n");
-    getchar();
+    (void)getchar();
 
 Error:
 

--- a/src/tools/lb/loadbalancer.cpp
+++ b/src/tools/lb/loadbalancer.cpp
@@ -220,7 +220,7 @@ main(int argc, char **argv)
     PublicInterface = new LbPublicInterface(&PublicAddr);
 
     printf("Press Enter to exit.\n\n");
-    getchar();
+    (void)getchar();
 
     delete PublicInterface;
     CxPlatDataPathUninitialize(Datapath);

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -664,7 +664,7 @@ RunServer(
     // Continue listening for connections until the Enter key is pressed.
     //
     printf("Press Enter to exit.\n\n");
-    getchar();
+    (void)getchar();
 
 Error:
 


### PR DESCRIPTION
## Description

There was an issue in updating ndk in openssl3/Configurations/15-android.conf. It gets updated based on value of 
env: ANDROID_NDK_ROOT, but this was not getting set properly. Updated the same in scripts/build.ps1 file.

Then there were errors related to unhandled return value for getchar() call, changed them to ignore the return value.

Resolves #4856.

## Testing

Existing tests should be run successfully.

## Documentation

No
