### PR TITLE
Rust: Implement various bitflags enums

### DIFF
--- a/src/rs/config.rs
+++ b/src/rs/config.rs
@@ -183,6 +183,7 @@ impl CertificateHash {
     }
 
     /// Construct from string hash.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, crate::Status> {
         Ok(Self::new(Self::decode_hex(s)?))
     }
@@ -224,7 +225,7 @@ impl CertificateHash {
 pub struct CertificateHashStore(crate::ffi::QUIC_CERTIFICATE_HASH_STORE);
 
 impl CertificateHashStore {
-    pub fn new(flags: CertificatHashStoreFlags, hash: [u8; 20], store_name: String) -> Self {
+    pub fn new(flags: CertificateHashStoreFlags, hash: [u8; 20], store_name: String) -> Self {
         // prepare slice with nul terminator
         let c_str = CString::new(store_name).unwrap();
         let c_slice = c_str.as_bytes_with_nul();
@@ -245,7 +246,7 @@ impl CertificateHashStore {
 bitflags::bitflags! {
     /// Modifies the default credential configuration.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct CertificatHashStoreFlags: crate::ffi::QUIC_CERTIFICATE_HASH_STORE_FLAGS {
+    pub struct CertificateHashStoreFlags: crate::ffi::QUIC_CERTIFICATE_HASH_STORE_FLAGS {
         const NONE = crate::ffi::QUIC_CERTIFICATE_HASH_STORE_FLAGS_QUIC_CERTIFICATE_HASH_STORE_FLAG_NONE;
         const MACHINE_STORE = crate::ffi::QUIC_CERTIFICATE_HASH_STORE_FLAGS_QUIC_CERTIFICATE_HASH_STORE_FLAG_MACHINE_STORE;
     }
@@ -427,7 +428,7 @@ impl Default for AllowedCipherSuiteFlags {
 mod tests {
     use crate::{
         config::{
-            CertificatHashStoreFlags, CertificateFile, CertificateHash, CertificateHashStore,
+            CertificateFile, CertificateHash, CertificateHashStore, CertificateHashStoreFlags,
             Credential,
         },
         BufferRef, Configuration, Registration, RegistrationConfig, Settings, StatusCode,
@@ -495,7 +496,7 @@ mod tests {
             // cert with empty hash store.
             let cred_config = cred_config.set_credential(Credential::CertificateHashStore(
                 CertificateHashStore::new(
-                    CertificatHashStoreFlags::MACHINE_STORE,
+                    CertificateHashStoreFlags::MACHINE_STORE,
                     [0; 20],
                     String::from("MY"),
                 ),

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -24,11 +24,19 @@ mod error;
 pub mod ffi;
 pub use error::{Status, StatusCode};
 mod types;
-pub use types::{BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, StreamEvent};
+pub use types::{
+    BufferRef, ConnectionEvent, ConnectionShutdownFlags, DatagramSendState, ListenerEvent,
+    NewConnectionInfo, ReceiveFlags, SendFlags, StreamEvent, StreamOpenFlags, StreamShutdownFlags,
+    StreamStartFlags, TlsProvider,
+};
 mod settings;
 pub use settings::{ServerResumptionLevel, Settings};
 mod config;
-pub use config::{CredentialConfig, ExecutionProfile, RegistrationConfig};
+pub use config::{
+    AllowedCipherSuiteFlags, CertificateFile, CertificateFileProtected, CertificateHash,
+    CertificateHashStore, CertificateHashStoreFlags, CertificatePkcs12, Credential,
+    CredentialConfig, CredentialFlags, ExecutionProfile, RegistrationConfig,
+};
 
 //
 // The following starts the C interop layer of MsQuic API.
@@ -126,11 +134,6 @@ impl From<SocketAddrV6> for Addr {
     }
 }
 
-/// The different possible TLS providers used by MsQuic.
-pub type TlsProvider = u32;
-pub const TLS_PROVIDER_SCHANNEL: TlsProvider = 0;
-pub const TLS_PROVIDER_OPENSSL: TlsProvider = 1;
-
 /// Represents how load balancing is performed.
 pub type LoadBalancingMode = u32;
 pub const LOAD_BALANCING_DISABLED: LoadBalancingMode = 0;
@@ -153,16 +156,6 @@ pub const TLS_ALERT_CODE_INTERNAL_ERROR: TlsAlertCode = 80;
 pub const TLS_ALERT_CODE_USER_CANCELED: TlsAlertCode = 90;
 pub const TLS_ALERT_CODE_CERTIFICATE_REQUIRED: TlsAlertCode = 116;
 
-/// Modifies the default certificate hash store configuration.
-pub type CertificateHashStoreFlags = u32;
-pub const CERTIFICATE_HASH_STORE_FLAG_NONE: CertificateHashStoreFlags = 0;
-pub const CERTIFICATE_HASH_STORE_FLAG_MACHINE_STORE: CertificateHashStoreFlags = 1;
-
-/// Controls connection shutdown behavior.
-pub type ConnectionShutdownFlags = u32;
-pub const CONNECTION_SHUTDOWN_FLAG_NONE: ConnectionShutdownFlags = 0;
-pub const CONNECTION_SHUTDOWN_FLAG_SILENT: ConnectionShutdownFlags = 1;
-
 /// Modifies the behavior when sending resumption data.
 pub type SendResumptionFlags = u32;
 pub const SEND_RESUMPTION_FLAG_NONE: SendResumptionFlags = 0;
@@ -173,49 +166,6 @@ pub type StreamSchedulingScheme = u32;
 pub const STREAM_SCHEDULING_SCHEME_FIFO: StreamSchedulingScheme = 0;
 pub const STREAM_SCHEDULING_SCHEME_ROUND_ROBIN: StreamSchedulingScheme = 1;
 pub const STREAM_SCHEDULING_SCHEME_COUNT: StreamSchedulingScheme = 2;
-
-pub type StreamOpenFlags = u32;
-pub const STREAM_OPEN_FLAG_NONE: StreamOpenFlags = 0;
-pub const STREAM_OPEN_FLAG_UNIDIRECTIONAL: StreamOpenFlags = 1;
-pub const STREAM_OPEN_FLAG_0_RTT: StreamOpenFlags = 2;
-
-pub type StreamStartFlags = u32;
-pub const STREAM_START_FLAG_NONE: StreamStartFlags = 0;
-pub const STREAM_START_FLAG_IMMEDIATE: StreamStartFlags = 1;
-pub const STREAM_START_FLAG_FAIL_BLOCKED: StreamStartFlags = 2;
-pub const STREAM_START_FLAG_SHUTDOWN_ON_FAIL: StreamStartFlags = 4;
-pub const STREAM_START_FLAG_INDICATE_PEER_ACCEPT: StreamStartFlags = 8;
-
-/// Controls stream shutdown behavior.
-pub type StreamShutdownFlags = u32;
-pub const STREAM_SHUTDOWN_FLAG_NONE: StreamShutdownFlags = 0;
-pub const STREAM_SHUTDOWN_FLAG_GRACEFUL: StreamShutdownFlags = 1;
-pub const STREAM_SHUTDOWN_FLAG_ABORT_SEND: StreamShutdownFlags = 2;
-pub const STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE: StreamShutdownFlags = 4;
-pub const STREAM_SHUTDOWN_FLAG_ABORT: StreamShutdownFlags = 6;
-pub const STREAM_SHUTDOWN_FLAG_IMMEDIATE: StreamShutdownFlags = 8;
-
-pub type ReceiveFlags = u32;
-pub const RECEIVE_FLAG_NONE: ReceiveFlags = 0;
-pub const RECEIVE_FLAG_0_RTT: ReceiveFlags = 1;
-pub const RECEIVE_FLAG_FIN: ReceiveFlags = 2;
-
-/// Controls stream and datagram send behavior.
-pub type SendFlags = u32;
-pub const SEND_FLAG_NONE: SendFlags = 0;
-pub const SEND_FLAG_ALLOW_0_RTT: SendFlags = 1;
-pub const SEND_FLAG_START: SendFlags = 2;
-pub const SEND_FLAG_FIN: SendFlags = 4;
-pub const SEND_FLAG_DGRAM_PRIORITY: SendFlags = 8;
-pub const SEND_FLAG_DELAY_SEND: SendFlags = 16;
-
-pub type DatagramSendState = u32;
-pub const DATAGRAM_SEND_SENT: DatagramSendState = 0;
-pub const DATAGRAM_SEND_LOST_SUSPECT: DatagramSendState = 1;
-pub const DATAGRAM_SEND_LOST_DISCARDED: DatagramSendState = 2;
-pub const DATAGRAM_SEND_ACKNOWLEDGED: DatagramSendState = 3;
-pub const DATAGRAM_SEND_ACKNOWLEDGED_SPURIOUS: DatagramSendState = 4;
-pub const DATAGRAM_SEND_CANCELED: DatagramSendState = 5;
 
 /// Key information for TLS session ticket encryption.
 #[repr(C)]
@@ -336,7 +286,6 @@ pub const PARAM_GLOBAL_GLOBAL_SETTINGS: u32 = 0x01000006;
 pub const PARAM_GLOBAL_VERSION_SETTINGS: u32 = 0x01000007;
 pub const PARAM_GLOBAL_LIBRARY_GIT_HASH: u32 = 0x01000008;
 pub const PARAM_GLOBAL_DATAPATH_PROCESSORS: u32 = 0x01000009;
-pub const PARAM_GLOBAL_TLS_PROVIDER: u32 = 0x0100000A;
 
 pub const PARAM_CONFIGURATION_SETTINGS: u32 = 0x03000000;
 pub const PARAM_CONFIGURATION_TICKET_KEYS: u32 = 0x03000001;
@@ -636,13 +585,14 @@ impl Api {
         }
     }
 
-    pub fn get_tls_provider() -> Result<crate::ffi::QUIC_TLS_PROVIDER, Status> {
-        unsafe {
+    pub fn get_tls_provider() -> Result<crate::TlsProvider, Status> {
+        let prov: crate::ffi::QUIC_TLS_PROVIDER = unsafe {
             Api::get_param_auto(
                 std::ptr::null_mut(),
                 crate::ffi::QUIC_PARAM_GLOBAL_TLS_PROVIDER,
             )
-        }
+        }?;
+        Ok(prov.into())
     }
 
     /// # Safety
@@ -980,11 +930,7 @@ impl Connection {
 
     pub fn shutdown(&self, flags: ConnectionShutdownFlags, error_code: u62) {
         unsafe {
-            Api::ffi_ref().ConnectionShutdown.unwrap()(
-                self.handle,
-                flags as crate::ffi::QuicFlag,
-                error_code,
-            );
+            Api::ffi_ref().ConnectionShutdown.unwrap()(self.handle, flags.bits(), error_code);
         }
     }
 
@@ -1039,7 +985,7 @@ impl Connection {
                 self.handle,
                 buffers.as_ptr() as *const QUIC_BUFFER,
                 buffers.len() as u32,
-                flags as crate::ffi::QuicFlag,
+                flags.bits(),
                 client_send_context as *mut c_void,
             )
         };
@@ -1229,7 +1175,7 @@ impl Stream {
         let status = unsafe {
             Api::ffi_ref().StreamOpen.unwrap()(
                 connection.handle,
-                flags as crate::ffi::QuicFlag,
+                flags.bits(),
                 Some(raw_stream_callback),
                 ctx as *mut c_void,
                 std::ptr::addr_of_mut!(self.handle),
@@ -1241,19 +1187,13 @@ impl Stream {
     }
 
     pub fn start(&self, flags: StreamStartFlags) -> Result<(), Status> {
-        let status = unsafe {
-            Api::ffi_ref().StreamStart.unwrap()(self.handle, flags as crate::ffi::QuicFlag)
-        };
+        let status = unsafe { Api::ffi_ref().StreamStart.unwrap()(self.handle, flags.bits()) };
         Status::ok_from_raw(status)
     }
 
     pub fn shutdown(&self, flags: StreamShutdownFlags, error_code: u62) -> Result<(), Status> {
         let status = unsafe {
-            Api::ffi_ref().StreamShutdown.unwrap()(
-                self.handle,
-                flags as crate::ffi::QuicFlag,
-                error_code,
-            )
+            Api::ffi_ref().StreamShutdown.unwrap()(self.handle, flags.bits(), error_code)
         };
         Status::ok_from_raw(status)
     }
@@ -1287,7 +1227,7 @@ impl Stream {
                 self.handle,
                 buffers.as_ptr() as *const QUIC_BUFFER,
                 buffers.len() as u32,
-                flags as crate::ffi::QuicFlag,
+                flags.bits(),
                 client_send_context as *mut c_void,
             )
         };
@@ -1363,7 +1303,7 @@ mod tests {
                 println!("Peer address changed: {:?}", address.as_socket().unwrap())
             }
             ConnectionEvent::PeerStreamStarted { stream, flags } => {
-                println!("Peer stream started: flags: {flags}");
+                println!("Peer stream started: flags: {flags:?}");
                 stream.set_callback_handler(test_stream_callback)
             }
             ConnectionEvent::StreamsAvailable {

--- a/src/rs/types.rs
+++ b/src/rs/types.rs
@@ -116,8 +116,7 @@ pub enum ConnectionEvent<'a> {
     // TODO: may need to change StreamRef to Stream for better safety.
     PeerStreamStarted {
         stream: crate::StreamRef,
-        // TODO: provide safe wrapper.
-        flags: crate::ffi::QUIC_STREAM_OPEN_FLAGS,
+        flags: StreamOpenFlags,
     },
     StreamsAvailable {
         bidirectional_count: u16,
@@ -136,13 +135,11 @@ pub enum ConnectionEvent<'a> {
     },
     DatagramReceived {
         buffer: &'a BufferRef,
-        // TODO: provide safe wrapper.
-        flags: crate::ffi::QUIC_RECEIVE_FLAGS,
+        flags: ReceiveFlags,
     },
     DatagramSendStateChanged {
         client_context: *const c_void,
-        // TODO: provide safe wrapper.
-        state: crate::ffi::QUIC_DATAGRAM_SEND_STATE,
+        state: DatagramSendState,
     },
     // Server-only; provides resumption data, if any.
     Resumed {
@@ -199,7 +196,7 @@ impl<'a> From<&'a QUIC_CONNECTION_EVENT> for ConnectionEvent<'a> {
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED => {
               let ev = unsafe { value.__bindgen_anon_1.PEER_STREAM_STARTED };
-              Self::PeerStreamStarted { stream: unsafe { crate::StreamRef::from_raw(ev.Stream) }, flags: ev.Flags }
+              Self::PeerStreamStarted { stream: unsafe { crate::StreamRef::from_raw(ev.Stream) }, flags: StreamOpenFlags::from_bits(ev.Flags).unwrap() }
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE => {
               let ev = unsafe { value.__bindgen_anon_1.STREAMS_AVAILABLE };
@@ -219,11 +216,11 @@ impl<'a> From<&'a QUIC_CONNECTION_EVENT> for ConnectionEvent<'a> {
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_DATAGRAM_RECEIVED => {
               let ev = unsafe { value.__bindgen_anon_1.DATAGRAM_RECEIVED };
-              Self::DatagramReceived { buffer: unsafe { BufferRef::from_ffi_ref(ev.Buffer.as_ref().unwrap()) }, flags: ev.Flags }
+              Self::DatagramReceived { buffer: unsafe { BufferRef::from_ffi_ref(ev.Buffer.as_ref().unwrap()) }, flags: ReceiveFlags::from_bits(ev.Flags).unwrap() }
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED => {
               let ev = unsafe { value.__bindgen_anon_1.DATAGRAM_SEND_STATE_CHANGED };
-              Self::DatagramSendStateChanged { client_context: ev.ClientContext, state: ev.State }
+              Self::DatagramSendStateChanged { client_context: ev.ClientContext, state: DatagramSendState::from(ev.State) }
             }
             crate::ffi::QUIC_CONNECTION_EVENT_TYPE_QUIC_CONNECTION_EVENT_RESUMED =>{
               let ev = unsafe { value.__bindgen_anon_1.RESUMED };
@@ -265,7 +262,7 @@ pub enum StreamEvent<'a> {
         absolute_offset: u64,
         total_buffer_length: &'a mut u64, // inout parameter
         buffers: &'a [BufferRef],
-        flags: crate::ffi::QUIC_RECEIVE_FLAGS,
+        flags: ReceiveFlags,
     },
     SendComplete {
         cancelled: bool,
@@ -320,7 +317,7 @@ impl<'b> From<&'b mut crate::ffi::QUIC_STREAM_EVENT> for StreamEvent<'b> {
                             ev.BufferCount as usize,
                         ))
                     },
-                    flags: ev.Flags,
+                    flags: ReceiveFlags::from_bits(ev.Flags).unwrap(),
                 }
             }
             crate::ffi::QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_SEND_COMPLETE => {
@@ -444,6 +441,141 @@ unsafe fn slice_conv<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
         &[]
     } else {
         std::slice::from_raw_parts(ptr, len)
+    }
+}
+
+/// The different possible TLS providers used by MsQuic.
+#[derive(Debug, PartialEq, Clone)]
+pub enum TlsProvider {
+    Schannel,
+    Openssl,
+}
+
+impl From<TlsProvider> for crate::ffi::QUIC_TLS_PROVIDER {
+    fn from(value: TlsProvider) -> Self {
+        match value {
+            TlsProvider::Schannel => crate::ffi::QUIC_TLS_PROVIDER_QUIC_TLS_PROVIDER_SCHANNEL,
+            TlsProvider::Openssl => crate::ffi::QUIC_TLS_PROVIDER_QUIC_TLS_PROVIDER_OPENSSL,
+        }
+    }
+}
+
+impl From<crate::ffi::QUIC_TLS_PROVIDER> for TlsProvider {
+    fn from(value: crate::ffi::QUIC_TLS_PROVIDER) -> Self {
+        match value {
+            crate::ffi::QUIC_TLS_PROVIDER_QUIC_TLS_PROVIDER_SCHANNEL => Self::Schannel,
+            crate::ffi::QUIC_TLS_PROVIDER_QUIC_TLS_PROVIDER_OPENSSL => Self::Openssl,
+            _ => panic!("unknown tls provider: {}", value),
+        }
+    }
+}
+
+bitflags::bitflags! {
+    /// Controls connection shutdown behavior.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ConnectionShutdownFlags: crate::ffi::QUIC_CONNECTION_SHUTDOWN_FLAGS {
+        const NONE = crate::ffi::QUIC_CONNECTION_SHUTDOWN_FLAGS_QUIC_CONNECTION_SHUTDOWN_FLAG_NONE;
+        /// Don't send the close frame over the network.
+        const SILENT = crate::ffi::QUIC_CONNECTION_SHUTDOWN_FLAGS_QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT;
+    }
+}
+
+bitflags::bitflags! {
+    /// Controls stream open behavior.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StreamOpenFlags: crate::ffi::QUIC_STREAM_OPEN_FLAGS {
+        const NONE = crate::ffi::QUIC_STREAM_OPEN_FLAGS_QUIC_STREAM_OPEN_FLAG_NONE;
+        const UNIDIRECTIONAL = crate::ffi::QUIC_STREAM_OPEN_FLAGS_QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL;
+        const ZERO_RTT = crate::ffi::QUIC_STREAM_OPEN_FLAGS_QUIC_STREAM_OPEN_FLAG_0_RTT;
+        const DELAY_ID_FC_UPDATES = crate::ffi::QUIC_STREAM_OPEN_FLAGS_QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES;
+        #[cfg(feature = "preview-api")]
+        const APP_OWNED_BUFFERS = crate::ffi::QUIC_STREAM_OPEN_FLAGS_QUIC_STREAM_OPEN_FLAG_APP_OWNED_BUFFERS;
+    }
+}
+
+bitflags::bitflags! {
+    /// Controls stream start behavior.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StreamStartFlags: crate::ffi::QUIC_STREAM_START_FLAGS {
+        const NONE                 = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_NONE;
+        const IMMEDIATE            = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_IMMEDIATE;
+        const FAIL_BLOCKED         = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_FAIL_BLOCKED;
+        const SHUTDOWN_ON_FAIL     = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_SHUTDOWN_ON_FAIL;
+        const INDICATE_PEER_ACCEPT = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_INDICATE_PEER_ACCEPT;
+        const PRIORITY_WORK        = crate::ffi::QUIC_STREAM_START_FLAGS_QUIC_STREAM_START_FLAG_PRIORITY_WORK;
+    }
+}
+
+bitflags::bitflags! {
+    /// Controls stream shutdown behavior.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StreamShutdownFlags: crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS {
+        const NONE          = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_NONE;
+        const GRACEFUL      = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL;
+        const ABORT_SEND    = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND;
+        const ABORT_RECEIVE = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE;
+        const ABORT         = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_ABORT;
+        const IMMEDIATE     = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE;
+        const INLINE        = crate::ffi::QUIC_STREAM_SHUTDOWN_FLAGS_QUIC_STREAM_SHUTDOWN_FLAG_INLINE;
+    }
+}
+
+bitflags::bitflags! {
+    /// Controls stream and datagram send behavior.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SendFlags: crate::ffi::QUIC_SEND_FLAGS {
+        const NONE                     = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_NONE;
+        const ALLOW_0_RTT              = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_ALLOW_0_RTT;
+        const START                    = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_START;
+        const FIN                      = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_FIN;
+        const DGRAM_PRIORITY           = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_DGRAM_PRIORITY;
+        const DELAY_SEND               = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_DELAY_SEND;
+        const CANCEL_ON_LOSS           = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_CANCEL_ON_LOSS;
+        const PRIORITY_WORK            = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_PRIORITY_WORK;
+        const CANCEL_ON_BLOCKED        = crate::ffi::QUIC_SEND_FLAGS_QUIC_SEND_FLAG_CANCEL_ON_BLOCKED;
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ReceiveFlags: crate::ffi::QUIC_RECEIVE_FLAGS {
+        const NONE      = crate::ffi::QUIC_RECEIVE_FLAGS_QUIC_RECEIVE_FLAG_NONE;
+        const ZERO_RTT  = crate::ffi::QUIC_RECEIVE_FLAGS_QUIC_RECEIVE_FLAG_0_RTT;
+        const FIN       = crate::ffi::QUIC_RECEIVE_FLAGS_QUIC_RECEIVE_FLAG_FIN;
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum DatagramSendState {
+    Unknown,              // Not yet sent
+    Sent,                 // Sent and awaiting acknowledgment
+    LostSuspect,          // Suspected as lost, but still tracked
+    LostDiscarded,        // Lost and no longer being tracked
+    Acknowledged,         // Acknowledged
+    AcknowledgedSpurious, // Acknowledged after being suspected lost
+    Canceled,             // Canceled before send
+}
+
+impl From<crate::ffi::QUIC_DATAGRAM_SEND_STATE> for DatagramSendState {
+    fn from(value: crate::ffi::QUIC_DATAGRAM_SEND_STATE) -> Self {
+        match value {
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_UNKNOWN => Self::Unknown,
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_SENT => Self::Sent,
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_LOST_SUSPECT => {
+                Self::LostSuspect
+            }
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_LOST_DISCARDED => {
+                Self::LostDiscarded
+            }
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_ACKNOWLEDGED => {
+                Self::Acknowledged
+            }
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_ACKNOWLEDGED_SPURIOUS => {
+                Self::AcknowledgedSpurious
+            }
+            crate::ffi::QUIC_DATAGRAM_SEND_STATE_QUIC_DATAGRAM_SEND_CANCELED => Self::Canceled,
+            _ => panic!("Unknown state: {:?}", value),
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Replaced various u32 flag types with bitflag enums.
Only the frequently used flags are implemented, other flags will be added when needed in the future.

## Testing
NA

## Documentation
NA
