### PR TITLE
Rust: Update cargo edition and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msquic"
 version = "2.5.0-beta"
-edition = "2018"
+edition = "2021"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"
 readme = "README.md"
@@ -62,9 +62,8 @@ cmake = "0.1"
 bindgen = { version = "0.71", optional = true }
 
 [dependencies]
-bitflags = "2.8"
-libc = "0.2.0"
-c-types = "4.0.0"
-serde = { version = "1.0.117", features = ["derive"] }
-ctor = "0.4.0"
-socket2 = "0.5.8"
+bitflags = "2.9"
+libc = "0.2"
+c-types = "4.0"
+ctor = "0.4"
+socket2 = "0.5"

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -10,7 +10,6 @@ use c_types::AF_UNSPEC;
 use c_types::{sa_family_t, sockaddr_in, sockaddr_in6, socklen_t};
 use ffi::{HQUIC, QUIC_API_TABLE, QUIC_BUFFER, QUIC_CREDENTIAL_CONFIG, QUIC_SETTINGS, QUIC_STATUS};
 use libc::c_void;
-use serde::{Deserialize, Serialize};
 use socket2::SockAddr;
 use std::fmt::Debug;
 use std::io;
@@ -250,7 +249,7 @@ pub const CIPHER_SUITE_TLS_AES_256_GCM_SHA384: CipherSuite = 4866;
 pub const CIPHER_SUITE_TLS_CHACHA20_POLY1305_SHA256: CipherSuite = 4867;
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct HandshakeInfo {
     pub tls_protocol_version: TlsProtocolVersion,
     pub cipher_algorithm: CipherAlgorithm,


### PR DESCRIPTION
## Description
* Update cargo edition from 2018 to 2021. We will update to the latest 2024 in the future.
* Update all dependencies to latest versions. And dependencies are specified up to the minor version, ignoring the patch version, which is typically what lib crate should do to allow apps to pick the exact patch version to use and avoid conflicts with other crates.
* Removed serde dependency since the manual ffi struct does not utilize it. In future serde might be added back if we support a safe wrapper over ffi types and the safe type might need serde.

## Testing
NA

## Documentation
NA
