### PR TITLE
Rust: Expand exported types related to certificate

### DIFF
--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -27,7 +27,11 @@ pub use types::{BufferRef, ConnectionEvent, ListenerEvent, NewConnectionInfo, St
 mod settings;
 pub use settings::{ServerResumptionLevel, Settings};
 mod config;
-pub use config::{CredentialConfig, ExecutionProfile, RegistrationConfig};
+pub use config::{
+    CertificateFile, CertificateFileProtected, CertificateHash, CertificateHashStore,
+    CertificatePkcs12, Credential, CredentialConfig, CredentialFlags, ExecutionProfile,
+    RegistrationConfig,
+};
 
 //
 // The following starts the C interop layer of MsQuic API.


### PR DESCRIPTION
## Description

Expand exported types related to certificate in MsQuic crate. Without these exports, any user of this crate cannot create a client/server.

## Testing

NA

## Documentation

NA
