### PR TITLE
Rust: Support linking pre-installed msquic lib

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -77,6 +77,7 @@ jobs:
         sudo dpkg -i packages-microsoft-prod.deb;
         sudo apt-get update;
         sudo apt-get install libmsquic;
+        dpkg -L libmsquic;
     - name: Cargo fmt
       run: cargo fmt --all -- --check
     - name: Cargo clippy

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -55,3 +55,26 @@ jobs:
       run: cargo test --all ${{ matrix.features }}
     - name: Cargo Publish (dry run)
       run: cargo publish --dry-run --allow-dirty
+  # Test rust crate with preinstalled msquic lib.
+  cargo-preinstall:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    name: Cargo-Preinstall
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481
+      with:
+        egress-policy: audit
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Install msquic from apt
+      run: |
+        wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
+        sudo dpkg -i packages-microsoft-prod.deb;
+        sudo apt-get update;
+        suto apt-get install libmsquic;
+    - name: Cargo test
+      run: cargo test --all --no-default-features --features find

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Cargo fmt
       run: cargo fmt --all -- --check
     - name: Cargo clippy
-      run: cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --all-targets ${{ matrix.features }} -- -D warnings
     - name: Cargo build
       run: cargo build --all ${{ matrix.features }}
     - name: Check all generated files with git
@@ -61,6 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        features: ["--no-default-features --features find"]
     runs-on: ${{ matrix.os }}
     name: Cargo-Preinstall
     steps:
@@ -75,6 +76,12 @@ jobs:
         wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
         sudo dpkg -i packages-microsoft-prod.deb;
         sudo apt-get update;
-        suto apt-get install libmsquic;
+        sudo apt-get install libmsquic;
+    - name: Cargo fmt
+      run: cargo fmt --all -- --check
+    - name: Cargo clippy
+      run: cargo clippy --all-targets ${{ matrix.features }} -- -D warnings
+    - name: Cargo build
+      run: cargo build --all ${{ matrix.features }}
     - name: Cargo test
-      run: cargo test --all --no-default-features --features find
+      run: cargo test --all ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ include = [
 path = "src/rs/lib.rs"
 
 [features]
-# default = ["src"]
-default = ["find"]
+default = ["src"]
 # Build c code from source
 src = [ "dep:cmake" ]
 # Find prebuilt msquic. Use vcpkg installed location on Windows,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,14 @@ include = [
 path = "src/rs/lib.rs"
 
 [features]
-default = []
+# default = ["src"]
+default = ["find"]
+# Build c code from source
+src = [ "dep:cmake" ]
+# Find prebuilt msquic. Use vcpkg installed location on Windows,
+# while use system installed location first and then use vcpkg location on linux.
+# MacOs is not supported.
+find = [] 
 # Windows uses schannel, and linux uses openssl by default. 
 # This feature enables openssl on windows, and has no effect on linux.
 openssl = []
@@ -58,7 +65,7 @@ preview-api = []
 overwrite = [ "dep:bindgen" ]
 
 [build-dependencies]
-cmake = "0.1"
+cmake = { version = "0.1", optional = true }
 bindgen = { version = "0.71", optional = true }
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ default = ["src"]
 # Build c code from source
 src = [ "dep:cmake" ]
 # Find prebuilt msquic. Use vcpkg installed location on Windows,
-# while use system installed location first and then use vcpkg location on linux.
+# while use system installed location on linux.
 # MacOs is not supported.
 find = [] 
 # Windows uses schannel, and linux uses openssl by default. 

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -92,14 +92,13 @@ mod find {
     /// Find and use preinstalled msquic binaries.
     pub(crate) fn find() {
         let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
-        // On linux try the known install location of libmsquic pkg.
         let libs = if cfg!(target_os = "linux") {
-            try_system_location()
+            // On linux try the known install location of libmsquic pkg.
+            try_system_location().expect("cannot find msquic in system")
         } else {
-            None
+            // On windows try find from vcpkg.
+            try_vcpkg().expect("cannot find msquic in vcpkg")
         };
-        // Try find msquic in vcpkg.
-        let libs = libs.unwrap_or_else(|| try_vcpkg().expect("cannot find use system and vcpkg"));
         #[cfg(target_os = "windows")]
         copy_libs(&libs, &out_dir);
 
@@ -169,7 +168,7 @@ mod find {
         Some(libs)
     }
 
-    /// Try get from system installed location.
+    /// Try get from system installed location. Linux only.
     fn try_system_location() -> Option<Vec<PathBuf>> {
         let installed_dir = "/usr/lib/x86_64-linux-gnu";
         let libs = get_preinstalled_libs(&PathBuf::from(installed_dir));

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -1,11 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use cmake::Config;
-use std::env;
-use std::path::Path;
-
 fn main() {
+    if cfg!(feature = "static") {
+        assert!(cfg!(feature = "src"), "static requires build for src");
+    }
+
+    #[cfg(all(feature = "src", feature = "find"))]
+    panic!("feature src and find are mutually exclusive");
+
+    #[cfg(feature = "src")]
+    cmake_build();
+
+    #[cfg(feature = "find")]
+    find::find();
+
+    #[cfg(all(feature = "overwrite", not(target_os = "macos")))]
+    overwrite_bindgen();
+}
+
+#[cfg(feature = "src")]
+fn cmake_build() {
+    use cmake::Config;
+    use std::env;
+    use std::path::Path;
     let path_extra = "lib";
     let mut logging_enabled = "off";
     if cfg!(windows) {
@@ -65,16 +83,97 @@ fn main() {
         }
         println!("cargo:rustc-link-lib=static=msquic");
     }
+}
 
-    #[cfg(all(feature = "overwrite", not(target_os = "macos")))]
-    overwrite_bindgen();
+mod find {
+    use std::path::{Path, PathBuf};
+
+    /// Find and use preinstalled msquic binaries.
+    pub(crate) fn find() {
+        let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+        // On linux try the known install location of libmsquic pkg.
+        let libs = if cfg!(target_os = "linux") {
+            try_system_location()
+        } else {
+            None
+        };
+        // Try find msquic in vcpkg.
+        let libs = libs.unwrap_or_else(|| try_vcpkg().expect("cannot find use system and vcpkg"));
+        copy_libs(&libs, &out_dir);
+        println!("cargo:rustc-link-search=native={}", out_dir.display());
+    }
+
+    #[cfg(target_os = "windows")]
+    const LIBS: [&str; 3] = ["bin/msquic.dll", "bin/msquic.pdb", "lib/msquic.lib"];
+
+    #[cfg(not(target_os = "windows"))]
+    const LIBS: [&str; 2] = ["lib/libmsquic.so", "lib/libmsquic.so.2"];
+
+    /// Get libs for preinstalled msquic.
+    fn get_preinstalled_libs(install_dir: &Path) -> Vec<PathBuf> {
+        LIBS.iter().map(|lib| install_dir.join(lib)).collect()
+    }
+
+    /// Copy libs from pre-installed dir to rust out_dir.
+    /// This ensures cargo link msquic from this dir, and propagates right
+    /// variables for test executables to load msquic.
+    fn copy_libs(libs: &Vec<PathBuf>, out_dir: &Path) {
+        for lib in libs {
+            let lib_out = out_dir.join(lib.file_name().unwrap());
+            if !lib_out.exists() {
+                assert!(lib.exists()); // we have checked it in prior steps.
+                #[cfg(target_os = "windows")]
+                std::fs::copy(lib, &lib_out).expect("cannot copy file");
+                // On unix use symlink to save space.
+                #[cfg(not(target_os = "windows"))]
+                std::os::unix::fs::symlink(lib, &lib_out).expect("cannot symlink file");
+            }
+        }
+    }
+
+    /// Try get msquic libs from vcpkg. Return the list of lib full paths.
+    /// vcpkg crate is not maintained, and does not work well on linux,
+    /// so we write this simple logic from scratch.
+    fn try_vcpkg() -> Option<Vec<PathBuf>> {
+        let vcpkg_dir = std::env::var("VCPKG_ROOT").ok()?;
+        let triplet = if cfg!(target_os = "windows") {
+            "x64-windows"
+        } else if cfg!(target_os = "linux") {
+            "x64-linux"
+        } else {
+            panic!("os not supported");
+        };
+        let dir = PathBuf::from(vcpkg_dir).join("installed").join(triplet);
+        if !dir.exists() {
+            return None;
+        }
+        let libs = get_preinstalled_libs(&dir);
+        for lib in &libs {
+            if !lib.exists() {
+                return None;
+            }
+        }
+        Some(libs)
+    }
+
+    /// Try get from system installed location.
+    fn try_system_location() -> Option<Vec<PathBuf>> {
+        let installed_dir = "/usr/lib/x86_64-linux-gnu";
+        let libs = get_preinstalled_libs(&PathBuf::from(installed_dir));
+        for lib in &libs {
+            if !lib.exists() {
+                return None;
+            }
+        }
+        Some(libs)
+    }
 }
 
 /// Read the c header and generate rust bindings.
 /// TODO: macos currently uses linux bindings.
 #[cfg(all(feature = "overwrite", not(target_os = "macos")))]
 fn overwrite_bindgen() {
-    let manifest_dir = std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let root_dir = manifest_dir;
     // include msquic headers
     let inc_dir = root_dir.join("src").join("inc");

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -85,6 +85,7 @@ fn cmake_build() {
     }
 }
 
+#[cfg(feature = "find")]
 mod find {
     use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Description
Added new feature to support linking pre-installed msquic lib in system location, and in vcpkg location. 

## Testing
Manual local testing with pre-installed deb pkg, and vcpkg respectively. 

## Documentation
NA
