### PR TITLE
Add Cibir tests to Connection Pool tests

### DIFF
--- a/src/test/bin/quic_gtest.h
+++ b/src/test/bin/quic_gtest.h
@@ -353,6 +353,7 @@ struct HandshakeArgs12 {
         ::std::vector<HandshakeArgs12> list;
         for (int Family : { 4, 6 })
         for (uint16_t NumberOfConnections : { 1, 2, 4 })
+        for (bool TestCibir : { false, true })
         for (bool XdpSupported : { false, true }) {
 #if !defined(_WIN32)
             if (XdpSupported) continue;
@@ -360,7 +361,7 @@ struct HandshakeArgs12 {
             if (!UseDuoNic && XdpSupported) {
                 continue;
             }
-            list.push_back({ Family, NumberOfConnections, XdpSupported, false /*Don't test CIBIR*/ });
+            list.push_back({ Family, NumberOfConnections, XdpSupported, TestCibir });
         }
         return list;
     }

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -4224,9 +4224,9 @@ QuicTestConnectionPoolCreate(
         Listener.Context = &ServerAcceptContext;
 
         if (TestCibirSupport) {
-            uint8_t CibirId[] = { 0 /* offset */, 9, 8, 7, 6 };
-            uint8_t CibirIdLength = sizeof(CibirId);
-            TEST_QUIC_SUCCEEDED(Listener.SetCibirId(CibirId, CibirIdLength));
+            uint8_t ServerCibirId[] = { 0 /* offset */, 9, 8, 7, 6 };
+            uint8_t ServerCibirIdLength = sizeof(CibirId);
+            TEST_QUIC_SUCCEEDED(Listener.SetCibirId(ServerCibirId, ServerCibirIdLength));
         }
 
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, ServerAddr));


### PR DESCRIPTION
## Description

Add CIBIR tests back to the connection pool API tests.

## Testing

Adding new tests

## Documentation

N/A.
