### PR TITLE
Fix data corruption in receive buffer

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -473,8 +473,8 @@ QuicRecvBufferCopyIntoChunks(
                 RecvBuffer->Chunks.Blink, // Last chunk
                 QUIC_RECV_CHUNK,
                 Link);
-        CXPLAT_DBG_ASSERT(WriteLength <= Chunk->AllocLength); // Should always fit in the last chunk
         uint64_t RelativeOffset = WriteOffset - RecvBuffer->BaseOffset;
+        CXPLAT_DBG_ASSERT(RelativeOffset + WriteLength <= Chunk->AllocLength); // Should always fit in the last chunk
         uint32_t ChunkOffset = (RecvBuffer->ReadStart + RelativeOffset) % Chunk->AllocLength;
 
         if (ChunkOffset + WriteLength > Chunk->AllocLength) {
@@ -675,7 +675,7 @@ QuicRecvBufferWrite(
                     RecvBuffer->Chunks.Blink,
                     QUIC_RECV_CHUNK,
                     Link)->AllocLength << 1;
-            while (AbsoluteLength > RecvBuffer->BaseOffset + NewBufferLength + RecvBuffer->ReadPendingLength) {
+            while (AbsoluteLength > RecvBuffer->BaseOffset + NewBufferLength) {
                 NewBufferLength <<= 1;
             }
             if (!QuicRecvBufferResize(RecvBuffer, NewBufferLength)) {


### PR DESCRIPTION
## Description

Fixes an edge case received data could be overwritten before being drained in the receive buffer.

The issue occurs when:
- A read is pending
- A write triggers a buffer re-allocation
- The math aligns such that the write almost fills the newly allocated buffer

The logic to determine the size needed for the new buffer would consider that the "read pendind" data doesn't need room in the newly allocated buffer. This is wrong, as the data needs to be kept in case it isn't drained.

This would lead to two issues:
- in Single mode, a write could wrap around
- in Single and Circular mode, the newly written data could overwrite the data pending a read
    - this doesn't cause an immediate issue since the pending read points to the now retired buffer
    - but if the data isn't drained, it will have been overwritten when notified again on the next read
   
## Testing

- Added a unit test to reproduce the issue
- Correct a Multi-receive mode test that is impacted by the change in the size of the new buffer allocation

## Documentation

N/A
