### PR TITLE
Add QUIC stream event documentation and other event related doc updates

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,8 +16,8 @@ Term | Definition
 *endpoint* | One side of a connection; client or server.
 *peer* | The *other* side of a connection.
 *callback handler* | The function pointer the app registers with an MsQuic object.
-*app context* or<br> *context* | A (possibly null) pointer registered with an MsQuic object. It is passed to callback handlers.
-*event* | An upcall to a callback handler.
+*app context* or<br> *context* | A (possibly null) pointer registered with an MsQuic object. It is passed to App's callback handlers.
+*event* | Beginning or ending of a specific condition or action in MsQuic library that results in the App's callback hander invocation.
 
 # High Level Overview
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,8 +16,8 @@ Term | Definition
 *endpoint* | One side of a connection; client or server.
 *peer* | The *other* side of a connection.
 *callback handler* | The function pointer the app registers with an MsQuic object.
-*app context* or<br> *context* | A (possibly null) pointer registered with an MsQuic object. It is passed to App's callback handlers.
-*event* | Beginning or ending of a specific condition or action in MsQuic library that results in the App's callback hander invocation.
+*app context* or<br> *context* | A (possibly null) pointer registered with an MsQuic object. It is passed to the app's callback handlers.
+*event* | Beginning or ending of a specific condition or action in the MsQuic library that results in the app's callback hander invocation.
 
 # High Level Overview
 

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -33,7 +33,7 @@ QUIC_STATUS
     );
 ```
 
-The application must register a callback handler for every MsQuic object it creates. This handler must manage all the events MsQuic may indicate for that object. The handler must also return a status for each event indicating to MsQuic how the event was handled. This returned status is often success/failure, but sometimes indicates MSQuic that further processing is required.
+The application must register a callback handler for every MsQuic object it creates. This handler must manage all the events MsQuic may indicate for that object. The handler must also return a status for each event indicating to MsQuic how the event was handled. This returned status is often success/failure, but sometimes indicates MsQuic that further processing is required.
 
 This approach differs significantly from sockets and most networking libraries, where the application must make a call (e.g., `send` or `recv`) to determine if something happened.
 This design choice was made for several reasons:
@@ -61,8 +61,8 @@ This does not imply that the application needs separate threads to perform all o
 Many operations are designed to be most efficient when executed within the callback.
 For example, closing a handle to a connection or stream is ideally done during the "shutdown complete" event notification callback.
 
-Some callbacks necessitate the application to call MsQuic API in return, which can be a source of deadlocks.
-MsQuic design ensures that MsQuic API (down) calls made from a callback thread always occur inline (thus avoiding deadlocks) and will take precedence over any calls in progress or queued from a separate thread.
+Some callbacks necessitate the application to call MsQuic API in return. Such cyclic call patterns could lead to deadlocks in a generic implementation, but not so in MsQuic.
+Special attention has been paid to ensure that MsQuic API (down) calls made from a callback thread always occur inline (thus avoiding deadlocks) and will take precedence over any calls in progress or queued from a separate thread.
 By default, MsQuic will **never** invoke a recursive callback to the application in these cases. The only exception to this rule is if the application opts in via the `QUIC_STREAM_SHUTDOWN_FLAG_INLINE` flag when calling `StreamShudown` on a callback.
 
 ## Threading
@@ -111,3 +111,12 @@ graph TD
         end
     end
 ```
+
+# See Also
+
+[QUIC_STREAM_CALLBACK](api/QUIC_STREAM_CALLBACK.md)<br>
+[QUIC_STREAM_EVENT](api/QUIC_STREAM_EVENT.md)<br>
+[QUIC_CONNECTION_CALLBACK](api/QUIC_CONNECTION_CALLBACK.md)<br>
+[QUIC_CONNECTION_EVENT](api/QUIC_CONNECTION_EVENT.md)<br>
+[QUIC_LISTENER_CALLBACK](api/QUIC_LISTENER_CALLBACK.md)<br>
+[QUIC_LISTENER_EVENT](api/QUIC_LISTENER_EVENT.md)<br>

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -8,7 +8,7 @@ The sections below detail the designs MsQuic uses and the reasons behind these c
 
 MsQuic [Object Model](./API.md#object-model) describes the hierarchy of MsQuic objects.
 
-MsQuic API delivers all state changes and notifications for a specific MsQuic object directly to the corresponding callback handler registered by the application. These include connection state changes, new streams being created, stream data being received, and stream sends completing, among others.
+The MsQuic API delivers all state changes and notifications for a specific MsQuic object directly to the corresponding callback handler registered by the application. These include connection state changes, new streams being created, stream data being received, and stream sends completing, among others.
 
 Example definition of Listener object callback API:
 

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -6,8 +6,12 @@ The sections below detail the designs MsQuic uses and the reasons behind these c
 
 ## Event Model
 
-In the MsQuic API, all asynchronous state changes and notifications are indicated directly to the application via a callback.
-This includes connection state changes, new streams being created, stream data being received, and stream sends completing.
+MsQuic [Object Model](./API.md#object-model) describes the hierarchy of MsQuic objects.
+
+MsQuic API delivers all state changes and notifications for a specific MsQuic object directly to the corresponding callback handler registered by the application.
+These include connection state changes, new streams being created, stream data being received, and stream sends completing.
+
+Example definition of Listener object callback API:
 
 ```c
 typedef struct QUIC_LISTENER_EVENT {
@@ -15,6 +19,7 @@ typedef struct QUIC_LISTENER_EVENT {
     union {
         struct { ... } NEW_CONNECTION;
         struct { ... } STOP_COMPLETE;
+        ...
     };
 } QUIC_LISTENER_EVENT;
 
@@ -29,52 +34,50 @@ QUIC_STATUS
     );
 ```
 
-Above is an example of a callback delivered to the listener interface.
-The application must register a per-object callback handler to manage all events MsQuic may indicate for that object, returning a status to show if it was successfully handled or not.
+The application must register a callback handler for every MsQuic object it creates. This handler must manage all the events MsQuic may indicate for that object. The handler must also return a status for each event indicating to MsQuic whether not not the event was successfully handled.
 
 This approach differs significantly from sockets and most networking libraries, where the application must make a call (e.g., `send` or `recv`) to determine if something happened.
 This design choice was made for several reasons:
 
 - The MsQuic API **runs in-process**, eliminating the need for a kernel to user mode boundary switch to notify the application layer. This makes the callback-based design more practical compared to sockets.
 
-- MsQuic, due to the QUIC protocol, has numerous event types. Applications may have hundreds of objects with potential state changes. The callback model allows the application to avoid managing pending calls on each object.
+- MsQuic, due to the QUIC protocol, has numerous event types. Applications may have hundreds of objects with potential state changes. The callback model allows the application to avoid call management on each object and focus on event management for a given object.
 
-- Writing correct, scalable code on top of the socket interfaces has proven challenging. By offloading the threading to MsQuic it enables MsQuic to abstract much complexity from applications, making things "just work" out of the box.
+- Writing correct, scalable code on top of the socket interfaces has proven challenging. Offloading the threading and call managementment to MsQuic enables every application to scalable with minimal effort, making things "just work" out of the box.
 
-- It simplifies MsQuic's logic by eliminating the need for a queue or cached state to indicate to the application. In the socket model, the networking stack must wait for a top-down call from the application before indicating completion, increasing code size, complexity, and memory usage.
+- Simplified logic flow in MsQuic by eliminating a queue/cached state of yet to be delivered application notifications. This queue/cached state is maintained in the socket model to track yet-to-be-picked-up events/data and the networking stack must wait for call(s) from the application before indicating completion. This represents additional code, complexity and memory usage in socket model that MsQuic does without.
 
 ### Writing Event Handlers
 
-Event handlers are **essential** for all objects that support them, as much of the MsQuic API operates through these callbacks.
+Event handlers are **required** for all objects that can receive events, as much of the MsQuic API operates through these callbacks.
 Critical events, such as "shutdown complete" notifications, provide vital information necessary for the application to function correctly.
 Without these events, the application cannot determine when it is safe to clean up objects.
 
-Applications should keep the execution time within callbacks **to a minimum**.
+Applications **must** keep the execution time within callbacks **to a minimum**.
 MsQuic does not use separate threads for protocol execution and upcalls to the application.
 Therefore, any significant delays in the callback **will delay the protocol**.
-Any substantial work required by the application should be performed on its own thread.
+Any substantial work required by the application **must** be performed on threads created by the application.
 
-This does not mean the application cannot perform any work in the callback handler.
-In fact, many operations are designed to be most efficient when executed within the callback.
-For example, closing a handle to a connection or stream is ideally done during the "shutdown complete" indication.
+This does not imply that the application needs separate threads to perform all of its work.
+Many operations are designed to be most efficient when executed within the callback.
+For example, closing a handle to a connection or stream is ideally done during the "shutdown complete" callback.
 
-A crucial aspect of this design is that all blocking API (down) calls invoked within a callback always occur inline (to prevent deadlocks) and will take precedence over any calls in progress or queued from a separate thread.
-It's also worth noting that MsQuic will not invoke a recursive callback to the application by default in these cases.
-The one exception to this rule is if the application opts in via the `QUIC_STREAM_SHUTDOWN_FLAG_INLINE` flag when calling `StreamShudown` on a callback.
+Some callbacks necessitate the application to call MsQuic API in return, which can be a source of deadlocks.
+MsQuic design ensures that MsQuic API (down) calls made from a callback thread always occur inline (thus avoiding deadlocks) and will take precedence over any calls in progress or queued from a separate thread.
+By default, MsQuic will **never** invoke a recursive callback to the application in these cases. The only exception to this rule is if the application opts in via the `QUIC_STREAM_SHUTDOWN_FLAG_INLINE` flag when calling `StreamShudown` on a callback.
 
 ## Threading
 
-By default, MsQuic creates its own threads to manage the execution of its logic.
+MsQuic creates its own threads by default to manage the execution of its logic.
 The number and configuration of these threads depend on the settings passed to [RegistrationOpen](api/RegistrationOpen.md) or `QUIC_PARAM_GLOBAL_EXECUTION_CONFIG`.
 
-Typically, MsQuic creates dedicated threads for each processor, which are hard-affinitized to a specific NUMA node and soft-affinitized (set as 'ideal processor') to a specific processor.
-These threads handle both the datapath (i.e., UDP) and QUIC layers.
-By default both layers are handled by a single thread (per-processor), but QUIC may be configured to run these layers on separate threads.
-By using the same thread MsQuic can achieve lower latency, but by using separate threads it can achieve higher throughput.
+MsQuic typically creates a dedicated worker thread for each processor, which are hard-affinitized to a specific NUMA node and soft-affinitized (set as 'ideal processor') to a specific processor.
+Each of these threads handle both the datapath (i.e., UDP) and QUIC layers by default. QUIC may be configured to run these layers on separate threads.
+Using a single worker thread for both layers helps MsQuic can achieve lower latency and using separate threads for the two layers can help achieve higher throughput.
 MsQuic aligns its processing logic with the rest of the networking stack (including hardware RSS) to ensure that all processing stays on the same NUMA node, and ideally, the same processor.
 
-The complexity of aligning processing across various threads and processors is why MsQuic manages its own threading by default.
-This abstraction simplifies the development process for applications built on top of MsQuic, ensuring that things "just work" for QUIC out of the box.
+The complexity of aligning processing across various threads and processors is the primary reason for MsQuic to manage its own threading. 
+This provides developers with a performant abstraction of both functionality and threading model, which simplifies application development using MsQuic, ensuring that things "just work" efficiently for QUIC by default.
 
 Each thread manages the execution of one or more connections.
 Connections are distributed across threads based on their RSS alignment, which should evenly distribute traffic based on different UDP tuples.

--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -79,6 +79,14 @@ The application can optimize its processing for that case but should be ready to
 
 When the buffer count is 0, it signifies the reception of a QUIC frame with empty data, which also indicates the end of stream data.
 
+## Summary - Common handling of receive data events
+
+If the application...
+ - processes all the received data synchronously in the stream event handler, `QUIC_STREAM_EVENT.RECEIVE.TotalBufferLength` parameter must be left unchanged and `QUIC_STATUS_SUCCESS` must be returned from the handler.
+ - could process only part of the received buffer synchronously in the stream event handler call and wants to process the remaining data in a subsequent event handler call, it **must** be indicated to MsQuic by setting this parameter to the byte count processed and returning `QUIC_STATUS_CONTINUE` from this call.
+ - desires to process the received data asynchronously, it should return `QUIC_STATUS_PENDING` from the event handler call.
+
+
 ## Handling a receive event
 
 The app then may respond to the event in a number of ways:

--- a/docs/api/QUIC_CONNECTION_CALLBACK.md
+++ b/docs/api/QUIC_CONNECTION_CALLBACK.md
@@ -21,7 +21,7 @@ QUIC_STATUS
 
 `Connection`
 
-The valid handle to the connection object this event handler is for.
+The valid handle to the connection object this event is for.
 
 `Context`
 

--- a/docs/api/QUIC_CONNECTION_CALLBACK.md
+++ b/docs/api/QUIC_CONNECTION_CALLBACK.md
@@ -21,7 +21,7 @@ QUIC_STATUS
 
 `Connection`
 
-The valid handle to the connection object this event is for.
+The valid handle to the connection object this event handler is for.
 
 `Context`
 

--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -1,7 +1,7 @@
 QUIC_CONNECTION_EVENT structure
 ======
 
-The payload for QUIC connection events.
+QUIC connection events and the corresponding payload
 
 # Syntax
 
@@ -25,6 +25,8 @@ typedef enum QUIC_CONNECTION_EVENT_TYPE {
     QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 15    // Only with QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED set
 } QUIC_CONNECTION_EVENT_TYPE;
 ```
+
+The payload for QUIC connection events.
 
 ```C
 typedef struct QUIC_CONNECTION_EVENT {

--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -87,7 +87,11 @@ The `QUIC_CONNECTION_EVENT_TYPE` that indicates which type of event this is, and
 
 ## QUIC_CONNECTION_EVENT_CONNECTED
 
-This event is delivered when the handshake has completed. This means the peer has been securely authenticated. This happens after one full round trip on the client side. The server side considers the handshake complete once the client responds after this. Additional state can be found in the `CONNECTED` struct/union.
+This event is delivered when the handshake has completed. This means the peer has been securely authenticated. This happens after one full round trip on the client side. The server side considers the handshake complete once the client responds after this.
+
+### Connected
+
+Additional state can be found in the `CONNECTED` struct/union.
 
 `SessionResumed`
 
@@ -105,10 +109,14 @@ The buffer (not null terminated) that holds the ALPN that was negotiated during 
 
 This event is delivered whenever the transport (e.g. QUIC layer) determines the connection has been terminated. This can happen for a number of different reasons. Some are as follows.
 
-- The handshake fails (any number of reasons).
-- The connection is idle for long enough.
-- The connection disconnects (loses contact with peer; no acknowledgments).
-- The connection encounters a protocol violation.
+- The handshake failed (any number of reasons).
+- The connection was idle for long enough.
+- The connection disconnected (lost contact with peer; no acknowledgments).
+- The connection encountered a protocol violation.
+
+### SHUTDOWN_INITIATED_BY_TRANSPORT
+
+Additional status can be found in the `SHUTDOWN_INITIATED_BY_TRANSPORT` struct/union.
 
 `Status`
 
@@ -122,6 +130,10 @@ The wire format error code that indicates the reason for the shutdown.
 
 This event is delivered when the peer application has terminated the application, with an application's protocol specific, 62-bit error code.
 
+### SHUTDOWN_INITIATED_BY_PEER
+
+Error code is found in the `SHUTDOWN_INITIATED_BY_PEER` struct/union.
+
 `ErrorCode`
 
 The error code received from the peer for the shutdown.
@@ -129,6 +141,10 @@ The error code received from the peer for the shutdown.
 ## QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE
 
 This event is the last one delivered to the application, and indicates the connection may now be safely closed.
+
+### SHUTDOWN_COMPLETE
+
+Various state flags are contained in the `SHUTDOWN_COMPLETE` struct/union.
 
 `HandshakeCompleted`
 
@@ -146,6 +162,10 @@ A flag indicating that the application called [ConnectionClose](ConnectionClose.
 
 This event is delivered when the local address used for the primary/active path communication has changed.
 
+### LOCAL_ADDRESS_CHANGED
+
+New local address is passed in the `LOCAL_ADDRESS_CHANGED` struct/union.
+
 `Address`
 
 The new local IP address.
@@ -154,6 +174,10 @@ The new local IP address.
 
 This event is delivered when the remote address used for the primary/active path communication has changed.
 
+### PEER_ADDRESS_CHANGED
+
+New peer ip address is passed in the `PEER_ADDRESS_CHANGED` struct/union.
+
 `Address`
 
 The new peer IP address.
@@ -161,6 +185,10 @@ The new peer IP address.
 ## QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED
 
 This event is delivered when the peer has created a new stream.
+
+### PEER_STREAM_STARTED
+
+Details of the new stream are passed in the `PEER_STREAM_STARTED` struct/union.
 
 `Stream`
 
@@ -182,6 +210,10 @@ If a server wishes to use `QUIC_STREAM_OPEN_FLAG_DELAY_ID_FC_UPDATES` for the ne
 
 This event indicates the number of streams the peer is willing to accept has changed.
 
+### STREAMS_AVAILABLE
+
+New stream counts are passed in the `STREAMS_AVAILABLE` struct/union.
+
 `BidirectionalCount`
 
 The number of bidirectional streams the peer is willing to accept.
@@ -198,6 +230,10 @@ This event indicates the peer is currently blocked on the number of parallel str
 
 This event indicates the processor or CPU that MsQuic has determined would be the best for processing the given connection.
 
+### IDEAL_PROCESSOR_CHANGED
+
+The new processor number is passed in the `IDEAL_PROCESSOR_CHANGED` struct/union.
+
 `IdealProcessor`
 
 The processor number that should be ideally used for processing the connection.
@@ -205,6 +241,10 @@ The processor number that should be ideally used for processing the connection.
 ## QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED
 
 This event indicates the current state for sending unreliable datagrams has changed.
+
+### DATAGRAM_STATE_CHANGED
+
+New datagram state is passed in the `DATAGRAM_STATE_CHANGED` struct/union.
 
 `SendEnabled`
 
@@ -217,6 +257,10 @@ When enabled, indicates the maximum length of a single datagram that can fit in 
 ## QUIC_CONNECTION_EVENT_DATAGRAM_RECEIVED
 
 This event indicates a received unreliable datagram from the peer.
+
+### DATAGRAM_RECEIVED
+
+Unreliable datagram buffer and metadata are passed in the `DATAGRAM_RECEIVED` struct/union.
 
 `Buffer`
 
@@ -235,6 +279,10 @@ Value | Meaning
 ## QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED
 
 This event indicates a state change for a previous unreliable datagram send via [DatagramSend](DatagramSend.md).
+
+### SEND_STATE_CHANGED
+
+Unreliable datagram send state is passed in the `SEND_STATE_CHANGED` struct/union.
 
 `ClientContext`
 
@@ -257,6 +305,10 @@ Value | Meaning
 
 This event indicates that a previous session has been successfully resumed at the TLS layer. This event is delivered for the server side only. The server app must indicate acceptance or rejection of the resumption ticket by returning a successful or failure status code from the event. If rejected by the server app, then resumption is rejected and a normal handshake will be performed.
 
+### RESUMED
+
+Connection resumption state is passed in the `Resumed` struct/union.
+
 `ResumptionStateLength`
 
 The length of the `ResumptionState` buffer.
@@ -267,7 +319,11 @@ The resumption ticket data previously sent to the client via [ConnectionSendResu
 
 ## QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED
 
-This event indicates a TLS resumption ticket has been received from the server.
+This event indicates the client that a TLS resumption ticket has been received from the server.
+
+### RESUMPTION_TICKET_RECEIVED
+
+Resumption ticket state is passed in the `RESUMPTION_TICKET_RECEIVED` struct/union.
 
 `ResumptionTicketLength`
 
@@ -280,6 +336,10 @@ The resumption ticket data received from the server. For a client to later resum
 ## QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED
 
 This event indicates a certificate has been received from the peer.
+
+### PEER_CERTIFICATE_RECEIVED
+
+The peer certificate and related data is passed in the `PEER_CERTIFICATE_RECEIVED` struct/union.
 
 `Certificate`
 

--- a/docs/api/QUIC_CONNECTION_EVENT.md
+++ b/docs/api/QUIC_CONNECTION_EVENT.md
@@ -6,6 +6,27 @@ The payload for QUIC connection events.
 # Syntax
 
 ```C
+typedef enum QUIC_CONNECTION_EVENT_TYPE {
+    QUIC_CONNECTION_EVENT_CONNECTED                         = 0,
+    QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT   = 1,    // The transport started the shutdown process.
+    QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER        = 2,    // The peer application started the shutdown process.
+    QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE                 = 3,    // Ready for the handle to be closed.
+    QUIC_CONNECTION_EVENT_LOCAL_ADDRESS_CHANGED             = 4,
+    QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED              = 5,
+    QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED               = 6,
+    QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE                 = 7,
+    QUIC_CONNECTION_EVENT_PEER_NEEDS_STREAMS                = 8,
+    QUIC_CONNECTION_EVENT_IDEAL_PROCESSOR_CHANGED           = 9,
+    QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED            = 10,
+    QUIC_CONNECTION_EVENT_DATAGRAM_RECEIVED                 = 11,
+    QUIC_CONNECTION_EVENT_DATAGRAM_SEND_STATE_CHANGED       = 12,
+    QUIC_CONNECTION_EVENT_RESUMED                           = 13,   // Server-only; provides resumption data, if any.
+    QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED        = 14,   // Client-only; provides ticket to persist, if any.
+    QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED         = 15    // Only with QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED set
+} QUIC_CONNECTION_EVENT_TYPE;
+```
+
+```C
 typedef struct QUIC_CONNECTION_EVENT {
     QUIC_CONNECTION_EVENT_TYPE Type;
     union {

--- a/docs/api/QUIC_LISTENER_EVENT.md
+++ b/docs/api/QUIC_LISTENER_EVENT.md
@@ -6,6 +6,14 @@ The payload for QUIC listener events.
 # Syntax
 
 ```C
+typedef enum QUIC_LISTENER_EVENT_TYPE {
+    QUIC_LISTENER_EVENT_NEW_CONNECTION      = 0,
+    QUIC_LISTENER_EVENT_STOP_COMPLETE       = 1,
+    QUIC_LISTENER_EVENT_DOS_MODE_CHANGED    = 2,
+} QUIC_LISTENER_EVENT_TYPE;
+```
+
+```C
 typedef struct QUIC_LISTENER_EVENT {
     QUIC_LISTENER_EVENT_TYPE Type;
     union {

--- a/docs/api/QUIC_LISTENER_EVENT.md
+++ b/docs/api/QUIC_LISTENER_EVENT.md
@@ -1,7 +1,7 @@
 QUIC_LISTENER_EVENT structure
 ======
 
-The payload for QUIC listener events.
+QUIC listener events and the corresponding payload
 
 # Syntax
 
@@ -12,6 +12,8 @@ typedef enum QUIC_LISTENER_EVENT_TYPE {
     QUIC_LISTENER_EVENT_DOS_MODE_CHANGED    = 2,
 } QUIC_LISTENER_EVENT_TYPE;
 ```
+
+The payload for QUIC listener events.
 
 ```C
 typedef struct QUIC_LISTENER_EVENT {
@@ -42,6 +44,10 @@ The `QUIC_LISTENER_EVENT_TYPE` that indicates which type of event this is, and w
 
 This event is delivered when a new connection is received by the listener.
 
+### NEW_CONNECTION
+
+Details of the new connection are passed in the `NEW_CONNECTION` struct/union.
+
 `Info`
 
 This field indicates the [QUIC_NEW_CONNECTION_INFO](QUIC_NEW_CONNECTION_INFO.md) structure for the new connection.
@@ -53,6 +59,10 @@ This field indicates the valid handle to the new incoming connection.
 ## QUIC_LISTENER_EVENT_STOP_COMPLETE
 
 This event is delivered when server app wants to stop receiving new incoming connections.
+
+### STOP_COMPLETE
+
+Details of the listener stopping are indicated in `STOP_COMPLETE` struct/union.
 
 `AppCloseInProgress`
 

--- a/docs/api/QUIC_STREAM_CALLBACK.md
+++ b/docs/api/QUIC_STREAM_CALLBACK.md
@@ -1,0 +1,43 @@
+QUIC_STREAM_CALLBACK function pointer signature
+======
+
+Handles stream events.
+
+# Syntax
+
+```C
+typedef
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Function_class_(QUIC_STREAM_CALLBACK)
+QUIC_STATUS
+(QUIC_API QUIC_STREAM_CALLBACK)(
+    _In_ HQUIC Stream,
+    _In_opt_ void* Context,
+    _Inout_ QUIC_STREAM_EVENT* Event
+    );
+```
+
+# Parameters
+
+`Stream`
+
+The valid handle to the stream object this event handler is for.
+
+`Context`
+
+The application callback context (optionally) supplied in [StreamOpen](StreamOpen.md), [SetCallbackHandler](SetCallbackHandler.md) or [SetContext](SetContext.md).
+
+`Event`
+
+A pointer to the [QUIC_STREAM_EVENT](QUIC_STREAM_EVENT.md) payload.
+
+# Remarks
+
+This is the signature of the function that handles callbacks from MsQuic for stream events. Apps are expected to keep any execution time in the callback **to a minimum**.
+
+# See Also
+
+[StreamOpen](StreamOpen.md)<br>
+[QUIC_STREAM_EVENT](QUIC_STREAM_EVENT.md)<br>
+[SetCallbackHandler](SetCallbackHandler.md)<br>
+[SetContext](SetContext.md)<br>

--- a/docs/api/QUIC_STREAM_CALLBACK.md
+++ b/docs/api/QUIC_STREAM_CALLBACK.md
@@ -21,7 +21,7 @@ QUIC_STATUS
 
 `Stream`
 
-The valid handle to the stream object this event handler is for.
+The valid handle to the stream object this event is for.
 
 `Context`
 

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -81,94 +81,184 @@ The `QUIC_STREAM_EVENT_TYPE` that indicates which type of event this is, and whi
 
 ## QUIC_STREAM_EVENT_START_COMPLETE
 
+This event is delivered when the [StreamStart](streamStart.md) operation completes. The accompanying payload contains data to indicate whether the operation succeeded or failed.
+
 ### START_COMPLETE
+
+Additional state from the `StreamStart` operation is included in this payload struct/union.
 
 `Status`
 
+QUIC_STATUS value to indicate the operation completion code. Check for success using the QUIC_SUCCEEDED macro.
+
 `ID`
+
+Stream ID if available.
 
 `PeerAccepted`
 
+Flag indicates whether the peer has accepted the stream.
+
 ## QUIC_STREAM_EVENT_RECEIVE
+
+Data received on an open stream is primarily delivered to the application through this event.
 
 ### RECEIVE
 
+Received data on the stream is passed in this struct/union.
+
 `AbsoluteOffset`
+
+Absolute offset of the current data payload from the start of the receive operation.
 
 `TotalBufferLength`
 
+MsQuic indicates the total buffer length of the data in this parameter.
+
+If the application can processes only part of the received buffer synchronously in this call, it can be indicated to MsQuic by setting this parameter to the byte count processed and returning `QUIC_STATUS_CONTINUE` from this call.
+If the application desires to process the received data asynchronously, it should return `QUIC_STATUS_PENDING` from this call.
+
+See [Receiving Data On Streams](../Streams.md#Receiving) for further details on receiving data on a stream.
+
 `Buffers`
+
+An array of `QUIC_BUFFERs` containing received data.
 
 `BufferCount`
 
+Count of `QUIC_BUFFERs` in this payload.
+
 `Flags`
 
+A set of flags indicating describing the received data:
+
+Value | Meaning
+--- | ---
+**QUIC_RECEIVE_FLAG_NONE**<br>0 | No special behavior.
+**QUIC_RECEIVE_FLAG_0_RTT**<br>1 | The data was received in 0-RTT.
+**QUIC_RECEIVE_FLAG_FIN**<br>2 | FIN was included with this data. Used only for streamed data.
 
 ## QUIC_STREAM_EVENT_SEND_COMPLETE
 
+Indicates that MsQuic has completed a [StreamSend](StreamSend.md) operation initated by the application.
+
 ### SEND_COMPLETE
 
+Data for `StreamSend` completion is included in this struct/union.
+
 `Canceled`
+Indicates that the StreamSend operation was canceled.
 
 `ClientContext`
+Client context to match this event with the original `StreamSend` operation.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN
 
+Indicates that the current send operation to the peer on this stream has been shutdown/completed.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_ABORTED
 
+Indicates that the peer has aborted `StreamSend` operation.
+
 ### SEND_ABORTED
 
+Additional details of the send abort event are passed in this struct/union.
+
 `ErrorCode`
+
+Application's protocol specific, 62-bit error code.
 
 ## QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED
 
+Indicates that the peer has aborted receiving data.
+
 ### RECEIVE_ABORTED
+
+Additional details of the receive abort event are passed in this struct/union.
 
 `ErrorCode`
 
+Application's protocol specific, 62-bit error code.
 
 ## QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE
 
+This event is raised when a stream send direction has been fully shut down.
+
 ### SEND_SHUTDOWN_COMPLETE
+
+Additional details of send shutdown completion are passed in this struct/union.
 
 `Graceful`
 
+TRUE if the send shutdown operation was gracefully shutdown, FALSE otherwise.
 
 ## QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE
 
+This event indicates that the stream has been completely shutdown.
+
 ### SHUTDOWN_COMPLETE
+
+Additional details for the stream shutdown are passed in this struct/union.
 
 `ConnectionShutdown`
 
+If TRUE, the Connection corresponding to this stream has been closed locally or remotely.
+
 `AppCloseInProgress`
+
+If TRUE, the application is in the process of closing the stream.
 
 `ConnectionShutdownByApp`
 
+If TRUE, the application shutdown the Connection corresponding to this stream.
+
 `ConnectionClosedRemotely`
+
+If TRUE, the Connection corresponding to this stream has been closed remotely.
 
 `ConnectionErrorCode`
 
+62-bit Connection closure error code, if any.
+
 `ConnectionCloseStatus`
+
+QUIC_STATUS value of the connection close operation, if any.
 
 ## QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE
 
+MsQuic indicates the ideal send buffer size to the application through this event, so as not to idle the connection.
+
 ### IDEAL_SEND_BUFFER_SIZE
+
+Ideal send buffer size is indicated in this struct/union.
 
 `ByteCount`
 
+Ideal send buffer size in bytes for each `StreamSend` operation to avoid idling the connection.
+
 ## QUIC_STREAM_EVENT_PEER_ACCEPTED
 
+This event is raised when a peer has provided sufficient flow control to accept a new stream. See [StreamStart](StreamStart.md) for additional information.
 
 ## QUIC_STREAM_EVENT_CANCEL_ON_LOSS
 
+This event is raised when a stream is shutdown due to packet loss
+
 ### CANCEL_ON_LOSS
+
+The application can supply an error code in this struct to be sent to the peer.
+
 `ErrorCode`
 
+The application can set this 62 bit error code to communicate to the peer about the stream shutdown, which is received by the peer as a `QUIC_STREAM_EVENT_PEER_SEND_ABORTED` event on its stream object.
 
 # See Also
 
+[Streams](../Streams.md)<br>
 [StreamOpen](StreamOpen.md)<br>
+[StreamStart](StreamStart.md)<br>
+[StreamSend](StreamSend.md)<br>
+[StreamShutdown](StreamShutdown.md)<br>
 [QUIC_STREAM_CALLBACK](QUIC_STREAM_CALLBACK.md)<br>
 [SetCallbackHandler](SetCallbackHandler.md)<br>
 [SetContext](SetContext.md)<br>

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -1,0 +1,174 @@
+QUIC_STREAM_EVENT structure
+======
+
+The payload for QUIC connection events.
+
+# Syntax
+```C
+typedef enum QUIC_STREAM_EVENT_TYPE {
+    QUIC_STREAM_EVENT_START_COMPLETE            = 0,
+    QUIC_STREAM_EVENT_RECEIVE                   = 1,
+    QUIC_STREAM_EVENT_SEND_COMPLETE             = 2,
+    QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN        = 3,
+    QUIC_STREAM_EVENT_PEER_SEND_ABORTED         = 4,
+    QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED      = 5,
+    QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE    = 6,
+    QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE         = 7,
+    QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE    = 8,
+    QUIC_STREAM_EVENT_PEER_ACCEPTED             = 9,
+    QUIC_STREAM_EVENT_CANCEL_ON_LOSS            = 10,
+} QUIC_STREAM_EVENT_TYPE;
+```
+
+```C
+typedef struct QUIC_STREAM_EVENT {
+    QUIC_STREAM_EVENT_TYPE Type;
+    union {
+        struct {
+            QUIC_STATUS Status;
+            QUIC_UINT62 ID;
+            BOOLEAN PeerAccepted : 1;
+            BOOLEAN RESERVED : 7;
+        } START_COMPLETE;
+        struct {
+            /* in */    uint64_t AbsoluteOffset;
+            /* inout */ uint64_t TotalBufferLength;
+            _Field_size_(BufferCount)
+            /* in */    const QUIC_BUFFER* Buffers;
+            _Field_range_(0, UINT32_MAX)
+            /* in */    uint32_t BufferCount;
+            /* in */    QUIC_RECEIVE_FLAGS Flags;
+        } RECEIVE;
+        struct {
+            BOOLEAN Canceled;
+            void* ClientContext;
+        } SEND_COMPLETE;
+        struct {
+            QUIC_UINT62 ErrorCode;
+        } PEER_SEND_ABORTED;
+        struct {
+            QUIC_UINT62 ErrorCode;
+        } PEER_RECEIVE_ABORTED;
+        struct {
+            BOOLEAN Graceful;
+        } SEND_SHUTDOWN_COMPLETE;
+        struct {
+            BOOLEAN ConnectionShutdown;
+            BOOLEAN AppCloseInProgress       : 1;
+            BOOLEAN ConnectionShutdownByApp  : 1;
+            BOOLEAN ConnectionClosedRemotely : 1;
+            BOOLEAN RESERVED                 : 5;
+            QUIC_UINT62 ConnectionErrorCode;
+            QUIC_STATUS ConnectionCloseStatus;
+        } SHUTDOWN_COMPLETE;
+        struct {
+            uint64_t ByteCount;
+        } IDEAL_SEND_BUFFER_SIZE;
+        struct {
+            /* out */ QUIC_UINT62 ErrorCode;
+        } CANCEL_ON_LOSS;
+    };
+} QUIC_STREAM_EVENT;
+```
+
+# Parameters
+
+`Type`
+
+The `QUIC_STREAM_EVENT_TYPE` that indicates which type of event this is, and which payload to reference (if any) for additional information.
+
+# Remarks
+
+## QUIC_STREAM_EVENT_START_COMPLETE
+
+### START_COMPLETE
+
+`Status`
+
+`ID`
+
+`PeerAccepted`
+
+## QUIC_STREAM_EVENT_RECEIVE
+
+### RECEIVE
+
+`AbsoluteOffset`
+
+`TotalBufferLength`
+
+`Buffers`
+
+`BufferCount`
+
+`Flags`
+
+
+## QUIC_STREAM_EVENT_SEND_COMPLETE
+
+### SEND_COMPLETE
+
+`Canceled`
+
+`ClientContext`
+
+## QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN
+
+
+## QUIC_STREAM_EVENT_PEER_SEND_ABORTED
+
+### SEND_ABORTED
+
+`ErrorCode`
+
+## QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED
+
+### RECEIVE_ABORTED
+
+`ErrorCode`
+
+
+## QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE
+
+### SEND_SHUTDOWN_COMPLETE
+
+`Graceful`
+
+
+## QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE
+
+### SHUTDOWN_COMPLETE
+
+`ConnectionShutdown`
+
+`AppCloseInProgress`
+
+`ConnectionShutdownByApp`
+
+`ConnectionClosedRemotely`
+
+`ConnectionErrorCode`
+
+`ConnectionCloseStatus`
+
+## QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE
+
+### IDEAL_SEND_BUFFER_SIZE
+
+`ByteCount`
+
+## QUIC_STREAM_EVENT_PEER_ACCEPTED
+
+
+## QUIC_STREAM_EVENT_CANCEL_ON_LOSS
+
+### CANCEL_ON_LOSS
+`ErrorCode`
+
+
+# See Also
+
+[StreamOpen](StreamOpen.md)<br>
+[QUIC_STREAM_CALLBACK](QUIC_STREAM_CALLBACK.md)<br>
+[SetCallbackHandler](SetCallbackHandler.md)<br>
+[SetContext](SetContext.md)<br>

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -117,10 +117,12 @@ Absolute offset of the current data payload from the start of the receive operat
 
 MsQuic indicates the total buffer length of the data in this parameter.
 
-If the application can processes only part of the received buffer synchronously in this call, it can be indicated to MsQuic by setting this parameter to the byte count processed and returning `QUIC_STATUS_CONTINUE` from this call.
-If the application desires to process the received data asynchronously, it should return `QUIC_STATUS_PENDING` from this call.
-
 See [Receiving Data On Streams](../Streams.md#Receiving) for further details on receiving data on a stream.
+
+Most notably, if the application...
+ - processes all the received data synchronously in this call, this parameter must be left unchanged and  `QUIC_STATUS_SUCCESS` must be returned from this call.
+ - can processes only part of the received buffer synchronously in this call, it should be indicated to MsQuic by setting this parameter to the byte count processed and returning `QUIC_STATUS_CONTINUE` from this call.
+ - desires to process the received data asynchronously, it should return `QUIC_STATUS_PENDING` from this call.
 
 `Buffers`
 
@@ -144,6 +146,11 @@ Value | Meaning
 
 Indicates that MsQuic has completed a [StreamSend](StreamSend.md) operation initated by the application.
 
+This is an important event in the asynchronous process of sending data over a stream.
+More info here:
+- [Send Buffering](../Streams.md#Send_Buffering)
+- [QUIC_BUFFER Handling Note](StreamSend.md#Remarks)
+
 ### SEND_COMPLETE
 
 Data for `StreamSend` completion is included in this struct/union.
@@ -156,7 +163,7 @@ Client context to match this event with the original `StreamSend` operation.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN
 
-Indicates that the current send operation to the peer on this stream has been shutdown/completed.
+Indicates that the current send operation from the peer on this stream has been completed/shutdown.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_ABORTED
 
@@ -244,7 +251,7 @@ This event is raised when a peer has provided sufficient flow control to accept 
 
 ## QUIC_STREAM_EVENT_CANCEL_ON_LOSS
 
-This event is raised when a stream is shutdown due to packet loss
+This event is raised when a stream is shutdown due to packet loss. See [Cancel on Loss](../Streams.md#Cancel_On_Loss) for further details.
 
 ### CANCEL_ON_LOSS
 

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -117,12 +117,9 @@ Absolute offset of the current data payload from the start of the receive operat
 
 MsQuic indicates the total buffer length of the data in this parameter.
 
-See [Receiving Data On Streams](../Streams.md#Receiving) for further details on receiving data on a stream.
+Receiving data goes beyond handling of this stream event callback. See [Receiving Data On Streams](../Streams.md#Receiving) for the various different approaches to receiving data on a stream.
 
-Most notably, if the application...
- - processes all the received data synchronously in this call, this parameter must be left unchanged and  `QUIC_STATUS_SUCCESS` must be returned from this call.
- - can processes only part of the received buffer synchronously in this call, it should be indicated to MsQuic by setting this parameter to the byte count processed and returning `QUIC_STATUS_CONTINUE` from this call.
- - desires to process the received data asynchronously, it should return `QUIC_STATUS_PENDING` from this call.
+Upon successful handling of this event, the event handler should return one of `QUIC_STATUS_SUCCESS` or `QUIC_STATUS_CONTINUE` or `QUIC_STATUS_PENDING` to the MsQuic library, depending on the chosen approach to handling the received data.
 
 `Buffers`
 
@@ -163,7 +160,7 @@ Client context to match this event with the original `StreamSend` operation.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN
 
-Indicates that the current send operation from the peer on this stream has been completed/shutdown.
+Indicates that the send direction of the stream **from the peer** has been shutdown and no further data is expected to be received on this stream.
 
 ## QUIC_STREAM_EVENT_PEER_SEND_ABORTED
 
@@ -191,7 +188,7 @@ Application's protocol specific, 62-bit error code.
 
 ## QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE
 
-This event is raised when a stream send direction has been fully shut down.
+This event is raised when the send direction of the stream **to the peer** has been shutdown and no further data can be sent on this stream.
 
 ### SEND_SHUTDOWN_COMPLETE
 

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -1,7 +1,7 @@
 QUIC_STREAM_EVENT structure
 ======
 
-The payload for QUIC connection events.
+QUIC stream events and the corresponding payload
 
 # Syntax
 ```C
@@ -19,6 +19,8 @@ typedef enum QUIC_STREAM_EVENT_TYPE {
     QUIC_STREAM_EVENT_CANCEL_ON_LOSS            = 10,
 } QUIC_STREAM_EVENT_TYPE;
 ```
+
+The payload for QUIC stream events.
 
 ```C
 typedef struct QUIC_STREAM_EVENT {
@@ -97,7 +99,7 @@ Stream ID if available.
 
 `PeerAccepted`
 
-Flag indicates whether the peer has accepted the stream.
+If TRUE, the peer has accepted the stream.
 
 ## QUIC_STREAM_EVENT_RECEIVE
 
@@ -122,11 +124,11 @@ See [Receiving Data On Streams](../Streams.md#Receiving) for further details on 
 
 `Buffers`
 
-An array of `QUIC_BUFFERs` containing received data.
+An array of `QUIC_BUFFER`s containing received data.
 
 `BufferCount`
 
-Count of `QUIC_BUFFERs` in this payload.
+Count of `QUIC_BUFFER`s in this payload.
 
 `Flags`
 


### PR DESCRIPTION
## Description

Add/update documentation around events in MsQuic

- Add documentation for QUIC Stream events
- Update/clarify existing documentation on use of events in MSQuic and events for other class types

## Testing

No new tests necessary

## Documentation

This is a documentation change
