### PR TITLE
Rust: Change open api signature for handles

### DIFF
--- a/src/rs/config.rs
+++ b/src/rs/config.rs
@@ -441,7 +441,7 @@ mod tests {
         let registration = Registration::new(&RegistrationConfig::default()).unwrap();
 
         let alpn = [BufferRef::from("h3")];
-        let configuration = Configuration::new(
+        let configuration = Configuration::open(
             &registration,
             &alpn,
             Some(


### PR DESCRIPTION
## Description
Connection, Stream, Listener and Configuration handles all requires create an empty struct using new() and then call open().
open() should return the struct, and new function can be eliminated. This also allows handle variables to be immutable.

## Testing
NA

## Documentation
NA
