### PR TITLE
Update documentation to clarify API ordering constraints

### DIFF
--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -33,8 +33,15 @@ For peer initiated streams, the app gets a `QUIC_CONNECTION_EVENT_PEER_STREAM_ST
 # Sending
 
 An app can send on any locally initiated stream or a peer initiated bidirectional stream. The app uses the [StreamSend](api/StreamSend.md) API to send data.
-MsQuic holds on to any buffers queued via [StreamSend](api/StreamSend.md) until they have been completed via the `QUIC_STREAM_EVENT_SEND_COMPLETE` event:
-the app must not free, reuse or otherwise access the buffers provided through [StreamSend](api/StreamSend.md) before the matching completion notification.
+
+MsQuic takes ownership of any buffers successfully queued via [StreamSend](api/StreamSend.md). Buffer ownership is
+returned to the application via the `QUIC_STREAM_EVENT_SEND_COMPLETE` event. The application must not free, reuse or
+otherwise access a buffer provided to [StreamSend](api/StreamSend.md) until the matching
+`QUIC_STREAM_EVENT_SEND_COMPLETE` event.
+
+![Note]
+> `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer, or even the it has been put on
+> the wire - only that MsQuic no longer needs the app send buffer.
 
 ## Send Buffering
 
@@ -59,7 +66,7 @@ To disable internal send buffering and use the second mode, the app must set `Se
 
 The send direction can be shut down in three different ways:
 
-- **Graceful** - The sender can gracefully shut down the send direction by calling [StreamShutdown](api/StreamShutdown.md) with the `QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL` flag or by including the `QUIC_SEND_FLAG_FIN` flag on the last [StreamSend](api/StreamSend.md) call. In this scenario all data will be delivered to the peer and then the peer is informed the stream has been gracefully shut down.
+- **Graceful** - The sender can gracefully shut down the send direction by calling [StreamShutdown](api/StreamShutdown.md) with the `QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL` flag or by including the `QUIC_SEND_FLAG_FIN` flag on the last [StreamSend](api/StreamSend.md) call. In this scenario all data will first be delivered to the peer, then the peer is informed the stream has been gracefully shut down.
 
 - **Sender Abort** - The sender can abortively shut down the send direction by calling [StreamShutdown](api/StreamShutdown.md) with the `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND` flag. In this scenario, all outstanding sends are immediately canceled and are not delivered to the peer. The peer is immediately informed of the abort.
 
@@ -186,3 +193,19 @@ MsQuic does not enforce it, and it is legal for an application to provide less b
 
 After the initial receive window is full, flow control will ensure that the peer does not send more data than there is buffer space available.
 However, the application should still provide enough buffer space to keep flow control from impacting performances.
+
+## Receive Shutdown
+
+The receiver can abortively shutdown a stream receive direction by calling [`StreamShutdown`](api/StreamShutdown.md) 
+with the `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE` option.
+
+# Closing a Stream
+
+Once all the directions relevant for a stream have been shutdown, the application receives a
+`QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.
+
+The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its notification
+handling context.
+
+Closing a stream before the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` is only allowed if the stream was not started yet.
+Otherwise, it will result in the connection being closed abortively.

--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -40,10 +40,9 @@ otherwise access a buffer provided to [StreamSend](api/StreamSend.md) until the 
 `QUIC_STREAM_EVENT_SEND_COMPLETE` event.
 
 ![Note]
-> `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer app, the peer transport, or
-> even the it has been put on the wire - it only means that MsQuic no longer needs the app send buffer and give the
-> owernship back to the application. The app should not assume anything about whether the data has been successfully
-> transmitted based on this notification.
+> `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer application layer.
+> It only means that MsQuic no longer needs the app send buffer and give the owernship back to the application. The app
+> should assume the data has been successfully transmitted based on this notification.
 
 ## Send Buffering
 
@@ -207,7 +206,7 @@ Once all the directions relevant for a stream have been shutdown, the applicatio
 `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.
 
 The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its notification
-handling context one the call returns.
+handling context once the call returns.
 
 If the app closes a stream before it is shutdown, the stream will be shutdown abortively with an error code of `0`.
 This should be avoided, the app should rather abortively shutdown the stream first with a meaningful error code.

--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -40,8 +40,10 @@ otherwise access a buffer provided to [StreamSend](api/StreamSend.md) until the 
 `QUIC_STREAM_EVENT_SEND_COMPLETE` event.
 
 ![Note]
-> `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer, or even the it has been put on
-> the wire - only that MsQuic no longer needs the app send buffer.
+> `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer app, the peer transport, or
+> even the it has been put on the wire - it only means that MsQuic no longer needs the app send buffer and give the
+> owernship back to the application. The app should not assume anything about whether the data has been successfully
+> transmitted based on this notification.
 
 ## Send Buffering
 
@@ -205,7 +207,9 @@ Once all the directions relevant for a stream have been shutdown, the applicatio
 `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.
 
 The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its notification
-handling context.
+handling context one the call returns.
 
-Closing a stream before the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` is only allowed if the stream was not started yet.
-Otherwise, it will result in the connection being closed abortively.
+If the app closes a stream before it is shutdown, the stream will be shutdown abortively with an error code of `0`.
+This should be avoided, the app should rather abortively shutdown the stream first with a meaningful error code.
+It is however possible for an application to abortively shutdown a stream and immediately close it from the same thread,
+without waiting for the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.

--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -42,7 +42,7 @@ otherwise access a buffer provided to [StreamSend](api/StreamSend.md) until the 
 ![Note]
 > `QUIC_STREAM_EVENT_SEND_COMPLETE` does not mean the data has been received by the peer application layer.
 > It only means that MsQuic no longer needs the app send buffer and give the owernship back to the application. The app
-> should assume the data has been successfully transmitted based on this notification.
+> should *not* assume the data has been successfully transmitted based on this notification.
 
 ## Send Buffering
 
@@ -202,7 +202,7 @@ with the `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE` option.
 
 # Closing a Stream
 
-Once a stream has been shutdown (on both direction for a bi-directional stream), the application receives a
+Once a stream has been shutdown (in both direction for a bi-directional stream), the application receives a
 `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.
 
 The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its context
@@ -210,5 +210,5 @@ pointer safely once the call returns.
 
 If the app closes a stream before it is shutdown, the stream will be shutdown abortively with an error code of `0`.
 This should be avoided; instead the app should abortively shutdown the stream first with a meaningful error code.
-It is however possible for an application to abortively shutdown a stream and immediately close it from the same thread,
+It is possible for an application to abortively shutdown a stream and immediately close it from the same thread,
 without waiting for the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.

--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -202,13 +202,13 @@ with the `QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE` option.
 
 # Closing a Stream
 
-Once all the directions relevant for a stream have been shutdown, the application receives a
+Once a stream has been shutdown (on both direction for a bi-directional stream), the application receives a
 `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.
 
-The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its notification
-handling context once the call returns.
+The application must then close the stream using [`StreamClose`](api/StreamClose.md), and can release its context
+pointer safely once the call returns.
 
 If the app closes a stream before it is shutdown, the stream will be shutdown abortively with an error code of `0`.
-This should be avoided, the app should rather abortively shutdown the stream first with a meaningful error code.
+This should be avoided; instead the app should abortively shutdown the stream first with a meaningful error code.
 It is however possible for an application to abortively shutdown a stream and immediately close it from the same thread,
 without waiting for the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` event.

--- a/docs/api/ConfigurationClose.md
+++ b/docs/api/ConfigurationClose.md
@@ -25,6 +25,9 @@ The valid handle to an open configuration object.
 
 This function releases the configuration object.
 
+`ConfigurationClose` is equivalent to `free` and **MUST** be the final call on a configuration handle.
+Any API calls using a configuration handle after `ConfigurationClose` has been called is a use-after-free error!
+
 # See Also
 
 [ConfigurationOpen](ConfigurationOpen.md)<br>

--- a/docs/api/ConnectionClose.md
+++ b/docs/api/ConnectionClose.md
@@ -27,7 +27,7 @@ The valid handle to an open connection object.
 
 A caller should shutdown an active connection via [ConnectionShutdown](ConnectionShutdown.md) before calling
 `ConnectionClose`. Calling `ConnectionClose` without [ConnectionShutdown](ConnectionShutdown.md) will abortively and
-silently shutdown the connection and all associated streams through an implicitly call to
+silently shutdown the connection as well as all associated streams through an implicit call to
 [ConnectionShutdown](ConnectionShutdown.md) with the `QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT` flag.
 
 A server application **MUST NOT** call `ConnectionClose` within the `QUIC_LISTENER_EVENT_NEW_CONNECTION` callback when returning failure, to reject a connection. This will result in a double-free in release builds, and an assert in debug builds.  It's acceptable to call `ConnectionClose` within the `QUIC_LISTENER_EVENT_NEW_CONNECTION` callback if returning `QUIC_STATUS_SUCCESS`, or `QUIC_STATUS_PENDING`, since the server application owns the connection object then.

--- a/docs/api/ConnectionClose.md
+++ b/docs/api/ConnectionClose.md
@@ -25,11 +25,15 @@ The valid handle to an open connection object.
 
 `ConnectionClose` cleans up and frees all resources allocated for the connection in `ConnectionOpen`.
 
-A caller should shutdown an active connection via [ConnectionShutdown](ConnectionShutdown.md) before calling `ConnectionClose`; calling `ConnectionClose` without [ConnectionShutdown](ConnectionShutdown.md) will implicitly call [ConnectionShutdown](ConnectionShutdown.md) with the `QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT` flag.
+A caller should shutdown an active connection via [ConnectionShutdown](ConnectionShutdown.md) before calling
+`ConnectionClose`. Calling `ConnectionClose` without [ConnectionShutdown](ConnectionShutdown.md) will abortively and
+silently shutdown the connection and all associated streams through an implicitly call to
+[ConnectionShutdown](ConnectionShutdown.md) with the `QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT` flag.
 
 A server application **MUST NOT** call `ConnectionClose` within the `QUIC_LISTENER_EVENT_NEW_CONNECTION` callback when returning failure, to reject a connection. This will result in a double-free in release builds, and an assert in debug builds.  It's acceptable to call `ConnectionClose` within the `QUIC_LISTENER_EVENT_NEW_CONNECTION` callback if returning `QUIC_STATUS_SUCCESS`, or `QUIC_STATUS_PENDING`, since the server application owns the connection object then.
 
-`ConnectionClose` is the **last** API call to use a connection handle. An application **MUST NOT** use a connection handle after calling `ConnectionClose`! Any calls using a connection handle after calling `ConnectionClose` is a use-after-free.
+`ConnectionClose` is equivalent to `free` and **MUST** be the final call on a connection handle.
+Any API calls using a connection handle after `ConnectionClose` has been called is a use-after-free error!
 
 # See Also
 

--- a/docs/api/ListenerClose.md
+++ b/docs/api/ListenerClose.md
@@ -23,9 +23,14 @@ A valid handle to an open listener object.
 
 # Remarks
 
-`ListenerClose` frees all allocated resources associated with the listener handle. If a listener has not had [ListenerStop](ListenerStop.md) called on it at the time `ListenerClose` is called, [ListenerStop](ListenerStop.md) is invoked internally. A server application **MUST NOT** call `ListenerClose` within any callback except for `QUIC_LISTENER_EVENT_STOP_COMPLETE`, unless it has already received the `QUIC_LISTENER_EVENT_STOP_COMPLETE` event.
+`ListenerClose` frees all allocated resources associated with the listener handle. If a listener has not had [ListenerStop](ListenerStop.md) called on it at the time `ListenerClose` is called, [ListenerStop](ListenerStop.md) is invoked internally.
 
-`ListenerClose` is equivalent to `free` and **MUST** be the final call on a listener handle. Any API calls using a listener handle after `ListenerClose` has been called is a use-after-free error!
+A call to `ListenerClose` is blocking: a server application **MUST NOT** call `ListenerClose` within any callback,
+unless it received the `QUIC_LISTENER_EVENT_STOP_COMPLETE` event, previously or as the current event.
+Calling `ListenerClose` in a callback before the `QUIC_LISTENER_EVENT_STOP_COMPLETE` event may cause a deadlock.
+
+`ListenerClose` is equivalent to `free` and **MUST** be the final call on a listener handle.
+Any API calls using a listener handle after `ListenerClose` has been called is a use-after-free error!
 
 # See Also
 

--- a/docs/api/StreamClose.md
+++ b/docs/api/StreamClose.md
@@ -23,11 +23,14 @@ A Stream handle from a previous call to [StreamOpen](StreamOpen.md).
 
 # Remarks
 
-The application should only close a stream after it has been completely shut down or it was never successfully started. Closing a stream before it has been completely shut down produces **undefined behavior** because clean up of the stream **must** be reflected on the wire with an application specific error code. When the app closes a stream without first shutting down, MsQuic has to guess which error code to use (currently uses `0`) when sending the state change to the peer.
+The application should only close a stream after it has been completely shut down or if it was never successfully started. Closing a stream before it has been completely shut down produces **undefined behavior** because clean up of the stream **must** be reflected on the wire with an application specific error code. When the app closes a stream without first shutting down, MsQuic has to guess which error code to use (currently uses `0`) when sending the state change to the peer.
 
 If the application needs to quickly discard all stream state and doesn't care about the result, it should first call [StreamShutdown](StreamShutdown.md) with the `QUIC_STREAM_SHUTDOWN_FLAG_ABORT` and `QUIC_STREAM_SHUTDOWN_FLAG_IMMEDIATE` flags, specifying an appropriate error code. Then, only after the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE` should the app call close. This event will happen immediately.
 
 `StreamClose` may be called on any callback, including one for the stream being closed.
+
+`StreamClose` is equivalent to `free` and **MUST** be the final call on a stream handle.
+Any API calls using a stream handle after `StreamClose` has been called is a use-after-free error!
 
 # See Also
 

--- a/docs/api/StreamReceiveComplete.md
+++ b/docs/api/StreamReceiveComplete.md
@@ -42,7 +42,7 @@ stop indicating new `QUIC_STREAM_EVENT_RECEIVE` events until a call to [`StreamR
 If Multi-receive mode has been enabled on the connection, the behavior is different from default behavior detailed above.
 
 In Multi-receive mode, calls to `StreamReceiveComplete` do not need to match `QUIC_STREAM_EVENT_RECEIVE`: there can be
-either more or less calls to `StreamReceiveComplete` than `QUIC_STREAM_EVENT_RECEIVE` events.
+either more or fewer calls to `StreamReceiveComplete` than `QUIC_STREAM_EVENT_RECEIVE` events.
 
 MsQuic will keep on indicating `QUIC_STREAM_EVENT_RECEIVE` irrespectively from calls to `StreamReceiveComplete` and the
 value of `BufferLength`.

--- a/docs/api/StreamReceiveComplete.md
+++ b/docs/api/StreamReceiveComplete.md
@@ -40,9 +40,9 @@ stop indicating new `QUIC_STREAM_EVENT_RECEIVE` events until a call to [`StreamR
 If Multi-receive mode has been enabled on the connection, the behavior is different from default behavior detailed above.
 
 In Multi-receive mode, calls to `StreamReceiveComplete` do not need to match `QUIC_STREAM_EVENT_RECEIVE`: there can be
-either more or less calls to `StramReceiveComplete` than `QUIC_STREAM_EVENT_RECEIVE` events.
+either more or less calls to `StreamReceiveComplete` than `QUIC_STREAM_EVENT_RECEIVE` events.
 
-MsQuic will keep on indicating `QUIC_STREAM_EVENT_RECEIVE` irrespectively from calls to `StramReceiveComplete` and the
+MsQuic will keep on indicating `QUIC_STREAM_EVENT_RECEIVE` irrespectively from calls to `StreamReceiveComplete` and the
 value of `BufferLength`.
 
 The application must keep track of the accumulated `TotalBufferLength` from `QUIC_STREAM_EVENT_RECEIVE` events and ensure that:

--- a/docs/api/StreamReceiveSetEnabled.md
+++ b/docs/api/StreamReceiveSetEnabled.md
@@ -17,7 +17,8 @@ QUIC_STATUS
 
 # Parameters
 
-**TODO**
+- `Stream`: A handle to a valid stream
+- `IsEnabled`: Whether MsQuic can indicate `QUIC_STREAM_EVENT_RECEIVE` notifications.
 
 # Return Value
 
@@ -35,3 +36,4 @@ This function always delegates to the worker queue, even if called from a quic w
 [StreamShutdown](StreamShutdown.md)<br>
 [StreamSend](StreamSend.md)<br>
 [StreamReceiveComplete](StreamReceiveComplete.md)<br>
+[Streams](../Streams.md)<br>

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -393,12 +393,6 @@ QuicStreamClose(
     if (!Stream->Flags.ShutdownComplete) {
 
         if (Stream->Flags.Started && !Stream->Flags.HandleShutdown) {
-            //
-            // TODO - If the stream hasn't been aborted already, then this is a
-            // fatal error for the connection. The QUIC transport cannot "just
-            // pick an error" to shutdown the stream with. It must abort the
-            // entire connection.
-            //
             QuicTraceLogStreamWarning(
                 CloseWithoutShutdown,
                 Stream,


### PR DESCRIPTION
## Description

Update documentation to clarify some ordering constraints between API.
Focuses on "*Close" calls and the send and receive operations.

Closes #3635.

## Testing

N/A

## Documentation

Doc only
