### PR TITLE
!!! DO NOT MERGE !!! Enable TTL feature on WS2022

### DIFF
--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -647,12 +647,7 @@ CxPlatDataPathQuerySockoptSupport(
 
     } while (FALSE);
 
-    //
-    // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
-    //
-    if (CxPlatform.dwBuildNumber != 20348) {
-        Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
-    }
+    Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
 
 Error:
 

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -728,13 +728,7 @@ CxPlatDataPathQuerySockoptSupport(
     closesocket(Udpv6Socket);
 }
 
-    //
-    // Some USO/URO bug blocks TTL feature support on Windows Server 2022.
-    //
-    if (CxPlatform.dwBuildNumber != 20348) {
-        Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
-    }
-
+    Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TTL;
     Datapath->Features |= CXPLAT_DATAPATH_FEATURE_TCP;
 
 Error:


### PR DESCRIPTION
## Description

A request to backport a bugfix was approved, so now let's get rid of the workaround code that skips the TTL feature on WS2022. 

Note that the patch hasn't yet propagated to the Github Actions runners yet. When they do, let's merge this PR

## Testing

CI

## Documentation

N/A
