### PR TITLE
Avoid Batching of Packets with Different Keys

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5521,12 +5521,13 @@ QuicConnRecvDatagramBatch(
         CxPlatZeroMemory(HpMask, BatchCount * CXPLAT_HP_SAMPLE_LENGTH);
     }
 
-    uint8_t prevPacket = 0;
+    //uint8_t prevPacket = 0;
     for (uint8_t i = 0; i < BatchCount; ++i) {
         CXPLAT_DBG_ASSERT(Packets[i]->Allocated);
         CXPLAT_ECN_TYPE ECN = CXPLAT_ECN_FROM_TOS(Packets[i]->TypeOfService);
         Packet = Packets[i];
 
+#if 0
         if (Packets[prevPacket]->KeyType != Packet->KeyType) {
             if (Packet->Encrypted &&
                 Connection->State.HeaderProtectionEnabled) {
@@ -5546,6 +5547,7 @@ QuicConnRecvDatagramBatch(
                 }
             }
         }
+#endif
 
         CXPLAT_DBG_ASSERT(Packet->PacketId != 0);
         if (!QuicConnRecvPrepareDecrypt(
@@ -5582,7 +5584,7 @@ QuicConnRecvDatagramBatch(
                 }
             }
         }
-        prevPacket = i;
+        //prevPacket = i;
     }
 }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5692,11 +5692,14 @@ QuicConnRecvDatagrams(
                 break;
             }
 
-            if (!Packet->IsShortHeader && BatchCount != 0) {
+            if ((BatchCount != 0) &&
+                (!Packet->IsShortHeader ||
+                (PrevPackKeyType != QUIC_PACKET_KEY_COUNT && PrevPackKeyType != Packet->KeyType))) {
                 //
                 // We already had some batched short header packets and then
-                // encountered a long header packet. Finish off the short
-                // headers first and then continue with the current packet.
+                // encountered a long header packet OR the current packet 
+                // has different key type. Finish off the batch first and
+                // then continue with the current packet.
                 //
                 QuicConnRecvDatagramBatch(
                     Connection,
@@ -5709,21 +5712,6 @@ QuicConnRecvDatagrams(
                     Cipher + BatchCount * CXPLAT_HP_SAMPLE_LENGTH,
                     Cipher,
                     CXPLAT_HP_SAMPLE_LENGTH);
-                BatchCount = 0;
-            }
-
-            if ((PrevPackKeyType != QUIC_PACKET_KEY_COUNT) &&
-                (PrevPackKeyType != Packet->KeyType) && (BatchCount != 0)) {
-                //
-                //  Dont batch different key type packets
-                //
-                QuicConnRecvDatagramBatch(
-                    Connection,
-                    CurrentPath,
-                    BatchCount,
-                    Batch,
-                    Cipher,
-                    &RecvState);
                 BatchCount = 0;
             }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5521,14 +5521,13 @@ QuicConnRecvDatagramBatch(
         CxPlatZeroMemory(HpMask, BatchCount * CXPLAT_HP_SAMPLE_LENGTH);
     }
 
-    //uint8_t prevPacket = 0;
+    QUIC_PACKET_KEY_TYPE CurrentKeyType = Packet->KeyType;
     for (uint8_t i = 0; i < BatchCount; ++i) {
         CXPLAT_DBG_ASSERT(Packets[i]->Allocated);
         CXPLAT_ECN_TYPE ECN = CXPLAT_ECN_FROM_TOS(Packets[i]->TypeOfService);
         Packet = Packets[i];
 
-#if 0
-        if (Packets[prevPacket]->KeyType != Packet->KeyType) {
+        if (CurrentKeyType != Packet->KeyType) {
             if (Packet->Encrypted &&
                 Connection->State.HeaderProtectionEnabled) {
                 uint8_t RemainingBatchCount = BatchCount - i;
@@ -5546,8 +5545,8 @@ QuicConnRecvDatagramBatch(
                     continue; // Skip this packet and move to the next one
                 }
             }
+            CurrentKeyType = Packet->KeyType;
         }
-#endif
 
         CXPLAT_DBG_ASSERT(Packet->PacketId != 0);
         if (!QuicConnRecvPrepareDecrypt(
@@ -5584,7 +5583,6 @@ QuicConnRecvDatagramBatch(
                 }
             }
         }
-        //prevPacket = i;
     }
 }
 


### PR DESCRIPTION
## Description

Fixes the issue #4326.

Update the HpMask when processing batch of packets in function QuicConnRecvDatagramBatch.
If KeyType of packet changes then use new KeyType of current packet (ReadKeys[Packet->KeyType]->HeaderKey) to compute HpMask which is used to decrypt the packets.

## Testing

Ran existing test cases to make sure it is not breaking anything.

This may not fully solve Misc/WithCidUpdateArgs.CidUpdate/5 faliure, but it solves decryption failure issues caused by change in packet header key.

## Documentation

_Is there any documentation impact for this change?_
No.
