### PR TITLE
RecvBuffer simplifications [2/N]

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -109,7 +109,7 @@ QuicRecvBufferGetChunkIterator(
 //
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return == TRUE)
-BOOL
+BOOLEAN
 QuicRecvChunkIteratorNext(
     _Inout_ QUIC_RECV_CHUNK_ITERATOR* Iterator,
     _In_ BOOLEAN ReferenceChunk,
@@ -652,7 +652,7 @@ QuicRecvBufferCopyIntoChunks(
     QUIC_RECV_CHUNK_ITERATOR Iterator = QuicRecvBufferGetChunkIterator(RecvBuffer, RelativeOffset);
     QUIC_BUFFER Buffer;
     while (WriteLength != 0 && QuicRecvChunkIteratorNext(&Iterator, FALSE, &Buffer)) {
-        const uint32_t CopyLength = min(Buffer.Length, WriteLength);
+        const uint32_t CopyLength = CXPLAT_MIN(Buffer.Length, WriteLength);
         CxPlatCopyMemory(Buffer.Buffer, WriteBuffer, CopyLength);
         WriteBuffer += CopyLength;
         WriteLength -= (uint16_t)CopyLength;
@@ -664,7 +664,7 @@ QuicRecvBufferCopyIntoChunks(
     //
     QUIC_SUBRANGE* FirstRange = QuicRangeGet(&RecvBuffer->WrittenRanges, 0);
     if (FirstRange->Low == 0) {
-        RecvBuffer->ReadLength = (uint32_t)min(
+        RecvBuffer->ReadLength = (uint32_t)CXPLAT_MIN(
             RecvBuffer->Capacity,
             FirstRange->Count - RecvBuffer->BaseOffset);
     }

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -244,6 +244,8 @@ QuicRecvBufferValidate(
     //
     CXPLAT_DBG_ASSERT(RecvBuffer->RetiredChunk == NULL || RecvBuffer->ReadPendingLength != 0);
 
+#else
+    UNREFERENCED_PARAMETER(RecvBuffer);
 #endif
 }
 

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -824,7 +824,7 @@ QuicRecvBufferReadBufferNeededCount(
     // Determine how much data is readable
     //
     const QUIC_SUBRANGE* FirstRange = QuicRangeGetSafe(&RecvBuffer->WrittenRanges, 0);
-    if (!FirstRange) {
+    if (!FirstRange || FirstRange->Low != 0) {
         return 0;
     }
     const uint64_t ReadableData = FirstRange->Count - RecvBuffer->BaseOffset;

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -191,6 +191,7 @@ QuicRecvChunkFree(
     }
 }
 
+#if DEBUG
 //
 // Validate the receive buffer invariants.
 // No-op in release builds.
@@ -201,7 +202,6 @@ QuicRecvBufferValidate(
     _In_ const QUIC_RECV_BUFFER* RecvBuffer
     )
 {
-#if DEBUG
     QUIC_RECV_CHUNK* FirstChunk =
         CXPLAT_CONTAINING_RECORD(
             RecvBuffer->Chunks.Flink,
@@ -243,11 +243,10 @@ QuicRecvBufferValidate(
     // There can be a retired chunk only when a read is pending.
     //
     CXPLAT_DBG_ASSERT(RecvBuffer->RetiredChunk == NULL || RecvBuffer->ReadPendingLength != 0);
-
-#else
-    UNREFERENCED_PARAMETER(RecvBuffer);
-#endif
 }
+#else
+#define QuicRecvBufferValidate(RecvBuffer)
+#endif
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -210,7 +210,7 @@ QuicRecvBufferRead(
     _In_ QUIC_RECV_BUFFER* RecvBuffer,
     _Out_ uint64_t* BufferOffset,
     _Inout_ uint32_t* BufferCount,
-    _Out_writes_all_(*BufferCount)
+    _Out_writes_to_(*BufferCount, *BufferCount)
         QUIC_BUFFER* Buffers
     );
 


### PR DESCRIPTION
## Description

Part of a series of PR to simplify the receive buffer code by unifying the handling of the different buffer modes where possible.

This change:

- introduces an iterator over the receive buffer chunk list. It provides a view to the contiguous spans of data in chunk list, skipping an initial offset
- refactors the read and write operations using the iterator
- introduce a validation function to enforce the receive buffer invariants consistently

## Testing

CI

## Documentation

N/A
