### PR TITLE
Epoll TCP accept load balancing and code clean up

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -524,7 +524,7 @@ CxPlatSocketConfigureRss(
     int Result = 0;
 
     struct sock_filter BpfCode[] = {
-        {BPF_LD | BPF_W | BPF_ABS, 0, 0, SKF_AD_OFF | SKF_AD_CPU}, // Loads CPU number
+        {BPF_LD | BPF_W | BPF_ABS, 0, 0, SKF_AD_OFF | SKF_AD_CPU}, // Load CPU number
         {BPF_ALU | BPF_MOD, 0, 0, SocketCount}, // MOD by SocketCount
         {BPF_RET | BPF_A, 0, 0, 0} // Return
     };
@@ -1412,7 +1412,7 @@ CxPlatSocketCreateTcpInternal(
     if (Type == CXPLAT_SOCKET_TCP_SERVER) {
         //
         // The accepted socket must be assigned to the same partition as the listener
-        // to prevent race conditions, e.g. accept handler racing with recieve handler.
+        // to prevent race conditions, e.g. accept handler racing with receive handler.
         // Also, it distributes the load across the partitions.
         //
         PartitionIndex = ListenerSocketContext->DatapathPartition->PartitionIndex;

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1572,6 +1572,7 @@ SocketCreateTcpListener(
     Binding->Datapath = Datapath;
     Binding->ClientContext = CallbackContext;
     Binding->HasFixedRemoteAddress = FALSE;
+    Binding->NumPerProcessorSockets = Datapath->PartitionCount > 1;
     Binding->Mtu = CXPLAT_MAX_MTU;
     Binding->Type = CXPLAT_SOCKET_TCP_LISTENER;
     if (LocalAddress) {


### PR DESCRIPTION
## Description

1.Temporarily stashing the newly accepted socket in the listener's socket context is unnecessary. It's copied from winuser where the listener always keeps a pre-posted acceptex IO.
2. Use accept4() to accept and set nonblocking in one shot.
3. Load balancing on accept to match UDP behavior. HPS increased ~30% on my 20-core linux home machine over loopback (`secnetperf -target:127.0.0.1 -tcp:1 --scenario:hps -rconn:1 -runtime:5s -conns:64`).

## Testing

CI