### PR TITLE
Rust: Add get stream id API

### DIFF
--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -1226,6 +1226,10 @@ impl Stream {
     pub fn receive_complete(&self, buffer_length: u64) {
         unsafe { Api::ffi_ref().StreamReceiveComplete.unwrap()(self.handle, buffer_length) }
     }
+
+    pub fn get_stream_id(&self) -> Result<u64, Status> {
+        unsafe { Api::get_param_auto(self.handle, ffi::QUIC_PARAM_STREAM_ID) }
+    }
 }
 
 define_quic_handle_impl!(Stream);

--- a/src/rs/server_client_test.rs
+++ b/src/rs/server_client_test.rs
@@ -204,6 +204,9 @@ fn test_server_client() {
         let stream_handler = move |stream: StreamRef, ev: StreamEvent| {
             println!("Client stream event: {ev:?}");
             match ev {
+                StreamEvent::StartComplete { id, .. } => {
+                    assert_eq!(stream.get_stream_id().unwrap(), id);
+                }
                 StreamEvent::SendComplete {
                     cancelled: _,
                     client_context,


### PR DESCRIPTION
## Description
Add api to get stream id.

## Testing
Added api call in existing test.

## Documentation
NA
