### PR TITLE
Rust: Fix rust ci build

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
       with:
-        toolchain: stable
+        toolchain: 1.86.0
         components: rustfmt, clippy
     - name: Cargo fmt
       run: cargo fmt --all -- --check
@@ -73,6 +73,11 @@ jobs:
         egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
+      with:
+        toolchain: 1.86.0
+        components: rustfmt, clippy
     - name: Install msquic from apt
       run: |
         wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -40,9 +40,11 @@ jobs:
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
-    - name: Install Cargo
-      if: runner.os == 'Linux'
-      run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
     - name: Cargo fmt
       run: cargo fmt --all -- --check
     - name: Cargo clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# Specify which version of rust should be used to compile the project
+# cargo + rustup will use this to consistently build the project
+# with the same version across all checkouts and environments
+[toolchain]
+channel = "1.86.0"
+profile = "default"

--- a/src/rs/error.rs
+++ b/src/rs/error.rs
@@ -142,10 +142,7 @@ impl From<StatusCode> for Status {
 impl core::fmt::Debug for Status {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut debug = fmt.debug_struct("Error");
-        let str_code = match self.try_as_status_code() {
-            Ok(c) => Some(c),
-            Err(_) => None,
-        };
+        let str_code = self.try_as_status_code().ok();
         debug.field("code", &format_args!("0x{:x}", self.0));
         match str_code {
             Some(c) => debug.field("message", &c),
@@ -158,10 +155,7 @@ impl core::fmt::Debug for Status {
 /// The display message is in the same format as error in windows crate.
 impl core::fmt::Display for Status {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let str_code = match self.try_as_status_code() {
-            Ok(c) => Some(c),
-            Err(_) => None,
-        };
+        let str_code = self.try_as_status_code().ok();
         match str_code {
             Some(c) => core::write!(fmt, "{} (0x{:x})", c, self.0),
             None => core::write!(fmt, "0x{:x}", self.0),


### PR DESCRIPTION
## Description
Rust ci is broken due to compiler version upgrade.
Fixed the clippy error and pinned the rust version in ci using standard setup rust github action.
CI should not be broken in the future like this time without code changes.

## Testing
NA

## Documentation
NA
