### PR TITLE
Change Formatting of QUIC Version Trace

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -579,7 +579,7 @@ QuicConnTraceRundownOper(
     if (Connection->Stats.QuicVersion != 0) {
         QuicTraceEvent(
             ConnVersionSet,
-            "[conn][%p] QUIC Version: %u",
+            "[conn][%p] QUIC Version: 0x%x",
             Connection,
             Connection->Stats.QuicVersion);
     }
@@ -1715,7 +1715,7 @@ QuicConnOnQuicVersionSet(
 {
     QuicTraceEvent(
         ConnVersionSet,
-        "[conn][%p] QUIC Version: %u",
+        "[conn][%p] QUIC Version: 0x%x",
         Connection,
         Connection->Stats.QuicVersion);
 
@@ -3412,19 +3412,17 @@ QuicConnRecvVerNeg(
     // requested version. If it does, we are supposed to ignore it. Cache the
     // first supported version.
     //
-    QuicTraceLogConnVerbose(
-        RecvVerNeg,
-        Connection,
-        "Received Version Negotation:");
+    QuicTraceLogVerbose(
+        PacketRxVersionNegotiation,
+        "[C][TX][-] VN");
     for (uint16_t i = 0; i < ServerVersionListLength; i++) {
 
         uint32_t ServerVersion;
         CxPlatCopyMemory(&ServerVersion, &ServerVersionList[i], sizeof(ServerVersion));
 
-        QuicTraceLogConnVerbose(
-            VerNegItem,
-            Connection,
-            "  Ver[%d]: 0x%x",
+        QuicTraceLogVerbose(
+            PacketRxVersionNegVer,
+            "[C][TX][-]   Ver[%d]: 0x%x",
             (int32_t)i,
             CxPlatByteSwapUint32(ServerVersion));
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3414,7 +3414,7 @@ QuicConnRecvVerNeg(
     //
     QuicTraceLogVerbose(
         PacketRxVersionNegotiation,
-        "[C][TX][-] VN");
+        "[C][RX][-] VN");
     for (uint16_t i = 0; i < ServerVersionListLength; i++) {
 
         uint32_t ServerVersion;
@@ -3422,7 +3422,7 @@ QuicConnRecvVerNeg(
 
         QuicTraceLogVerbose(
             PacketRxVersionNegVer,
-            "[C][TX][-]   Ver[%d]: 0x%x",
+            "[C][RX][-]   Ver[%d]: 0x%x",
             (int32_t)i,
             CxPlatByteSwapUint32(ServerVersion));
 
@@ -5697,7 +5697,7 @@ QuicConnRecvDatagrams(
                 (PrevPackKeyType != QUIC_PACKET_KEY_COUNT && PrevPackKeyType != Packet->KeyType))) {
                 //
                 // We already had some batched short header packets and then
-                // encountered a long header packet OR the current packet 
+                // encountered a long header packet OR the current packet
                 // has different key type. Finish off the batch first and
                 // then continue with the current packet.
                 //

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -42,6 +42,42 @@
 extern "C" {
 #endif
 /*----------------------------------------------------------
+// Decoder Ring for PacketRxVersionNegotiation
+// [C][TX][-] VN
+// QuicTraceLogVerbose(
+        PacketRxVersionNegotiation,
+        "[C][TX][-] VN");
+----------------------------------------------------------*/
+#ifndef _clog_2_ARGS_TRACE_PacketRxVersionNegotiation
+#define _clog_2_ARGS_TRACE_PacketRxVersionNegotiation(uniqueId, encoded_arg_string)\
+tracepoint(CLOG_CONNECTION_C, PacketRxVersionNegotiation );\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for PacketRxVersionNegVer
+// [C][TX][-]   Ver[%d]: 0x%x
+// QuicTraceLogVerbose(
+            PacketRxVersionNegVer,
+            "[C][TX][-]   Ver[%d]: 0x%x",
+            (int32_t)i,
+            CxPlatByteSwapUint32(ServerVersion));
+// arg2 = arg2 = (int32_t)i = arg2
+// arg3 = arg3 = CxPlatByteSwapUint32(ServerVersion) = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_PacketRxVersionNegVer
+#define _clog_4_ARGS_TRACE_PacketRxVersionNegVer(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_CONNECTION_C, PacketRxVersionNegVer , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for PacketRxStatelessReset
 // [S][RX][-] SR %s
 // QuicTraceLogVerbose(
@@ -1200,46 +1236,6 @@ tracepoint(CLOG_CONNECTION_C, QueueDatagrams , arg1, arg3);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for RecvVerNeg
-// [conn][%p] Received Version Negotation:
-// QuicTraceLogConnVerbose(
-        RecvVerNeg,
-        Connection,
-        "Received Version Negotation:");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_RecvVerNeg
-#define _clog_3_ARGS_TRACE_RecvVerNeg(uniqueId, arg1, encoded_arg_string)\
-tracepoint(CLOG_CONNECTION_C, RecvVerNeg , arg1);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for VerNegItem
-// [conn][%p]   Ver[%d]: 0x%x
-// QuicTraceLogConnVerbose(
-            VerNegItem,
-            Connection,
-            "  Ver[%d]: 0x%x",
-            (int32_t)i,
-            CxPlatByteSwapUint32(ServerVersion));
-// arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = (int32_t)i = arg3
-// arg4 = arg4 = CxPlatByteSwapUint32(ServerVersion) = arg4
-----------------------------------------------------------*/
-#ifndef _clog_5_ARGS_TRACE_VerNegItem
-#define _clog_5_ARGS_TRACE_VerNegItem(uniqueId, arg1, encoded_arg_string, arg3, arg4)\
-tracepoint(CLOG_CONNECTION_C, VerNegItem , arg1, arg3, arg4);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for DeferDatagram
 // [conn][%p] Deferring datagram (type=%hu)
 // QuicTraceLogConnVerbose(
@@ -1820,10 +1816,10 @@ tracepoint(CLOG_CONNECTION_C, ConnEcnCapable , arg2, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnVersionSet
-// [conn][%p] QUIC Version: %u
+// [conn][%p] QUIC Version: 0x%x
 // QuicTraceEvent(
             ConnVersionSet,
-            "[conn][%p] QUIC Version: %u",
+            "[conn][%p] QUIC Version: 0x%x",
             Connection,
             Connection->Stats.QuicVersion);
 // arg2 = arg2 = Connection = arg2

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -43,10 +43,10 @@ extern "C" {
 #endif
 /*----------------------------------------------------------
 // Decoder Ring for PacketRxVersionNegotiation
-// [C][TX][-] VN
+// [C][RX][-] VN
 // QuicTraceLogVerbose(
         PacketRxVersionNegotiation,
-        "[C][TX][-] VN");
+        "[C][RX][-] VN");
 ----------------------------------------------------------*/
 #ifndef _clog_2_ARGS_TRACE_PacketRxVersionNegotiation
 #define _clog_2_ARGS_TRACE_PacketRxVersionNegotiation(uniqueId, encoded_arg_string)\
@@ -59,10 +59,10 @@ tracepoint(CLOG_CONNECTION_C, PacketRxVersionNegotiation );\
 
 /*----------------------------------------------------------
 // Decoder Ring for PacketRxVersionNegVer
-// [C][TX][-]   Ver[%d]: 0x%x
+// [C][RX][-]   Ver[%d]: 0x%x
 // QuicTraceLogVerbose(
             PacketRxVersionNegVer,
-            "[C][TX][-]   Ver[%d]: 0x%x",
+            "[C][RX][-]   Ver[%d]: 0x%x",
             (int32_t)i,
             CxPlatByteSwapUint32(ServerVersion));
 // arg2 = arg2 = (int32_t)i = arg2

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -3,10 +3,10 @@
 
 /*----------------------------------------------------------
 // Decoder Ring for PacketRxVersionNegotiation
-// [C][TX][-] VN
+// [C][RX][-] VN
 // QuicTraceLogVerbose(
         PacketRxVersionNegotiation,
-        "[C][TX][-] VN");
+        "[C][RX][-] VN");
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, PacketRxVersionNegotiation,
     TP_ARGS(
@@ -19,10 +19,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, PacketRxVersionNegotiation,
 
 /*----------------------------------------------------------
 // Decoder Ring for PacketRxVersionNegVer
-// [C][TX][-]   Ver[%d]: 0x%x
+// [C][RX][-]   Ver[%d]: 0x%x
 // QuicTraceLogVerbose(
             PacketRxVersionNegVer,
-            "[C][TX][-]   Ver[%d]: 0x%x",
+            "[C][RX][-]   Ver[%d]: 0x%x",
             (int32_t)i,
             CxPlatByteSwapUint32(ServerVersion));
 // arg2 = arg2 = (int32_t)i = arg2

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -2,6 +2,45 @@
 
 
 /*----------------------------------------------------------
+// Decoder Ring for PacketRxVersionNegotiation
+// [C][TX][-] VN
+// QuicTraceLogVerbose(
+        PacketRxVersionNegotiation,
+        "[C][TX][-] VN");
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_CONNECTION_C, PacketRxVersionNegotiation,
+    TP_ARGS(
+), 
+    TP_FIELDS(
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for PacketRxVersionNegVer
+// [C][TX][-]   Ver[%d]: 0x%x
+// QuicTraceLogVerbose(
+            PacketRxVersionNegVer,
+            "[C][TX][-]   Ver[%d]: 0x%x",
+            (int32_t)i,
+            CxPlatByteSwapUint32(ServerVersion));
+// arg2 = arg2 = (int32_t)i = arg2
+// arg3 = arg3 = CxPlatByteSwapUint32(ServerVersion) = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_CONNECTION_C, PacketRxVersionNegVer,
+    TP_ARGS(
+        int, arg2,
+        unsigned int, arg3), 
+    TP_FIELDS(
+        ctf_integer(int, arg2, arg2)
+        ctf_integer(unsigned int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for PacketRxStatelessReset
 // [S][RX][-] SR %s
 // QuicTraceLogVerbose(
@@ -1319,52 +1358,6 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, QueueDatagrams,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for RecvVerNeg
-// [conn][%p] Received Version Negotation:
-// QuicTraceLogConnVerbose(
-        RecvVerNeg,
-        Connection,
-        "Received Version Negotation:");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CONNECTION_C, RecvVerNeg,
-    TP_ARGS(
-        const void *, arg1), 
-    TP_FIELDS(
-        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-    )
-)
-
-
-
-/*----------------------------------------------------------
-// Decoder Ring for VerNegItem
-// [conn][%p]   Ver[%d]: 0x%x
-// QuicTraceLogConnVerbose(
-            VerNegItem,
-            Connection,
-            "  Ver[%d]: 0x%x",
-            (int32_t)i,
-            CxPlatByteSwapUint32(ServerVersion));
-// arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = (int32_t)i = arg3
-// arg4 = arg4 = CxPlatByteSwapUint32(ServerVersion) = arg4
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CONNECTION_C, VerNegItem,
-    TP_ARGS(
-        const void *, arg1,
-        int, arg3,
-        unsigned int, arg4), 
-    TP_FIELDS(
-        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(int, arg3, arg3)
-        ctf_integer(unsigned int, arg4, arg4)
-    )
-)
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for DeferDatagram
 // [conn][%p] Deferring datagram (type=%hu)
 // QuicTraceLogConnVerbose(
@@ -2038,10 +2031,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnEcnCapable,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnVersionSet
-// [conn][%p] QUIC Version: %u
+// [conn][%p] QUIC Version: 0x%x
 // QuicTraceEvent(
             ConnVersionSet,
-            "[conn][%p] QUIC Version: %u",
+            "[conn][%p] QUIC Version: 0x%x",
             Connection,
             Connection->Stats.QuicVersion);
 // arg2 = arg2 = Connection = arg2

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -2473,7 +2473,7 @@
     },
     "ConnVersionSet": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] QUIC Version: %u",
+      "TraceString": "[conn][%p] QUIC Version: 0x%x",
       "UniqueId": "ConnVersionSet",
       "splitArgs": [
         {
@@ -2481,7 +2481,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "u",
+          "DefinationEncoding": "x",
           "MacroVariableName": "arg3"
         }
       ],
@@ -8208,6 +8208,29 @@
         {
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "PacketRxVersionNegotiation": {
+      "ModuleProperites": {},
+      "TraceString": "[C][TX][-] VN",
+      "UniqueId": "PacketRxVersionNegotiation",
+      "splitArgs": [],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "PacketRxVersionNegVer": {
+      "ModuleProperites": {},
+      "TraceString": "[C][TX][-]   Ver[%d]: 0x%x",
+      "UniqueId": "PacketRxVersionNegVer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "x",
+          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceLogVerbose"
@@ -14606,9 +14629,9 @@
         "EncodingString": "[conn][%p] Unregistered from %p"
       },
       {
-        "UniquenessHash": "8fbe1b93-5e48-0738-c64d-8e60a387bc13",
+        "UniquenessHash": "4dba1f55-4a25-f194-dc19-c0d6beba3de7",
         "TraceID": "ConnVersionSet",
-        "EncodingString": "[conn][%p] QUIC Version: %u"
+        "EncodingString": "[conn][%p] QUIC Version: 0x%x"
       },
       {
         "UniquenessHash": "6a04dcf8-d84b-933c-ab7a-6f700e5111d2",
@@ -16304,6 +16327,16 @@
         "UniquenessHash": "74a3473b-5ac0-6376-652d-882aac50b01a",
         "TraceID": "PacketRxStatelessReset",
         "EncodingString": "[S][RX][-] SR %s"
+      },
+      {
+        "UniquenessHash": "2b9ae921-d91b-43c5-ae24-347669e9476d",
+        "TraceID": "PacketRxVersionNegotiation",
+        "EncodingString": "[C][TX][-] VN"
+      },
+      {
+        "UniquenessHash": "2c479fb4-18d6-413d-ce18-ea47d4bb8271",
+        "TraceID": "PacketRxVersionNegVer",
+        "EncodingString": "[C][TX][-]   Ver[%d]: 0x%x"
       },
       {
         "UniquenessHash": "9d72c640-7512-38fd-8823-f24b7e1ad94c",

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -8214,14 +8214,14 @@
     },
     "PacketRxVersionNegotiation": {
       "ModuleProperites": {},
-      "TraceString": "[C][TX][-] VN",
+      "TraceString": "[C][RX][-] VN",
       "UniqueId": "PacketRxVersionNegotiation",
       "splitArgs": [],
       "macroName": "QuicTraceLogVerbose"
     },
     "PacketRxVersionNegVer": {
       "ModuleProperites": {},
-      "TraceString": "[C][TX][-]   Ver[%d]: 0x%x",
+      "TraceString": "[C][RX][-]   Ver[%d]: 0x%x",
       "UniqueId": "PacketRxVersionNegVer",
       "splitArgs": [
         {
@@ -16329,14 +16329,14 @@
         "EncodingString": "[S][RX][-] SR %s"
       },
       {
-        "UniquenessHash": "2b9ae921-d91b-43c5-ae24-347669e9476d",
+        "UniquenessHash": "46f11126-1b95-7be6-d4b5-355e596c8e8e",
         "TraceID": "PacketRxVersionNegotiation",
-        "EncodingString": "[C][TX][-] VN"
+        "EncodingString": "[C][RX][-] VN"
       },
       {
-        "UniquenessHash": "2c479fb4-18d6-413d-ce18-ea47d4bb8271",
+        "UniquenessHash": "0026470e-9655-96a1-ef44-5e613a17a5dc",
         "TraceID": "PacketRxVersionNegVer",
-        "EncodingString": "[C][TX][-]   Ver[%d]: 0x%x"
+        "EncodingString": "[C][RX][-]   Ver[%d]: 0x%x"
       },
       {
         "UniquenessHash": "9d72c640-7512-38fd-8823-f24b7e1ad94c",


### PR DESCRIPTION
## Description

Log the version in hex instead of decimal.

## Testing

Automation

## Documentation

N/A
