### PR TITLE
Add ConnectionOpenInPartition

### DIFF
--- a/docs/api/ConnectionOpen.md
+++ b/docs/api/ConnectionOpen.md
@@ -52,7 +52,7 @@ Once the connection has been shutdown, it must be cleaned up with a call to [Con
 
 # See Also
 
-[ConnectionOpenEx1](ConnectionOpenEx1.md)<br>
+[ConnectionOpenInPartition](ConnectionOpenInPartition.md)<br>
 [ConnectionClose](ConnectionClose.md)<br>
 [ConnectionShutdown](ConnectionShutdown.md)<br>
 [ConnectionStart](ConnectionStart.md)<br>

--- a/docs/api/ConnectionOpenEx1.md
+++ b/docs/api/ConnectionOpenEx1.md
@@ -1,7 +1,7 @@
-ConnectionOpen function
+ConnectionOpenEx1 function
 ======
 
-Creates a new connection.
+Creates a new connection in a specific partition.
 
 # Syntax
 
@@ -9,8 +9,9 @@ Creates a new connection.
 typedef
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
-(QUIC_API * QUIC_CONNECTION_OPEN_FN)(
+(QUIC_API * QUIC_CONNECTION_OPEN_EX1_FN)(
     _In_ _Pre_defensive_ HQUIC Registration,
+    _In_ uint16_t PartitionIndex,
     _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
     _In_opt_ void* Context,
     _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem)) _Pre_defensive_
@@ -23,6 +24,10 @@ QUIC_STATUS
 `Registration`
 
 The valid handle to an open registration object.
+
+`PartitionIndex`
+
+An index into the global partition set.
 
 `Handler`
 
@@ -42,7 +47,7 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 # Remarks
 
-`ConnectionOpen` is used to create a connection in the client application. In server applications, [ListenerOpen](ListenerOpen.md) and [ListenerStart](ListenerStart.md) must be called to listen for incoming connection attempts, and the server side Connection is created in the `QUIC_LISTENER_EVENT_NEW_CONNECTION` event.
+`ConnectionOpenEx1` is used to create a connection in the client application, with an explicit partition index. In server applications, [ListenerOpen](ListenerOpen.md) and [ListenerStart](ListenerStart.md) must be called to listen for incoming connection attempts, and the server side Connection is created in the `QUIC_LISTENER_EVENT_NEW_CONNECTION` event.
 
 'ConnectionOpen' only allocates the resources for the connection, it does not start the connection. To start the connect, the application must call [ConnectionStart](ConnectionStart.md).
 
@@ -52,7 +57,7 @@ Once the connection has been shutdown, it must be cleaned up with a call to [Con
 
 # See Also
 
-[ConnectionOpenEx1](ConnectionOpenEx1.md)<br>
+[ConnectionOpen](ConnectionOpen.md)<br>
 [ConnectionClose](ConnectionClose.md)<br>
 [ConnectionShutdown](ConnectionShutdown.md)<br>
 [ConnectionStart](ConnectionStart.md)<br>

--- a/docs/api/ConnectionOpenInPartition.md
+++ b/docs/api/ConnectionOpenInPartition.md
@@ -47,13 +47,9 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 # Remarks
 
-`ConnectionOpenInPartition` is used to create a connection in the client application, with an explicit partition index. In server applications, [ListenerOpen](ListenerOpen.md) and [ListenerStart](ListenerStart.md) must be called to listen for incoming connection attempts, and the server side Connection is created in the `QUIC_LISTENER_EVENT_NEW_CONNECTION` event.
+See [ConnectionOpen](ConnectionOpen.md#Remarks) for more remarks.
 
-'ConnectionOpen' only allocates the resources for the connection, it does not start the connection. To start the connect, the application must call [ConnectionStart](ConnectionStart.md).
-
-Once `ConnectionOpen` completes successfully, the application may create streams, and queue data for sending. This is when 0-RTT streams and data **MUST** be created and queued. See [StreamOpen](StreamOpen.md), and [StreamStart](StreamStart.md).
-
-Once the connection has been shutdown, it must be cleaned up with a call to [ConnectionClose](ConnectionClose.md).
+This function is the same as `ConnectionOpen` with the exception that this puts the connection in an explicit partition instead of inferring it based on the calling thread's current processor.
 
 # See Also
 

--- a/docs/api/ConnectionOpenInPartition.md
+++ b/docs/api/ConnectionOpenInPartition.md
@@ -1,4 +1,4 @@
-ConnectionOpenEx1 function
+ConnectionOpenInPartition function
 ======
 
 Creates a new connection in a specific partition.
@@ -9,7 +9,7 @@ Creates a new connection in a specific partition.
 typedef
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
-(QUIC_API * QUIC_CONNECTION_OPEN_EX1_FN)(
+(QUIC_API * QUIC_CONNECTION_OPEN_IN_PARTITION_FN)(
     _In_ _Pre_defensive_ HQUIC Registration,
     _In_ uint16_t PartitionIndex,
     _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
@@ -47,7 +47,7 @@ The function returns a [QUIC_STATUS](QUIC_STATUS.md). The app may use `QUIC_FAIL
 
 # Remarks
 
-`ConnectionOpenEx1` is used to create a connection in the client application, with an explicit partition index. In server applications, [ListenerOpen](ListenerOpen.md) and [ListenerStart](ListenerStart.md) must be called to listen for incoming connection attempts, and the server side Connection is created in the `QUIC_LISTENER_EVENT_NEW_CONNECTION` event.
+`ConnectionOpenInPartition` is used to create a connection in the client application, with an explicit partition index. In server applications, [ListenerOpen](ListenerOpen.md) and [ListenerStart](ListenerStart.md) must be called to listen for incoming connection attempts, and the server side Connection is created in the `QUIC_LISTENER_EVENT_NEW_CONNECTION` event.
 
 'ConnectionOpen' only allocates the resources for the connection, it does not start the connection. To start the connect, the application must call [ConnectionStart](ConnectionStart.md).
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -41,6 +41,27 @@ MsQuicConnectionOpen(
         HQUIC *NewConnection
     )
 {
+    return
+        MsQuicConnectionOpenEx1(
+            RegistrationHandle,
+            QuicLibraryGetCurrentPartition()->Index,
+            Handler,
+            Context,
+            NewConnection);
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_STATUS
+QUIC_API
+MsQuicConnectionOpenEx1(
+    _In_ _Pre_defensive_ HQUIC RegistrationHandle,
+    _In_ uint16_t PartitionIndex,
+    _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
+    _In_opt_ void* Context,
+    _Outptr_ _At_(*NewConnection, __drv_allocatesMem(Mem)) _Pre_defensive_
+        HQUIC *NewConnection
+    )
+{
     QUIC_STATUS Status;
     QUIC_REGISTRATION* Registration;
     QUIC_CONNECTION* Connection = NULL;
@@ -52,6 +73,7 @@ MsQuicConnectionOpen(
         RegistrationHandle);
 
     if (!IS_REGISTRATION_HANDLE(RegistrationHandle) ||
+        PartitionIndex >= MsQuicLib.PartitionCount ||
         NewConnection == NULL ||
         Handler == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
@@ -68,7 +90,7 @@ MsQuicConnectionOpen(
     Status =
         QuicConnAlloc(
             Registration,
-            QuicLibraryGetCurrentPartition(),
+            &MsQuicLib.Partitions[PartitionIndex],
             NULL,
             NULL,
             &Connection);

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -42,7 +42,7 @@ MsQuicConnectionOpen(
     )
 {
     return
-        MsQuicConnectionOpenEx1(
+        MsQuicConnectionOpenInPartition(
             RegistrationHandle,
             QuicLibraryGetCurrentPartition()->Index,
             Handler,
@@ -53,7 +53,7 @@ MsQuicConnectionOpen(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QUIC_API
-MsQuicConnectionOpenEx1(
+MsQuicConnectionOpenInPartition(
     _In_ _Pre_defensive_ HQUIC RegistrationHandle,
     _In_ uint16_t PartitionIndex,
     _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,

--- a/src/core/api.h
+++ b/src/core/api.h
@@ -114,7 +114,7 @@ MsQuicConnectionOpen(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
 QUIC_API
-MsQuicConnectionOpenEx1(
+MsQuicConnectionOpenInPartition(
     _In_ _Pre_defensive_ HQUIC Registration,
     _In_ uint16_t PartitionIndex,
     _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,

--- a/src/core/api.h
+++ b/src/core/api.h
@@ -111,6 +111,18 @@ MsQuicConnectionOpen(
         HQUIC *Connection
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_STATUS
+QUIC_API
+MsQuicConnectionOpenEx1(
+    _In_ _Pre_defensive_ HQUIC Registration,
+    _In_ uint16_t PartitionIndex,
+    _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
+    _In_opt_ void* Context,
+    _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem)) _Pre_defensive_
+        HQUIC *Connection
+    );
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QUIC_API

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1787,7 +1787,7 @@ MsQuicOpenVersion(
     Api->ListenerStop = MsQuicListenerStop;
 
     Api->ConnectionOpen = MsQuicConnectionOpen;
-    Api->ConnectionOpenEx1 = MsQuicConnectionOpenEx1;
+    Api->ConnectionOpenInPartition = MsQuicConnectionOpenInPartition;
     Api->ConnectionClose = MsQuicConnectionClose;
     Api->ConnectionShutdown = MsQuicConnectionShutdown;
     Api->ConnectionStart = MsQuicConnectionStart;

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1787,6 +1787,7 @@ MsQuicOpenVersion(
     Api->ListenerStop = MsQuicListenerStop;
 
     Api->ConnectionOpen = MsQuicConnectionOpen;
+    Api->ConnectionOpenEx1 = MsQuicConnectionOpenEx1;
     Api->ConnectionClose = MsQuicConnectionClose;
     Api->ConnectionShutdown = MsQuicConnectionShutdown;
     Api->ConnectionStart = MsQuicConnectionStart;

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -3388,6 +3388,9 @@ namespace Microsoft.Quic
         [NativeTypeName("QUIC_CONNECTION_COMP_CERT_FN")]
         internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, byte, QUIC_TLS_ALERT_CODES, int> ConnectionCertificateValidationComplete;
 
+        [NativeTypeName("QUIC_CONNECTION_OPEN_EX1_FN")]
+        internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, ushort, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_CONNECTION_EVENT*, int>, void*, QUIC_HANDLE**, int> ConnectionOpenEx1;
+
         [NativeTypeName("QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN")]
         internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, uint, QUIC_BUFFER*, int> StreamProvideReceiveBuffers;
 

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -3388,8 +3388,8 @@ namespace Microsoft.Quic
         [NativeTypeName("QUIC_CONNECTION_COMP_CERT_FN")]
         internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, byte, QUIC_TLS_ALERT_CODES, int> ConnectionCertificateValidationComplete;
 
-        [NativeTypeName("QUIC_CONNECTION_OPEN_EX1_FN")]
-        internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, ushort, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_CONNECTION_EVENT*, int>, void*, QUIC_HANDLE**, int> ConnectionOpenEx1;
+        [NativeTypeName("QUIC_CONNECTION_OPEN_IN_PARTITION_FN")]
+        internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, ushort, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_CONNECTION_EVENT*, int>, void*, QUIC_HANDLE**, int> ConnectionOpenInPartition;
 
         [NativeTypeName("QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN")]
         internal delegate* unmanaged[Cdecl]<QUIC_HANDLE*, uint, QUIC_BUFFER*, int> StreamProvideReceiveBuffers;

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1316,6 +1316,17 @@ QUIC_STATUS
     _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem)) _Pre_defensive_
         HQUIC* Connection
     );
+typedef
+_IRQL_requires_max_(DISPATCH_LEVEL)
+QUIC_STATUS
+(QUIC_API * QUIC_CONNECTION_OPEN_EX1_FN)(
+    _In_ _Pre_defensive_ HQUIC Registration,
+    _In_ uint16_t PartitionIndex,
+    _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
+    _In_opt_ void* Context,
+    _Outptr_ _At_(*Connection, __drv_allocatesMem(Mem)) _Pre_defensive_
+        HQUIC* Connection
+    );
 
 //
 // Closes an existing connection.
@@ -1713,6 +1724,8 @@ typedef struct QUIC_API_TABLE {
 
     QUIC_CONNECTION_COMP_RESUMPTION_FN  ConnectionResumptionTicketValidationComplete; // Available from v2.2
     QUIC_CONNECTION_COMP_CERT_FN        ConnectionCertificateValidationComplete;      // Available from v2.2
+
+    QUIC_CONNECTION_OPEN_EX1_FN         ConnectionOpenEx1;          // Available from v2.5
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1319,7 +1319,7 @@ QUIC_STATUS
 typedef
 _IRQL_requires_max_(DISPATCH_LEVEL)
 QUIC_STATUS
-(QUIC_API * QUIC_CONNECTION_OPEN_EX1_FN)(
+(QUIC_API * QUIC_CONNECTION_OPEN_IN_PARTITION_FN)(
     _In_ _Pre_defensive_ HQUIC Registration,
     _In_ uint16_t PartitionIndex,
     _In_ _Pre_defensive_ QUIC_CONNECTION_CALLBACK_HANDLER Handler,
@@ -1725,7 +1725,8 @@ typedef struct QUIC_API_TABLE {
     QUIC_CONNECTION_COMP_RESUMPTION_FN  ConnectionResumptionTicketValidationComplete; // Available from v2.2
     QUIC_CONNECTION_COMP_CERT_FN        ConnectionCertificateValidationComplete;      // Available from v2.2
 
-    QUIC_CONNECTION_OPEN_EX1_FN         ConnectionOpenEx1;          // Available from v2.5
+    QUIC_CONNECTION_OPEN_IN_PARTITION_FN
+                                        ConnectionOpenInPartition;   // Available from v2.5
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1025,6 +1025,29 @@ struct MsQuicConnection {
     }
 
     MsQuicConnection(
+        _In_ const MsQuicRegistration& Registration,
+        _In_ uint16_t PartitionIndex,
+        _In_ MsQuicCleanUpMode CleanUpMode = CleanUpManual,
+        _In_ MsQuicConnectionCallback* Callback = NoOpCallback,
+        _In_ void* Context = nullptr
+        ) noexcept : CleanUpMode(CleanUpMode), Callback(Callback), Context(Context) {
+        if (!Registration.IsValid()) {
+            InitStatus = Registration.GetInitStatus();
+            return;
+        }
+        if (QUIC_FAILED(
+            InitStatus =
+                MsQuic->ConnectionOpenEx1(
+                    Registration,
+                    PartitionIndex,
+                    (QUIC_CONNECTION_CALLBACK_HANDLER)MsQuicCallback,
+                    this,
+                    &Handle))) {
+            Handle = nullptr;
+        }
+    }
+
+    MsQuicConnection(
         _In_ HQUIC ConnectionHandle,
         _In_ MsQuicCleanUpMode CleanUpMode,
         _In_ MsQuicConnectionCallback* Callback,

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -1037,7 +1037,7 @@ struct MsQuicConnection {
         }
         if (QUIC_FAILED(
             InitStatus =
-                MsQuic->ConnectionOpenEx1(
+                MsQuic->ConnectionOpenInPartition(
                     Registration,
                     PartitionIndex,
                     (QUIC_CONNECTION_CALLBACK_HANDLER)MsQuicCallback,

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -5697,7 +5697,7 @@ pub type QUIC_CONNECTION_OPEN_FN = ::std::option::Option<
         Connection: *mut HQUIC,
     ) -> ::std::os::raw::c_uint,
 >;
-pub type QUIC_CONNECTION_OPEN_EX1_FN = ::std::option::Option<
+pub type QUIC_CONNECTION_OPEN_IN_PARTITION_FN = ::std::option::Option<
     unsafe extern "C" fn(
         Registration: HQUIC,
         PartitionIndex: u16,
@@ -6376,7 +6376,7 @@ pub struct QUIC_API_TABLE {
     pub DatagramSend: QUIC_DATAGRAM_SEND_FN,
     pub ConnectionResumptionTicketValidationComplete: QUIC_CONNECTION_COMP_RESUMPTION_FN,
     pub ConnectionCertificateValidationComplete: QUIC_CONNECTION_COMP_CERT_FN,
-    pub ConnectionOpenEx1: QUIC_CONNECTION_OPEN_EX1_FN,
+    pub ConnectionOpenInPartition: QUIC_CONNECTION_OPEN_IN_PARTITION_FN,
     pub StreamProvideReceiveBuffers: QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN,
     pub ConnectionPoolCreate: QUIC_CONN_POOL_CREATE_FN,
 }
@@ -6450,8 +6450,8 @@ const _: () = {
         QUIC_API_TABLE,
         ConnectionCertificateValidationComplete
     ) - 240usize];
-    ["Offset of field: QUIC_API_TABLE::ConnectionOpenEx1"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenEx1) - 248usize];
+    ["Offset of field: QUIC_API_TABLE::ConnectionOpenInPartition"]
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenInPartition) - 248usize];
     ["Offset of field: QUIC_API_TABLE::StreamProvideReceiveBuffers"]
         [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 256usize];
     ["Offset of field: QUIC_API_TABLE::ConnectionPoolCreate"]

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -5697,6 +5697,15 @@ pub type QUIC_CONNECTION_OPEN_FN = ::std::option::Option<
         Connection: *mut HQUIC,
     ) -> ::std::os::raw::c_uint,
 >;
+pub type QUIC_CONNECTION_OPEN_EX1_FN = ::std::option::Option<
+    unsafe extern "C" fn(
+        Registration: HQUIC,
+        PartitionIndex: u16,
+        Handler: QUIC_CONNECTION_CALLBACK_HANDLER,
+        Context: *mut ::std::os::raw::c_void,
+        Connection: *mut HQUIC,
+    ) -> ::std::os::raw::c_uint,
+>;
 pub type QUIC_CONNECTION_CLOSE_FN = ::std::option::Option<unsafe extern "C" fn(Connection: HQUIC)>;
 pub type QUIC_CONNECTION_SHUTDOWN_FN = ::std::option::Option<
     unsafe extern "C" fn(
@@ -6367,12 +6376,13 @@ pub struct QUIC_API_TABLE {
     pub DatagramSend: QUIC_DATAGRAM_SEND_FN,
     pub ConnectionResumptionTicketValidationComplete: QUIC_CONNECTION_COMP_RESUMPTION_FN,
     pub ConnectionCertificateValidationComplete: QUIC_CONNECTION_COMP_CERT_FN,
+    pub ConnectionOpenEx1: QUIC_CONNECTION_OPEN_EX1_FN,
     pub StreamProvideReceiveBuffers: QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN,
     pub ConnectionPoolCreate: QUIC_CONN_POOL_CREATE_FN,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_API_TABLE"][::std::mem::size_of::<QUIC_API_TABLE>() - 264usize];
+    ["Size of QUIC_API_TABLE"][::std::mem::size_of::<QUIC_API_TABLE>() - 272usize];
     ["Alignment of QUIC_API_TABLE"][::std::mem::align_of::<QUIC_API_TABLE>() - 8usize];
     ["Offset of field: QUIC_API_TABLE::SetContext"]
         [::std::mem::offset_of!(QUIC_API_TABLE, SetContext) - 0usize];
@@ -6440,10 +6450,12 @@ const _: () = {
         QUIC_API_TABLE,
         ConnectionCertificateValidationComplete
     ) - 240usize];
+    ["Offset of field: QUIC_API_TABLE::ConnectionOpenEx1"]
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenEx1) - 248usize];
     ["Offset of field: QUIC_API_TABLE::StreamProvideReceiveBuffers"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 248usize];
+        [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 256usize];
     ["Offset of field: QUIC_API_TABLE::ConnectionPoolCreate"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionPoolCreate) - 256usize];
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionPoolCreate) - 264usize];
 };
 pub const QUIC_STATUS_SUCCESS: QUIC_STATUS = 0;
 pub const QUIC_STATUS_PENDING: QUIC_STATUS = 4294967294;

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -5726,7 +5726,7 @@ pub type QUIC_CONNECTION_OPEN_FN = ::std::option::Option<
         Connection: *mut HQUIC,
     ) -> HRESULT,
 >;
-pub type QUIC_CONNECTION_OPEN_EX1_FN = ::std::option::Option<
+pub type QUIC_CONNECTION_OPEN_IN_PARTITION_FN = ::std::option::Option<
     unsafe extern "C" fn(
         Registration: HQUIC,
         PartitionIndex: u16,
@@ -6397,7 +6397,7 @@ pub struct QUIC_API_TABLE {
     pub DatagramSend: QUIC_DATAGRAM_SEND_FN,
     pub ConnectionResumptionTicketValidationComplete: QUIC_CONNECTION_COMP_RESUMPTION_FN,
     pub ConnectionCertificateValidationComplete: QUIC_CONNECTION_COMP_CERT_FN,
-    pub ConnectionOpenEx1: QUIC_CONNECTION_OPEN_EX1_FN,
+    pub ConnectionOpenInPartition: QUIC_CONNECTION_OPEN_IN_PARTITION_FN,
     pub StreamProvideReceiveBuffers: QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN,
     pub ConnectionPoolCreate: QUIC_CONN_POOL_CREATE_FN,
 }
@@ -6471,8 +6471,8 @@ const _: () = {
         QUIC_API_TABLE,
         ConnectionCertificateValidationComplete
     ) - 240usize];
-    ["Offset of field: QUIC_API_TABLE::ConnectionOpenEx1"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenEx1) - 248usize];
+    ["Offset of field: QUIC_API_TABLE::ConnectionOpenInPartition"]
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenInPartition) - 248usize];
     ["Offset of field: QUIC_API_TABLE::StreamProvideReceiveBuffers"]
         [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 256usize];
     ["Offset of field: QUIC_API_TABLE::ConnectionPoolCreate"]

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -5726,6 +5726,15 @@ pub type QUIC_CONNECTION_OPEN_FN = ::std::option::Option<
         Connection: *mut HQUIC,
     ) -> HRESULT,
 >;
+pub type QUIC_CONNECTION_OPEN_EX1_FN = ::std::option::Option<
+    unsafe extern "C" fn(
+        Registration: HQUIC,
+        PartitionIndex: u16,
+        Handler: QUIC_CONNECTION_CALLBACK_HANDLER,
+        Context: *mut ::std::os::raw::c_void,
+        Connection: *mut HQUIC,
+    ) -> ::std::os::raw::c_uint,
+>;
 pub type QUIC_CONNECTION_CLOSE_FN = ::std::option::Option<unsafe extern "C" fn(Connection: HQUIC)>;
 pub type QUIC_CONNECTION_SHUTDOWN_FN = ::std::option::Option<
     unsafe extern "C" fn(
@@ -6388,6 +6397,7 @@ pub struct QUIC_API_TABLE {
     pub DatagramSend: QUIC_DATAGRAM_SEND_FN,
     pub ConnectionResumptionTicketValidationComplete: QUIC_CONNECTION_COMP_RESUMPTION_FN,
     pub ConnectionCertificateValidationComplete: QUIC_CONNECTION_COMP_CERT_FN,
+    pub ConnectionOpenEx1: QUIC_CONNECTION_OPEN_EX1_FN,
     pub StreamProvideReceiveBuffers: QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN,
     pub ConnectionPoolCreate: QUIC_CONN_POOL_CREATE_FN,
 }
@@ -6461,10 +6471,12 @@ const _: () = {
         QUIC_API_TABLE,
         ConnectionCertificateValidationComplete
     ) - 240usize];
+    ["Offset of field: QUIC_API_TABLE::ConnectionOpenEx1"]
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionOpenEx1) - 248usize];
     ["Offset of field: QUIC_API_TABLE::StreamProvideReceiveBuffers"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 248usize];
+        [::std::mem::offset_of!(QUIC_API_TABLE, StreamProvideReceiveBuffers) - 256usize];
     ["Offset of field: QUIC_API_TABLE::ConnectionPoolCreate"]
-        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionPoolCreate) - 256usize];
+        [::std::mem::offset_of!(QUIC_API_TABLE, ConnectionPoolCreate) - 264usize];
 };
 pub const QUIC_STATUS_SUCCESS: QUIC_STATUS = 0;
 pub const QUIC_STATUS_PENDING: QUIC_STATUS = 459749;

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -5733,7 +5733,7 @@ pub type QUIC_CONNECTION_OPEN_EX1_FN = ::std::option::Option<
         Handler: QUIC_CONNECTION_CALLBACK_HANDLER,
         Context: *mut ::std::os::raw::c_void,
         Connection: *mut HQUIC,
-    ) -> ::std::os::raw::c_uint,
+    ) -> HRESULT,
 >;
 pub type QUIC_CONNECTION_CLOSE_FN = ::std::option::Option<unsafe extern "C" fn(Connection: HQUIC)>;
 pub type QUIC_CONNECTION_SHUTDOWN_FN = ::std::option::Option<
@@ -6403,7 +6403,7 @@ pub struct QUIC_API_TABLE {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_API_TABLE"][::std::mem::size_of::<QUIC_API_TABLE>() - 264usize];
+    ["Size of QUIC_API_TABLE"][::std::mem::size_of::<QUIC_API_TABLE>() - 272usize];
     ["Alignment of QUIC_API_TABLE"][::std::mem::align_of::<QUIC_API_TABLE>() - 8usize];
     ["Offset of field: QUIC_API_TABLE::SetContext"]
         [::std::mem::offset_of!(QUIC_API_TABLE, SetContext) - 0usize];

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -700,7 +700,7 @@ void QuicTestValidateConnection()
         ConnectionScope Connection;
         TEST_QUIC_STATUS(
             QUIC_STATUS_INVALID_PARAMETER,
-            MsQuic->ConnectionOpenEx1(
+            MsQuic->ConnectionOpenInPartition(
                 Registration,
                 UINT16_MAX,
                 DummyConnectionCallback,

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -693,6 +693,22 @@ void QuicTestValidateConnection()
     }
 
     //
+    // Invalid partition index.
+    //
+    {
+        TestScopeLogger logScope("Invalid partition index");
+        ConnectionScope Connection;
+        TEST_QUIC_STATUS(
+            QUIC_STATUS_INVALID_PARAMETER,
+            MsQuic->ConnectionOpenEx1(
+                Registration,
+                UINT16_MAX,
+                DummyConnectionCallback,
+                nullptr,
+                &Connection.Handle));
+    }
+
+    //
     // Null connection parameter.
     //
     {


### PR DESCRIPTION
## Description

Adds the new API `ConnectionOpenInPartition` that adds a new parameter that allows the application to specify the partition index explicitly so we don't need to infer/guess based on the current processor it's running on.

## Testing

Updated, but the old function goes through the new one, so really it is completely covered already.

## Documentation

Updated/added.
