### PR TITLE
Disable Parallel Builds for Rust on Windows

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -41,6 +41,11 @@ fn cmake_build() {
         .define("QUIC_ENABLE_LOGGING", logging_enabled)
         .define("QUIC_OUTPUT_DIR", quic_output_dir.to_str().unwrap());
 
+    // Disable parallel builds on Windows, as they seems to break manifest builds.
+    if cfg!(windows) {
+        config.define("CMAKE_BUILD_PARALLEL_LEVEL", "1");
+    }
+
     // By default enable schannel on windows, unless openssl feature is selected.
     if cfg!(windows) && !cfg!(feature = "openssl") {
         config.define("QUIC_TLS", "schannel");


### PR DESCRIPTION
## Description

Should hopefully fix the following random build failure:
```
D:/a/msquic/msquic/target/debug/build/msquic-7d379929a28ccd7c/out/build/inc\MsQuicEtwTEMP.BIN : error : Failed to open file for write: 'D:/a/msquic/msquic/target/debug/build/msquic-7d379929a28ccd7c/out/build/inc\MsQuicEtwTEMP.BIN' [D:\a\msquic\msquic\target\debug\build\msquic-7d379929a28ccd7c\out\build\MsQuicEtw_HeaderBuild.vcxproj]
```

## Testing

CI/CD

## Documentation

N/A
