### PR TITLE
[DO NOT MERGE] Rename valid client test certificate

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -420,18 +420,18 @@ function Install-TestCertificates {
         Write-Debug "Found existing MsQuicTestExpiredServer certificate!"
     }
 
-    Write-Debug "Searching for MsQuicTestClient certificate..."
-    $ClientCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestClient"}
+    Write-Debug "Searching for MsQuicTestValidClient certificate..."
+    $ClientCert = Get-ChildItem -path Cert:\LocalMachine\My\* -Recurse | Where-Object {$_.Subject -eq "CN=MsQuicTestValidClient"}
     if (!$ClientCert) {
-        Write-Host "MsQuicTestClient not found! Creating new MsQuicTestClient certificate..."
-        $ClientCert = New-SelfSignedCertificate -Subject "CN=MsQuicTestClient" -FriendlyName MsQuicTestClient -KeyUsageProperty Sign -KeyUsage DigitalSignature -CertStoreLocation cert:\CurrentUser\My -HashAlgorithm SHA256 -Provider "Microsoft Software Key Storage Provider" -KeyExportPolicy Exportable -KeyAlgorithm ECDSA_nistP256 -CurveExport CurveName -NotAfter(Get-Date).AddYears(5) -TextExtension @("2.5.29.19 = {text}","2.5.29.37 = {text}1.3.6.1.5.5.7.3.2") -Signer $RootCert
-        $TempClientPath = Join-Path $Env:TEMP "MsQuicTestClientCert.pfx"
+        Write-Host "MsQuicTestValidClient not found! Creating new MsQuicTestValidClient certificate..."
+        $ClientCert = New-SelfSignedCertificate -Subject "CN=MsQuicTestValidClient" -FriendlyName MsQuicTestValidClient -KeyUsageProperty Sign -KeyUsage DigitalSignature -CertStoreLocation cert:\CurrentUser\My -HashAlgorithm SHA256 -Provider "Microsoft Software Key Storage Provider" -KeyExportPolicy Exportable -KeyAlgorithm ECDSA_nistP256 -CurveExport CurveName -NotAfter(Get-Date).AddYears(5) -TextExtension @("2.5.29.19 = {text}","2.5.29.37 = {text}1.3.6.1.5.5.7.3.2") -Signer $RootCert
+        $TempClientPath = Join-Path $Env:TEMP "MsQuicTestValidClientCert.pfx"
         Export-PfxCertificate -Cert $ClientCert -Password $PfxPassword -FilePath $TempClientPath
         Import-PfxCertificate -FilePath $TempClientPath -Password $PfxPassword -Exportable -CertStoreLocation Cert:\LocalMachine\My
         Remove-Item $TempClientPath
-        Write-Host "New MsQuicTestClient certificate installed!"
+        Write-Host "New MsQuicTestValidClient certificate installed!"
     } else {
-        Write-Debug "Found existing MsQuicTestClient certificate!"
+        Write-Debug "Found existing MsQuicTestValidClient certificate!"
     }
 
     Write-Debug "Searching for MsQuicTestExpiredClient certificate..."

--- a/src/platform/selfsign_capi.c
+++ b/src/platform/selfsign_capi.c
@@ -30,11 +30,11 @@ Abstract:
 #define CXPLAT_KEY_SIZE                                 2048
 
 #define CXPLAT_TEST_CERT_VALID_SERVER_FRIENDLY_NAME         L"MsQuicTestServer"
-#define CXPLAT_TEST_CERT_VALID_CLIENT_FRIENDLY_NAME         L"MsQuicTestClient"
+#define CXPLAT_TEST_CERT_VALID_CLIENT_FRIENDLY_NAME         L"MsQuicTestValidClient"
 #define CXPLAT_TEST_CERT_EXPIRED_SERVER_FRIENDLY_NAME       L"MsQuicTestExpiredServer"
 #define CXPLAT_TEST_CERT_EXPIRED_CLIENT_FRIENDLY_NAME       L"MsQuicTestExpiredClient"
 #define CXPLAT_TEST_CERT_VALID_SERVER_SUBJECT_NAME          "MsQuicTestServer"
-#define CXPLAT_TEST_CERT_VALID_CLIENT_SUBJECT_NAME          "MsQuicTestClient"
+#define CXPLAT_TEST_CERT_VALID_CLIENT_SUBJECT_NAME          "MsQuicTestValidClient"
 #define CXPLAT_TEST_CERT_EXPIRED_SERVER_SUBJECT_NAME        "MsQuicTestExpiredServer"
 #define CXPLAT_TEST_CERT_EXPIRED_CLIENT_SUBJECT_NAME        "MsQuicTestExpiredClient"
 #define CXPLAT_TEST_CERT_SELF_SIGNED_CLIENT_SUBJECT_NAME    "MsQuicClient"


### PR DESCRIPTION
## Description

Try renaming the SubjectName and FriendlyName of the valid client test certificate to see if that results in more stable tests.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
