### PR TITLE
[DO NOT MERGE] Use Out-of-proc Schannel validation API

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2325,7 +2325,7 @@ CxPlatTlsWriteDataToSchannel(
                 SecStatus =
                     QueryContextAttributesW(
                         &TlsContext->SchannelContext,
-                        SECPKG_ATTR_CERT_CHECK_RESULT_INPROC,
+                        SECPKG_ATTR_CERT_CHECK_RESULT,
                         &CertValidationResult);
                 if (SecStatus == SEC_E_NO_CREDENTIALS) {
                     CertValidationResult.hrVerifyChainStatus = SecStatus;


### PR DESCRIPTION
## Description

Try switching to the out of proc Schannel validation API to see if the validation fails in the same way.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
