### PR TITLE
Try An Environmental Variable to Disable Rust Parallel Builds on Windows

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -43,7 +43,7 @@ fn cmake_build() {
 
     // Disable parallel builds on Windows, as they seems to break manifest builds.
     if cfg!(windows) {
-        config.define("CMAKE_BUILD_PARALLEL_LEVEL", "1");
+        env::set_var("CMAKE_BUILD_PARALLEL_LEVEL", "1");
     }
 
     // By default enable schannel on windows, unless openssl feature is selected.


### PR DESCRIPTION
## Description

Another attempt at fixing the parallel build failure with Rust.

## Testing

CI/CD

## Documentation

N/A
