### PR TITLE
Document the lifetime of the QUIC_BUFFER array in receive events

### DIFF
--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -112,6 +112,9 @@ The app has the option of either processing the received data in the callback (s
 
 If the app wants to queue the data to a separate thread, the app must return `QUIC_STATUS_PENDING` from the receive callback. This informs MsQuic that the app still has an outstanding reference on the buffers, and it will not modify or free them. Once the app is done with the buffers it must call [StreamReceiveComplete](api/StreamReceiveComplete.md).
 
+The lifetime of the `QUIC_BUFFER`s themselves is limited to the scope of the callback: when handling the received data
+asynchronously, the `QUIC_BUFFER`s must be copied.
+
 ### Partial Data Acceptance
 
 Whenever the app gets the `QUIC_STREAM_EVENT_RECEIVE` event, it can partially accept/consume the received data.

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -126,7 +126,7 @@ Upon successful handling of this event, the event handler should return one of `
 An array of `QUIC_BUFFER`s containing received data.
 
 The lifetime of the `Buffers` array itself is limited to the scope of the callback: if the received
-data is handled asynchronously (`QUIC_STATUS_PENDING`), the `QUIC_BUFFER` array should be copied.
+data is handled asynchronously (`QUIC_STATUS_PENDING`), the `QUIC_BUFFER` array must be copied.
 
 `BufferCount`
 

--- a/docs/api/QUIC_STREAM_EVENT.md
+++ b/docs/api/QUIC_STREAM_EVENT.md
@@ -125,6 +125,9 @@ Upon successful handling of this event, the event handler should return one of `
 
 An array of `QUIC_BUFFER`s containing received data.
 
+The lifetime of the `Buffers` array itself is limited to the scope of the callback: if the received
+data is handled asynchronously (`QUIC_STATUS_PENDING`), the `QUIC_BUFFER` array should be copied.
+
 `BufferCount`
 
 Count of `QUIC_BUFFER`s in this payload.


### PR DESCRIPTION
## Description

Document the lifetime of the QUIC_BUFFER array in receive events.
It is otherwise easy to assume the pointer to the provided to the callback is alive until the receive is completed.

## Testing

N/A

## Documentation

N/A
