### PR TITLE
Fix secnetperf calling some cxplat functions twice

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -51,7 +51,7 @@ QUIC_TRACE_RUNDOWN_CALLBACK* QuicTraceRundownCallback;
 
 static const char TpLibName[] = "libmsquic.lttng.so." LIBRARY_VERSION;
 
-uint8_t SystemLoaded;
+uint8_t CxPlatSystemLoaded;
 uint8_t CxPlatInitialized;
 
 uint32_t CxPlatProcessorCount;
@@ -106,11 +106,11 @@ CxPlatSystemLoad(
     // once. Let's guard against that. The caller is responsible for ensuring
     // it's not called concurrently.
     //
-    if (SystemLoaded) {
+    if (CxPlatSystemLoaded) {
         return;
     }
 
-    SystemLoaded = TRUE;
+    CxPlatSystemLoaded = TRUE;
 
 #if defined(CX_PLATFORM_DARWIN)
     //
@@ -224,7 +224,7 @@ CxPlatSystemUnload(
     void
     )
 {
-    if (!SystemLoaded) {
+    if (!CxPlatSystemLoaded) {
         return;
     }
 
@@ -235,6 +235,8 @@ CxPlatSystemUnload(
     QuicTraceLogInfo(
         PosixUnloaded,
         "[ dso] Unloaded");
+    
+    CxPlatSystemLoaded = FALSE;
 }
 
 uint64_t CGroupGetMemoryLimit();
@@ -294,6 +296,7 @@ CxPlatUninitialize(
     QuicTraceLogInfo(
         PosixUninitialized,
         "[ dso] Uninitialized");
+    CxPlatInitialized = FALSE;
 }
 
 void*

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -235,7 +235,6 @@ CxPlatSystemUnload(
     QuicTraceLogInfo(
         PosixUnloaded,
         "[ dso] Unloaded");
-    
     CxPlatSystemLoaded = FALSE;
 }
 
@@ -248,6 +247,9 @@ CxPlatInitialize(
 {
     QUIC_STATUS Status;
 
+    //
+    // The caller is responsible for ensuring this is not called concurrently.
+    //
     if (CxPlatInitialized) {
         return QUIC_STATUS_SUCCESS;
     }

--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -44,6 +44,11 @@ CxPlatSystemLoad(
     void
     )
 {
+    //
+    // There are a few cases where we might call CxPlatSystemLoad more than
+    // once. Let's guard against that. The caller is responsible for ensuring
+    // it's not called concurrently.
+    //
     if (CxPlatSystemLoaded) {
         return;
     }
@@ -259,6 +264,9 @@ CxPlatInitialize(
     BOOLEAN CryptoInitialized = FALSE;
     BOOLEAN ProcInfoInitialized = FALSE;
 
+    //
+    // The caller is responsible for ensuring this is not called concurrently.
+    //
     if (CxPlatInitialized) {
         return QUIC_STATUS_SUCCESS;
     }


### PR DESCRIPTION
## Description

In secnetperf, we call CxPlatSystemLoad and CxPlatInitialize before calling into msquic open. When statically linking to msquic, CxPlatSystemLoad and CxPlatInitialize access the set of global variables in memory. This leads to double free.

Add a safety guard to prevent it from happening.

## Testing

CI
