### PR TITLE
Lockless Synchronization of MsQuic Library Load/Unload

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -40,7 +40,7 @@ MsQuicLibraryLoad(
     )
 {
     //
-    // Use interlocked operations synchronizes loading and unloading across
+    // Use interlocked operations to synchronize loading and unloading across
     // multiple threads.
     //
     long LoadRefCount = MsQuicLib.LoadRefCount;
@@ -111,7 +111,7 @@ MsQuicLibraryUnload(
     CXPLAT_FRE_ASSERT(MsQuicLib.Loaded);
 
     //
-    // Use interlocked operations synchronizes loading and unloading across
+    // Use interlocked operations to synchronize loading and unloading across
     // multiple threads.
     //
     long LoadRefCount = MsQuicLib.LoadRefCount;

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -58,7 +58,7 @@ MsQuicLibraryLoad(
                     LoadRefCount + 1, // Try to increment the count.
                     LoadRefCount);
             if (PrevLoadRefCount == LoadRefCount) {
-                return; // Succesfully incremented the count.
+                return; // Successfully incremented the count.
             }
             LoadRefCount = PrevLoadRefCount;
             continue;
@@ -130,7 +130,7 @@ MsQuicLibraryUnload(
                     LoadRefCount - 1, // Try to decrement the count.
                     LoadRefCount);
             if (PrevLoadRefCount == LoadRefCount) {
-                return; // Succesfully decremented the count.
+                return; // Successfully decremented the count.
             }
             LoadRefCount = PrevLoadRefCount;
             continue;
@@ -158,6 +158,7 @@ MsQuicLibraryUnload(
             0, // Clear 'loading' bit.
             0x80000000);
         return;
+
     } while (TRUE);
 }
 

--- a/src/core/library.h
+++ b/src/core/library.h
@@ -104,10 +104,17 @@ typedef struct QUIC_LIBRARY {
     //
     CXPLAT_DISPATCH_LOCK DatapathLock;
 
+    #if DEBUG
+        //
+        // Number of connections current allocated.
+        //
+        long ConnectionCount;
+    #endif
+
     //
     // Total outstanding references from calls to MsQuicLoadLibrary.
     //
-    volatile short LoadRefCount;
+    volatile long LoadRefCount;
 
     //
     // Total outstanding references from calls to MsQuicOpenVersion.
@@ -124,13 +131,6 @@ typedef struct QUIC_LIBRARY {
     // Mask for the worker index in the connection's partition ID.
     //
     uint16_t PartitionMask;
-
-#if DEBUG
-    //
-    // Number of connections current allocated.
-    //
-    long ConnectionCount;
-#endif
 
     //
     // Estimated timer resolution for the platform.


### PR DESCRIPTION
## Description

A recent change exposed a sychronization problem for calls into MsQuic library load and unload, since they didn't use a lock.

This PR leverages interlocked compare and exchange calls to synchronize this code.

## Testing

Ran spinquic locally. CI/CD

## Documentation

N/A
