### PR TITLE
Hotfix: add support for building on ubuntu 20.04

### DIFF
--- a/.github/workflows/build-reuse-unix.yml
+++ b/.github/workflows/build-reuse-unix.yml
@@ -87,7 +87,7 @@ permissions: read-all
 jobs:
   build-unix-reuse:
     name: Build
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.os == 'ubuntu-20.04' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=ubuntu-20.04'']') || inputs.os }}
     container:
       image: ${{ (inputs.plat == 'linux' && format('ghcr.io/microsoft/msquic/linux-build-xcomp:{0}-cross', inputs.os)) || '' }}
     steps:


### PR DESCRIPTION
## Description

https://github.com/actions/runner-images/issues/11101 broke ubuntu 20.04 builds.
Let's add this patch to fix netperf, while transitioning towards ubuntu 22.04.

## Testing

CI 

## Documentation

N/A