### PR TITLE
disable stub log event check

### DIFF
--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -15,6 +15,7 @@ on:
     - scripts/xdp.json
     - src/bin/**
     - src/core/**
+    - src/inc/**
     - src/platform/**
     - src/perf/**
     - submodules/openssl/**

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -180,12 +180,7 @@ clog_stdout(struct clog_param * head, const char * format, ...)
 #endif
 
 #if defined(QUIC_EVENTS_STDOUT) || defined(QUIC_LOGS_STUB)
-
-#if defined(QUIC_EVENTS_STDOUT)
-#define QuicTraceEventEnabled(Name) TRUE
-#else
 #define QuicTraceEventEnabled(Name) FALSE
-#endif
 
 #define QuicTrace(Name, Fmt, ...)                                              \
     clog((Fmt " [" #Name ":%s:%d]\n"), ##__VA_ARGS__, __FILE__, __LINE__)

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -180,7 +180,12 @@ clog_stdout(struct clog_param * head, const char * format, ...)
 #endif
 
 #if defined(QUIC_EVENTS_STDOUT) || defined(QUIC_LOGS_STUB)
+
+#if defined(QUIC_EVENTS_STDOUT)
 #define QuicTraceEventEnabled(Name) TRUE
+#else
+#define QuicTraceEventEnabled(Name) FALSE
+#endif
 
 #define QuicTrace(Name, Fmt, ...)                                              \
     clog((Fmt " [" #Name ":%s:%d]\n"), ##__VA_ARGS__, __FILE__, __LINE__)


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Linux perf shows QuicConnLogOutFlowStats is a hot spot on Linux, which is because a slow logging path is unconditionally enabled with the "stub" logger. Instead, treat the logs as always disabled when optimizing hot paths.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.