### PR TITLE
Missing QUIC_SUCCEEDED in secnetperf main

### DIFF
--- a/src/perf/bin/appmain.cpp
+++ b/src/perf/bin/appmain.cpp
@@ -299,7 +299,7 @@ main(
     //
     MsQuicApi MsQuic;
     
-    CXPLAT_FRE_ASSERT(MsQuic.GetInitStatus());
+    CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(MsQuic.GetInitStatus()));
 #else
     CxPlatSystemLoad();
     CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(CxPlatInitialize()));


### PR DESCRIPTION
## Description

#5004 has a bug where QUIC_SUCCEEDED is missing in `CXPLAT_FRE_ASSERT(MsQuic.GetInitStatus())`. I probably forgot to run it locally on the last iteration.

## Testing

Ran locally.
