### PR TITLE
Fix a memory corruption in secnetperf

### DIFF
--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -459,6 +459,7 @@ void
 PerfClientWorker::OnConnectionComplete() {
     InterlockedIncrement64((int64_t*)&ConnectionsCompleted);
     InterlockedDecrement64((int64_t*)&ConnectionsActive);
+
     if (Client->RepeatConnections) {
         QueueNewConnection();
     } else {
@@ -613,9 +614,9 @@ void
 PerfClientConnection::OnHandshakeComplete() {
     InterlockedIncrement64((int64_t*)&Worker.ConnectionsConnected);
     if (!Client.StreamCount) {
-        Shutdown();
         WorkerConnComplete = true;
         Worker.OnConnectionComplete();
+        Shutdown();
     } else {
         for (uint32_t i = 0; i < Client.StreamCount; ++i) {
             StartNewStream();

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -459,7 +459,6 @@ void
 PerfClientWorker::OnConnectionComplete() {
     InterlockedIncrement64((int64_t*)&ConnectionsCompleted);
     InterlockedDecrement64((int64_t*)&ConnectionsActive);
-
     if (Client->RepeatConnections) {
         QueueNewConnection();
     } else {


### PR DESCRIPTION
## Description

For TCP, in `PerfClientConnection::OnHandshakeComplete`, we free up the `PerfClientConnection` object inline in the shutdown call. Immediately after that, we still try to access fields on this `PerfClientConnection` object to queue a new connection. This is writing to already freed memory. It also leads to queuing 2 connections on each handshake completion (once in `PerfClientConnection::OnShutdownComplete` and once in `PerfClientConnection::OnHandshakeComplete`).

## Testing

Locally ran secnetperf with ASAN.
