### PR TITLE
Refactor TCP Security Config for Reuse on Client Connections

### DIFF
--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -227,6 +227,11 @@ PerfClient::Init(
                 PerfClientConnection::TcpReceiveCallback,
                 PerfClientConnection::TcpSendCompleteCallback,
                 TcpDefaultExecutionProfile)); // Client defaults to using LowLatency profile
+        auto CredConfig = MsQuicCredentialConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION);
+        if (!TcpSecurityConfig.Load(&CredConfig)) {
+            WriteOutput("Failed to load TCP SecConfig!\n");
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
     } else {
         if (UseSendBuffering || !UsePacing || UseQtip) { // Update settings if non-default
             MsQuicSettings Settings;
@@ -479,9 +484,8 @@ PerfClientConnection::~PerfClientConnection() {
 void
 PerfClientConnection::Initialize() {
     if (Client.UseTCP) {
-        auto CredConfig = MsQuicCredentialConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION);
         TcpConn = // TODO: replace new/delete with pool alloc/free
-            new (std::nothrow) TcpConnection(Client.Engine.get(), &CredConfig, this);
+            new (std::nothrow) TcpConnection(Client.Engine.get(), &Client.TcpSecurityConfig, this);
         if (!TcpConn->IsInitialized()) {
             Worker.ConnectionPool.Free(this);
             return;

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -227,11 +227,6 @@ PerfClient::Init(
                 PerfClientConnection::TcpReceiveCallback,
                 PerfClientConnection::TcpSendCompleteCallback,
                 TcpDefaultExecutionProfile)); // Client defaults to using LowLatency profile
-        auto CredConfig = MsQuicCredentialConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION);
-        if (!TcpSecurityConfig.Load(&CredConfig)) {
-            WriteOutput("Failed to load TCP SecConfig!\n");
-            return QUIC_STATUS_OUT_OF_MEMORY;
-        }
     } else {
         if (UseSendBuffering || !UsePacing || UseQtip) { // Update settings if non-default
             MsQuicSettings Settings;
@@ -485,7 +480,7 @@ void
 PerfClientConnection::Initialize() {
     if (Client.UseTCP) {
         TcpConn = // TODO: replace new/delete with pool alloc/free
-            new (std::nothrow) TcpConnection(Client.Engine.get(), &Client.TcpSecurityConfig, this);
+            new (std::nothrow) TcpConnection(Client.Engine.get(), &Client.TcpConfig, this);
         if (!TcpConn->IsInitialized()) {
             Worker.ConnectionPool.Free(this);
             return;

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -152,7 +152,10 @@ struct PerfClient {
     PerfClientWorker Workers[PERF_MAX_THREAD_COUNT];
 
     UniquePtr<TcpEngine> Engine;
-    TcpSecConfig TcpSecurityConfig {};
+    MsQuicCredentialConfig CredentialConfig {
+        QUIC_CREDENTIAL_FLAG_CLIENT |
+        QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION};
+    TcpConfiguration TcpConfig {&CredentialConfig};
     MsQuicRegistration Registration {
         "perf-client",
         PerfDefaultExecutionProfile,
@@ -167,9 +170,7 @@ struct PerfClient {
             .SetCongestionControlAlgorithm(PerfDefaultCongestionControl)
             .SetEcnEnabled(PerfDefaultEcnEnabled)
             .SetEncryptionOffloadAllowed(PerfDefaultQeoAllowed),
-        MsQuicCredentialConfig(
-            QUIC_CREDENTIAL_FLAG_CLIENT |
-            QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION)};
+        CredentialConfig};
     // Target parameters
     UniquePtr<char[]> Target;
     QUIC_ADDRESS_FAMILY TargetFamily {QUIC_ADDRESS_FAMILY_UNSPEC};

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -152,7 +152,7 @@ struct PerfClient {
     PerfClientWorker Workers[PERF_MAX_THREAD_COUNT];
 
     UniquePtr<TcpEngine> Engine;
-    TcpSecConfig TcpSecurityConfig;
+    TcpSecConfig TcpSecurityConfig {};
     MsQuicRegistration Registration {
         "perf-client",
         PerfDefaultExecutionProfile,

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -152,6 +152,7 @@ struct PerfClient {
     PerfClientWorker Workers[PERF_MAX_THREAD_COUNT];
 
     UniquePtr<TcpEngine> Engine;
+    TcpSecConfig TcpSecurityConfig;
     MsQuicRegistration Registration {
         "perf-client",
         PerfDefaultExecutionProfile,

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -58,7 +58,8 @@ class PerfServer {
 public:
     PerfServer(const QUIC_CREDENTIAL_CONFIG* CredConfig) :
         Engine(TcpAcceptCallback, TcpConnectCallback, TcpReceiveCallback, TcpSendCompleteCallback, TcpDefaultExecutionProfile),
-        Server(&Engine, CredConfig, this) {
+        TcpSecurityConfig(CredConfig),
+        Server(&Engine, &TcpSecurityConfig, this) {
         CxPlatZeroMemory(&LocalAddr, sizeof(LocalAddr));
         QuicAddrSetFamily(&LocalAddr, QUIC_ADDRESS_FAMILY_UNSPEC);
         QuicAddrSetPort(&LocalAddr, PERF_DEFAULT_PORT);
@@ -189,6 +190,7 @@ private:
     uint8_t PrintStats {FALSE};
 
     TcpEngine Engine;
+    TcpSecConfig TcpSecurityConfig;
     TcpServer Server;
 
     uint32_t DelayMicroseconds {0};

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -58,8 +58,8 @@ class PerfServer {
 public:
     PerfServer(const QUIC_CREDENTIAL_CONFIG* CredConfig) :
         Engine(TcpAcceptCallback, TcpConnectCallback, TcpReceiveCallback, TcpSendCompleteCallback, TcpDefaultExecutionProfile),
-        TcpSecurityConfig(CredConfig),
-        Server(&Engine, &TcpSecurityConfig, this) {
+        TcpConfig(CredConfig),
+        Server(&Engine, &TcpConfig, this) {
         CxPlatZeroMemory(&LocalAddr, sizeof(LocalAddr));
         QuicAddrSetFamily(&LocalAddr, QUIC_ADDRESS_FAMILY_UNSPEC);
         QuicAddrSetPort(&LocalAddr, PERF_DEFAULT_PORT);
@@ -190,7 +190,7 @@ private:
     uint8_t PrintStats {FALSE};
 
     TcpEngine Engine;
-    TcpConfiguration TcpSecurityConfig;
+    TcpConfiguration TcpConfig;
     TcpServer Server;
 
     uint32_t DelayMicroseconds {0};

--- a/src/perf/lib/PerfServer.h
+++ b/src/perf/lib/PerfServer.h
@@ -190,7 +190,7 @@ private:
     uint8_t PrintStats {FALSE};
 
     TcpEngine Engine;
-    TcpSecConfig TcpSecurityConfig;
+    TcpConfiguration TcpSecurityConfig;
     TcpServer Server;
 
     uint32_t DelayMicroseconds {0};

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -381,7 +381,7 @@ TcpServer::AcceptCallback(
 
 TcpConnection::TcpConnection(
     TcpEngine* Engine,
-    TcpConfiguration* Config,
+    const TcpConfiguration* Config,
     void* Context) :
     IsServer(false), Engine(Engine), SecConfig(Config->SecConfig), Context(Context)
 {

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -751,7 +751,7 @@ bool TcpConnection::ProcessTls(const uint8_t* Buffer, uint32_t BufferLength)
             &BufferLength,
             &TlsState);
     if (Results & CXPLAT_TLS_RESULT_ERROR) {
-        WriteOutput("CxPlatTlsProcessData FAILED\n");
+        //WriteOutput("CxPlatTlsProcessData FAILED, Alert=0x%hx\n", TlsState.AlertCode);
         return false;
     }
 

--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -85,6 +85,8 @@ bool TcpSecConfig::Load(const QUIC_CREDENTIAL_CONFIG* CredConfig) noexcept
     return SecConfig != nullptr;
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Function_class_(CXPLAT_SEC_CONFIG_CREATE_COMPLETE)
 void TcpSecConfig::SecConfigCallback(
     _In_ const QUIC_CREDENTIAL_CONFIG* /* CredConfig */,
     _In_opt_ void* Context,

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -135,7 +135,7 @@ class TcpWorker {
     );
 };
 
-class TcpSecConfig {
+class TcpConfiguration {
     CXPLAT_EVENT CallbackEvent;
     static
     _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -150,10 +150,8 @@ class TcpSecConfig {
         );
 public:
     CXPLAT_SEC_CONFIG* SecConfig{nullptr};
-    TcpSecConfig() noexcept;
-    TcpSecConfig(const QUIC_CREDENTIAL_CONFIG* CredConfig) noexcept;
-    ~TcpSecConfig() noexcept;
-    bool Load(const QUIC_CREDENTIAL_CONFIG* CredConfig) noexcept;
+    TcpConfiguration(const QUIC_CREDENTIAL_CONFIG* CredConfig) noexcept;
+    ~TcpConfiguration() noexcept;
 };
 
 class TcpServer {
@@ -174,7 +172,7 @@ class TcpServer {
         );
 public:
     void* Context; // App context
-    TcpServer(TcpEngine* Engine, TcpSecConfig* SecConfig, void* Context = nullptr);
+    TcpServer(TcpEngine* Engine, TcpConfiguration* Config, void* Context = nullptr);
     ~TcpServer();
     bool IsInitialized() const { return Initialized; }
     bool Start(const QUIC_ADDR* LocalAddress);
@@ -284,7 +282,7 @@ public:
     void* Context{nullptr}; // App context
     TcpConnection(
         _In_ TcpEngine* Engine,
-        _In_ TcpSecConfig* SecConfig,
+        _In_ TcpConfiguration* Config,
         _In_ void* Context = nullptr);
     bool IsInitialized() const { return Initialized; }
     void Close();

--- a/src/perf/lib/Tcp.h
+++ b/src/perf/lib/Tcp.h
@@ -282,7 +282,7 @@ public:
     void* Context{nullptr}; // App context
     TcpConnection(
         _In_ TcpEngine* Engine,
-        _In_ TcpConfiguration* Config,
+        _In_ const TcpConfiguration* Config,
         _In_ void* Context = nullptr);
     bool IsInitialized() const { return Initialized; }
     void Close();

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1740,7 +1740,7 @@ CxPlatSocketHandleErrors(
             SocketContext->Binding,
             errno,
             "getsockopt(SO_ERROR) failed");
-    } else {
+    } else if (ErrNum != 0) {
         QuicTraceEvent(
             DatapathErrorStatus,
             "[data][%p] ERROR, %u, %s.",
@@ -1763,11 +1763,7 @@ CxPlatSocketHandleErrors(
                         &SocketContext->Binding->RemoteAddress);
                 }
             }
-        } else if (ErrNum == ENOTSOCK ||
-                   ErrNum == EINTR ||
-                   ErrNum == ECANCELED ||
-                   ErrNum == ECONNABORTED ||
-                   ErrNum == ECONNRESET) {
+        } else {
             if (!SocketContext->Binding->DisconnectIndicated) {
                 SocketContext->Binding->DisconnectIndicated = TRUE;
                 SocketContext->Binding->Datapath->TcpHandlers.Connect(


### PR DESCRIPTION
## Description

By reusing the security config for TCP, this should significiantly improve performance on the client side.

## Testing

CI/CD

## Documentation

N/A
