### PR TITLE
Prevent duplicate definitions of CXPLAT_DBG_ASSERT

### DIFF
--- a/src/fuzzing/fuzz.cc
+++ b/src/fuzzing/fuzz.cc
@@ -16,9 +16,9 @@ Abstract:
 #include <stdlib.h>
 #include <stdint.h>
 #include <string>
+#include "quic_platform.h"
 #include "msquic.h"
 #include "msquic.hpp"
-#include "quic_platform.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {


### PR DESCRIPTION
CXPLAT_DBG_ASSERT is failing compilation in the fuzzer here: https://github.com/google/oss-fuzz/actions/runs/14454075706/job/40663846040?pr=13222

Because both msquic.hpp and quic_platform.h define the macro, and only the former has ifndef guards around the definition.  This is not problematic in other inclusion sites because quic_platform.h is always included first.  This is not true in the case of fuzz.cc, which reverses the inclusion order.

Correct fuzz.cc to include files in the same order as other inclusion sites to avoid the duplicate definition issues

## Description
CXPLAT_DBG_ASSERT is failing compilation in the fuzzer here: https://github.com/google/oss-fuzz/actions/runs/14454075706/job/40663846040?pr=13222

## Testing

Building the fuzzer in oss-fuzz covers the needed testing for this issue

## Documentation

None
