### PR TITLE
Disable SIGPIPE signal on epoll TCP send 

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -2593,7 +2593,7 @@ CxPlatSendDataSendTcp(
                 SendData->SocketContext->SocketFd,
                 SendData->Buffer + SendData->TotalBytesSent,
                 SendData->TotalSize - SendData->TotalBytesSent,
-                0);
+                MSG_NOSIGNAL);
         if (BytesSent < 0) {
             return FALSE;
         }


### PR DESCRIPTION
## Description

Writing on a peer closed TCP socket triggers a SIGPIPE signal, which can cause the application to exit silently if not captured. Disable it by setting the MSG_NOSIGNAL flag in the `CxPlatSendDataSendTcp` function.

## Testing

CI. Locally ran secnetperf and I have not seen server exit silently with this change.

