### PR TITLE
Enable NuGet Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
+    <PackageVersion Include="Microsoft.Performance.SDK" Version="1.0.16" />
+    <PackageVersion Include="Microsoft.Performance.Toolkit.Engine" Version="1.0.16" />
+    <PackageVersion Include="Microsoft.Performance.Toolkit.Plugins.LTTngPlugin" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.4" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+</Project>

--- a/scripts/generatevpackpat/generatevpackpat.csproj
+++ b/scripts/generatevpackpat/generatevpackpat.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/cs/lib/msquic.csproj
+++ b/src/cs/lib/msquic.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/plugins/trace/dll/QuicTraceLib.csproj
+++ b/src/plugins/trace/dll/QuicTraceLib.csproj
@@ -16,10 +16,10 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
-    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.16" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Performance.Toolkit.Plugins.LTTngPlugin" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" />
+    <PackageReference Include="Microsoft.Performance.SDK" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Performance.Toolkit.Plugins.LTTngPlugin" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)..\..\LICENSE">

--- a/src/plugins/trace/exe/QuicTrace.csproj
+++ b/src/plugins/trace/exe/QuicTrace.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.16" />
-    <PackageReference Include="Microsoft.Performance.Toolkit.Engine" Version="1.0.16" />
+    <PackageReference Include="Microsoft.Performance.SDK" />
+    <PackageReference Include="Microsoft.Performance.Toolkit.Engine" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dll\QuicTraceLib.csproj" />


### PR DESCRIPTION
## Description

This pull request introduces the NuGet [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) feature to streamline dependency management. Key benefits and changes include:

- **Centralized Version Management**: All NuGet package versions are now managed centrally in the `Directory.Packages.props` file. This ensures consistency across all projects in the repository.
  
- **Simplified Project Files**: The individual project files are simplified, as they no longer need to specify version numbers for NuGet packages. This change reduces duplication and the potential for version conflicts.
  
- **Ease of Updating Dependencies**: Updating a package version is now a matter of changing it in one place, making the process of keeping dependencies up-to-date more straightforward and less error-prone.

By implementing Central Package Versioning, we're taking a significant step towards more efficient and reliable dependency management. This change will be particularly beneficial to assist with tools like Dependabot and Gardener. These tools automate dependency updates, and having a centralized versioning system significantly enhances their effectiveness, ensuring a smooth and consistent update process.

## Testing

CI/CD

## Documentation

N/A
