### PR TITLE
Sum Throughput Rates Across Streams/Connections

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -474,7 +474,7 @@ function Get-TestOutput {
         $Output -match "(\d+) HPS" | Out-Null
         return $matches[1]
     } else { # throughput
-        $Output -match "@ (\d+) kbps" | Out-Null
+        $Output -match "(\d+) kbps" | Out-Null
         return $matches[1]
     }
 }

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -370,7 +370,7 @@ PerfClient::Wait(
         return QUIC_STATUS_CONNECTION_REFUSED;
     }
 
-    unsigned long long CompletedConnections = GetConnectionsCompleted();
+    unsigned long long CompletedConnections = GetConnectedConnections();
     unsigned long long CompletedStreams = GetStreamsCompleted();
 
     if (PrintIoRate) {
@@ -383,11 +383,11 @@ PerfClient::Wait(
             WriteOutput("Result: %llu RPS\n", RPS);
         }
     } else if (PrintThroughput) {
-        auto UploadRate = GetUploadRate();
+        unsigned long long UploadRate = GetUploadRate();
         if (UploadRate) {
             WriteOutput("Result: Upload %llu kbps.\n", UploadRate);
         }
-        auto DownloadRate = GetDownloadRate();
+        unsigned long long DownloadRate = GetDownloadRate();
         if (DownloadRate) {
             WriteOutput("Result: Download %llu kbps.\n", DownloadRate);
         }

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -95,6 +95,8 @@ struct QUIC_CACHEALIGN PerfClientWorker {
     uint64_t ConnectionsCompleted {0};
     uint64_t StreamsStarted {0};
     uint64_t StreamsCompleted {0};
+    uint64_t UploadRate {0};
+    uint64_t DownloadRate {0};
     UniquePtr<char[]> Target;
     QuicAddr LocalAddr;
     QuicAddr RemoteAddr;
@@ -192,6 +194,7 @@ struct PerfClient {
     uint8_t UsePacing {TRUE};
     uint8_t UseSendBuffering {FALSE};
     uint8_t PrintThroughput {FALSE};
+    uint8_t PrintConnThroughput {FALSE};
     uint8_t PrintIoRate {FALSE};
     uint8_t PrintConnections {FALSE};
     uint8_t PrintStreams {FALSE};
@@ -257,6 +260,20 @@ struct PerfClient {
             StreamsCompleted += Workers[i].StreamsCompleted;
         }
         return StreamsCompleted;
+    }
+    uint64_t GetUploadRate() const {
+        uint64_t UploadRate = 0;
+        for (uint32_t i = 0; i < WorkerCount; ++i) {
+            UploadRate += Workers[i].UploadRate;
+        }
+        return UploadRate;
+    }
+    uint64_t GetDownloadRate() const {
+        uint64_t DownloadRate = 0;
+        for (uint32_t i = 0; i < WorkerCount; ++i) {
+            DownloadRate += Workers[i].DownloadRate;
+        }
+        return DownloadRate;
     }
 
     void OnConnectionsComplete() { // Called when a worker has completed its set of connections


### PR DESCRIPTION
## Description

Updates the output for throughput prints to sum the rates across all the streams/connections that were run. Makes it much easier to understand total throughput with multi-connection tests.

## Testing

Locally. CI/CD

## Documentation

N/A
