### PR TITLE
Shutdown Connections on QuicTestHandshakeSpecificLossPatterns Exit

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -4066,7 +4066,7 @@ QuicTestHandshakeSpecificLossPatterns(
     _In_ QUIC_CONGESTION_CONTROL_ALGORITHM CcAlgo
     )
 {
-    MsQuicRegistration Registration;
+    MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
     MsQuicSettings Settings;


### PR DESCRIPTION
## Description

Updates `QuicTestHandshakeSpecificLossPatterns` to have the registration shutdown/abort any leftover connections on test exit.

Related to #5024, but may not fix it.

## Testing

CI/CD

## Documentation

N/A
