### PR TITLE
Fix the QUIC_HANDSHAKE_INFO Test to Allow for Future Versions to Grow Size

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -4820,7 +4820,7 @@ void QuicTestTlsParam()
                     QUIC_PARAM_TLS_HANDSHAKE_INFO,
                     &Length,
                     nullptr));
-            TEST_EQUAL(Length, sizeof(QUIC_HANDSHAKE_INFO));
+            TEST_TRUE(Length >= sizeof(QUIC_HANDSHAKE_INFO));
 
             //
             // Before handshake


### PR DESCRIPTION
## Description

This will need to be backported to 2.3 and 2.4, to fix down level tests.

## Testing

CI/CD

## Documentation

N/A
