### PR TITLE
Rust: disable cmake-rs --parallel option on windows

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -43,7 +43,8 @@ fn cmake_build() {
 
     // Disable parallel builds on Windows, as they seems to break manifest builds.
     if cfg!(windows) {
-        env::set_var("CMAKE_BUILD_PARALLEL_LEVEL", "1");
+        // cmake-rs uses this cargo env var to pass "--parallel" arg to cmake
+        std::env::remove_var("NUM_JOBS");
     }
 
     // By default enable schannel on windows, unless openssl feature is selected.


### PR DESCRIPTION
## Description
windows "static" build for rust is flakey maybe due to the cmake --parallel option.
It is injected by cmake-rs:
https://github.com/rust-lang/cmake-rs/blob/fd56c5a6b4ecda8815c863eb5b12d7b3f0391197/src/lib.rs#L877
Removing the cargo env var NUM_JOBS prevents the injection.

## Testing
CI

## Documentation
NA
