### PR TITLE
Print connections and stream number for more useful throughput data

### DIFF
--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -392,7 +392,7 @@ PerfClient::Wait(
             WriteOutput("Result: Download %llu kbps.\n", DownloadRate);
         }
 
-    } else if (!PrintThroughput && !PrintLatency) {
+    } else if (!PrintConnThroughput && !PrintLatency) {
         if (CompletedConnections && CompletedStreams) {
             WriteOutput(
                 "Completed %llu connections and %llu streams!\n",


### PR DESCRIPTION
## Description

In #5023, PrintThroughput was changed and PrintConnThroughput was added. This add the number of connections and streams to the -ptput argument, which prints the sum of the throughputs.
## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

The documentation has to be updated. The -pctput argument is not documented.
