### PR TITLE
Avoid passing incompatible argument to ninja in build.ps1

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -545,7 +545,7 @@ function CMake-Build {
     }
     if ($IsWindows) {
         $Arguments += " --config " + $Config
-    } else {
+    } elseif (@("", "cmake") -contains $Generator) {
         $Arguments += " -- VERBOSE=1"
     }
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -545,7 +545,7 @@ function CMake-Build {
     }
     if ($IsWindows) {
         $Arguments += " --config " + $Config
-    } elseif (@("", "cmake") -contains $Generator) {
+    } elseif (@("", "Unix Makefiles") -contains $Generator) {
         $Arguments += " -- VERBOSE=1"
     }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The `VERBOSE=1` arg is nonstandard and not supported by Ninja build, so pass that param only to default or "cmake" generators.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Seems to work on my machine.

## Documentation

_Is there any documentation impact for this change?_

Nope.