### PR TITLE
Fix Recent BabelTrace Issues on Ubuntu

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -313,19 +313,17 @@ function Log-Stop {
         tar -cvzf $LTTNGTarFile -P $TempLTTngDir | Write-Debug
 
         if (!$RawLogOnly) {
-            Write-Debug "Decoding LTTng into BabelTrace format ($BableTraceFile)"
-            babeltrace --names all $TempLTTngDir/* > $BableTraceFile
-            Write-Host "Decoding into human-readable text: $ClogOutputDecodeFile"
-            $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile --showTimestamp --showCpuInfo"
-            Write-Host $Command
-
             try {
+                Write-Debug "Decoding LTTng into BabelTrace format ($BableTraceFile)"
+                babeltrace --names all $TempLTTngDir/* > $BableTraceFile
+                Write-Host "Decoding into human-readable text: $ClogOutputDecodeFile"
+                $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile --showTimestamp --showCpuInfo"
+                Write-Host $Command
                 Invoke-Expression $Command | Write-Debug
             } catch {
                 $err = $_
                 Write-Host "Failed to decode logs."
-                Write-Host "Babeltrace ran. Run `"prepare-machine.ps1 -InstallClog2Text`" and run the following command"
-                $Command
+                Write-Host "Run `"prepare-machine.ps1 -InstallClog2Text`" and try again"
                 Write-Host $err
             }
         }
@@ -358,19 +356,17 @@ function Log-Decode {
         Write-Host "Decompressing $Logfile into $DecompressedLogs"
         tar xvfz $Logfile -C $DecompressedLogs
 
-        Write-Host "Decoding LTTng into BabelTrace format ($BableTraceFile)"
-        babeltrace --names all $DecompressedLogs/* > $BableTraceFile
-        Write-Host "Decoding Babeltrace into human text using CLOG"
-        $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile"
-        Write-Host $Command
-
         try {
+            Write-Host "Decoding LTTng into BabelTrace format ($BableTraceFile)"
+            babeltrace --names all $DecompressedLogs/* > $BableTraceFile
+            Write-Host "Decoding Babeltrace into human text using CLOG"
+            $Command = "$Clog2Text_lttng -i $BableTraceFile -s $SideCar -o $ClogOutputDecodeFile"
+            Write-Host $Command
             Invoke-Expression $Command
         } catch {
             $err = $_
             Write-Host "Failed to decode logs."
-            Write-Host "Babeltrace ran. Run `"prepare-machine.ps1 -InstallClog2Text`" and run the following command"
-            $Command
+            Write-Host "Run `"prepare-machine.ps1 -InstallClog2Text`" and try again"
             Write-Host $err
         }
     }

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -532,6 +532,7 @@ if ($IsLinux) {
         sudo apt-get install -y cmake
         sudo apt-get install -y build-essential
         sudo apt-get install -y liblttng-ust-dev
+        sudo apt-get install -y babeltrace
         sudo apt-get install -y libssl-dev
         sudo apt-get install -y libnuma-dev
         if ($InstallArm64Toolchain) {


### PR DESCRIPTION
## Description

Recently, the babeltrace command has started failing. This updates the log script to be more resilent to failures as well as ensures the tool is installed.

## Testing

CI/CD

## Documentation

N/A
