### PR TITLE
Always use host silo for ETW registration

### DIFF
--- a/src/bin/winkernel/driver.c
+++ b/src/bin/winkernel/driver.c
@@ -95,6 +95,8 @@ Return Value:
     NTSTATUS Status;
     WDF_DRIVER_CONFIG Config;
     WDFDRIVER Driver;
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServerSilo());
+    CXPLAT_DBG_ASSERT(!QuicSiloIsServerSilo());
 
     //
     // We explicitly load the MsQuic library upfront (instead of letting it
@@ -143,6 +145,7 @@ Error:
         MsQuicLibraryUnload();
     }
 
+    QuicSiloDetatch(PrevSilo);
     return Status;
 }
 
@@ -168,10 +171,13 @@ Arguments:
 --*/
 {
     UNREFERENCED_PARAMETER(Driver);
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServerSilo());
+    CXPLAT_DBG_ASSERT(!QuicSiloIsServerSilo());
 
     PAGED_CODE();
 
     MsQuicDeregisterNmrProvider();
     MsQuicPcwCleanup();
     MsQuicLibraryUnload();
+    QuicSiloDetatch(PrevSilo);
 }

--- a/src/bin/winkernel/driver.c
+++ b/src/bin/winkernel/driver.c
@@ -95,7 +95,7 @@ Return Value:
     NTSTATUS Status;
     WDF_DRIVER_CONFIG Config;
     WDFDRIVER Driver;
-    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServerSilo());
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostSilo());
     CXPLAT_DBG_ASSERT(!QuicSiloIsServerSilo());
 
     //
@@ -171,7 +171,7 @@ Arguments:
 --*/
 {
     UNREFERENCED_PARAMETER(Driver);
-    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServerSilo());
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostSilo());
     CXPLAT_DBG_ASSERT(!QuicSiloIsServerSilo());
 
     PAGED_CODE();

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -116,7 +116,7 @@ MsQuicConfigurationOpen(
     //
 
 #ifdef QUIC_SILO
-    Configuration->Silo = QuicSiloGetCurrentServer();
+    Configuration->Silo = QuicSiloGetCurrentServerSilo();
     QuicSiloAddRef(Configuration->Silo);
     if (Configuration->Silo != NULL) {
         //

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -72,7 +72,7 @@ MsQuicListenerOpen(
     CxPlatEventInitialize(&Listener->StopEvent, TRUE, TRUE);
 
 #ifdef QUIC_SILO
-    Listener->Silo = QuicSiloGetCurrentServer();
+    Listener->Silo = QuicSiloGetCurrentServerSilo();
     QuicSiloAddRef(Listener->Silo);
 #endif
 

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -955,7 +955,7 @@ CxPlatRandom(
 #define QUIC_SILO PESILO
 #define QUIC_SILO_INVALID ((PESILO)(void*)(LONG_PTR)-1)
 
-#define QuicSiloGetHostServerSilo() PsGetHostSilo()
+#define QuicSiloGetHostSilo() PsGetHostSilo()
 #define QuicSiloIsServerSilo() PsIsCurrentThreadInServerSilo()
 #define QuicSiloGetCurrentServerSilo() PsGetCurrentServerSilo()
 #define QuicSiloAddRef(Silo) if (Silo != NULL) { ObReferenceObjectWithTag(Silo, QUIC_POOL_SILO); }

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -955,6 +955,8 @@ CxPlatRandom(
 #define QUIC_SILO PESILO
 #define QUIC_SILO_INVALID ((PESILO)(void*)(LONG_PTR)-1)
 
+#define QuicSiloGetHostServer() (PsGetHostSilo())
+#define QuicSiloIsServer() (PsIsCurrentThreadInServerSilo())
 #define QuicSiloGetCurrentServer() PsGetCurrentServerSilo()
 #define QuicSiloAddRef(Silo) if (Silo != NULL) { ObReferenceObjectWithTag(Silo, QUIC_POOL_SILO); }
 #define QuicSiloRelease(Silo) if (Silo != NULL) { ObDereferenceObjectWithTag(Silo, QUIC_POOL_SILO); }

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -955,9 +955,9 @@ CxPlatRandom(
 #define QUIC_SILO PESILO
 #define QUIC_SILO_INVALID ((PESILO)(void*)(LONG_PTR)-1)
 
-#define QuicSiloGetHostServer() (PsGetHostSilo())
-#define QuicSiloIsServer() (PsIsCurrentThreadInServerSilo())
-#define QuicSiloGetCurrentServer() PsGetCurrentServerSilo()
+#define QuicSiloGetHostServerSilo() PsGetHostSilo()
+#define QuicSiloIsServerSilo() PsIsCurrentThreadInServerSilo()
+#define QuicSiloGetCurrentServerSilo() PsGetCurrentServerSilo()
 #define QuicSiloAddRef(Silo) if (Silo != NULL) { ObReferenceObjectWithTag(Silo, QUIC_POOL_SILO); }
 #define QuicSiloRelease(Silo) if (Silo != NULL) { ObDereferenceObjectWithTag(Silo, QUIC_POOL_SILO); }
 #define QuicSiloAttach(Silo) PsAttachSiloToCurrentThread(Silo)

--- a/src/platform/platform_winkernel.c
+++ b/src/platform/platform_winkernel.c
@@ -72,7 +72,10 @@ CxPlatSystemLoad(
     PAGED_CODE();
 
 #ifdef QUIC_EVENTS_MANIFEST_ETW
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServer());
+    CXPLAT_DBG_ASSERT(!QuicSiloIsServer());
     EventRegisterMicrosoft_Quic();
+    QuicSiloDetatch(PrevSilo);
 #endif
 
     (VOID)KeQueryPerformanceCounter((LARGE_INTEGER*)&CxPlatPerfFreq);
@@ -102,7 +105,10 @@ CxPlatSystemUnload(
         "[ sys] Unloaded");
 
 #ifdef QUIC_EVENTS_MANIFEST_ETW
+    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServer());
+    CXPLAT_DBG_ASSERT(!QuicSiloIsServer());
     EventUnregisterMicrosoft_Quic();
+    QuicSiloDetatch(PrevSilo);
 #endif
 }
 

--- a/src/platform/platform_winkernel.c
+++ b/src/platform/platform_winkernel.c
@@ -72,10 +72,7 @@ CxPlatSystemLoad(
     PAGED_CODE();
 
 #ifdef QUIC_EVENTS_MANIFEST_ETW
-    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServer());
-    CXPLAT_DBG_ASSERT(!QuicSiloIsServer());
     EventRegisterMicrosoft_Quic();
-    QuicSiloDetatch(PrevSilo);
 #endif
 
     (VOID)KeQueryPerformanceCounter((LARGE_INTEGER*)&CxPlatPerfFreq);
@@ -105,10 +102,7 @@ CxPlatSystemUnload(
         "[ sys] Unloaded");
 
 #ifdef QUIC_EVENTS_MANIFEST_ETW
-    QUIC_SILO PrevSilo = QuicSiloAttach(QuicSiloGetHostServer());
-    CXPLAT_DBG_ASSERT(!QuicSiloIsServer());
     EventUnregisterMicrosoft_Quic();
-    QuicSiloDetatch(PrevSilo);
 #endif
 }
 


### PR DESCRIPTION
## Description

We don't support per-silo ETW tracing. So, always use the host silo for everything in DriverEntry and DriverUnload,

## Testing

Locally tested in a VM. CI.

