### PR TITLE
Remove Harden Runner

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -25,10 +25,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Cargo
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Prepare Machine
@@ -99,10 +95,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Cargo-Preinstall
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
-      with:
-        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Install Rust

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
-        with:
-          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/docker-publish-xcomp.yml
+++ b/.github/workflows/docker-publish-xcomp.yml
@@ -37,11 +37,6 @@ jobs:
       packages: write
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
-        with:
-          egress-policy: audit
-
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,10 +25,6 @@ jobs:
       packages: write
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
-        with:
-          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:


### PR DESCRIPTION
## Description

Remove the Harden Runner github action as it was not actually doing anything and we're not using it as intended.

Harden Runner has two modes: audit mode and enforcement mode. In audit mode, it prints out the domains that the runner resolves during execution, so you know which are the "known-good" domains to allow in enforcement mode. Then you put those domains in a list and switch over to enforcement mode. Now Harden Runner will block all DNS resolutions for domains that are not in the list.

We did have it in enforcement mode for a short time in the past, but then something changed and all runs started failing. Rather than fix the list to allow the new domain, it was reverted back to audit mode. We could switch it back to enforcement mode again, but that creates an on-going cost to keep the list updated, and also can cause some spurious failures when services change their DNS name.

But more importantly, because we download github artifacts in our runners, and anyone can create a github account and upload malicious packages there, Harden Runner doesn't buy us any protection as long as the github.com domain is in the allowed list.

## Testing

CI

## Documentation

N/A
