### PR TITLE
Revert Recent Large Retry

### DIFF
--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -263,7 +263,7 @@ TestConnection::ForceKeyUpdate()
                 0,
                 nullptr);
 
-    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 50);
+    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 20);
 
     return Status;
 }
@@ -291,7 +291,7 @@ TestConnection::ForceCidUpdate()
                 0,
                 nullptr);
 
-    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 50);
+    } while (Status == QUIC_STATUS_INVALID_STATE && ++Try <= 20);
 
     return Status;
 }


### PR DESCRIPTION
## Description

Revert recent retry increase because it's causing other test issues.

## Testing

Automation

## Documentation

N/A
