### PR TITLE
Add liburing to ubuntu 22.04 and 24.04 Docker images

### DIFF
--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     liblttng-ust-dev \
     libssl-dev \
     libnuma-dev \
+    liburing-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install fpm
@@ -103,4 +104,6 @@ RUN apt-get update \
     libssl-dev:armhf \
     libnuma-dev:arm64 \
     libnuma-dev:armhf \
+    liburing-dev:arm64 \
+    liburing-dev:armhf \
     && rm -rf /var/lib/apt/lists/*

--- a/.docker/ubuntu-24.04/Dockerfile
+++ b/.docker/ubuntu-24.04/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     liblttng-ust-dev \
     libssl-dev \
     libnuma-dev \
+    liburing-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install fpm
@@ -103,4 +104,6 @@ RUN apt-get update \
     libssl-dev:armhf \
     libnuma-dev:arm64 \
     libnuma-dev:armhf \
+    liburing-dev:arm64 \
+    liburing-dev:armhf \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

For the io_uring PR #5061, the build containers need liburing-dev.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI?

## Documentation

_Is there any documentation impact for this change?_

No.