### PR TITLE
Added RttVariance to connection statistics.

### DIFF
--- a/scripts/generate-dotnet.ps1
+++ b/scripts/generate-dotnet.ps1
@@ -48,6 +48,7 @@ $Arguments = @(
     "-e QUIC_STATISTICS_V2_SIZE_1" # Inconsistent definitions across platforms
     "-e QUIC_STATISTICS_V2_SIZE_2" # Inconsistent definitions across platforms
     "-e QUIC_STATISTICS_V2_SIZE_3" # Inconsistent definitions across platforms
+    "-e QUIC_STATISTICS_V2_SIZE_4" # Inconsistent definitions across platforms
 )
 
 $FullArgs = $Arguments -join " "

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6871,9 +6871,11 @@ QuicConnGetV2Statistics(
     if (STATISTICS_HAS_FIELD(*StatsLength, SendEcnCongestionCount)) {
         Stats->SendEcnCongestionCount = Connection->Stats.Send.EcnCongestionCount;
     }
-
     if (STATISTICS_HAS_FIELD(*StatsLength, HandshakeHopLimitTTL)) {
         Stats->HandshakeHopLimitTTL = Connection->Stats.Handshake.HandshakeHopLimitTTL;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, RttVariance)) {
+        Stats->RttVariance = (uint32_t)Path->RttVariance;
     }
 
     *StatsLength = CXPLAT_MIN(*StatsLength, sizeof(QUIC_STATISTICS_V2));

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -910,6 +910,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("uint8_t")]
         internal byte HandshakeHopLimitTTL;
+
+        [NativeTypeName("uint32_t")]
+        internal uint RttVariance;
     }
 
     internal partial struct QUIC_LISTENER_STATISTICS

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -590,10 +590,10 @@ typedef struct QUIC_STATISTICS_V2 {
 #define QUIC_STRUCT_SIZE_THRU_FIELD(Struct, Field) \
     (FIELD_OFFSET(Struct, Field) + sizeof(((Struct*)0)->Field))
 
-#define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)         // v2.0 final size
-#define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // v2.1 final size
-#define QUIC_STATISTICS_V2_SIZE_3   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendEcnCongestionCount) // v2.2 final size
-#define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // v2.5 final size
+#define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)         // MsQuic v2.0 final size
+#define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // MsQuic v2.1 final size
+#define QUIC_STATISTICS_V2_SIZE_3   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendEcnCongestionCount) // MsQuic v2.2 final size
+#define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // MsQuic v2.5 final size
 
 typedef struct QUIC_LISTENER_STATISTICS {
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -593,7 +593,7 @@ typedef struct QUIC_STATISTICS_V2 {
 #define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)         // v2.0 final size
 #define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // v2.1 final size
 #define QUIC_STATISTICS_V2_SIZE_3   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendEcnCongestionCount) // v2.2 final size
-#define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // v2.3 final size
+#define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // v2.5 final size
 
 typedef struct QUIC_LISTENER_STATISTICS {
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -581,6 +581,8 @@ typedef struct QUIC_STATISTICS_V2 {
 
     uint8_t  HandshakeHopLimitTTL;          // The TTL value in the initial packet of the handshake.
 
+    uint32_t RttVariance;                   // In microseconds
+
     // N.B. New fields must be appended to end
 
 } QUIC_STATISTICS_V2;
@@ -591,6 +593,7 @@ typedef struct QUIC_STATISTICS_V2 {
 #define QUIC_STATISTICS_V2_SIZE_1   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, KeyUpdateCount)         // v2.0 final size
 #define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // v2.1 final size
 #define QUIC_STATISTICS_V2_SIZE_3   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendEcnCongestionCount) // v2.2 final size
+#define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // v2.3 final size
 
 typedef struct QUIC_LISTENER_STATISTICS {
 

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -1142,6 +1142,7 @@ pub struct QUIC_STATISTICS_V2 {
     pub DestCidUpdateCount: u32,
     pub SendEcnCongestionCount: u32,
     pub HandshakeHopLimitTTL: u8,
+    pub RttVariance: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1211,6 +1212,8 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendEcnCongestionCount) - 196usize];
     ["Offset of field: QUIC_STATISTICS_V2::HandshakeHopLimitTTL"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, HandshakeHopLimitTTL) - 200usize];
+    ["Offset of field: QUIC_STATISTICS_V2::RttVariance"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, RttVariance) - 204usize];
 };
 impl QUIC_STATISTICS_V2 {
     #[inline]

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -1136,6 +1136,7 @@ pub struct QUIC_STATISTICS_V2 {
     pub DestCidUpdateCount: u32,
     pub SendEcnCongestionCount: u32,
     pub HandshakeHopLimitTTL: u8,
+    pub RttVariance: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1205,6 +1206,8 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendEcnCongestionCount) - 196usize];
     ["Offset of field: QUIC_STATISTICS_V2::HandshakeHopLimitTTL"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, HandshakeHopLimitTTL) - 200usize];
+    ["Offset of field: QUIC_STATISTICS_V2::RttVariance"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, RttVariance) - 204usize];
 };
 impl QUIC_STATISTICS_V2 {
     #[inline]


### PR DESCRIPTION
Added RttVariance to connection statistics. Fixes #4360

## Description

Adds the RttVariance statistic to QUIC_STATISTICS_V2, allowing applications to monitor changes to the Rtt of a connection over time.
