### PR TITLE
Allow update-sidecar to run on newer framework versions

### DIFF
--- a/scripts/update-sidecar.ps1
+++ b/scripts/update-sidecar.ps1
@@ -61,12 +61,22 @@ foreach ($File in $allFiles) {
     $allFiles = $allFiles + " " + $File
 }
 
-# Generate code for all different permutations we need
-Invoke-Expression "${ClogDir}/clog -p windows --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
-Invoke-Expression "${ClogDir}/clog -p windows_kernel --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
-Invoke-Expression "${ClogDir}/clog -p stubs --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
-Invoke-Expression "${ClogDir}/clog -p linux --dynamicTracepointProvider --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory (Join-Path $OutputDir linux) --inputFiles $allFiles"
-Invoke-Expression "${ClogDir}/clog -p macos --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
+#
+# Allow the sidecar to run on a newer .NET version.
+#
+$OriginalDOTNET_ROLL_FORWARD = $env:DOTNET_ROLL_FORWARD
+
+try {
+    $env:DOTNET_ROLL_FORWARD = "Major"
+    # Generate code for all different permutations we need
+    Invoke-Expression "${ClogDir}/clog -p windows --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
+    Invoke-Expression "${ClogDir}/clog -p windows_kernel --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
+    Invoke-Expression "${ClogDir}/clog -p stubs --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
+    Invoke-Expression "${ClogDir}/clog -p linux --dynamicTracepointProvider --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory (Join-Path $OutputDir linux) --inputFiles $allFiles"
+    Invoke-Expression "${ClogDir}/clog -p macos --scopePrefix quic.clog -s $Sidecar -c $ConfigFile --outputDirectory $TmpOutputDir --inputFiles $allFiles"
+} finally {
+    $env:DOTNET_ROLL_FORWARD = $OriginalDOTNET_ROLL_FORWARD
+}
 
 # Return to where we started
 Set-Location $OrigDir


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

CLOG currently requires a .NET framework be installed matching its target framework version, which is 6.0. Since 6.0 is out of support, we should not require build or test machines to have this obsolete library installed, or even to keep in lockstep.

Instead, use a .NET [environment variable](https://learn.microsoft.com/en-us/dotnet/core/versions/selection) to allow any newer framework to run the older code in compatibility mode.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Works locally with only .NET 8.x installed.

## Documentation

_Is there any documentation impact for this change?_

Nope.