### PR TITLE
Upload rust binding diff as an artifact

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -66,7 +66,7 @@ jobs:
         fi
     - name: Upload the diff file
       if: steps.bindings_diff.outputs.diff-found == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: cargo_generated_diff_${{ matrix.os }}.txt
         path: cargo_generated_diff.txt

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -62,7 +62,14 @@ jobs:
             echo "$(cat cargo_generated_diff.txt)"
             echo '@@@'
           } >> $GITHUB_OUTPUT
+          echo "$(cat cargo_generated_diff.txt)"
         fi
+    - name: Upload the diff file
+      if: steps.bindings_diff.outputs.diff-found == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: cargo_generated_diff_${{ matrix.os }}.txt
+        path: cargo_generated_diff.txt
     - name: Post a comment on PR on mismatch
       if: |
         !github.event.pull_request.head.repo.fork &&

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -64,12 +64,13 @@ jobs:
           } >> $GITHUB_OUTPUT
           echo "$(cat cargo_generated_diff.txt)"
         fi
-    - name: Upload the diff file
+    - name: Upload the patch file
       if: steps.bindings_diff.outputs.diff-found == 'true'
+      id: upload_patch
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
-        name: cargo_generated_diff_${{ matrix.os }}.txt
-        path: cargo_generated_diff.txt
+      name: cargo_generated_diff_${{ matrix.os }}.patch
+      path: cargo_generated_diff.txt
     - name: Post a comment on PR on mismatch
       if: |
         !github.event.pull_request.head.repo.fork &&
@@ -80,7 +81,7 @@ jobs:
         issue-number: ${{ github.event.number }}
         body: |
           ## ${{ github.workflow }}
-          The rust bindings need to be updated. Please apply (`git apply`) this diff:
+          The rust bindings need to be updated. Please apply (`git apply`) this [patch](${{ steps.upload_patch.outputs.artifact-url }}):
           ```diff
           ${{ steps.bindings_diff.outputs.diff-content }}
           ```

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -53,24 +53,24 @@ jobs:
       id: bindings_diff
       shell: bash
       run: |
-        if git diff --exit-code >> cargo_generated_diff.txt; then
+        if git diff --exit-code >> cargo_binding_update.patch; then
           echo "diff-found=false" >> $GITHUB_OUTPUT
         else
           echo "diff-found=true" >> $GITHUB_OUTPUT
           {
             echo 'diff-content<<@@@'
-            echo "$(cat cargo_generated_diff.txt)"
+            echo "$(cat cargo_binding_update.patch)"
             echo '@@@'
           } >> $GITHUB_OUTPUT
-          echo "$(cat cargo_generated_diff.txt)"
+          echo "$(cat cargo_binding_update.patch)"
         fi
     - name: Upload the patch file
       if: steps.bindings_diff.outputs.diff-found == 'true'
       id: upload_patch
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
-        name: cargo_generated_diff_${{ matrix.os }}.patch
-        path: cargo_generated_diff.txt
+        name: cargo_binding_update_${{ matrix.os }}
+        path: cargo_binding_update.patch
     - name: Post a comment on PR on mismatch
       if: |
         !github.event.pull_request.head.repo.fork &&

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -69,8 +69,8 @@ jobs:
       id: upload_patch
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
-      name: cargo_generated_diff_${{ matrix.os }}.patch
-      path: cargo_generated_diff.txt
+        name: cargo_generated_diff_${{ matrix.os }}.patch
+        path: cargo_generated_diff.txt
     - name: Post a comment on PR on mismatch
       if: |
         !github.event.pull_request.head.repo.fork &&
@@ -80,7 +80,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ github.event.number }}
         body: |
-          ## ${{ github.workflow }}
+          ## ${{ github.workflow }} - ${{ matrix.os }}
           The rust bindings need to be updated. Please apply (`git apply`) this [patch](${{ steps.upload_patch.outputs.artifact-url }}):
           ```diff
           ${{ steps.bindings_diff.outputs.diff-content }}

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1746,6 +1746,9 @@ typedef struct QUIC_API_TABLE {
     QUIC_CONNECTION_OPEN_IN_PARTITION_FN
                                         ConnectionOpenInPartition;   // Available from v2.5
 
+    QUIC_CONNECTION_OPEN_IN_PARTITION_FN
+                                        Dummy;   // TODO guhetier: For testing CI, to remove
+
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN
                                         StreamProvideReceiveBuffers; // Available from v2.5

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1746,9 +1746,6 @@ typedef struct QUIC_API_TABLE {
     QUIC_CONNECTION_OPEN_IN_PARTITION_FN
                                         ConnectionOpenInPartition;   // Available from v2.5
 
-    QUIC_CONNECTION_OPEN_IN_PARTITION_FN
-                                        Dummy;   // TODO guhetier: For testing CI, to remove
-
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     QUIC_STREAM_PROVIDE_RECEIVE_BUFFERS_FN
                                         StreamProvideReceiveBuffers; // Available from v2.5


### PR DESCRIPTION
## Description

Upload rust binding diff as an artifact + print it in the logs: the comment on the PR doesn't work for forks based PRs.

## Testing

See on this PR CI run.

## Documentation

N/A
