### PR TITLE
Receive buffer simplication [4/4]

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -454,11 +454,10 @@ QuicRecvBufferResize(
         TargetBufferLength != 0 &&
         (TargetBufferLength & (TargetBufferLength - 1)) == 0); // Power of 2
     CXPLAT_DBG_ASSERT(!CxPlatListIsEmpty(&RecvBuffer->Chunks)); // Should always have at least one chunk
+    CXPLAT_DBG_ASSERT(RecvBuffer->RetiredChunk == NULL);
+
     QUIC_RECV_CHUNK* LastChunk =
-        CXPLAT_CONTAINING_RECORD(
-            RecvBuffer->Chunks.Blink,
-            QUIC_RECV_CHUNK,
-            Link);
+        CXPLAT_CONTAINING_RECORD(RecvBuffer->Chunks.Blink, QUIC_RECV_CHUNK, Link);
     CXPLAT_DBG_ASSERT(TargetBufferLength > LastChunk->AllocLength); // Should only be called when buffer needs to grow
     BOOLEAN LastChunkIsFirst = LastChunk->Link.Blink == &RecvBuffer->Chunks;
 
@@ -476,95 +475,67 @@ QuicRecvBufferResize(
     QuicRecvChunkInitialize(NewChunk, TargetBufferLength, (uint8_t*)(NewChunk + 1), FALSE);
     CxPlatListInsertTail(&RecvBuffer->Chunks, &NewChunk->Link);
 
-    if (!LastChunk->ExternalReference) {
+    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_MULTIPLE && LastChunk->ExternalReference) {
         //
-        // If the last chunk isn't externally referenced, then we can just
-        // replace it with the new chunk.
+        // In Multiple mode, if the last chunk is referenced, simply add the new chunk to the list.
+        // The last chunk is still used for reads and writes but drains reduce its capacity until it
+        // can be freed.
         //
-        if (LastChunkIsFirst) {
-            //
-            // If it's the first chunk, then the data may not start from the
-            // beginning.
-            //
-            uint32_t Span = QuicRecvBufferGetSpan(RecvBuffer);
-            if (Span < LastChunk->AllocLength) {
-                Span = LastChunk->AllocLength;
-            }
-            uint32_t LengthTillWrap = LastChunk->AllocLength - RecvBuffer->ReadStart;
-            if (Span <= LengthTillWrap) {
-                CxPlatCopyMemory(
-                    NewChunk->Buffer,
-                    LastChunk->Buffer + RecvBuffer->ReadStart,
-                    Span);
-            } else {
-                CxPlatCopyMemory(
-                    NewChunk->Buffer,
-                    LastChunk->Buffer + RecvBuffer->ReadStart,
-                    LengthTillWrap);
-                CxPlatCopyMemory(
-                    NewChunk->Buffer + LengthTillWrap,
-                    LastChunk->Buffer,
-                    Span - LengthTillWrap);
-            }
-            RecvBuffer->ReadStart = 0;
-            CXPLAT_DBG_ASSERT(NewChunk->AllocLength == TargetBufferLength);
-            RecvBuffer->Capacity = NewChunk->AllocLength;
+        return TRUE;
+    }
 
-        } else {
-            //
-            // If it's not the first chunk, then it always starts from the
-            // beginning of the buffer.
-            //
+    //
+    // In Single and Circular modes, or in Multiple mode when the last chunk is not referenced,
+    // replace the last chunk is with the new one:
+    // - copy the data to the new chunk
+    // - remove the last chunk from the list
+    //
+
+    if (LastChunkIsFirst) {
+        uint32_t WrittenSpan =
+            CXPLAT_MIN(LastChunk->AllocLength, QuicRecvBufferGetSpan(RecvBuffer));
+        uint32_t LengthBeforeWrap = LastChunk->AllocLength - RecvBuffer->ReadStart;
+        if (WrittenSpan <= LengthBeforeWrap) {
             CxPlatCopyMemory(
                 NewChunk->Buffer,
+                LastChunk->Buffer + RecvBuffer->ReadStart,
+                WrittenSpan);
+        } else {
+            CxPlatCopyMemory(
+                NewChunk->Buffer,
+                LastChunk->Buffer + RecvBuffer->ReadStart,
+                LengthBeforeWrap);
+            CxPlatCopyMemory(
+                NewChunk->Buffer + LengthBeforeWrap,
                 LastChunk->Buffer,
-                LastChunk->AllocLength);
+                WrittenSpan - LengthBeforeWrap);
         }
-
-        CxPlatListEntryRemove(&LastChunk->Link);
-        QuicRecvChunkFree(RecvBuffer, LastChunk);
-
-        return TRUE;
-    }
-
-    //
-    // If the chunk is already referenced, and if we're in multiple receive
-    // mode, we can just add the new chunk to the end of the list.
-    //
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_MULTIPLE) {
-        return TRUE;
-    }
-
-    //
-    // Otherwise, we need to copy the data from the existing chunk
-    // into the new chunk, and retire the existing chunk until we can free it.
-    //
-
-    //
-    // If it's the first chunk, then it may not start from the beginning.
-    //
-    uint32_t Span = QuicRecvBufferGetSpan(RecvBuffer);
-    uint32_t LengthTillWrap = LastChunk->AllocLength - RecvBuffer->ReadStart;
-    if (Span <= LengthTillWrap) {
-        CxPlatCopyMemory(
-            NewChunk->Buffer,
-            LastChunk->Buffer + RecvBuffer->ReadStart,
-            Span);
+        RecvBuffer->ReadStart = 0;
+        RecvBuffer->Capacity = NewChunk->AllocLength;
     } else {
-        CxPlatCopyMemory(
-            NewChunk->Buffer,
-            LastChunk->Buffer + RecvBuffer->ReadStart,
-            LengthTillWrap);
-        CxPlatCopyMemory(
-            NewChunk->Buffer + LengthTillWrap,
-            LastChunk->Buffer,
-            Span - LengthTillWrap);
+        //
+        // If it isn't the first chunk, it always starts from the beginning of the buffer.
+        //
+        CxPlatCopyMemory(NewChunk->Buffer, LastChunk->Buffer, LastChunk->AllocLength);
     }
-    RecvBuffer->ReadStart = 0;
-    RecvBuffer->Capacity = NewChunk->AllocLength;
+
+    //
+    // The chunk data has been copied, remove the chunk from the list.
+    //
     CxPlatListEntryRemove(&LastChunk->Link);
-    CXPLAT_DBG_ASSERT(RecvBuffer->RetiredChunk == NULL);
-    RecvBuffer->RetiredChunk = LastChunk;
+
+    if (LastChunk->ExternalReference) {
+        //
+        // The chunk is referenced, so we need to retire it until we can free it.
+        //
+        CXPLAT_DBG_ASSERT(
+            RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_SINGLE ||
+            RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_CIRCULAR);
+
+        RecvBuffer->RetiredChunk = LastChunk;
+    } else {
+        QuicRecvChunkFree(RecvBuffer, LastChunk);
+    }
 
     return TRUE;
 }
@@ -575,55 +546,17 @@ QuicRecvBufferGetTotalAllocLength(
     _In_ QUIC_RECV_BUFFER* RecvBuffer
     )
 {
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_SINGLE ||
-        RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_CIRCULAR) {
-        //
-        // In single and circular mode, the last chunk is the only chunk being
-        // written to at any given time, and therefore the only chunk we care
-        // about in terms of total allocation space.
-        //
-        QUIC_RECV_CHUNK* Chunk =
-            CXPLAT_CONTAINING_RECORD(
-                RecvBuffer->Chunks.Blink,
-                QUIC_RECV_CHUNK,
-                Link);
-        return Chunk->AllocLength;
-    }
+    CXPLAT_DBG_ASSERT(!CxPlatListIsEmpty(&RecvBuffer->Chunks));
 
     //
-    // For multiple mode and app-owned mode, several chunks may be used at any
-    // point in time, so we need to consider the space allocated for all of them.
-    // Additionally, the first one is special because it may be already partially
-    // drained, making it only partially usable.
-    //
-    QUIC_RECV_CHUNK* Chunk =
-        CXPLAT_CONTAINING_RECORD(
-            RecvBuffer->Chunks.Flink,
-            QUIC_RECV_CHUNK,
-            Link);
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_MULTIPLE &&
-        Chunk->Link.Flink == &RecvBuffer->Chunks) {
-        //
-        // In Multiple mode, only one chunk means we don't have an artificial
-        // "end", and are using the full allocated length of the buffer in a
-        // circular fashion.
-        //
-        return Chunk->AllocLength;
-    }
-
-    //
-    // Otherwise, it is possible part of the first chunk has already been
-    // drained, so we don't use the allocated length, but the Capacity instead
-    // when calculating total available space.
+    // The first chunk might have a reduced capacity (if more chunks are present and it is being
+    // consumed). Other chunks are always allocated at their full alloc size.
     //
     uint32_t AllocLength = RecvBuffer->Capacity;
-    while (Chunk->Link.Flink != &RecvBuffer->Chunks) {
-        Chunk =
-            CXPLAT_CONTAINING_RECORD(
-                Chunk->Link.Flink,
-                QUIC_RECV_CHUNK,
-                Link);
-        CXPLAT_DBG_ASSERT((uint64_t)AllocLength + (uint64_t)Chunk->AllocLength < UINT32_MAX);
+    for (CXPLAT_LIST_ENTRY* Link = RecvBuffer->Chunks.Flink->Flink; // Skip the first chunk
+         Link != &RecvBuffer->Chunks;
+         Link = Link->Flink) {
+        QUIC_RECV_CHUNK* Chunk = CXPLAT_CONTAINING_RECORD(Link, QUIC_RECV_CHUNK, Link);
         AllocLength += Chunk->AllocLength;
     }
     return AllocLength;
@@ -702,7 +635,7 @@ QuicRecvBufferWrite(
     //
     // Check if the write buffer has already been completely written before.
     //
-    uint64_t AbsoluteLength = WriteOffset + WriteLength;
+    const uint64_t AbsoluteLength = WriteOffset + WriteLength;
     if (AbsoluteLength <= RecvBuffer->BaseOffset) {
         *WriteLimit = 0;
         return QUIC_STATUS_SUCCESS;
@@ -744,15 +677,13 @@ QuicRecvBufferWrite(
         uint32_t AllocLength = QuicRecvBufferGetTotalAllocLength(RecvBuffer);
         if (AbsoluteLength > RecvBuffer->BaseOffset + AllocLength) {
             //
-            // If we don't currently have enough room then we will want to resize
-            // the last chunk to be big enough to hold everything. We do this by
-            // repeatedly doubling its size until it is large enough.
+            // There isn't enough space to write the data.
+            // Add a new chunk (or replace the existing one), doubling the size of the largest chunk
+            // until there is enough space for the write.
             //
-            uint32_t NewBufferLength =
-                CXPLAT_CONTAINING_RECORD(
-                    RecvBuffer->Chunks.Blink,
-                    QUIC_RECV_CHUNK,
-                    Link)->AllocLength << 1;
+            QUIC_RECV_CHUNK* LastChunk =
+                CXPLAT_CONTAINING_RECORD(RecvBuffer->Chunks.Blink, QUIC_RECV_CHUNK, Link);
+            uint32_t NewBufferLength = LastChunk->AllocLength << 1;
             while (AbsoluteLength > RecvBuffer->BaseOffset + NewBufferLength) {
                 NewBufferLength <<= 1;
             }
@@ -1025,10 +956,10 @@ QuicRecvBufferDrainFirstChunk(
         // In Single mode, the readable data must always start at the front of the buffer,
         // move all written data if needed.
         //
+        uint32_t WrittenSpan =
+            CXPLAT_MIN(FirstChunk->AllocLength, QuicRecvBufferGetSpan(RecvBuffer));
         CxPlatMoveMemory(
-            FirstChunk->Buffer,
-            FirstChunk->Buffer + RecvBuffer->ReadStart,
-            FirstChunk->AllocLength - RecvBuffer->ReadStart); // TODO - Might be able to copy less than the full alloc length
+            FirstChunk->Buffer, FirstChunk->Buffer + RecvBuffer->ReadStart, WrittenSpan);
         RecvBuffer->ReadStart = 0;
     }
 }

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -24,10 +24,10 @@ typedef struct QUIC_RECV_CHUNK {
     CXPLAT_LIST_ENTRY Link;          // Link in the list of chunks.
     uint32_t AllocLength;            // Allocation size of Buffer
     uint8_t ExternalReference  : 1;  // Indicates the buffer is being used externally.
-    uint8_t AppOwnedBuffer     : 1;  // Indicates the buffer is managed by the app.
+    uint8_t AllocatedFromPool  : 1;  // Indicates the buffer is was allocated from a pool.
     uint8_t* Buffer;                 // Pointer to the buffer itself. Doesn't need to be freed independently:
                                      //  - for internally allocated buffers, points in the same allocation.
-                                     //  - for exteral buffers, the buffer isn't owned
+                                     //  - for app-owned buffers, the buffer isn't owned
 } QUIC_RECV_CHUNK;
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -50,11 +50,6 @@ typedef struct QUIC_RECV_BUFFER {
     // Optional, retired chunk waiting to no longer be referenced.
     //
     QUIC_RECV_CHUNK* RetiredChunk;
-
-    //
-    // Optional, preallocated initial chunk.
-    //
-    QUIC_RECV_CHUNK* PreallocatedChunk;
 
     //
     // Ranges of stream offsets that have been written to the buffer,

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -139,7 +139,7 @@ QuicStreamInitialize(
             PreallocatedRecvChunk,
             InitialRecvBufferLength,
             (uint8_t *)(PreallocatedRecvChunk + 1),
-            FALSE);
+            TRUE);
     }
 
     const uint32_t FlowControlWindowSize = Stream->Flags.Unidirectional
@@ -222,10 +222,6 @@ QuicStreamFree(
     QuicRangeUninitialize(&Stream->SparseAckRanges);
     CxPlatDispatchLockUninitialize(&Stream->ApiSendRequestLock);
     CxPlatRefUninitialize(&Stream->RefCount);
-
-    if (Stream->RecvBuffer.PreallocatedChunk) {
-        CxPlatPoolFree(Stream->RecvBuffer.PreallocatedChunk);
-    }
 
     Stream->Flags.Freed = TRUE;
     CxPlatPoolFree(Stream);
@@ -977,13 +973,9 @@ QuicStreamSwitchToAppOwnedBuffers(
     )
 {
     //
-    // Reset the current receive buffer and preallocated chunk.
+    // Reset the current receive buffer
     //
     QuicRecvBufferUninitialize(&Stream->RecvBuffer);
-    if (Stream->RecvBuffer.PreallocatedChunk) {
-        CxPlatPoolFree(Stream->RecvBuffer.PreallocatedChunk);
-        Stream->RecvBuffer.PreallocatedChunk = NULL;
-    }
 
     //
     // Can't fail when initializing in app-owned mode.


### PR DESCRIPTION
## Description

- Simplify the logic around the receive buffer growth logic
    - Remove code duplication and simplify control flow
- Simplify logic around the pre-allocated chunk memory management
    - The receive buffer now own the chunk. The refactoring of pools makes it possible to deallocate it easily.

## Testing

CI

## Documentation

Already covered by existing documentation, comments updated.