### PR TITLE
Double free bugfix in Secnetperf

### DIFF
--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -342,9 +342,6 @@ TcpServer::~TcpServer()
     if (Listener) {
         CxPlatSocketDelete(Listener);
     }
-    if (SecConfig) {
-        CxPlatTlsSecConfigDelete(SecConfig); // TODO - Ref counted instead?
-    }
 }
 
 bool TcpServer::Start(const QUIC_ADDR* LocalAddress)


### PR DESCRIPTION
## Description

Recent netperf runs has been consistently bugchecking in WSK scenarios and failing with exit code 1 on linux runs.
This likely stemmed from recent refactors in the TCP codepaths (https://github.com/microsoft/msquic/pull/5015/files#diff-a3cdfe61c9e7048c98568a0977fd801e3a1b3f065e82a84b57bbf9146c17dac4) 

## Testing

CI

## Documentation

N/A