### PR TITLE
Update quictls to 3.1.7 on main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "submodules/quictls"]
 	path = submodules/quictls
 	url = https://github.com/quictls/openssl.git
-	branch = openssl-3.1.4+quic
+	branch = main
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git


### PR DESCRIPTION
## Description

Switch to the quictls main branch, which updates the submodule to version 3.1.7.

## Testing

Existing tests cover this.

## Documentation

N/A
