### PR TITLE
Update XDP to latest prerelease, dedupdupduplicate xdp install/uninstall

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -235,6 +235,11 @@ function Install-Xdp-Driver {
     Write-Host "Downloading XDP msi"
     $MsiPath = Join-Path $ArtifactsPath "xdp.msi"
     Invoke-WebRequest -Uri (Get-Content (Join-Path $PSScriptRoot "xdp.json") | ConvertFrom-Json).installer -OutFile $MsiPath
+    Write-Host "Installing XDP driver certificate"
+    $CertFileName = Join-Path $ArtifactsPath 'xdp.cer'
+    Get-AuthenticodeSignature $MsiPath | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
+    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root'
+    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
     Write-Host "Installing XDP driver"
     msiexec.exe /i $MsiPath /quiet | Out-Null
 }

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -78,13 +78,7 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     ./artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats
 } elseif ($Command.Contains("Install_XDP")) {
     Write-Host "Executing command: Install_XDP"
-    Write-Host "(SERVER) Downloading XDP installer"
-    $installerUri = $Command.Split(";")[1]
-    $msiPath = Repo-Path "xdp.msi"
-    Invoke-WebRequest -Uri $installerUri -OutFile $msiPath -UseBasicParsing
-    Write-Host "(SERVER) Installing XDP. Msi path: $msiPath"
-    msiexec.exe /i $msiPath /quiet | Out-Host
-    Wait-DriverStarted "xdp" 10000
+    .\scripts\prepare-machine.ps1 -InstallXdpDriver
 } elseif ($Command -eq "Install_Kernel") {
     Write-Host "Executing command: Install_Kernel"
     $KernelDir = Repo-Path "./artifacts/bin/winkernel/x64_Release_schannel"

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -141,7 +141,7 @@ function Install-XDP {
     Write-Host "Installing XDP driver on peer"
 
     if ($Session -eq "NOT_SUPPORTED") {
-        NetperfSendCommand "Install_XDP;$installerUri"
+        NetperfSendCommand "Install_XDP"
         NetperfWaitServerFinishExecution
         return
     }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -147,7 +147,7 @@ function Install-XDP {
     }
 
     Invoke-Command -Session $Session -ScriptBlock {
-        .\scripts\prepare-machine.ps1 -InstallXdpDriver
+        & "$Using:RemoteDir\scripts\prepare-machine.ps1" -InstallXdpDriver
     }
 }
 
@@ -158,7 +158,7 @@ function Uninstall-XDP {
     try { .\scripts\prepare-machine.ps1 -UninstallXdp } catch {}
     Write-Host "Uninstalling XDP driver on peer"
     Invoke-Command -Session $Session -ScriptBlock {
-        try { .\scripts\prepare-machine.ps1 -UninstallXdp } catch {}
+        try { & "$Using:RemoteDir\scripts\prepare-machine.ps1" -UninstallXdp } catch {}
     }
 }
 

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -135,16 +135,9 @@ function Wait-DriverStarted {
 # Download and install XDP on both local and remote machines.
 function Install-XDP {
     param ($Session, $RemoteDir)
-    $installerUri = (Get-Content (Join-Path $PSScriptRoot "xdp.json") | ConvertFrom-Json).installer
-    $msiPath = Repo-Path "artifacts/xdp.msi"
-    Write-Host "Downloading XDP installer"
     whoami
-    Invoke-WebRequest -Uri $installerUri -OutFile $msiPath -UseBasicParsing
     Write-Host "Installing XDP driver locally"
-    msiexec.exe /i $msiPath /quiet | Out-Null
-    $Size = Get-FileHash $msiPath
-    Write-Host "MSI file hash: $Size"
-    Wait-DriverStarted "xdp" 10000
+    .\scripts\prepare-machine.ps1 -InstallXdpDriver
     Write-Host "Installing XDP driver on peer"
 
     if ($Session -eq "NOT_SUPPORTED") {
@@ -153,26 +146,19 @@ function Install-XDP {
         return
     }
 
-    $remoteMsiPath = Join-Path $RemoteDir "artifacts/xdp.msi"
-    Copy-Item -ToSession $Session $msiPath -Destination $remoteMsiPath
-    $WaitDriverStartedStr = "${function:Wait-DriverStarted}"
     Invoke-Command -Session $Session -ScriptBlock {
-        msiexec.exe /i $Using:remoteMsiPath /quiet | Out-Host
-        $WaitDriverStarted = [scriptblock]::Create($Using:WaitDriverStartedStr)
-        & $WaitDriverStarted xdp 10000
+        .\scripts\prepare-machine.ps1 -InstallXdpDriver
     }
 }
 
 # Uninstalls the XDP driver on both local and remote machines.
 function Uninstall-XDP {
     param ($Session, $RemoteDir)
-    $msiPath = Repo-Path "artifacts/xdp.msi"
-    $remoteMsiPath = Join-Path $RemoteDir "artifacts/xdp.msi"
     Write-Host "Uninstalling XDP driver locally"
-    try { msiexec.exe /x $msiPath /quiet | Out-Null } catch {}
+    try { .\scripts\prepare-machine.ps1 -UninstallXdp } catch {}
     Write-Host "Uninstalling XDP driver on peer"
     Invoke-Command -Session $Session -ScriptBlock {
-        try { msiexec.exe /x $Using:remoteMsiPath /quiet | Out-Null } catch {}
+        try { .\scripts\prepare-machine.ps1 -UninstallXdp } catch {}
     }
 }
 

--- a/scripts/xdp.json
+++ b/scripts/xdp.json
@@ -1,3 +1,3 @@
 {
-    "installer": "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0/xdp-for-windows.x64.1.1.0.msi"
+    "installer": "https://github.com/microsoft/xdp-for-windows/releases/download/v1.2.0-prerelease-793dc2a0/xdp-for-windows.x64.1.2.0-prerelease-793dc2a0.msi"
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The steps to install and uninstall XDP are implemented in several different places, each one subtly different. This is contrary to the software engineering best practice of reducing duplication and having a single point of maintenance for a given piece of functionality. 

For unknown reasons, each of these duplicated implementations was actually not duplicated, but subtly different.

Use one function to do one thing.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.