### PR TITLE
always collect Get-NetView in secnetperf

### DIFF
--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -196,9 +196,11 @@ if (!($Session -eq "NOT_SUPPORTED")) {
     Copy-Item -ToSession $Session ./artifacts -Destination "$RemoteDir/artifacts" -Recurse
     Copy-Item -ToSession $Session ./scripts -Destination "$RemoteDir/scripts" -Recurse
     Copy-Item -ToSession $Session ./src/manifest/MsQuic.wprp -Destination "$RemoteDir/scripts"
+}
 
-    # Create the logs directories on both machines.
-    New-Item -ItemType Directory -Path ./artifacts/logs | Out-Null
+# Create the logs directories on both machines.
+New-Item -ItemType Directory -Path ./artifacts/logs | Out-Null
+if ($Session -ne "NOT_SUPPORTED") {
     Invoke-Command -Session $Session -ScriptBlock {
         New-Item -ItemType Directory -Path $Using:RemoteDir/artifacts/logs | Out-Null
     }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -205,7 +205,7 @@ if (!($Session -eq "NOT_SUPPORTED")) {
 }
 
 # Collect some info about machine state.
-if (!$NoLogs -and $isWindows -and !($Session -eq "NOT_SUPPORTED")) {
+if (!$NoLogs -and $isWindows) {
     $Arguments = "-SkipNetsh"
     if (Get-Help Get-NetView -Parameter SkipWindowsRegistry -ErrorAction Ignore) {
         $Arguments += " -SkipWindowsRegistry"
@@ -224,18 +224,20 @@ if (!$NoLogs -and $isWindows -and !($Session -eq "NOT_SUPPORTED")) {
     } catch { Write-Host $_ }
     Write-Host "::endgroup::"
 
-    Write-Host "::group::Collecting information on peer machine state"
-    try {
-        Invoke-Command -Session $Session -ScriptBlock {
-            Invoke-Expression "Get-NetView -OutputDirectory $Using:RemoteDir/artifacts/logs $Using:Arguments"
-            Remove-Item $Using:RemoteDir/artifacts/logs/msdbg.$env:COMPUTERNAME -recurse
-            $filePath = (Get-ChildItem -Path $Using:RemoteDir/artifacts/logs/ -Recurse -Filter msdbg.$env:COMPUTERNAME*.zip)[0].FullName
-            Rename-Item $filePath "get-netview.peer.zip"
-        }
-        Copy-Item -FromSession $Session -Path "$RemoteDir/artifacts/logs/get-netview.peer.zip" -Destination ./artifacts/logs/
-        Write-Host "Generated get-netview.peer.zip"
-    } catch { Write-Host $_ }
-    Write-Host "::endgroup::"
+    if ($Session -ne "NOT_SUPPORTED") {
+        Write-Host "::group::Collecting information on peer machine state"
+        try {
+            Invoke-Command -Session $Session -ScriptBlock {
+                Invoke-Expression "Get-NetView -OutputDirectory $Using:RemoteDir/artifacts/logs $Using:Arguments"
+                Remove-Item $Using:RemoteDir/artifacts/logs/msdbg.$env:COMPUTERNAME -recurse
+                $filePath = (Get-ChildItem -Path $Using:RemoteDir/artifacts/logs/ -Recurse -Filter msdbg.$env:COMPUTERNAME*.zip)[0].FullName
+                Rename-Item $filePath "get-netview.peer.zip"
+            }
+            Copy-Item -FromSession $Session -Path "$RemoteDir/artifacts/logs/get-netview.peer.zip" -Destination ./artifacts/logs/
+            Write-Host "Generated get-netview.peer.zip"
+        } catch { Write-Host $_ }
+        Write-Host "::endgroup::"
+    }
 }
 
 $json = @{}


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The secnetperf script collects Get-NetView only if a session exists, which isn't very useful if a session doesn't exist.

Update the script to always collect local data.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.