### PR TITLE
Fix Rebind for Raw Datapath

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6265,6 +6265,7 @@ QuicConnParamSet(
                 Connection->Paths[0].Binding = OldBinding;
                 break;
             }
+            Connection->Paths[0].Route.State = RouteUnresolved;
             Connection->Paths[0].Route.Queue = NULL;
 
             //

--- a/src/platform/datapath_raw_xdp_linux.c
+++ b/src/platform/datapath_raw_xdp_linux.c
@@ -1268,6 +1268,7 @@ CxPlatXdpRx(
         // a route lookup.
         //
         Packet->RecvData.Route->State = RouteResolved;
+        CXPLAT_DBG_ASSERT(Packet->RecvData.Route->Queue != NULL);
 
         if (Packet->RecvData.Buffer) {
             Packet->Addr = Addr - (XDP_PACKET_HEADROOM + XskInfo->UmemInfo->RxHeadRoom);

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1516,6 +1516,7 @@ CxPlatXdpRx(
         // a route lookup.
         //
         Packet->RecvData.Route->State = RouteResolved;
+        CXPLAT_DBG_ASSERT(Packet->RecvData.Route->Queue != NULL);
 
         if (Packet->RecvData.Buffer) {
             Packet->RecvData.Allocated = TRUE;


### PR DESCRIPTION
## Description

Recent onboarding of the interop over XDP exposed an issue with the RAW datapath and the rebind scenario. The route was kept as resolved, but it was clearing the queue, which would later crash on send. This fix clears the resolved state to force a new route resolution.

## Testing

Validated locally over XDP. CI/CD

## Documentation

N/A
