### PR TITLE
Remove DataIndication Queuing from  Kernel Datapath

### DIFF
--- a/src/generated/linux/datapath_winkernel.c.clog.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h
@@ -363,9 +363,9 @@ tracepoint(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocIoBlockFailure , arg2);\
 // Decoder Ring for DatapathDropAllocRecvBufferFailure
 // [%p] Couldn't allocate receive buffers.
 // QuicTraceLogWarning(
-                            DatapathDropAllocRecvBufferFailure,
-                            "[%p] Couldn't allocate receive buffers.",
-                            Binding);
+                        DatapathDropAllocRecvBufferFailure,
+                        "[%p] Couldn't allocate receive buffers.",
+                        Binding);
 // arg2 = arg2 = Binding = arg2
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_DatapathDropAllocRecvBufferFailure

--- a/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_winkernel.c.clog.h.lttng.h
@@ -351,9 +351,9 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocIoBlockFailure,
 // Decoder Ring for DatapathDropAllocRecvBufferFailure
 // [%p] Couldn't allocate receive buffers.
 // QuicTraceLogWarning(
-                            DatapathDropAllocRecvBufferFailure,
-                            "[%p] Couldn't allocate receive buffers.",
-                            Binding);
+                        DatapathDropAllocRecvBufferFailure,
+                        "[%p] Couldn't allocate receive buffers.",
+                        Binding);
 // arg2 = arg2 = Binding = arg2
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_DATAPATH_WINKERNEL_C, DatapathDropAllocRecvBufferFailure,

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2001,7 +2001,6 @@ CxPlatDataPathSocketReceive(
     }
 
     CXPLAT_DBG_ASSERT(Context != NULL);
-
     CXPLAT_SOCKET* Binding = (CXPLAT_SOCKET*)Context;
 
     const uint32_t CurProcNumber = CxPlatProcCurrentNumber();
@@ -2020,9 +2019,6 @@ CxPlatDataPathSocketReceive(
     PWSK_DATAGRAM_INDICATION DataIndication = DataIndicationHead;
     while (DataIndication != NULL) {
 
-        DATAPATH_RX_IO_BLOCK* IoBlock = NULL;
-        DATAPATH_RX_PACKET* Datagram = NULL;
-
         if (DataIndication->Buffer.Mdl == NULL ||
             DataIndication->Buffer.Length == 0) {
             QuicTraceLogWarning(
@@ -2032,6 +2028,8 @@ CxPlatDataPathSocketReceive(
             goto Drop;
         }
 
+        DATAPATH_RX_IO_BLOCK* IoBlock = NULL;
+        DATAPATH_RX_PACKET* Datagram = NULL;
         BOOLEAN FoundLocalAddr = FALSE;
         BOOLEAN IsUnreachableError = FALSE;
         BOOLEAN IsCoalesced = FALSE;
@@ -2319,14 +2317,9 @@ CxPlatDataPathSocketReceive(
         }
     }
 
-    //
-    // Release any dropped or copied datagrams.
-    //
-    Binding->DgrmSocket->Dispatch->WskRelease(Binding->Socket, DataIndicationHead);
-
     CxPlatRundownRelease(&Binding->Rundown[CurProcNumber]);
 
-    return STATUS_PENDING;
+    return STATUS_SUCCESS;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)


### PR DESCRIPTION
## Description

For several years now, the Windows kernel datapath has been always copying the recevied data in to local buffers because we found that any significant queuing can cause problems lower in the stack (i.e., the NIC); even if we queued only 1 indication. So, let's just remove all the code that supported the queuing mode to eliminate unnecessary branches in the kernel datapath code.

## Testing

CI/CD

## Documentation

N/A
