### PR TITLE
Revert to XDP version 1.1 (official)

### DIFF
--- a/scripts/xdp.json
+++ b/scripts/xdp.json
@@ -1,3 +1,3 @@
 {
-    "installer": "https://github.com/microsoft/xdp-for-windows/releases/download/v1.2.0-prerelease-793dc2a0/xdp-for-windows.x64.1.2.0-prerelease-793dc2a0.msi"
+    "installer": "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0/xdp-for-windows.x64.1.1.0.msi"
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Partially revert #5085 and use the most recent official XDP release, version 1.1.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.