### PR TITLE
Match casing in Dockerfile FROM commands

### DIFF
--- a/scripts/qns.Dockerfile
+++ b/scripts/qns.Dockerfile
@@ -1,4 +1,4 @@
-FROM    martenseemann/quic-network-simulator-endpoint@sha256:2ec0a19a54f4547f068a81afcb3e92251b8808934eb86e5cb6919d91c4958791 as source
+FROM    martenseemann/quic-network-simulator-endpoint@sha256:2ec0a19a54f4547f068a81afcb3e92251b8808934eb86e5cb6919d91c4958791 AS source
 ENV     DEBIAN_FRONTEND=noninteractive
 RUN     apt-get update -y \
             && apt-get install -y \
@@ -9,7 +9,7 @@ RUN     apt-get update -y \
             && apt-get clean
 COPY    . /src
 
-FROM    source as build
+FROM    source AS build
 WORKDIR /src/Debug
 RUN     chmod +x /src/scripts/install-powershell-docker.sh
 RUN     /src/scripts/install-powershell-docker.sh


### PR DESCRIPTION
## Description

Match the casing in the `FROM` commands in the `Dockerfile` to ensure consistency and readability as reported here: https://github.com/microsoft/msquic/pull/4959/files#annotation_34624477466

## Testing

CI

## Documentation

N/A
