### PR TITLE
Make server IO independently configurable in secnetperf

### DIFF
--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -502,15 +502,21 @@ function Get-LatencyOutput {
     }
 }
 
+function Is-TcpSupportedByIo {
+    param ($Io)
+
+    return $Io -ne "xdp" -and $Io -ne "qtip" -and $Io -ne "wsk"
+}
+
 # Invokes secnetperf with the given arguments for both TCP and QUIC.
 function Invoke-Secnetperf {
-    param ($Session, $RemoteName, $RemoteDir, $UserName, $SecNetPerfPath, $LogProfile, $Scenario, $io, $Filter, $Environment, $RunId, $SyncerSecret)
+    param ($Session, $RemoteName, $RemoteDir, $UserName, $SecNetPerfPath, $LogProfile, $Scenario, $io, $ServerIo, $Filter, $Environment, $RunId, $SyncerSecret)
 
     $values = @(@(), @())
     $latency = $null
     $extraOutput = $null
     $hasFailures = $false
-    if ($io -ne "xdp" -and $io -ne "qtip" -and $io -ne "wsk") {
+    if ((Is-TcpSupportedByIo $io) -and (Is-TcpSupportedByIo $ServerIo)) {
         $tcpSupported = 1
     } else {
         $tcpSupported = 0
@@ -533,7 +539,7 @@ function Invoke-Secnetperf {
 
     # Set up all the parameters and paths for running the test.
     $clientPath = Repo-Path $SecNetPerfPath
-    $serverArgs = "-scenario:$Scenario -io:$io"
+    $serverArgs = "-scenario:$Scenario -io:$ServerIo"
 
     if ($env:collect_cpu_traces) {
         $updated_runtime_for_cpu_traces = @{


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

To independently test the client IO mode vs a constant server IO mode across IO models, add a new serverio knob.
Used by https://github.com/microsoft/netperf/pull/629.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Manually triggered run in netperf - https://github.com/microsoft/netperf/actions/runs/15030683055.

## Documentation

_Is there any documentation impact for this change?_

No.