### PR TITLE
added no-asm to the config flag for openssl build

### DIFF
--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -32,7 +32,7 @@ set(OPENSSL_CONFIG_FLAGS
     no-ssl3-method no-tls1-method no-tls1_1-method no-tls1_2-method no-dtls1-method no-dtls1_2-method
     no-siphash no-whirlpool no-aria no-bf no-blake2 no-sm2 no-sm3 no-sm4 no-camellia no-cast no-md4 no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt no-seed
     no-weak-ssl-ciphers no-shared no-tests
-    no-uplink no-cmp no-fips no-padlockeng no-siv no-legacy no-dtls no-deprecated --libdir=lib)
+    no-uplink no-cmp no-fips no-padlockeng no-siv no-legacy no-dtls no-deprecated no-asm --libdir=lib)
 
 if (WIN32)
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
MSQuic builds fail for amd64 using native compiler. It found that the issue is the assembly implementation of openssl doesnt support control flow guards. Adding no-asm to the config flags fixes the issue. 
## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
