### PR TITLE
Suppress GCC warning for multi-character constant in CxPlatPoolT

### DIFF
--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -117,6 +117,9 @@ constexpr _Ty&& CxPlatForward(
     return static_cast<_Ty&&>(_Arg);
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmultichar" // Multi-character constant used intentionally for the tag
+#endif
 template<typename T, uint32_t Tag = 'lPxC', bool Paged = false>
 class CxPlatPoolT {
     CXPLAT_POOL Pool;


### PR DESCRIPTION
## Description

Suppresses the following warning:
```
/home/runner/work/msh3/msh3/msquic/src/inc/msquic.hpp:120:37: warning: multi-character character constant [-Wmultichar]
  120 | template<typename T, uint32_t Tag = 'lPxC', bool Paged = false>
      |                                     ^~~~~~
```

I plan to CP this to release/2.5 too.

## Testing

CI/CD

## Documentation

N/A
