### PR TITLE
Set checksum field to zero before performing SW checksum

### DIFF
--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -769,12 +769,14 @@ CxPlatFramingWriteHeaders(
             IPv4->HeaderChecksum = 0;
             CxPlatDpRawTxSetL3ChecksumOffload(SendData);
         } else {
+            WRITE_ONCE(IPv4->HeaderChecksum, 0);
             IPv4->HeaderChecksum = ~CxPlatFramingChecksum((uint8_t*)IPv4, sizeof(IPV4_HEADER), 0);
         }
         EthType = ETHERNET_TYPE_IPV4;
         Ethernet = (ETHERNET_HEADER*)(((uint8_t*)IPv4) - sizeof(ETHERNET_HEADER));
         IpHeaderLen = sizeof(IPV4_HEADER);
         if (Route->UseQTIP) {
+            WRITE_ONCE(TCP->Checksum, 0);
             TCP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv4->Source, IPv4->Destination,
@@ -783,6 +785,7 @@ CxPlatFramingWriteHeaders(
                     (uint8_t*)TCP, sizeof(TCP_HEADER) + Buffer->Length,
                     SkipTransportLayerXsum);
         } else {
+            WRITE_ONCE(UDP->Checksum, 0);
             UDP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv4->Source, IPv4->Destination,
@@ -827,6 +830,7 @@ CxPlatFramingWriteHeaders(
         Ethernet = (ETHERNET_HEADER*)(((uint8_t*)IPv6) - sizeof(ETHERNET_HEADER));
         IpHeaderLen = sizeof(IPV6_HEADER);
         if (Route->UseQTIP) {
+            WRITE_ONCE(TCP->Checksum, 0);
             TCP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv6->Source, IPv6->Destination,
@@ -835,6 +839,7 @@ CxPlatFramingWriteHeaders(
                     (uint8_t*)TCP, sizeof(TCP_HEADER) + Buffer->Length,
                     SkipTransportLayerXsum);
         } else {
+            WRITE_ONCE(UDP->Checksum, 0);
             UDP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv6->Source, IPv6->Destination,

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -769,14 +769,14 @@ CxPlatFramingWriteHeaders(
             IPv4->HeaderChecksum = 0;
             CxPlatDpRawTxSetL3ChecksumOffload(SendData);
         } else {
-            WRITE_ONCE(IPv4->HeaderChecksum, 0);
+            *((volatile uint16_t*)(&IPv4->HeaderChecksum)) = 0;
             IPv4->HeaderChecksum = ~CxPlatFramingChecksum((uint8_t*)IPv4, sizeof(IPV4_HEADER), 0);
         }
         EthType = ETHERNET_TYPE_IPV4;
         Ethernet = (ETHERNET_HEADER*)(((uint8_t*)IPv4) - sizeof(ETHERNET_HEADER));
         IpHeaderLen = sizeof(IPV4_HEADER);
         if (Route->UseQTIP) {
-            WRITE_ONCE(TCP->Checksum, 0);
+            *((volatile uint16_t*)(&TCP->Checksum)) = 0;
             TCP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv4->Source, IPv4->Destination,
@@ -785,7 +785,7 @@ CxPlatFramingWriteHeaders(
                     (uint8_t*)TCP, sizeof(TCP_HEADER) + Buffer->Length,
                     SkipTransportLayerXsum);
         } else {
-            WRITE_ONCE(UDP->Checksum, 0);
+            *((volatile uint16_t*)(&UDP->Checksum)) = 0;
             UDP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv4->Source, IPv4->Destination,
@@ -830,7 +830,7 @@ CxPlatFramingWriteHeaders(
         Ethernet = (ETHERNET_HEADER*)(((uint8_t*)IPv6) - sizeof(ETHERNET_HEADER));
         IpHeaderLen = sizeof(IPV6_HEADER);
         if (Route->UseQTIP) {
-            WRITE_ONCE(TCP->Checksum, 0);
+            *((volatile uint16_t*)(&TCP->Checksum)) = 0;
             TCP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv6->Source, IPv6->Destination,
@@ -839,7 +839,7 @@ CxPlatFramingWriteHeaders(
                     (uint8_t*)TCP, sizeof(TCP_HEADER) + Buffer->Length,
                     SkipTransportLayerXsum);
         } else {
-            WRITE_ONCE(UDP->Checksum, 0);
+            *((volatile uint16_t*)(&UDP->Checksum)) = 0;
             UDP->Checksum =
                 CxPlatFramingTransportChecksum(
                     IPv6->Source, IPv6->Destination,

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -128,7 +128,6 @@ typedef enum CXPLAT_SOCKET_TYPE {
 } CXPLAT_SOCKET_TYPE;
 
 #define DatapathType(SendData) ((CXPLAT_SEND_DATA_COMMON*)(SendData))->DatapathType
-#define WRITE_ONCE(var, val) (*(volatile typeof(var) *)&(var) = (val))
 
 #ifdef _KERNEL_MODE
 

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -128,6 +128,7 @@ typedef enum CXPLAT_SOCKET_TYPE {
 } CXPLAT_SOCKET_TYPE;
 
 #define DatapathType(SendData) ((CXPLAT_SEND_DATA_COMMON*)(SendData))->DatapathType
+#define WRITE_ONCE(var, val) (*(volatile typeof(var) *)&(var) = (val))
 
 #ifdef _KERNEL_MODE
 


### PR DESCRIPTION
## Description

Our SW checksum code does not reset the checksum field on IP/TCP/UDP header to zero before calculating the checksum. This will lead to packet drops if it happens not to be zero.

## Testing

CI