### PR TITLE
Patch prefix 'L' on unevaluated string literal having no effect causing an Error

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -292,7 +292,7 @@ CxPlatLogAssert(
     _In_z_ const char* Expr
     );
 
-#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X, Y);
+#define CXPLAT_STATIC_ASSERT(X,Y) static_assert(X, #Y);
 #define CXPLAT_ANALYSIS_ASSERT(X)
 #define CXPLAT_ANALYSIS_ASSUME(X)
 #define CXPLAT_FRE_ASSERT(exp) ((exp) ? (void)0 : (CxPlatLogAssert(__FILE__, __LINE__, #exp), quic_bugcheck(__FILE__, __LINE__, #exp)));


### PR DESCRIPTION
…ng error

## Description

_Describe the purpose of and changes within this Pull Request._

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
