### PR TITLE
Implement packet number skipping for attack detection and improve security

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -383,7 +383,7 @@ QuicPacketBuilderPrepare(
         // Implement packet number skipping for improved security.
         // Randomly skip a packet number and track it as dummy packet.
         //
-        if (QuicSendShouldSkipPacketNumber(&Connection->Send)) {
+        if (Connection->Send.NextSkippedPacketNumber == Connection->Send.NextPacketNumber) {
             Connection->Send.SkippedPacketNumber =
                 Connection->Send.NextPacketNumber++;
             QuicTraceLogConnWarning(
@@ -391,6 +391,11 @@ QuicPacketBuilderPrepare(
                 Connection,
                 "Skipped packet number %llu",
                 Connection->Send.SkippedPacketNumber);
+
+            uint16_t RandomSkip = 0;
+            CxPlatRandom(sizeof(RandomSkip), &RandomSkip);
+            Connection->Send.NextSkippedPacketNumber =
+                Connection->Send.NextPacketNumber + RandomSkip;
         }
 
         Builder->Metadata->FrameCount = 0;

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -380,8 +380,7 @@ QuicPacketBuilderPrepare(
             Builder->BatchId);
 
         //
-        // Implement packet number skipping for improved security.
-        // Randomly skip a packet number and track it as dummy packet.
+        // Occassionally skip a packet number for improved security.
         //
         if (Connection->Send.NextSkippedPacketNumber == Connection->Send.NextPacketNumber) {
             Connection->Send.SkippedPacketNumber =
@@ -392,6 +391,9 @@ QuicPacketBuilderPrepare(
                 "Skipped packet number %llu",
                 Connection->Send.SkippedPacketNumber);
 
+            //
+            // Randomly skip a packet number (from 0 to 65535).
+            //
             uint16_t RandomSkip = 0;
             CxPlatRandom(sizeof(RandomSkip), &RandomSkip);
             Connection->Send.NextSkippedPacketNumber =

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -379,6 +379,20 @@ QuicPacketBuilderPrepare(
             Builder->Metadata->PacketId,
             Builder->BatchId);
 
+        //
+        // Implement packet number skipping for improved security.
+        // Randomly skip a packet number and track it as dummy packet.
+        //
+        if (QuicSendShouldSkipPacketNumber(&Connection->Send)) {
+            Connection->Send.SkippedPacketNumber =
+                Connection->Send.NextPacketNumber++;
+            QuicTraceLogConnWarning(
+                SkipPacketNumber,
+                Connection,
+                "Skipped packet number %llu",
+                Connection->Send.SkippedPacketNumber);
+        }
+
         Builder->Metadata->FrameCount = 0;
         Builder->Metadata->PacketNumber = Connection->Send.NextPacketNumber++;
         Builder->Metadata->Flags.KeyType = NewPacketKeyType;

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -44,6 +44,9 @@ QuicSendInitialize(
     CxPlatRandom(sizeof(RandomValue), &RandomValue);
     Send->NextPacketNumber = RandomValue;
 
+    //
+    // Randomly skip a packet number (from 0 to 65535).
+    //
     uint16_t RandomSkip = 0;
     CxPlatRandom(sizeof(RandomSkip), &RandomSkip);
     Send->NextSkippedPacketNumber = Send->NextPacketNumber + RandomSkip;

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -43,6 +43,10 @@ QuicSendInitialize(
     uint8_t RandomValue = 0;
     CxPlatRandom(sizeof(RandomValue), &RandomValue);
     Send->NextPacketNumber = RandomValue;
+
+    uint16_t RandomSkip = 0;
+    CxPlatRandom(sizeof(RandomSkip), &RandomSkip);
+    Send->NextSkippedPacketNumber = Send->NextPacketNumber + RandomSkip;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1576,16 +1580,4 @@ QuicSendProcessDelayedAckTimer(
     }
 
     QuicSendValidate(Send);
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
-QuicSendShouldSkipPacketNumber(
-    _In_ QUIC_SEND* Send
-    )
-{
-    uint16_t RandomValue;
-    return
-        QUIC_SUCCEEDED(CxPlatRandom(sizeof(RandomValue), &RandomValue)) &&
-        RandomValue == 0; // 1 in 64K packets will be skipped.
 }

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -45,11 +45,10 @@ QuicSendInitialize(
     Send->NextPacketNumber = RandomValue;
 
     //
-    // Randomly skip a packet number (from 0 to 65535).
+    // Randomly skip a packet number (from 0 to 256).
     //
-    uint16_t RandomSkip = 0;
-    CxPlatRandom(sizeof(RandomSkip), &RandomSkip);
-    Send->NextSkippedPacketNumber = Send->NextPacketNumber + RandomSkip;
+    CxPlatRandom(sizeof(RandomValue), &RandomValue);
+    Send->NextSkippedPacketNumber = Send->NextPacketNumber + RandomValue;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/send.h
+++ b/src/core/send.h
@@ -263,6 +263,12 @@ typedef struct QUIC_SEND {
     BOOLEAN Uninitialized : 1;
 
     //
+    // The current skipped packet number for attack detection. If this is
+    // acknowledged, it indicates an attack.
+    //
+    uint64_t SkippedPacketNumber;
+
+    //
     // The next packet number to use.
     //
     uint64_t NextPacketNumber;
@@ -511,4 +517,14 @@ QuicSendClearStreamSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ QUIC_STREAM* Stream,
     _In_ uint32_t SendFlag
+    );
+
+//
+// Helper function to determine if we should skip a packet number.
+// Returns TRUE if we should skip the current packet number.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicSendShouldSkipPacketNumber(
+    _In_ QUIC_SEND* Send
     );

--- a/src/core/send.h
+++ b/src/core/send.h
@@ -263,15 +263,20 @@ typedef struct QUIC_SEND {
     BOOLEAN Uninitialized : 1;
 
     //
+    // The next packet number to use.
+    //
+    uint64_t NextPacketNumber;
+
+    //
     // The current skipped packet number for attack detection. If this is
     // acknowledged, it indicates an attack.
     //
     uint64_t SkippedPacketNumber;
 
     //
-    // The next packet number to use.
+    // The next packet number we will skip for attack detection.
     //
-    uint64_t NextPacketNumber;
+    uint64_t NextSkippedPacketNumber;
 
     //
     // Last time send flush occurred. Used for pacing calculations.
@@ -517,14 +522,4 @@ QuicSendClearStreamSendFlag(
     _In_ QUIC_SEND* Send,
     _In_ QUIC_STREAM* Stream,
     _In_ uint32_t SendFlag
-    );
-
-//
-// Helper function to determine if we should skip a packet number.
-// Returns TRUE if we should skip the current packet number.
-//
-_IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
-QuicSendShouldSkipPacketNumber(
-    _In_ QUIC_SEND* Send
     );

--- a/src/generated/linux/loss_detection.c.clog.h
+++ b/src/generated/linux/loss_detection.c.clog.h
@@ -18,6 +18,10 @@
 #define _clog_MACRO_QuicTraceLogVerbose  1
 #define QuicTraceLogVerbose(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
 #endif
+#ifndef _clog_MACRO_QuicTraceLogConnError
+#define _clog_MACRO_QuicTraceLogConnError  1
+#define QuicTraceLogConnError(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
+#endif
 #ifndef _clog_MACRO_QuicTraceLogConnInfo
 #define _clog_MACRO_QuicTraceLogConnInfo  1
 #define QuicTraceLogConnInfo(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
@@ -235,6 +239,30 @@ tracepoint(CLOG_LOSS_DETECTION_C, PacketTxAcked , arg2, arg3, arg4, arg5);\
 #ifndef _clog_4_ARGS_TRACE_PacketTxProbeRetransmit
 #define _clog_4_ARGS_TRACE_PacketTxProbeRetransmit(uniqueId, encoded_arg_string, arg2, arg3)\
 tracepoint(CLOG_LOSS_DETECTION_C, PacketTxProbeRetransmit , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for AttackDetected
+// [conn][%p] Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]
+// QuicTraceLogConnError(
+                AttackDetected,
+                Connection,
+                "Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]",
+                Connection->Send.SkippedPacketNumber,
+                AckBlock->Low,
+                QuicRangeGetHigh(AckBlock));
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = Connection->Send.SkippedPacketNumber = arg3
+// arg4 = arg4 = AckBlock->Low = arg4
+// arg5 = arg5 = QuicRangeGetHigh(AckBlock) = arg5
+----------------------------------------------------------*/
+#ifndef _clog_6_ARGS_TRACE_AttackDetected
+#define _clog_6_ARGS_TRACE_AttackDetected(uniqueId, arg1, encoded_arg_string, arg3, arg4, arg5)\
+tracepoint(CLOG_LOSS_DETECTION_C, AttackDetected , arg1, arg3, arg4, arg5);\
 
 #endif
 

--- a/src/generated/linux/loss_detection.c.clog.h.lttng.h
+++ b/src/generated/linux/loss_detection.c.clog.h.lttng.h
@@ -248,6 +248,37 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PacketTxProbeRetransmit,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for AttackDetected
+// [conn][%p] Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]
+// QuicTraceLogConnError(
+                AttackDetected,
+                Connection,
+                "Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]",
+                Connection->Send.SkippedPacketNumber,
+                AckBlock->Low,
+                QuicRangeGetHigh(AckBlock));
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = Connection->Send.SkippedPacketNumber = arg3
+// arg4 = arg4 = AckBlock->Low = arg4
+// arg5 = arg5 = QuicRangeGetHigh(AckBlock) = arg5
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, AttackDetected,
+    TP_ARGS(
+        const void *, arg1,
+        unsigned long long, arg3,
+        unsigned long long, arg4,
+        unsigned long long, arg5), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+        ctf_integer(uint64_t, arg3, arg3)
+        ctf_integer(uint64_t, arg4, arg4)
+        ctf_integer(uint64_t, arg5, arg5)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for HandshakeConfirmedAck
 // [conn][%p] Handshake confirmed (ack)
 // QuicTraceLogConnInfo(

--- a/src/generated/linux/packet_builder.c.clog.h
+++ b/src/generated/linux/packet_builder.c.clog.h
@@ -48,6 +48,26 @@ tracepoint(CLOG_PACKET_BUILDER_C, NoSrcCidAvailable , arg1);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SkipPacketNumber
+// [conn][%p] Skipped packet number %llu
+// QuicTraceLogConnWarning(
+                SkipPacketNumber,
+                Connection,
+                "Skipped packet number %llu",
+                Connection->Send.SkippedPacketNumber);
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = Connection->Send.SkippedPacketNumber = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_SkipPacketNumber
+#define _clog_4_ARGS_TRACE_SkipPacketNumber(uniqueId, arg1, encoded_arg_string, arg3)\
+tracepoint(CLOG_PACKET_BUILDER_C, SkipPacketNumber , arg1, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for GetPacketTypeFailure
 // [conn][%p] Failed to get packet type for control frames, 0x%x
 // QuicTraceLogConnWarning(

--- a/src/generated/linux/packet_builder.c.clog.h.lttng.h
+++ b/src/generated/linux/packet_builder.c.clog.h.lttng.h
@@ -21,6 +21,29 @@ TRACEPOINT_EVENT(CLOG_PACKET_BUILDER_C, NoSrcCidAvailable,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SkipPacketNumber
+// [conn][%p] Skipped packet number %llu
+// QuicTraceLogConnWarning(
+                SkipPacketNumber,
+                Connection,
+                "Skipped packet number %llu",
+                Connection->Send.SkippedPacketNumber);
+// arg1 = arg1 = Connection = arg1
+// arg3 = arg3 = Connection->Send.SkippedPacketNumber = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PACKET_BUILDER_C, SkipPacketNumber,
+    TP_ARGS(
+        const void *, arg1,
+        unsigned long long, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+        ctf_integer(uint64_t, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for GetPacketTypeFailure
 // [conn][%p] Failed to get packet type for control frames, 0x%x
 // QuicTraceLogConnWarning(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -219,6 +219,30 @@
       ],
       "macroName": "QuicTraceLogConnInfo"
     },
+    "AttackDetected": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]",
+      "UniqueId": "AttackDetected",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg5"
+        }
+      ],
+      "macroName": "QuicTraceLogConnError"
+    },
     "BindingCleanup": {
       "ModuleProperites": {},
       "TraceString": "[bind][%p] Cleaning up",
@@ -11525,6 +11549,22 @@
       ],
       "macroName": "QuicTraceLogStreamWarning"
     },
+    "SkipPacketNumber": {
+      "ModuleProperites": {},
+      "TraceString": "[conn][%p] Skipped packet number %llu",
+      "UniqueId": "SkipPacketNumber",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogConnWarning"
+    },
     "SockCreateFail": {
       "ModuleProperites": {},
       "TraceString": "[sock] Failed to create socket, status:%d",
@@ -14029,6 +14069,11 @@
         "UniquenessHash": "87c499a7-b21e-c2df-9d11-9176e9730676",
         "TraceID": "ApplySettings",
         "EncodingString": "[conn][%p] Applying new settings"
+      },
+      {
+        "UniquenessHash": "2577283e-0a65-186c-be40-d33b66b0062d",
+        "TraceID": "AttackDetected",
+        "EncodingString": "[conn][%p] Attack detected: Skipped packet number %llu ACKed in range [%llu, %llu]"
       },
       {
         "UniquenessHash": "5d83e63e-7ce5-0102-8dd2-cbcf5946da2e",
@@ -17499,6 +17544,11 @@
         "UniquenessHash": "f34a9d8e-7798-1d30-2104-37dac8a3c0e0",
         "TraceID": "ShutdownImmediatePendingReliableReset",
         "EncodingString": "[strm][%p] Invalid immediate shutdown request (pending reliable reset)."
+      },
+      {
+        "UniquenessHash": "2656ff28-78a8-28d2-b18f-0aa4ec664a0d",
+        "TraceID": "SkipPacketNumber",
+        "EncodingString": "[conn][%p] Skipped packet number %llu"
       },
       {
         "UniquenessHash": "7b00c1b9-3578-872f-c41f-75bb4f92de18",


### PR DESCRIPTION
## Description

Randomizes the initial packet number used and periodically (randomly) skips packet numbers.

## Testing

CI/CD

## Documentation

N/A
