### PR TITLE
Add Kernel Static Assert Correct Version is Targetted

### DIFF
--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -254,6 +254,18 @@ extern uint64_t CxPlatTotalMemory;
 #define CXPLAT_ALLOC_NONPAGED(Size, Tag) ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_UNINITIALIZED, Size, Tag)
 #define CXPLAT_FREE(Mem, Tag) ExFreePoolWithTag((void*)Mem, Tag)
 
+//
+// If the following assert fails, then something broke and we're no longer
+// calling the inline version of ExAllocateFromLookasideListEx, and instead
+// trying to dynamically link to the more recent version of this function,
+// which doesn't exist down level.
+//
+// This value should be set via the projects _NT_TARGET_VERSION xml property.
+//
+CXPLAT_STATIC_ASSERT(
+    NTDDI_VERSION == NTDDI_WIN10_FE, // 0x0A00000A
+    "Incorrect version breaks down-level builds");
+
 typedef LOOKASIDE_LIST_EX CXPLAT_POOL;
 
 typedef struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) CXPLAT_POOL_HEADER {


### PR DESCRIPTION
## Description

This adds a static assert to the kernel header to ensure we're targetting the right downlevel release (Fe). Otherwise, it can break back-compat.

## Testing

CI/CD

## Documentation

N/A
