### PR TITLE
Reduce rust crate size by excluding fuzz test corpora

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.5.0"
+version = "2.6.0-beta"
 edition = "2021"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.6.0-beta"
+version = "2.5.0"
 edition = "2021"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"
@@ -28,7 +28,11 @@ include = [
     "/submodules/quictls/engines",
     "/submodules/quictls/exporters",
     "/submodules/quictls/external",
-    "/submodules/quictls/fuzz",
+    "/submodules/quictls/fuzz/*.c",
+    "/submodules/quictls/fuzz/*.h", 
+    "/submodules/quictls/fuzz/*.py",
+    "/submodules/quictls/fuzz/*.pl",
+    "/submodules/quictls/fuzz/build.info",
     "/submodules/quictls/include",
     "/submodules/quictls/ms",
     "/submodules/quictls/os-dep",
@@ -36,7 +40,6 @@ include = [
     "/submodules/quictls/ssl",
     "/submodules/quictls/tools",
     "/submodules/quictls/util",
-    "/submodules/quictls/VMS",
     "/submodules/openssl/*.*",
     "/submodules/openssl/apps",
     "/submodules/openssl/CHANGES",
@@ -51,12 +54,15 @@ include = [
     "/submodules/openssl/os-dep",
     "/submodules/openssl/ssl",
     "/submodules/openssl/tools",
-    "/submodules/openssl/fuzz",
+    "/submodules/openssl/fuzz/*.c",
+    "/submodules/openssl/fuzz/*.h",
+    "/submodules/openssl/fuzz/*.py",
+    "/submodules/openssl/fuzz/*.pl",
+    "/submodules/openssl/fuzz/build.info",
     "/submodules/openssl/doc",
     "/submodules/openssl/exporters",
     "/submodules/openssl/providers",
     "/submodules/openssl/util",
-    "/submodules/openssl/VMS",
     "/submodules/xdp-for-windows/published/external",
     "/scripts/build.rs",
     "/src/**/*.rs",


### PR DESCRIPTION
## Description

Crates.io only accept crates of less than 10MB and MsQuic.crate grew above it.

This reduces the weigth by trimming OpenSSL and QuicTLS fuzzing cases.
More would be nice to trim (test, documentation), but it causes build failures.

Related to #5175.

## Testing

`cargo publish --dry-run --allow-dirty` succeeds and create 9.9MB crate.

## Documentation

N/A
