### PR TITLE
Fix size check for QUIC_HANDSHAKE_INFO

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -3431,7 +3431,7 @@ CxPlatTlsParamGet(
     switch (Param) {
 
         case QUIC_PARAM_TLS_HANDSHAKE_INFO: {
-            if (*BufferLength < sizeof(QUIC_HANDSHAKE_INFO)) {
+            if (*BufferLength < CXPLAT_STRUCT_SIZE_THRU_FIELD(QUIC_HANDSHAKE_INFO, CipherSuite)) {
                 *BufferLength = sizeof(QUIC_HANDSHAKE_INFO);
                 Status = QUIC_STATUS_BUFFER_TOO_SMALL;
                 break;


### PR DESCRIPTION
Size checks on QUIC_HANDSHAKE_INFO need to take into account backward compatibility, as some prior versions were a shorter length.  Quictls and schannel account for this but openssl does not.

Fix that up

Fixes #5217

