### PR TITLE
More silo enlightenment

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -375,6 +375,11 @@ QuicConnFree(
     QuicDatagramUninitialize(&Connection->Datagram);
     if (Connection->Configuration != NULL) {
 #ifdef QUIC_SILO
+        //
+        // Take a ref on the silo before releasing the configuration
+        // to prevent the silo from being destroyed while we are still
+        // holding onto the thread to clean up other stuff for this connection.
+        //
         Silo = Connection->Configuration->Silo;
         QuicSiloAddRef(Silo);
 #endif

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -309,6 +309,7 @@ QuicConnFree(
     )
 {
     QUIC_PARTITION* Partition = Connection->Partition;
+    QuicConfigurationAttachSilo(Connection->Configuration);
     CXPLAT_FRE_ASSERT(!Connection->State.Freed);
     CXPLAT_TEL_ASSERT(Connection->RefCount == 0);
     if (Connection->State.ExternalOwner) {
@@ -408,6 +409,7 @@ QuicConnFree(
     InterlockedDecrement(&MsQuicLib.ConnectionCount);
 #endif
     QuicPerfCounterDecrement(Partition, QUIC_PERF_COUNTER_CONN_ACTIVE);
+    QuicConfigurationDetachSilo();
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -310,7 +310,7 @@ QuicConnFree(
 {
     QUIC_PARTITION* Partition = Connection->Partition;
 #ifdef QUIC_SILO
-    QUIC_SILO Silo = QUIC_SILO_INVALID;
+    QUIC_SILO Silo = NULL;
     QuicConfigurationAttachSilo(Connection->Configuration);
 #endif
 
@@ -424,9 +424,7 @@ QuicConnFree(
     QuicPerfCounterDecrement(Partition, QUIC_PERF_COUNTER_CONN_ACTIVE);
 #ifdef QUIC_SILO
     QuicConfigurationDetachSilo();
-    if (Silo != QUIC_SILO_INVALID) {
-        QuicSiloRelease(Silo);
-    }
+    QuicSiloRelease(Silo);
 #endif
 }
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -309,7 +309,6 @@ QuicConnFree(
     )
 {
     QUIC_PARTITION* Partition = Connection->Partition;
-    QuicConfigurationAttachSilo(Connection->Configuration);
     CXPLAT_FRE_ASSERT(!Connection->State.Freed);
     CXPLAT_TEL_ASSERT(Connection->RefCount == 0);
     if (Connection->State.ExternalOwner) {
@@ -318,7 +317,9 @@ QuicConnFree(
     CXPLAT_TEL_ASSERT(Connection->SourceCids.Next == NULL);
     CXPLAT_TEL_ASSERT(CxPlatListIsEmpty(&Connection->Streams.ClosedStreams));
     QuicRangeUninitialize(&Connection->DecodedAckRanges);
+    QuicConfigurationAttachSilo(Connection->Configuration);
     QuicCryptoUninitialize(&Connection->Crypto);
+    QuicConfigurationDetachSilo();
     QuicLossDetectionUninitialize(&Connection->LossDetection);
     QuicSendUninitialize(&Connection->Send);
     for (uint32_t i = 0; i < ARRAYSIZE(Connection->Packets); i++) {
@@ -409,7 +410,6 @@ QuicConnFree(
     InterlockedDecrement(&MsQuicLib.ConnectionCount);
 #endif
     QuicPerfCounterDecrement(Partition, QUIC_PERF_COUNTER_CONN_ACTIVE);
-    QuicConfigurationDetachSilo();
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)


### PR DESCRIPTION
## Description

Attach to the right silo when uninitializing a connection. Otherwise, the security context could be freed in a silo that's not where the context was allocated.

## Testing

CI and local testing

## Documentation

N/A
