### PR TITLE
CP: Fix MDL mapping size when allocating send buffers in Windows kernel mode

### DIFF
--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2586,7 +2586,7 @@ CxPlatSendBufferPoolAlloc(
     MmInitializeMdl(
         &SendBuffer->Mdl,
         SendBuffer->RawBuffer,
-        NumberOfBytes - sizeof(*SendBuffer));
+        NumberOfBytes - sizeof(*Header) - sizeof(*SendBuffer));
     MmBuildMdlForNonPagedPool(&SendBuffer->Mdl);
 
     return Header;


### PR DESCRIPTION
## Description

#4929 added a header to all pool allocation to simplify their management.
However, the computation of the actual data buffer size was not adapted when initializing the MDL in Windows Kernel mode and overestimated the buffer size by the size of the header.

This PR corrects the size computation.

## Testing

CI + running HTTP stress tests that discovered the issue.

## Documentation

N/A
