### PR TITLE
Use standard KDF for stateless retry

### DIFF
--- a/src/inc/quic_crypt.h
+++ b/src/inc/quic_crypt.h
@@ -394,6 +394,18 @@ CxPlatCryptSupports(
     CXPLAT_AEAD_TYPE AeadType
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatKbKdfDerive(
+    _In_reads_(SecretLength) const uint8_t* Secret,
+    _In_ uint32_t SecretLength,
+    _In_z_ const char* Label,
+    _In_reads_opt_(ContextLength) const uint8_t* Context,
+    _In_ uint32_t ContextLength,
+    _In_ uint32_t OutputLength,
+    _Out_writes_(OutputLength) uint8_t* Output
+    );
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/platform/crypt_bcrypt.c
+++ b/src/platform/crypt_bcrypt.c
@@ -807,7 +807,7 @@ CxPlatKbKdfDerive(
     ULONG LabelLength = 0;
     ULONG DerivedKeyLength;
 
-    LabelLength = strnlen_s(Label, 255);
+    LabelLength = (ULONG)strnlen_s(Label, 255);
 
     // Create symmetric key from the secret using HMAC-SHA256
     Status =

--- a/src/platform/crypt_bcrypt.c
+++ b/src/platform/crypt_bcrypt.c
@@ -46,12 +46,14 @@ BCRYPT_ALG_HANDLE CXPLAT_HMAC_SHA384_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_HMAC_SHA512_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_AES_ECB_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_AES_GCM_ALG_HANDLE;
+BCRYPT_ALG_HANDLE CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE;
 #else
 BCRYPT_ALG_HANDLE CXPLAT_HMAC_SHA256_ALG_HANDLE = BCRYPT_HMAC_SHA256_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_HMAC_SHA384_ALG_HANDLE = BCRYPT_HMAC_SHA384_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_HMAC_SHA512_ALG_HANDLE = BCRYPT_HMAC_SHA512_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_AES_ECB_ALG_HANDLE = BCRYPT_AES_ECB_ALG_HANDLE;
 BCRYPT_ALG_HANDLE CXPLAT_AES_GCM_ALG_HANDLE = BCRYPT_AES_GCM_ALG_HANDLE;
+BCRYPT_ALG_HANDLE CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE = BCRYPT_SP800108_CTR_HMAC_ALG_HANDLE;
 #endif
 BCRYPT_ALG_HANDLE CXPLAT_CHACHA20_POLY1305_ALG_HANDLE = NULL;
 
@@ -204,6 +206,21 @@ CxPlatCryptInitialize(
         }
     }
 
+    Status =
+        BCryptOpenAlgorithmProvider(
+            CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE,
+            BCRYPT_SP800108_CTR_HMAC_ALGORITHM,
+            NULL,
+            BCRYPT_PROV_DISPATCH);
+    if (!NT_SUCCESS(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "Open SP800-108 CTR HMAC KDF algorithm");
+        goto Error;
+    }
+
 Error:
 
     if (!NT_SUCCESS(Status)) {
@@ -230,6 +247,10 @@ Error:
         if (CXPLAT_CHACHA20_POLY1305_ALG_HANDLE) {
             BCryptCloseAlgorithmProvider(CXPLAT_CHACHA20_POLY1305_ALG_HANDLE, 0);
             CXPLAT_CHACHA20_POLY1305_ALG_HANDLE = NULL;
+        }
+        if (CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE) {
+            BCryptCloseAlgorithmProvider(CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE, 0);
+            CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE = NULL;
         }
     }
 
@@ -304,11 +325,13 @@ CxPlatCryptUninitialize(
     )
 {
 #ifdef _KERNEL_MODE
+    BCryptCloseAlgorithmProvider(CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE, 0);
     BCryptCloseAlgorithmProvider(CXPLAT_HMAC_SHA256_ALG_HANDLE, 0);
     BCryptCloseAlgorithmProvider(CXPLAT_HMAC_SHA384_ALG_HANDLE, 0);
     BCryptCloseAlgorithmProvider(CXPLAT_HMAC_SHA512_ALG_HANDLE, 0);
     BCryptCloseAlgorithmProvider(CXPLAT_AES_ECB_ALG_HANDLE, 0);
     BCryptCloseAlgorithmProvider(CXPLAT_AES_GCM_ALG_HANDLE, 0);
+    CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE = NULL;
     CXPLAT_HMAC_SHA256_ALG_HANDLE = NULL;
     CXPLAT_HMAC_SHA384_ALG_HANDLE = NULL;
     CXPLAT_HMAC_SHA512_ALG_HANDLE = NULL;
@@ -761,6 +784,91 @@ CxPlatHashCompute(
     }
 
 Error:
+
+    return NtStatusToQuicStatus(Status);
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatKbKdfDerive(
+    _In_reads_(SecretLength) const uint8_t* Secret,
+    _In_ uint32_t SecretLength,
+    _In_z_ const char* Label,
+    _In_reads_opt_(ContextLength) const uint8_t* Context,
+    _In_ uint32_t ContextLength,
+    _In_ uint32_t OutputLength,
+    _Out_writes_(OutputLength) uint8_t* Output
+    )
+{
+    NTSTATUS Status;
+    BCRYPT_KEY_HANDLE KeyHandle = NULL;
+    BCryptBuffer ParameterList[3];
+    BCryptBufferDesc Parameters;
+    ULONG LabelLength = 0;
+    ULONG DerivedKeyLength;
+
+    LabelLength = strnlen_s(Label, 255);
+
+    // Create symmetric key from the secret using HMAC-SHA256
+    Status =
+        BCryptGenerateSymmetricKey(
+            CXPLAT_SP800108_CTR_HMAC_ALG_HANDLE,
+            &KeyHandle,
+            NULL, // Let BCrypt manage the memory
+            0,
+            (PUCHAR)Secret,
+            SecretLength,
+            0);
+    if (!NT_SUCCESS(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "BCryptGenerateSymmetricKey for KDF");
+        goto Error;
+    }
+
+    ParameterList[0].BufferType = KDF_HASH_ALGORITHM;
+    ParameterList[0].pvBuffer = (PVOID)BCRYPT_SHA256_ALGORITHM;
+    ParameterList[0].cbBuffer = sizeof(BCRYPT_SHA256_ALGORITHM);
+
+    ParameterList[1].BufferType = KDF_LABEL;
+    ParameterList[1].pvBuffer = (PVOID)Label;
+    ParameterList[1].cbBuffer = LabelLength;
+
+    ParameterList[2].BufferType = KDF_CONTEXT;
+    ParameterList[2].pvBuffer = (PVOID)Context;
+    ParameterList[2].cbBuffer = ContextLength;
+
+    Parameters.ulVersion = BCRYPTBUFFER_VERSION;
+    Parameters.cBuffers = ARRAYSIZE(ParameterList);
+    Parameters.pBuffers = ParameterList;
+
+    //
+    // Derive the key using SP800-108 CTR mode
+    //
+    Status = BCryptKeyDerivation(
+        KeyHandle,
+        &Parameters,
+        Output,
+        OutputLength,
+        &DerivedKeyLength,
+        0);
+    if (!NT_SUCCESS(Status)) {
+        QuicTraceEvent(
+            LibraryErrorStatus,
+            "[ lib] ERROR, %u, %s.",
+            Status,
+            "BCryptKeyDerivation SP800-108 CTR");
+        goto Error;
+    }
+
+    CXPLAT_DBG_ASSERT(DerivedKeyLength == OutputLength);
+
+Error:
+    if (KeyHandle) {
+        BCryptDestroyKey(KeyHandle);
+    }
 
     return NtStatusToQuicStatus(Status);
 }

--- a/src/platform/unittest/CryptTest.cpp
+++ b/src/platform/unittest/CryptTest.cpp
@@ -350,16 +350,18 @@ struct CryptTest : public ::testing::TestWithParam<int32_t>
     }
 
     void
-    TestKdfDerive(
+    TestKbKdfDerive(
         _In_ QuicBuffer& Key,
         _In_z_ const char* const Label,
         _In_ const void* Context,
-        _In_ const size_t ContextLength,
-        _In_ const size_t OutputLength,
+        _In_ const uint32_t ContextLength,
+        _In_ const uint32_t OutputLength,
         _In_ QuicBuffer& ExpectedOutput)
     {
-        uint8_t Output[OutputLength];
+        uint8_t Output[CXPLAT_AEAD_MAX_SIZE];
+        ASSERT_LE(OutputLength, sizeof(Output)); // Ensure the test doesn't overrun the buffer.
         CxPlatZeroMemory(Output, OutputLength);
+
         VERIFY_QUIC_SUCCESS(
             CxPlatKbKdfDerive(
                 Key.Data,
@@ -516,13 +518,13 @@ TEST_F(CryptTest, HpMaskAes128)
     CxPlatHpKeyFree(HpKey);
 }
 
-TEST_F(CryptTest, KdfDerive)
+TEST_F(CryptTest, KbKdfDerive)
 {
     QuicBuffer Key("3edc6b5b8f7aadbd713732b482b8f979286e1ea3b8f8f99c30c884cfe3349b83");
     uint64_t Context = 1752112221;
     const char* Label = "test";
     QuicBuffer ExpectedOutput256("B7BFF374C8928335AA41589D41084B64211876771C459C23B06BA4A2EA89B5AE");
-    TestKdfDerive(
+    TestKbKdfDerive(
         Key,
         Label,
         &Context,
@@ -531,7 +533,7 @@ TEST_F(CryptTest, KdfDerive)
         ExpectedOutput256);
 
     QuicBuffer ExpectedOutput128("2775BB8F82B3B5EB667C8CF548C2F06F");
-    TestKdfDerive(
+    TestKbKdfDerive(
         Key,
         Label,
         &Context,


### PR DESCRIPTION
## Description

Addresses #5193

## Testing

New unit tests added to validate implementation is correctly using the underlying crypto libraries correctly.

## Documentation

No documentation change is needed.
