### PR TITLE
CP: More silo enlightenment (#5220) - v2.4

### DIFF
--- a/src/platform/datapath_win.c
+++ b/src/platform/datapath_win.c
@@ -368,7 +368,8 @@ CxPlatDataPathProcessCqe(
     case CXPLAT_CQE_TYPE_SOCKET_IO: {
         DATAPATH_IO_SQE* Sqe =
             CONTAINING_RECORD(CxPlatCqeUserData(Cqe), DATAPATH_IO_SQE, DatapathSqe);
-        if (Sqe->IoType == DATAPATH_XDP_IO_RECV || Sqe->IoType == DATAPATH_XDP_IO_SEND) {
+        if ((DATAPATH_XDP_IO_TYPE)Sqe->IoType == DATAPATH_XDP_IO_RECV ||
+            (DATAPATH_XDP_IO_TYPE)Sqe->IoType == DATAPATH_XDP_IO_SEND) {
             RawDataPathProcessCqe(Cqe);
         } else {
             DataPathProcessCqe(Cqe);

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -381,10 +381,10 @@ CxPlatTlsCertificateVerifyCallback(
     return status;
 }
 
-CXPLAT_STATIC_ASSERT((int)ssl_encryption_initial == (int)QUIC_PACKET_KEY_INITIAL, "Code assumes exact match!");
-CXPLAT_STATIC_ASSERT((int)ssl_encryption_early_data == (int)QUIC_PACKET_KEY_0_RTT, "Code assumes exact match!");
-CXPLAT_STATIC_ASSERT((int)ssl_encryption_handshake == (int)QUIC_PACKET_KEY_HANDSHAKE, "Code assumes exact match!");
-CXPLAT_STATIC_ASSERT((int)ssl_encryption_application == (int)QUIC_PACKET_KEY_1_RTT, "Code assumes exact match!");
+CXPLAT_STATIC_ASSERT((QUIC_PACKET_KEY_TYPE)ssl_encryption_initial == QUIC_PACKET_KEY_INITIAL, "Code assumes exact match!");
+CXPLAT_STATIC_ASSERT((QUIC_PACKET_KEY_TYPE)ssl_encryption_early_data == QUIC_PACKET_KEY_0_RTT, "Code assumes exact match!");
+CXPLAT_STATIC_ASSERT((QUIC_PACKET_KEY_TYPE)ssl_encryption_handshake == QUIC_PACKET_KEY_HANDSHAKE, "Code assumes exact match!");
+CXPLAT_STATIC_ASSERT((QUIC_PACKET_KEY_TYPE)ssl_encryption_application == QUIC_PACKET_KEY_1_RTT, "Code assumes exact match!");
 
 void
 CxPlatTlsNegotiatedCiphers(


### PR DESCRIPTION
## Description

#5220 Attach to the right silo when uninitializing a connection. Otherwise, the security context could be freed in a silo that's not where the context was allocated.

## Testing

CI and local repro

## Documentation

N/A
