### PR TITLE
Fix Linux Log "perf not found" errors

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -147,8 +147,8 @@ if ($IsLinux) {
         sudo apt-get install -y lttng-tools
         sudo apt-get install -y liblttng-ust-dev
     }
-    perf version 2>&1 | Out-Null
-    if (!$?) {
+    try { perf version | Out-Null }
+    catch {
         Write-Debug "Installing perf"
         sudo apt-get install -y linux-tools-$(uname -r)
         sudo wget https://raw.githubusercontent.com/brendangregg/FlameGraph/master/stackcollapse-perf.pl -O /usr/bin/stackcollapse-perf.pl


### PR DESCRIPTION
## Description
Fixes #4375 

In the `log.ps1` script, we test if 'perf' is installed by running the CLI tool directly.
Obviously, if perf was not installed, we will throw a "Command Not Found" error.

This problem has been silently lurking for so long due to most linux machines already having perf installed.

## Testing

CI + manual testing with WSL

## Documentation

N/A