### PR TITLE
CP: Use standard KDF for stateless retry (#5232)

### DIFF
--- a/src/inc/quic_crypt.h
+++ b/src/inc/quic_crypt.h
@@ -394,6 +394,18 @@ CxPlatCryptSupports(
     CXPLAT_AEAD_TYPE AeadType
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatKbKdfDerive(
+    _In_reads_(SecretLength) const uint8_t* Secret,
+    _In_ uint32_t SecretLength,
+    _In_z_ const char* Label,
+    _In_reads_opt_(ContextLength) const uint8_t* Context,
+    _In_ uint32_t ContextLength,
+    _In_ uint32_t OutputLength,
+    _Out_writes_(OutputLength) uint8_t* Output
+    );
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/platform/crypt_openssl.c
+++ b/src/platform/crypt_openssl.c
@@ -711,3 +711,62 @@ CxPlatHashCompute(
     CXPLAT_FRE_ASSERT(ActualOutputSize == OutputLength);
     return QUIC_STATUS_SUCCESS;
 }
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatKbKdfDerive(
+    _In_reads_(SecretLength) const uint8_t* Secret,
+    _In_ uint32_t SecretLength,
+    _In_z_ const char* Label,
+    _In_reads_opt_(ContextLength) const uint8_t* Context,
+    _In_ uint32_t ContextLength,
+    _In_ uint32_t OutputLength,
+    _Out_writes_(OutputLength) uint8_t* Output
+    )
+{
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+    EVP_KDF* Kdf;
+    EVP_KDF_CTX* KdfCtx;
+    OSSL_PARAM Params[6];
+
+    Kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
+    KdfCtx = EVP_KDF_CTX_new(Kdf);
+    EVP_KDF_free(Kdf);
+
+    Params[0] =
+        OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,"SHA2-256", 0);
+
+    Params[1] =
+        OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC,"HMAC", 0);
+
+    Params[2] =
+        OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_KEY,
+            (void*)Secret,
+            SecretLength);
+
+    Params[3] =
+        OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_SALT,
+            (void*)Label,
+            strnlen(Label, 255));
+
+    Params[4] =
+        OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_INFO,
+            (void*)Context,
+            ContextLength);
+
+    Params[5] = OSSL_PARAM_construct_end();
+
+    if (EVP_KDF_derive(KdfCtx, Output, OutputLength, Params) <= 0) {
+        QuicTraceEvent(
+            LibraryError,
+            "[ lib] ERROR, %s.",
+            "EVP_KDF_derive failed");
+        Status = QUIC_STATUS_INTERNAL_ERROR;
+    }
+
+    EVP_KDF_CTX_free(KdfCtx);
+    return Status;
+}


### PR DESCRIPTION
* Implement SP800-108 CTR-HMAC KBKDF and use it for stateless retry key generation.

* Add tests
