### PR TITLE
Use O0 instead of Og in Linux debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,7 @@ else() #!WIN32
         set(MARCH -march=native)
     endif()
 
-    set(CMAKE_C_FLAGS_DEBUG "-Og -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer")
     set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -fno-omit-frame-pointer ${MARCH} -DNDEBUG")
     set(CMAKE_C_FLAGS_RELEASE "-O3 ${MARCH} -DNDEBUG")


### PR DESCRIPTION
## Description

Optimization level -Og doesn't allow proper debugging, as most functions and variables still end up being optimized.
This PR uses -O0 instead for Linux debug builds.

Related to #5024

## Testing

CI.

## Documentation

N/A