### PR TITLE
Move clang-incompatible flag under separate check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,11 @@ else() #!WIN32
 
     if(QUIC_ENABLE_SANITIZERS)
         message(STATUS "Configuring sanitizers")
-        list(APPEND QUIC_COMMON_FLAGS -fsanitize=address,leak,undefined,alignment -fsanitize-address-use-after-scope -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-var-tracking-assignments)
+        list(APPEND QUIC_COMMON_FLAGS -fsanitize=address,leak,undefined,alignment -fsanitize-address-use-after-scope -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        check_c_compiler_flag(-fno-var-tracking-assignments HAS_NO_VAR_TRACKING)
+        if (HAS_NO_VAR_TRACKING)
+            list(APPEND QUIC_COMMON_FLAGS -fno-var-tracking-assignments)
+        endif()
         if (CX_PLATFORM STREQUAL "darwin")
             list(APPEND QUIC_COMMON_FLAGS -gdwarf)
         else()


### PR DESCRIPTION
## Description

When building with clang, -fno-var-tracking-assignments is not recognized and causes an error. This change moves the flag behind a compiler check to ensure it is applied to compilers that support it.

## Testing

CI will validate the change.

## Documentation

N/A
