### PR TITLE
Log 1-RTT keys in SSLKEYLOG when using OpenSSL

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -129,7 +129,7 @@ elseif(QUIC_LINUX_XDP_ENABLED)
     target_include_directories(msquic_platform PRIVATE ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES})
 endif()
 
-if (MSVC AND (QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "schannel") AND NOT QUIC_ENABLE_SANITIZERS)
+if (MSVC AND (QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl" OR QUIC_TLS_LIB STREQUAL "schannel") AND NOT QUIC_ENABLE_SANITIZERS)
     target_compile_options(msquic_platform PRIVATE /analyze)
 endif()
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -630,6 +630,7 @@ static int QuicTlsYieldSecret(SSL *S, uint32_t ProtLevel,
     // If we are installing initial Secrets TlsSecrets aren't allocated yet
     //
     if (TlsContext->TlsSecrets != NULL) {
+        TlsContext->TlsSecrets->SecretLength = (uint8_t)SecretLen;
         //
         // We pass our Secrets one at a time instead of together
         // So we need to map which Secret we're assigning based
@@ -641,7 +642,7 @@ static int QuicTlsYieldSecret(SSL *S, uint32_t ProtLevel,
             if (TlsContext->IsServer) {
                 if (AData->SecretSet[ProtLevel][DIR_WRITE].Secret != NULL) {
                     memcpy(TlsContext->TlsSecrets->ServerHandshakeTrafficSecret,
-                           AData->SecretSet[ProtLevel][DIR_WRITE].Secret, AData->SecretSet[ProtLevel][1].SecretLen);
+                           AData->SecretSet[ProtLevel][DIR_WRITE].Secret, AData->SecretSet[ProtLevel][DIR_WRITE].SecretLen);
                     TlsContext->TlsSecrets->IsSet.ServerHandshakeTrafficSecret = TRUE;
                 }
                 if (AData->SecretSet[ProtLevel][DIR_READ].Secret != NULL) {
@@ -679,6 +680,31 @@ static int QuicTlsYieldSecret(SSL *S, uint32_t ProtLevel,
             }
             break;
         case QUIC_PACKET_KEY_1_RTT:
+            if (TlsContext->IsServer) {
+                if (AData->SecretSet[ProtLevel][DIR_WRITE].Secret != NULL) {
+                    memcpy(TlsContext->TlsSecrets->ServerTrafficSecret0,
+                           AData->SecretSet[ProtLevel][DIR_WRITE].Secret, AData->SecretSet[ProtLevel][DIR_WRITE].SecretLen);
+                    TlsContext->TlsSecrets->IsSet.ServerTrafficSecret0 = TRUE;
+                }
+                if (AData->SecretSet[ProtLevel][DIR_READ].Secret != NULL) {
+                    memcpy(TlsContext->TlsSecrets->ClientTrafficSecret0,
+                           AData->SecretSet[ProtLevel][DIR_READ].Secret, AData->SecretSet[ProtLevel][DIR_READ].SecretLen);
+                    TlsContext->TlsSecrets->IsSet.ClientTrafficSecret0 = TRUE;
+                }
+            } else {
+                if (AData->SecretSet[ProtLevel][DIR_WRITE].Secret != NULL) {
+                    memcpy(TlsContext->TlsSecrets->ClientTrafficSecret0,
+                           AData->SecretSet[ProtLevel][DIR_WRITE].Secret, AData->SecretSet[ProtLevel][DIR_WRITE].SecretLen);
+                    TlsContext->TlsSecrets->IsSet.ClientTrafficSecret0 = TRUE;
+                }
+                if (AData->SecretSet[ProtLevel][DIR_READ].Secret != NULL) {
+                    memcpy(TlsContext->TlsSecrets->ServerTrafficSecret0,
+                           AData->SecretSet[ProtLevel][DIR_READ].Secret, AData->SecretSet[ProtLevel][DIR_READ].SecretLen);
+                    TlsContext->TlsSecrets->IsSet.ServerTrafficSecret0 = TRUE;
+                }
+            }
+
+            break;
         default:
             break;
         }


### PR DESCRIPTION
## Description

This change ensures that all 1-RTT keys are properly logged to the SSLKEYLOGFILE, which was not fully implemented in [microsoft/msquic#4959](https://github.com/microsoft/msquic/pull/4959). Without this, some QUIC traffic could not be decrypted during analysis.

Example SSLKEYLOGFILE from running resumption QUIC interop test:
```
# TLS 1.3 secrets log file, generated by quicinterop
CLIENT_HANDSHAKE_TRAFFIC_SECRET xxxx xxxx
SERVER_HANDSHAKE_TRAFFIC_SECRET xxxx xxxx
CLIENT_TRAFFIC_SECRET_0 xxxx xxxx
SERVER_TRAFFIC_SECRET_0 xxxx xxxx
CLIENT_EARLY_TRAFFIC_SECRET xxxx xxxx
CLIENT_HANDSHAKE_TRAFFIC_SECRET xxxx xxxx
SERVER_HANDSHAKE_TRAFFIC_SECRET xxxx xxxx
CLIENT_TRAFFIC_SECRET_0 xxxx xxxx
SERVER_TRAFFIC_SECRET_0 xxxx xxxx

```

Additionally, this update fixes an unrelated issue where a conditional block for `if openssl` was missing.

## Testing

Previously, Wireshark was unable to decrypt certain packets in QUIC interop tests due to missing 1-RTT keys in the SSLKEYLOGFILE when using MsQuic built with the OpenSSL backend.

With this fix:
- I am now able to successfully decrypt QUIC packets using the SSL key log in Wireshark.
- More QUIC interop tests pass, since the test suite uses tshark to analyze traffic using the SSLKEYLOGFILE.

These changes will be validated through the https://github.com/openssl/openssl GitHub Actions CI, which includes interop testing using MsQuic built with OpenSSL backend. Here is a QUIC interop run on my own fork before it is merged to https://github.com/openssl/openssl: https://github.com/andrewkdinh/openssl/actions/runs/16625623943