### PR TITLE
Fix: correctly populate the 'Secret' field in SSLKEYLOGFILE when using OpenSSL

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -636,6 +636,7 @@ static int QuicTlsYieldSecret(SSL *S, uint32_t ProtLevel,
         // on whether we are a server, what type of key we're writing
         // and the Direction (1 for write, 0 for read)
         //
+	TlsContext->TlsSecrets->SecretLength = (uint8_t)SecretLen;
         switch(KeyType) {
         case QUIC_PACKET_KEY_HANDSHAKE:
             if (TlsContext->IsServer) {


### PR DESCRIPTION
## Description
Fixes an issue where the `Secret` field in the SSLKEYLOGFILE output was not correctly populated when using OpenSSL. This could prevent tools like Wireshark from properly parsing TLS sessions.

## Changes:
Properly sets the length of the `Secret` field when OpenSSL is used, ensuring the SSLKEYLOGFILE output conforms to the expected format.

## Impact
Affects only scenarios where SSLKEYLOGFILE output is enabled and OpenSSL is used as the TLS provider.
Does not affect other crypto modules or normal connection flows.

## Test Scenarios
Run `quicsample` to establish TLS sessions using OpenSSL and verify that the SSLKEYLOGFILE output is correctly formatted and can be parsed by Wireshark.