### PR TITLE
Copy submodules/openssl when building Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !cmake
 !submodules/clog
 !submodules/quictls
+!submodules/openssl
 !submodules/CMakeLists.txt
 submodules/quictls/pyca-cryptography
 submodules/quictls/boringssl


### PR DESCRIPTION
## Description

Copy submodules/openssl when building Docker container

## Testing

msquic with openssl QUIC interop runner builds correctly now: https://github.com/andrewkdinh/openssl/actions/runs/16654150994

## Documentation

N/A
