### PR TITLE
disable all optimizations in linux debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,7 @@ else() #!WIN32
         set(MARCH -march=native)
     endif()
 
-    set(CMAKE_C_FLAGS_DEBUG "-Og -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS_DEBUG "-O0 -g -fno-omit-frame-pointer")
     set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -fno-omit-frame-pointer ${MARCH} -DNDEBUG")
     set(CMAKE_C_FLAGS_RELEASE "-O3 ${MARCH} -DNDEBUG")


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The `-Og` flag reduces optimizations, but debugging is still slower and less productive than necessary due to the remaining compiler optimizations. Turn the optimizations all the way back to `-O0` and add a separate `-g` flag.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Seems to improve debugging efficiency locally.

## Documentation

_Is there any documentation impact for this change?_

No.