### PR TITLE
Link to libcrypto and libssl dynamically when using SYSTEM_LIBCRYPTO

### DIFF
--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -348,7 +348,7 @@ else()
             if (OPENSSL_VERSION VERSION_EQUAL EXPECTED_OPENSSL_VERSION OR OPENSSL_MAJORMINOR VERSION_EQUAL EXPECTED_OPENSSL_VERSION OR
                 # 3.1 is compatible with 3.0, 3.2 and beyond maybe as well.
                 (EXPECTED_OPENSSL_VERSION VERSION_EQUAL "3.0" AND OPENSSL_MAJOR EQUAL "3"))
-                target_link_libraries(OpenSSLQuic INTERFACE OpenSSL::Crypto)
+                target_link_libraries(OpenSSLQuic INTERFACE OpenSSL::Crypto OpenSSL::SSL)
             else()
                 message(FATAL_ERROR "OpenSSL ${EXPECTED_OPENSSL_VERSION} not found, found ${OPENSSL_VERSION}")
             endif()


### PR DESCRIPTION
When using SYSTEM_LIBCRYPTO, the cmake build system attempts to link libssl statically and libcrypto dynamically.  This leads to missing symbols as openssl expects either both libraries to be linked statically or dynamically, not one or the other

Fixes #5210

## Description

#5210 reported an issue in which, when using the cmake build infrastructure directly, missing symbols were found when loaded (most notably ossl_time_now).  This occured because libssl is being linked statically (which references ossl_time_now in the static archive), but ossl_time_now is only defined as an internal symbol in the libcrypto.dso.

## Testing

Unsure, I think most of the tests use the powershell build scripts to build (which link libssl and libcrypto statically avoiding the problem).  presumably we would want to test cmake directly, but I'm not sure if thats worthwhile

## Documentation

No
