### PR TITLE
[BACKPORT to 2.5] Fix flaky Kernel BVT test timeouts (#5289)

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1986,6 +1986,7 @@ CxPlatSocketReceiveCoalesced(
             goto Exit;
         }
 
+        CxPlatZeroMemory(&IoBlock->Route, sizeof(CXPLAT_ROUTE));
         IoBlock->Route.State = RouteResolved;
 
         struct msghdr* MsgHdr = &RecvMsgHdr.msg_hdr;
@@ -2060,6 +2061,7 @@ CxPlatSocketReceiveMessages(
             }
 
             IoBlocks[i] = IoBlock;
+            CxPlatZeroMemory(&IoBlock->Route, sizeof(CXPLAT_ROUTE));
             IoBlock->Route.State = RouteResolved;
 
             struct msghdr* MsgHdr = &RecvMsgHdr[i].msg_hdr;
@@ -2133,6 +2135,7 @@ CxPlatSocketReceiveTcpData(
             goto Exit;
         }
 
+        CxPlatZeroMemory(&IoBlock->Route, sizeof(CXPLAT_ROUTE));
         IoBlock->Route.State = RouteResolved;
         IoBlock->Route.Queue = SocketContext;
         IoBlock->RefCount = 0;

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -2004,6 +2004,7 @@ CxPlatSocketAllocRxIoBlock(
     DATAPATH_RX_IO_BLOCK* IoBlock = CxPlatPoolAlloc(Pool);
 
     if (IoBlock != NULL) {
+        CxPlatZeroMemory(&IoBlock->Route, sizeof(CXPLAT_ROUTE));
         IoBlock->Route.State = RouteResolved;
         IoBlock->ProcContext = &Datapath->ProcContexts[ProcIndex];
         IoBlock->DataBufferStart = NULL;

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2856,6 +2856,7 @@ CxPlatSocketAllocRxIoBlock(
     }
 
     if (IoBlock != NULL) {
+        CxPlatZeroMemory(&IoBlock->Route, sizeof(CXPLAT_ROUTE));
         IoBlock->Route.State = RouteResolved;
         IoBlock->ReferenceCount = 0;
         IoBlock->SocketProc = SocketProc;

--- a/src/platform/datapath_xplat.c
+++ b/src/platform/datapath_xplat.c
@@ -436,6 +436,10 @@ CxPlatResolveRoute(
         Route->UseQTIP = Socket->ReserveAuxTcpSock;
     }
 
+    #if defined(_KERNEL_MODE) || defined(CX_PLATFORM_LINUX) || defined(CX_PLATFORM_DARWIN)
+    CXPLAT_DBG_ASSERT(Route->UseQTIP == FALSE);
+    #endif
+
     if (Route->UseQTIP || Route->DatapathType == CXPLAT_DATAPATH_TYPE_RAW ||
         (Route->DatapathType == CXPLAT_DATAPATH_TYPE_UNKNOWN &&
         Socket->RawSocketAvailable && !IS_LOOPBACK(Route->RemoteAddress))) {


### PR DESCRIPTION
## Description

Original issue: https://github.com/microsoft/msquic/issues/5247

This backport fixes the recent surge in Kernel BVT test timeouts. 
From investigations, the root cause was an invalid assumption that CXPLAT_ROUTE is zero initialized.

Changes:

ensure Routes are properly zero initialized when memory is allocated for it.

## Testing

CI

I modifed the BVT kernel runs to loop 15 times in a row, and it all passed in:

https://github.com/microsoft/msquic/actions/runs/16633197399/job/47068270266?pr=5289
and
https://github.com/microsoft/msquic/actions/runs/16631906495/job/47063807097?pr=5289

## Documentation

N/A
