### PR TITLE
Update Sample.md

### DIFF
--- a/docs/Sample.md
+++ b/docs/Sample.md
@@ -20,8 +20,12 @@ This works with OpenSSL TLS Provider. It can also be used for Windows OpenSSL, h
 
 ## Start the server
 Locate the executable quicsample.exe or quicsample under your `artifacts/bin` directory under repo root. Start the server providing the certificate and key obtained in the previous step.
-
-```Powershell
+On Windows, certificate hash can be used to load from certficate store:
+```
+quicsample.exe -server -cert_hash:FAF9B176D64930D67C372CB456BAD38E7E5689F7
+```
+On Linux, file paths can be used to load server credential:
+```
 quicsample -server -cert_file:path/to/server.cert -key_file:path/to/server.key
 ```
 By default, the server listens on port 4567.

--- a/docs/Sample.md
+++ b/docs/Sample.md
@@ -19,7 +19,7 @@ This works with OpenSSL TLS Provider. It can also be used for Windows OpenSSL, h
 
 
 ## Start the server
-Locate the executable quicsample.exe or quicsample under your `artifacts/bin` directory under repo root. Start the server providing the thumbrint obtained in the previous step.
+Locate the executable quicsample.exe or quicsample under your `artifacts/bin` directory under repo root. Start the server providing the certificate and key obtained in the previous step.
 
 ```Powershell
 quicsample -server -cert_file:path/to/server.cert -key_file path/to/server.key

--- a/docs/Sample.md
+++ b/docs/Sample.md
@@ -19,10 +19,10 @@ This works with OpenSSL TLS Provider. It can also be used for Windows OpenSSL, h
 
 
 ## Start the server
-Locate the quicsample.exe under your `artifacts/bin` directory under repo root. Start the server providing the thumbrint obtained in the previous step.
+Locate the executable quicsample.exe or quicsample under your `artifacts/bin` directory under repo root. Start the server providing the thumbrint obtained in the previous step.
 
 ```Powershell
-quicsample.exe -server -cert_hash:FAF9B176D64930D67C372CB456BAD38E7E5689F7
+quicsample -server -cert_file:path/to/server.cert -key_file path/to/server.key
 ```
 By default, the server listens on port 4567.
 
@@ -30,7 +30,7 @@ By default, the server listens on port 4567.
 Start the client providing the IP address for the server. Here 127.0.0.1 is used as an example.
 
 ```Powershell
-quicsample.exe -client -unsecure -target:127.0.0.1
+quicsample -client -unsecure -target:127.0.0.1
 ```
 
 ## Troubleshooting with Wireshark 

--- a/docs/Sample.md
+++ b/docs/Sample.md
@@ -22,7 +22,7 @@ This works with OpenSSL TLS Provider. It can also be used for Windows OpenSSL, h
 Locate the executable quicsample.exe or quicsample under your `artifacts/bin` directory under repo root. Start the server providing the certificate and key obtained in the previous step.
 
 ```Powershell
-quicsample -server -cert_file:path/to/server.cert -key_file path/to/server.key
+quicsample -server -cert_file:path/to/server.cert -key_file:path/to/server.key
 ```
 By default, the server listens on port 4567.
 


### PR DESCRIPTION
## Description
quicsample works for launching the sample on both Windows and Linux, while quicsample.exe only works on Windows.
Also, -cert_file and -key_file can be used in the launch command to avoid using specific hash value.

_Describe the purpose of and changes within this Pull Request._

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
