### PR TITLE
fixes to unblock netperf testing of io_uring

### DIFF
--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -534,6 +534,8 @@ if ($InstallTestCertificates) { Install-TestCertificates }
 
 if ($IsLinux) {
     if ($InstallClog2Text) {
+        sudo apt-get update -y
+        sudo apt-get install -y dotnet-runtime-8.0
         Install-Clog2Text
     }
 

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -42,6 +42,10 @@ if ($Command.Contains("epoll")) {
     $io = "epoll"
 }
 
+if ($Command.Contains("iouring")) {
+    $io = "iouring"
+}
+
 if ($Command.Contains("xdp")) {
     $io = "xdp"
 }

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -80,6 +80,9 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
 } elseif ($Command.Contains("C:/_work/quic/artifacts/bin/windows/x64_Release_schannel/secnetperf")) {
     Write-Host "Executing command: $(pwd)/artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats"
     ./artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats
+} elseif ($Command.Contains("Prepare_MachineForTest")) {
+    Write-Host "Executing command: Prepare_MachineForTest"
+    .\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates
 } elseif ($Command.Contains("Install_XDP")) {
     Write-Host "Executing command: Install_XDP"
     .\scripts\prepare-machine.ps1 -InstallXdpDriver

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -509,7 +509,7 @@ function Get-LatencyOutput {
 function Is-TcpSupportedByIo {
     param ($Io)
 
-    return $Io -ne "xdp" -and $Io -ne "qtip" -and $Io -ne "wsk"
+    return $Io -ne "xdp" -and $Io -ne "qtip" -and $Io -ne "wsk" -and $Io -ne "iouring"
 }
 
 # Invokes secnetperf with the given arguments for both TCP and QUIC.

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -132,6 +132,23 @@ function Wait-DriverStarted {
     throw "$DriverName failed to start!"
 }
 
+function Prepare-MachineForTest {
+    param ($Session, $RemoteDir)
+    Write-Host "Running prepare-machine.ps1 -ForTest -InstallSigningCertificates"
+    .\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates
+    Write-Host "Running prepare-machine.ps1 -ForTest -InstallSigningCertificates on peer"
+
+    if ($Session -eq "NOT_SUPPORTED") {
+        NetperfSendCommand "Prepare_MachineForTest"
+        NetperfWaitServerFinishExecution
+        return
+    }
+
+    Invoke-Command -Session $Session -ScriptBlock {
+        & "$Using:RemoteDir\scripts\prepare-machine.ps1" -ForTest -InstallSigningCertificates
+    }
+}
+
 # Download and install XDP on both local and remote machines.
 function Install-XDP {
     param ($Session, $RemoteDir)

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -277,13 +277,7 @@ $allScenarios = @("upload", "download", "hps", "rps", "rps-multi", "latency")
 $hasFailures = $false
 
 try {
-Write-Host "Preparing local machine for testing"
-./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
-
-Write-Host "Preparing peer machine for testing"
-Invoke-Command -Session $Session -ScriptBlock {
-    & "$Using:RemoteDir/scripts/prepare-machine.ps1" -ForTest -InstallSigningCertificates
-}
+Prepare-MachineForTest
 
 if ($isWindows -and !($environment -eq "azure")) {
     $HasTestSigning = $false

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -64,11 +64,11 @@ param (
     [string]$tls = "schannel",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("", "iocp", "xdp", "qtip", "wsk", "epoll", "kqueue")]
+    [ValidateSet("", "iocp", "xdp", "qtip", "wsk", "epoll", "iouring", "kqueue")]
     [string]$io = "",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("", "iocp", "xdp", "qtip", "wsk", "epoll", "kqueue")]
+    [ValidateSet("", "iocp", "xdp", "qtip", "wsk", "epoll", "iouring","kqueue")]
     [string]$serverio = "",
 
     [Parameter(Mandatory = $false)]

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -277,7 +277,7 @@ $allScenarios = @("upload", "download", "hps", "rps", "rps-multi", "latency")
 $hasFailures = $false
 
 try {
-Prepare-MachineForTest
+Prepare-MachineForTest $Session $RemoteDir
 
 if ($isWindows -and !($environment -eq "azure")) {
     $HasTestSigning = $false

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -277,19 +277,18 @@ $allScenarios = @("upload", "download", "hps", "rps", "rps-multi", "latency")
 $hasFailures = $false
 
 try {
-    Write-Host "Preparing local machine for testing"
-    ./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
+Write-Host "Preparing local machine for testing"
+./scripts/prepare-machine.ps1 -ForTest -InstallSigningCertificates
 
-    Write-Host "Preparing peer machine for testing"
-    Invoke-Command -Session $Session -ScriptBlock {
-        & "$Using:RemoteDir/scripts/prepare-machine.ps1" -ForTest -InstallSigningCertificates
-    }
+Write-Host "Preparing peer machine for testing"
+Invoke-Command -Session $Session -ScriptBlock {
+    & "$Using:RemoteDir/scripts/prepare-machine.ps1" -ForTest -InstallSigningCertificates
+}
 
-    if ($isWindows -and !($environment -eq "azure")) {
-        $HasTestSigning = $false
-        try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
-        if (!$HasTestSigning) { Write-Host "Test Signing Not Enabled!" }
-    }
+if ($isWindows -and !($environment -eq "azure")) {
+    $HasTestSigning = $false
+    try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
+    if (!$HasTestSigning) { Write-Host "Test Signing Not Enabled!" }
 }
 
 # Install any dependent drivers.

--- a/src/perf/lib/PerfClient.cpp
+++ b/src/perf/lib/PerfClient.cpp
@@ -239,6 +239,12 @@ PerfClient::Init(
             Settings.SetXdpEnabled(true);
             Settings.SetQtipEnabled(true);
         }
+#ifndef CXPLAT_USE_IO_URING
+        if (IoMode && IsValue(IoMode, "iouring")) {
+            WriteOutput("iouring is not supported on this build\n");
+            return QUIC_STATUS_NOT_SUPPORTED;
+        }
+#endif
         Configuration.SetSettings(Settings);
     }
 

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -135,7 +135,7 @@ PrintHelp(
         "  -qeo:<0/1>               Allows/disallowes QUIC encryption offload. (def:0)\n"
 #ifndef _KERNEL_MODE
         "  -io:<mode>               Configures a requested network IO model to be used.\n"
-        "                            - {iocp, xdp, qtip, epoll, kqueue}\n"
+        "                            - {iocp, xdp, qtip, epoll, iouring, kqueue}\n"
 #else
         "  -io:<mode>               Configures a requested network IO model to be used.\n"
         "                            - {wsk}\n"


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

#5061 added a skeleton of io_uring support within MsQuic. PR https://github.com/microsoft/netperf/pull/704 in netperf can't execute the io_uring code paths, though, because of several more pieces of infrastructure within MsQuic. This PR addresses those dependencies by uniformly executing `prepare-machine.ps1` on netperf test machines and allowing `io:uring` as a secnetperf parameter.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Manually ran CI across these two repos.

## Documentation

_Is there any documentation impact for this change?_

Updated help text.