### PR TITLE
modified cmake to disable xdp for arm architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,12 @@ else()
             set(QUIC_LOGGING_TYPE "lttng")
             message(STATUS "Choosing lttng as default logging type for platform")
         endif()
+        
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)$")
+            set(QUIC_LINUX_XDP_ENABLED OFF CACHE BOOL "XDP not supported on ARM architectures" FORCE)
+        else()
+            option(QUIC_LINUX_XDP_ENABLED "Enables XDP support" OFF)
+        endif()
 
     elseif(CX_PLATFORM STREQUAL "darwin")
         check_function_exists(sysctl HAS_SYSCTL)


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
The undock pipeline uses the same cmake flags for all the archs of a target container which means it will throw an error when QUIC_LINUX_XDP_ENABLED is on for arm architectures as its not supported. This PR adds a check to disable the flag for arm archs.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
