### PR TITLE
CP: Allow the app to react when app-provided buffer is insufficient

### DIFF
--- a/docs/PreviewFeatures.md
+++ b/docs/PreviewFeatures.md
@@ -1,4 +1,4 @@
-Preview features
+GPreview features
 =========
 > [!IMPORTANT]
 >
@@ -35,8 +35,7 @@ TODO
 
 TODO
 
-### StreamProvideReceiveBuffers
+### App-provided receive buffers
 
-[StreamProvideReceiveBuffers](StreamProvideReceiveBuffers.md)
-
-TODO
+- [StreamProvideReceiveBuffers](api/StreamProvideReceiveBuffers.md)
+- [QUIC_API_ENABLE_PREVIEW_FEATURES](api/QUIC_STREAM_EVENT.md#quic_stream_event_receive_buffer_needed)

--- a/docs/PreviewFeatures.md
+++ b/docs/PreviewFeatures.md
@@ -1,4 +1,4 @@
-GPreview features
+Preview features
 =========
 > [!IMPORTANT]
 >

--- a/docs/api/StreamProvideReceiveBuffers.md
+++ b/docs/api/StreamProvideReceiveBuffers.md
@@ -28,7 +28,12 @@ QUIC_STATUS
 # Remarks
 
 This is an asynchronous API but it can run inline if called in a callback.
-If called inline when handling a `QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED` event, it will convert the stream to app-owned buffer mode.
+
+If called inline when handling a `QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED` event, it will convert
+the stream to app-owned buffer mode.
+
+If called inline when handling a `QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED` event, the provided
+memory buffers will be used to store the received data.
 
 # See also
 

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1235,7 +1235,6 @@ QuicCryptoProcessDataFrame(
     QUIC_STATUS Status;
     QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
     uint64_t FlowControlQuota = UINT16_MAX;
-    uint32_t EncLevelOffset = 0;
 
     *DataReady = FALSE;
 

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1234,7 +1234,8 @@ QuicCryptoProcessDataFrame(
 {
     QUIC_STATUS Status;
     QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
-    uint64_t FlowControlLimit = UINT16_MAX;
+    uint64_t FlowControlQuota = UINT16_MAX;
+    uint32_t EncLevelOffset = 0;
 
     *DataReady = FALSE;
 
@@ -1267,14 +1268,18 @@ QuicCryptoProcessDataFrame(
         // Write the received data (could be duplicate) to the stream buffer. The
         // stream buffer will indicate if there is data to process.
         //
+        uint64_t BufferSizeNeeded = 0;
         Status =
             QuicRecvBufferWrite(
                 &Crypto->RecvBuffer,
                 Crypto->RecvEncryptLevelStartOffset + Frame->Offset,
                 (uint16_t)Frame->Length,
                 Frame->Data,
-                &FlowControlLimit,
-                DataReady);
+                FlowControlQuota,
+                &FlowControlQuota,
+                DataReady,
+                &BufferSizeNeeded);
+        CXPLAT_DBG_ASSERT(BufferSizeNeeded == 0);
         if (QUIC_FAILED(Status)) {
             if (Status == QUIC_STATUS_BUFFER_TOO_SMALL) {
                 QuicTraceEvent(

--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -284,6 +284,7 @@ QuicRecvBufferInitialize(
     RecvBuffer->RecvMode = RecvMode;
     RecvBuffer->PreallocatedChunk = PreallocatedChunk;
     RecvBuffer->RetiredChunk = NULL;
+    RecvBuffer->VirtualBufferLength = VirtualBufferLength;
     QuicRangeInitialize(QUIC_MAX_RANGE_ALLOC_SIZE, &RecvBuffer->WrittenRanges);
     CxPlatListInitializeHead(&RecvBuffer->Chunks);
 
@@ -308,10 +309,8 @@ QuicRecvBufferInitialize(
         }
         CxPlatListInsertHead(&RecvBuffer->Chunks, &Chunk->Link);
         RecvBuffer->Capacity = AllocBufferLength;
-        RecvBuffer->VirtualBufferLength = VirtualBufferLength;
     } else {
         RecvBuffer->Capacity = 0;
-        RecvBuffer->VirtualBufferLength = 0;
     }
 
     return QUIC_STATUS_SUCCESS;
@@ -389,9 +388,32 @@ QuicRecvBufferIncreaseVirtualBufferLength(
     _In_ uint32_t NewLength
     )
 {
-    CXPLAT_DBG_ASSERT(RecvBuffer->RecvMode != QUIC_RECV_BUF_MODE_APP_OWNED);
     CXPLAT_DBG_ASSERT(NewLength >= RecvBuffer->VirtualBufferLength); // Don't support decrease.
     RecvBuffer->VirtualBufferLength = NewLength;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+uint32_t
+QuicRecvBufferGetTotalAllocLength(
+    _In_ QUIC_RECV_BUFFER* RecvBuffer
+    )
+{
+    if (CxPlatListIsEmpty(&RecvBuffer->Chunks)) {
+        return 0;
+    }
+
+    //
+    // The first chunk might have a reduced capacity (if more chunks are present and it is being
+    // consumed). Other chunks are always allocated at their full alloc size.
+    //
+    uint32_t AllocLength = RecvBuffer->Capacity;
+    for (CXPLAT_LIST_ENTRY* Link = RecvBuffer->Chunks.Flink->Flink; // Skip the first chunk
+         Link != &RecvBuffer->Chunks;
+         Link = Link->Flink) {
+        QUIC_RECV_CHUNK* Chunk = CXPLAT_CONTAINING_RECORD(Link, QUIC_RECV_CHUNK, Link);
+        AllocLength += Chunk->AllocLength;
+    }
+    return AllocLength;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -404,7 +426,7 @@ QuicRecvBufferProvideChunks(
     CXPLAT_DBG_ASSERT(RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_APP_OWNED);
     CXPLAT_DBG_ASSERT(!CxPlatListIsEmpty(Chunks));
 
-    uint64_t NewBufferLength = RecvBuffer->VirtualBufferLength;
+    uint64_t NewBufferLength = QuicRecvBufferGetTotalAllocLength(RecvBuffer);
     for (CXPLAT_LIST_ENTRY* Link = Chunks->Flink;
          Link != Chunks;
          Link = Link->Flink) {
@@ -429,7 +451,12 @@ QuicRecvBufferProvideChunks(
         RecvBuffer->Capacity = FirstChunk->AllocLength;
     }
 
-    RecvBuffer->VirtualBufferLength = (uint32_t)NewBufferLength;
+    //
+    // Ensure the virtual length is at least the allocated length.
+    //
+    RecvBuffer->VirtualBufferLength =
+        CXPLAT_MAX(RecvBuffer->VirtualBufferLength, (uint32_t)NewBufferLength);
+
     CxPlatListMoveItems(Chunks, &RecvBuffer->Chunks);
 
     return QUIC_STATUS_SUCCESS;
@@ -570,66 +597,6 @@ QuicRecvBufferResize(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
-uint32_t
-QuicRecvBufferGetTotalAllocLength(
-    _In_ QUIC_RECV_BUFFER* RecvBuffer
-    )
-{
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_SINGLE ||
-        RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_CIRCULAR) {
-        //
-        // In single and circular mode, the last chunk is the only chunk being
-        // written to at any given time, and therefore the only chunk we care
-        // about in terms of total allocation space.
-        //
-        QUIC_RECV_CHUNK* Chunk =
-            CXPLAT_CONTAINING_RECORD(
-                RecvBuffer->Chunks.Blink,
-                QUIC_RECV_CHUNK,
-                Link);
-        return Chunk->AllocLength;
-    }
-
-    //
-    // For multiple mode and app-owned mode, several chunks may be used at any
-    // point in time, so we need to consider the space allocated for all of them.
-    // Additionally, the first one is special because it may be already partially
-    // drained, making it only partially usable.
-    //
-    QUIC_RECV_CHUNK* Chunk =
-        CXPLAT_CONTAINING_RECORD(
-            RecvBuffer->Chunks.Flink,
-            QUIC_RECV_CHUNK,
-            Link);
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_MULTIPLE &&
-        Chunk->Link.Flink == &RecvBuffer->Chunks) {
-        //
-        // In Multiple mode, only one chunk means we don't have an artificial
-        // "end", and are using the full allocated length of the buffer in a
-        // circular fashion.
-        //
-        return Chunk->AllocLength;
-    }
-
-    //
-    // Otherwise, it is possible part of the first chunk has already been
-    // drained, so we don't use the allocated length, but the Capacity instead
-    // when calculating total available space.
-    //
-    uint32_t AllocLength = RecvBuffer->Capacity;
-    while (Chunk->Link.Flink != &RecvBuffer->Chunks) {
-        Chunk =
-            CXPLAT_CONTAINING_RECORD(
-                Chunk->Link.Flink,
-                QUIC_RECV_CHUNK,
-                Link);
-        CXPLAT_DBG_ASSERT((uint64_t)AllocLength + (uint64_t)Chunk->AllocLength < UINT32_MAX);
-        AllocLength += Chunk->AllocLength;
-    }
-    return AllocLength;
-}
-
-_IRQL_requires_max_(DISPATCH_LEVEL)
 void
 QuicRecvBufferCopyIntoChunks(
     _In_ QUIC_RECV_BUFFER* RecvBuffer,
@@ -692,19 +659,22 @@ QuicRecvBufferWrite(
     _In_ uint64_t WriteOffset,
     _In_ uint16_t WriteLength,
     _In_reads_bytes_(WriteLength) uint8_t const* WriteBuffer,
-    _Inout_ uint64_t* WriteLimit,
-    _Out_ BOOLEAN* ReadyToRead
+    _In_ uint64_t WriteQuota,
+    _Out_ uint64_t* QuotaConsumed,
+    _Out_ BOOLEAN* NewDataReady,
+    _Out_ uint64_t* BufferSizeNeeded
     )
 {
     CXPLAT_DBG_ASSERT(WriteLength != 0);
-    *ReadyToRead = FALSE; // Most cases below aren't ready to read.
+    *NewDataReady = FALSE; // Most cases below aren't ready to read.
+    *QuotaConsumed = 0;
+    *BufferSizeNeeded = 0;
 
     //
     // Check if the write buffer has already been completely written before.
     //
     uint64_t AbsoluteLength = WriteOffset + WriteLength;
     if (AbsoluteLength <= RecvBuffer->BaseOffset) {
-        *WriteLimit = 0;
         return QUIC_STATUS_SUCCESS;
     }
 
@@ -717,18 +687,17 @@ QuicRecvBufferWrite(
     }
 
     //
-    // Check to see if the write buffer is trying to write beyond the allowed
-    // (input) limit. If it's in bounds, update the output to indicate how much
-    // new data was actually written.
+    // Check that the write is not going to cause us to consume more than the
+    // quota allocated by the connection flow control.
+    // If it is in bound, update the output to indicate how much of the quota is
+    // being consumed.
     //
-    uint64_t CurrentMaxLength = QuicRecvBufferGetTotalLength(RecvBuffer);
+    const uint64_t CurrentMaxLength = QuicRecvBufferGetTotalLength(RecvBuffer);
     if (AbsoluteLength > CurrentMaxLength) {
-        if (AbsoluteLength - CurrentMaxLength > *WriteLimit) {
+        if (AbsoluteLength - CurrentMaxLength > WriteQuota) {
             return QUIC_STATUS_BUFFER_TOO_SMALL;
         }
-        *WriteLimit = AbsoluteLength - CurrentMaxLength;
-    } else {
-        *WriteLimit = 0;
+        *QuotaConsumed = AbsoluteLength - CurrentMaxLength;
     }
 
     //
@@ -740,25 +709,33 @@ QuicRecvBufferWrite(
     // This is skipped in app-owned mode since the entire virtual length is
     // always allocated.
     //
-    if (RecvBuffer->RecvMode != QUIC_RECV_BUF_MODE_APP_OWNED) {
-        uint32_t AllocLength = QuicRecvBufferGetTotalAllocLength(RecvBuffer);
-        if (AbsoluteLength > RecvBuffer->BaseOffset + AllocLength) {
+    const uint32_t AllocLength = QuicRecvBufferGetTotalAllocLength(RecvBuffer);
+    if (AbsoluteLength > RecvBuffer->BaseOffset + AllocLength) {
+        //
+        // There isn't enough space to write the data.
+        //
+        if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_APP_OWNED) {
             //
-            // If we don't currently have enough room then we will want to resize
-            // the last chunk to be big enough to hold everything. We do this by
-            // repeatedly doubling its size until it is large enough.
+            // We can't allocate more space in app-owned mode.
+            // Let the caller notify the app to provide more buffer space.
             //
-            uint32_t NewBufferLength =
-                CXPLAT_CONTAINING_RECORD(
-                    RecvBuffer->Chunks.Blink,
-                    QUIC_RECV_CHUNK,
-                    Link)->AllocLength << 1;
-            while (AbsoluteLength > RecvBuffer->BaseOffset + NewBufferLength) {
-                NewBufferLength <<= 1;
-            }
-            if (!QuicRecvBufferResize(RecvBuffer, NewBufferLength)) {
-                return QUIC_STATUS_OUT_OF_MEMORY;
-            }
+            *BufferSizeNeeded = AbsoluteLength - (RecvBuffer->BaseOffset + AllocLength);
+            return QUIC_STATUS_BUFFER_TOO_SMALL;
+        }
+
+        //
+        // Add a new chunk (or replace the existing one), doubling the size of the largest chunk
+        // until there is enough space for the write.
+        //
+        QUIC_RECV_CHUNK* LastChunk =
+            CXPLAT_CONTAINING_RECORD(RecvBuffer->Chunks.Blink, QUIC_RECV_CHUNK, Link);
+        uint32_t NewBufferLength = LastChunk->AllocLength << 1;
+        while (AbsoluteLength > RecvBuffer->BaseOffset + NewBufferLength) {
+            NewBufferLength <<= 1;
+        }
+        if (!QuicRecvBufferResize(RecvBuffer, NewBufferLength)) {
+            *BufferSizeNeeded = AbsoluteLength - (RecvBuffer->BaseOffset + AllocLength);
+            return QUIC_STATUS_OUT_OF_MEMORY;
         }
     }
 
@@ -790,7 +767,7 @@ QuicRecvBufferWrite(
     //
     // We have new data to read if we just wrote to the front of the buffer.
     //
-    *ReadyToRead = UpdatedRange->Low == 0;
+    *NewDataReady = UpdatedRange->Low == 0;
 
     //
     // Write the data into the chunks now that everything has been validated.
@@ -1043,6 +1020,7 @@ QuicRecvBufferDrain(
     CXPLAT_DBG_ASSERT(QuicRangeGetSafe(&RecvBuffer->WrittenRanges, 0) != NULL);
     CXPLAT_DBG_ASSERT(DrainLength <= RecvBuffer->ReadPendingLength);
     CXPLAT_DBG_ASSERT(!CxPlatListIsEmpty(&RecvBuffer->Chunks));
+    CXPLAT_DBG_ASSERT(DrainLength <= RecvBuffer->VirtualBufferLength);
 
     if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_MULTIPLE) {
         //
@@ -1051,14 +1029,6 @@ QuicRecvBufferDrain(
         RecvBuffer->ReadPendingLength -= DrainLength;
     } else {
         RecvBuffer->ReadPendingLength = 0;
-    }
-
-    CXPLAT_DBG_ASSERT(DrainLength <= RecvBuffer->VirtualBufferLength);
-    if (RecvBuffer->RecvMode == QUIC_RECV_BUF_MODE_APP_OWNED) {
-        //
-        // In App-owned mode, memory is never reused: a drain consume virtual buffer length.
-        //
-        RecvBuffer->VirtualBufferLength -= (uint32_t)(DrainLength);
     }
 
     RecvBuffer->BaseOffset += DrainLength;

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -183,8 +183,10 @@ QuicRecvBufferWrite(
     _In_ uint64_t WriteOffset,
     _In_ uint16_t WriteLength,
     _In_reads_bytes_(WriteLength) uint8_t const* WriteBuffer,
-    _Inout_ uint64_t* WriteLimit,
-    _Out_ BOOLEAN* NewDataReady
+    _In_ uint64_t WriteQuota,
+    _Out_ uint64_t* QuotaConsumed,
+    _Out_ BOOLEAN* NewDataReady,
+    _Out_ uint64_t* BufferSizeNeeded
     );
 
 //

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -1007,16 +1007,42 @@ QuicStreamProvideRecvBuffers(
     QUIC_STATUS Status = QuicRecvBufferProvideChunks(&Stream->RecvBuffer, Chunks);
     if (Status == QUIC_STATUS_SUCCESS) {
         //
-        // Update the maximum allowed received size to take into account the new
-        // capacity.
+        // Update the maximum allowed received offset if the new chunks caused an update of the
+        // virtual buffer size.
         //
-        Stream->MaxAllowedRecvOffset =
+        uint64_t NewMaxAllowedRecvOffset =
             Stream->RecvBuffer.BaseOffset + Stream->RecvBuffer.VirtualBufferLength;
-        QuicSendSetStreamSendFlag(
-            &Stream->Connection->Send,
-            Stream,
-            QUIC_STREAM_SEND_FLAG_MAX_DATA,
-            FALSE);
+        if (Stream->MaxAllowedRecvOffset < NewMaxAllowedRecvOffset) {
+            Stream->MaxAllowedRecvOffset =
+                Stream->RecvBuffer.BaseOffset + Stream->RecvBuffer.VirtualBufferLength;
+            QuicSendSetStreamSendFlag(
+                &Stream->Connection->Send,
+                Stream,
+                QUIC_STREAM_SEND_FLAG_MAX_DATA,
+                FALSE);
+        }
     }
     return Status;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicStreamNotifyReceiveBufferNeeded(
+    _In_ QUIC_STREAM* Stream,
+    _In_ uint64_t BufferLengthNeeded
+    )
+{
+    CXPLAT_DBG_ASSERT(Stream->RecvBuffer.RecvMode == QUIC_RECV_BUF_MODE_APP_OWNED);
+
+    QUIC_STREAM_EVENT Event = {0};
+    Event.Type = QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED;
+    Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded = BufferLengthNeeded;
+
+    QuicTraceLogStreamVerbose(
+        StreamNotifyInsufficientRecvBuffer,
+        Stream,
+        "Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]",
+        Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded);
+
+    (void)QuicStreamIndicateEvent(Stream, &Event);
 }

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -1056,3 +1056,16 @@ QuicStreamProvideRecvBuffers(
     _In_ QUIC_STREAM* Stream,
     _Inout_ CXPLAT_LIST_ENTRY* /* QUIC_RECV_CHUNK */ Chunks
     );
+
+//
+// Notifies the app that the receive buffer is too small to hold the
+// incoming data.
+// The app can increase the buffer size or shutdown the stream inline
+// as a reaction. Only for app-owned buffering mode.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicStreamNotifyReceiveBufferNeeded(
+    _In_ QUIC_STREAM* Stream,
+    _In_ uint64_t BufferLengthNeeded
+    );

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -3095,6 +3095,7 @@ namespace Microsoft.Quic
         IDEAL_SEND_BUFFER_SIZE = 8,
         PEER_ACCEPTED = 9,
         CANCEL_ON_LOSS = 10,
+        RECEIVE_BUFFER_NEEDED = 11,
     }
 
     internal partial struct QUIC_STREAM_EVENT
@@ -3176,6 +3177,14 @@ namespace Microsoft.Quic
             }
         }
 
+        internal ref _Anonymous_e__Union._RECEIVE_BUFFER_NEEDED_e__Struct RECEIVE_BUFFER_NEEDED
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.RECEIVE_BUFFER_NEEDED, 1));
+            }
+        }
+
         [StructLayout(LayoutKind.Explicit)]
         internal partial struct _Anonymous_e__Union
         {
@@ -3214,6 +3223,10 @@ namespace Microsoft.Quic
             [FieldOffset(0)]
             [NativeTypeName("struct (anonymous struct)")]
             internal _CANCEL_ON_LOSS_e__Struct CANCEL_ON_LOSS;
+
+            [FieldOffset(0)]
+            [NativeTypeName("struct (anonymous struct)")]
+            internal _RECEIVE_BUFFER_NEEDED_e__Struct RECEIVE_BUFFER_NEEDED;
 
             internal partial struct _START_COMPLETE_e__Struct
             {
@@ -3377,6 +3390,12 @@ namespace Microsoft.Quic
             {
                 [NativeTypeName("QUIC_UINT62")]
                 internal ulong ErrorCode;
+            }
+
+            internal partial struct _RECEIVE_BUFFER_NEEDED_e__Struct
+            {
+                [NativeTypeName("uint64_t")]
+                internal ulong BufferLengthNeeded;
             }
         }
     }

--- a/src/generated/linux/stream.c.clog.h
+++ b/src/generated/linux/stream.c.clog.h
@@ -216,6 +216,26 @@ tracepoint(CLOG_STREAM_C, IndicateStreamShutdownComplete , arg1, arg3, arg4, arg
 
 
 /*----------------------------------------------------------
+// Decoder Ring for StreamNotifyInsufficientRecvBuffer
+// [strm][%p] Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]
+// QuicTraceLogStreamVerbose(
+        StreamNotifyInsufficientRecvBuffer,
+        Stream,
+        "Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]",
+        Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded);
+// arg1 = arg1 = Stream = arg1
+// arg3 = arg3 = Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_StreamNotifyInsufficientRecvBuffer
+#define _clog_4_ARGS_TRACE_StreamNotifyInsufficientRecvBuffer(uniqueId, arg1, encoded_arg_string, arg3)\
+tracepoint(CLOG_STREAM_C, StreamNotifyInsufficientRecvBuffer , arg1, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for StreamAlloc
 // [strm][%p] Allocated, Conn=%p
 // QuicTraceEvent(

--- a/src/generated/linux/stream.c.clog.h.lttng.h
+++ b/src/generated/linux/stream.c.clog.h.lttng.h
@@ -213,6 +213,29 @@ TRACEPOINT_EVENT(CLOG_STREAM_C, IndicateStreamShutdownComplete,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for StreamNotifyInsufficientRecvBuffer
+// [strm][%p] Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]
+// QuicTraceLogStreamVerbose(
+        StreamNotifyInsufficientRecvBuffer,
+        Stream,
+        "Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]",
+        Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded);
+// arg1 = arg1 = Stream = arg1
+// arg3 = arg3 = Event.RECEIVE_BUFFER_NEEDED.BufferLengthNeeded = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_STREAM_C, StreamNotifyInsufficientRecvBuffer,
+    TP_ARGS(
+        const void *, arg1,
+        unsigned long long, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+        ctf_integer(uint64_t, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for StreamAlloc
 // [strm][%p] Allocated, Conn=%p
 // QuicTraceEvent(

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -1536,6 +1536,9 @@ typedef enum QUIC_STREAM_EVENT_TYPE {
     QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE    = 8,
     QUIC_STREAM_EVENT_PEER_ACCEPTED             = 9,
     QUIC_STREAM_EVENT_CANCEL_ON_LOSS            = 10,
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+    QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED = 11,
+#endif
 } QUIC_STREAM_EVENT_TYPE;
 
 typedef struct QUIC_STREAM_EVENT {
@@ -1584,6 +1587,11 @@ typedef struct QUIC_STREAM_EVENT {
         struct {
             /* out */ QUIC_UINT62 ErrorCode;
         } CANCEL_ON_LOSS;
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+        struct {
+            /* in */  uint64_t BufferLengthNeeded;
+        } RECEIVE_BUFFER_NEEDED;
+#endif
     };
 } QUIC_STREAM_EVENT;
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -157,18 +157,6 @@
       ],
       "macroName": "QuicTraceEvent"
     },
-    "ApiError": {
-      "ModuleProperites": {},
-      "TraceString": "[ api] Error %u",
-      "UniqueId": "ApiError",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "ApiEventNoHandler": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Event silently discarded (no handler).",
@@ -411,22 +399,6 @@
       ],
       "macroName": "QuicTraceEvent"
     },
-    "BindingSendFailed": {
-      "ModuleProperites": {},
-      "TraceString": "[bind][%p] Send failed, 0x%x",
-      "UniqueId": "BindingSendFailed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogWarning"
-    },
     "BindingSendTestDrop": {
       "ModuleProperites": {},
       "TraceString": "[bind][%p] Test dropped packet",
@@ -458,18 +430,6 @@
       "splitArgs": [
         {
           "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "CertCapiSign": {
-      "ModuleProperites": {},
-      "TraceString": "[cert] QuicCertSign alg=0x%4.4x",
-      "UniqueId": "CertCapiSign",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "4.4x",
           "MacroVariableName": "arg2"
         }
       ],
@@ -763,18 +723,6 @@
       ],
       "macroName": "QuicTraceLogConnInfo"
     },
-    "CloseUserCanceled": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Connection close using user canceled error",
-      "UniqueId": "CloseUserCanceled",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
     "CloseWithoutShutdown": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] Closing handle without fully shutting down",
@@ -1051,22 +999,6 @@
         {
           "DefinationEncoding": "u",
           "MacroVariableName": "arg10"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "ConnCancelTimer": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Canceling %hhu",
-      "UniqueId": "ConnCancelTimer",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceEvent"
@@ -1867,294 +1799,6 @@
       ],
       "macroName": "QuicTraceEvent"
     },
-    "ConnPoolCreateSocket": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to create socket, 0x%x",
-      "UniqueId": "ConnPoolCreateSocket",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolGetLocalAddress": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to get local address, 0x%x",
-      "UniqueId": "ConnPoolGetLocalAddress",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolGetLocalAddresses": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to get local address info, 0x%x",
-      "UniqueId": "ConnPoolGetLocalAddresses",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolGetRssConfig": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to get RSS config, 0x%x",
-      "UniqueId": "ConnPoolGetRssConfig",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolInvalidParam": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Invalid parameter, 0x%x",
-      "UniqueId": "ConnPoolInvalidParam",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolInvalidParamNeedRemoteAddress": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Neither ServerName nor ServerAddress were set, 0x%x",
-      "UniqueId": "ConnPoolInvalidParamNeedRemoteAddress",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolLocalAddressNotFound": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to find local address, 0x%x",
-      "UniqueId": "ConnPoolLocalAddressNotFound",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolMaxRetries": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Ran out of retries. MaxRetries %u, Iteration %u, Port %u, 0x%x",
-      "UniqueId": "ConnPoolMaxRetries",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolOpenConnection": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to open connection[%u], 0x%x",
-      "UniqueId": "ConnPoolOpenConnection",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolResolveAddress": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to resolve address, 0x%x",
-      "UniqueId": "ConnPoolResolveAddress",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolRssNotConfigured": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] RSS not configured, 0x%x",
-      "UniqueId": "ConnPoolRssNotConfigured",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolRssNotSupported": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] RSS not supported for UDP, 0x%x. RssHashTypes 0x%x",
-      "UniqueId": "ConnPoolRssNotSupported",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolRssSecretKeyTooLong": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] RSS secret key too long (%u bytes), 0x%x",
-      "UniqueId": "ConnPoolRssSecretKeyTooLong",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolRssSecretKeyTooShort": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] RSS secret key too short (%u bytes), 0x%x",
-      "UniqueId": "ConnPoolRssSecretKeyTooShort",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolServerNameTooLong": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] ServerName too long (%llu bytes)",
-      "UniqueId": "ConnPoolServerNameTooLong",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "llu",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolSetCibirId": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to set CIBIR ID on connection[%u], 0x%x",
-      "UniqueId": "ConnPoolSetCibirId",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolSetLocalAddress": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to set local address on connection[%u], 0x%x",
-      "UniqueId": "ConnPoolSetLocalAddress",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolSetRemoteAddress": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to set remote address on connection[%u], 0x%x",
-      "UniqueId": "ConnPoolSetRemoteAddress",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolSetShareBinding": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to set share binding on connection[%u], 0x%x",
-      "UniqueId": "ConnPoolSetShareBinding",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "ConnPoolStartConnection": {
-      "ModuleProperites": {},
-      "TraceString": "[conp] Failed to start connection[%u], 0x%x",
-      "UniqueId": "ConnPoolStartConnection",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
     "ConnQueueSendFlush": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Queueing send flush, reason=%u",
@@ -2915,18 +2559,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "DatapathInitialize": {
-      "ModuleProperites": {},
-      "TraceString": "[data][%p] Datapath initialize",
-      "UniqueId": "DatapathInitialize",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "DataPathInitialized": {
       "ModuleProperites": {},
       "TraceString": "[data] Initialized, DatapathFeatures=%u",
@@ -3147,34 +2779,6 @@
       ],
       "macroName": "QuicTraceLogWarning"
     },
-    "DatapathRecvXdp": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!",
-      "UniqueId": "DatapathRecvXdp",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg5"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg6"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "DatapathResolveHostNameFailed": {
       "ModuleProperites": {},
       "TraceString": "[%p] Couldn't resolve hostname '%s' to an IP address",
@@ -3287,30 +2891,6 @@
         {
           "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg6"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "DatapathSendXdp": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Send %u bytes Dst=%!ADDR!, Src=%!ADDR!",
-      "UniqueId": "DatapathSendXdp",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg5"
         }
       ],
       "macroName": "QuicTraceEvent"
@@ -3945,18 +3525,9 @@
     },
     "DoneSendTo": {
       "ModuleProperites": {},
-      "TraceString": "[ xdp][TX  ] Done sendto. len:%d, Umem addr:%lld",
+      "TraceString": "[ xdp][TX  ] Done sendto.",
       "UniqueId": "DoneSendTo",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "lld",
-          "MacroVariableName": "arg3"
-        }
-      ],
+      "splitArgs": [],
       "macroName": "QuicTraceLogVerbose"
     },
     "DrainCrypto": {
@@ -4456,22 +4027,6 @@
       "TraceString": "[ xdp][rx  ] OOM for Rx",
       "UniqueId": "FailRxAlloc",
       "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "FailSendTo": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][tx  ] Faild sendto. errno:%d, Umem addr:%lld",
-      "UniqueId": "FailSendTo",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "lld",
-          "MacroVariableName": "arg3"
-        }
-      ],
       "macroName": "QuicTraceLogVerbose"
     },
     "FailTxAlloc": {
@@ -5992,22 +5547,6 @@
       ],
       "macroName": "QuicTraceLogStreamVerbose"
     },
-    "IgnoreRecvFlushByReadPending": {
-      "ModuleProperites": {},
-      "TraceString": "[strm][%p] Ignoring recv flush (ReadPendingLenght=%lu)",
-      "UniqueId": "IgnoreRecvFlushByReadPending",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "lu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogStreamVerbose"
-    },
     "IgnoreUnreachable": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Ignoring received unreachable event (inline)",
@@ -6328,22 +5867,6 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
-    "IndicateQTIPSettingsBubbledDown": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Bubbling down UseQTIP setting: %hhu",
-      "UniqueId": "IndicateQTIPSettingsBubbledDown",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogConnInfo"
-    },
     "IndicateReliableResetNegotiated": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED [IsNegotiated=%hhu]",
@@ -6536,42 +6059,10 @@
       ],
       "macroName": "QuicTraceLogStreamVerbose"
     },
-    "InsertSocket": {
-      "ModuleProperites": {},
-      "TraceString": "[sock][%p] InsertSocket: LocalAddr=%!ADDR! RemoteAddr=%!ADDR!",
-      "UniqueId": "InsertSocket",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "InterfaceFree": {
       "ModuleProperites": {},
       "TraceString": "[ xdp][%p] Freeing Interface",
       "UniqueId": "InterfaceFree",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "InterfaceInit": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Interface init done",
-      "UniqueId": "InterfaceInit",
       "splitArgs": [
         {
           "DefinationEncoding": "p",
@@ -6880,22 +6371,6 @@
       "UniqueId": "LibraryServerInit",
       "splitArgs": [],
       "macroName": "QuicTraceEvent"
-    },
-    "LibrarySetRetryConfigLengthInvalid": {
-      "ModuleProperites": {},
-      "TraceString": "[ lib] Config buffer insufficient: %u. Expected %u",
-      "UniqueId": "LibrarySetRetryConfigLengthInvalid",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
     },
     "LibrarySetRetryKeyAlgorithmInvalid": {
       "ModuleProperites": {},
@@ -8931,27 +8406,6 @@
       "splitArgs": [],
       "macroName": "QuicTraceLogInfo"
     },
-    "PerfRpsComplete": {
-      "ModuleProperites": {},
-      "TraceString": "[perf] RPS Client complete",
-      "UniqueId": "PerfRpsComplete",
-      "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "PerfRpsStart": {
-      "ModuleProperites": {},
-      "TraceString": "[perf] RPS Client start",
-      "UniqueId": "PerfRpsStart",
-      "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "PerfRpsTimeout": {
-      "ModuleProperites": {},
-      "TraceString": "[perf] RPS Client timeout",
-      "UniqueId": "PerfRpsTimeout",
-      "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "PerfTcpAppAccept": {
       "ModuleProperites": {},
       "TraceString": "[perf][tcp][%p] App Accept",
@@ -9316,30 +8770,6 @@
       ],
       "macroName": "QuicTraceLogInfo"
     },
-    "ProcessorInfoV2": {
-      "ModuleProperites": {},
-      "TraceString": "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu",
-      "UniqueId": "ProcessorInfoV2",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "hu",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "hhu",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceLogInfo"
-    },
     "ProcessorInfoV3": {
       "ModuleProperites": {},
       "TraceString": "[ dll] Proc[%u] Group[%hu] Index[%hhu] Active=%hhu",
@@ -9448,22 +8878,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "QueueInit": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Setting up Queue on Interface:%p",
-      "UniqueId": "QueueInit",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "QueueRecvFlush": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] Queuing recv flush",
@@ -9475,58 +8889,6 @@
         }
       ],
       "macroName": "QuicTraceLogStreamVerbose"
-    },
-    "QuicConnRecvDatagrams": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Recv %u UDP datagrams, %u bytes",
-      "UniqueId": "QuicConnRecvDatagrams",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "QuicConnRecvUdpDatagrams": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Recv %u UDP datagrams, %u bytes",
-      "UniqueId": "QuicConnRecvUdpDatagrams",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
-    "RawDatapathInitFail": {
-      "ModuleProperites": {},
-      "TraceString": "[ raw] Failed to initialize raw datapath, status:%d",
-      "UniqueId": "RawDatapathInitFail",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
     },
     "RawSockCreateFail": {
       "ModuleProperites": {},
@@ -9687,18 +9049,6 @@
         }
       ],
       "macroName": "QuicTraceLogConnInfo"
-    },
-    "RecvVerNeg": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p] Received Version Negotation:",
-      "UniqueId": "RecvVerNeg",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
     },
     "RecvVerNegCryptoError": {
       "ModuleProperites": {},
@@ -9888,26 +9238,6 @@
       ],
       "macroName": "QuicTraceLogConnVerbose"
     },
-    "RemoveSocket": {
-      "ModuleProperites": {},
-      "TraceString": "[sock][%p] RemoveSocket: LocalAddr=%!ADDR! RemoteAddr=%!ADDR!",
-      "UniqueId": "RemoveSocket",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceEvent"
-    },
     "ResetEarly": {
       "ModuleProperites": {},
       "TraceString": "[strm][%p] Tried to reset at earlier final size!",
@@ -10043,25 +9373,6 @@
         }
       ],
       "macroName": "QuicTraceLogConnVerbose"
-    },
-    "RxConsPeekFail": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][rx  ] Failed to peek from Rx queue",
-      "UniqueId": "RxConsPeekFail",
-      "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "RxConsPeekSucceed": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][rx  ] Succeed peek %d from Rx queue",
-      "UniqueId": "RxConsPeekSucceed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
     },
     "RxConstructPacket": {
       "ModuleProperites": {},
@@ -11600,50 +10911,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "SockStatus": {
-      "ModuleProperites": {},
-      "TraceString": "[sock] Allocated socket. IsServer: %d, UseQTIP: %d:",
-      "UniqueId": "SockStatus",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "SockStatus2": {
-      "ModuleProperites": {},
-      "TraceString": "[sock] Allocated socket. IgnoreRawSocketFailure: %d",
-      "UniqueId": "SockStatus2",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "SockStatus3": {
-      "ModuleProperites": {},
-      "TraceString": "[sock] Allocated socket. IsServer: %d, UseQTIP: %d",
-      "UniqueId": "SockStatus3",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "StartAckDelayTimer": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Starting ACK_DELAY timer for %u ms",
@@ -11831,6 +11098,22 @@
         }
       ],
       "macroName": "QuicTraceEvent"
+    },
+    "StreamNotifyInsufficientRecvBuffer": {
+      "ModuleProperites": {},
+      "TraceString": "[strm][%p] Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]",
+      "UniqueId": "StreamNotifyInsufficientRecvBuffer",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg1"
+        },
+        {
+          "DefinationEncoding": "llu",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogStreamVerbose"
     },
     "StreamOutFlowBlocked": {
       "ModuleProperites": {},
@@ -12513,26 +11796,6 @@
       ],
       "macroName": "QuicTraceLogConnInfo"
     },
-    "VerNegItem": {
-      "ModuleProperites": {},
-      "TraceString": "[conn][%p]   Ver[%d]: 0x%x",
-      "UniqueId": "VerNegItem",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg1"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "x",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogConnVerbose"
-    },
     "VersionInfoChosenVersionZero": {
       "ModuleProperites": {},
       "TraceString": "[conn][%p] Version Info Chosen Version is zero!",
@@ -12838,21 +12101,9 @@
       "splitArgs": [],
       "macroName": "QuicTraceLogVerbose"
     },
-    "XdpAttached": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] XDP program already attached to %s",
-      "UniqueId": "XdpAttached",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "XdpAttachFails": {
       "ModuleProperites": {},
-      "TraceString": "[ xdp] Failed to attach XDP program to %s. error:%d",
+      "TraceString": "[ xdp] Failed to attach XDP program to %s. error:%s",
       "UniqueId": "XdpAttachFails",
       "splitArgs": [
         {
@@ -12860,7 +12111,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "d",
+          "DefinationEncoding": "s",
           "MacroVariableName": "arg3"
         }
       ],
@@ -12873,29 +12124,6 @@
       "splitArgs": [
         {
           "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpBypassMapError": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Failed to open stack bypass map",
-      "UniqueId": "XdpBypassMapError",
-      "splitArgs": [],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpChainingBuffer": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Done chaining buffer %d/%d",
-      "UniqueId": "XdpChainingBuffer",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
           "MacroVariableName": "arg2"
         },
         {
@@ -12946,20 +12174,16 @@
     },
     "XdpEpollErrorStatus": {
       "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] ERROR, %u, %s.",
+      "TraceString": "[ xdp]ERROR, %u, %s.",
       "UniqueId": "XdpEpollErrorStatus",
       "splitArgs": [
         {
-          "DefinationEncoding": "p",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
           "DefinationEncoding": "s",
-          "MacroVariableName": "arg4"
+          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceEvent"
@@ -12975,82 +12199,6 @@
         }
       ],
       "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpFindProbramSectionError": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] ERROR, finding program section '%s'",
-      "UniqueId": "XdpFindProbramSectionError",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpGetRssConfigFailed": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Failed to get RSS configuration on IfIndex %u, RssConfigSize %u, Result %d",
-      "UniqueId": "XdpGetRssConfigFailed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "XdpGetRssConfigInterfaceOpenFailed": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Failed to open Xdp interface for index %u. Error %d",
-      "UniqueId": "XdpGetRssConfigInterfaceOpenFailed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
-    },
-    "XdpGetRssConfigSizeFailed": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Failed to get RSS configuration size on IfIndex %u, RssConfigSize %u, Result %d",
-      "UniqueId": "XdpGetRssConfigSizeFailed",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "u",
-          "MacroVariableName": "arg4"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg5"
-        }
-      ],
-      "macroName": "QuicTraceLogError"
     },
     "XdpInitialize": {
       "ModuleProperites": {},
@@ -13100,26 +12248,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "XdpLoadBpfObjectError": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] ERROR:, loading BPF-OBJ file:%s, %d: [%s].",
-      "UniqueId": "XdpLoadBpfObjectError",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        },
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg4"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "XdpLoadObject": {
       "ModuleProperites": {},
       "TraceString": "[ xdp] Successfully loaded xdp object of %s",
@@ -13128,38 +12256,6 @@
         {
           "DefinationEncoding": "s",
           "MacroVariableName": "arg2"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpModeDowngrade": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Downgrading from DRV mode to SKB mode for interface:%s",
-      "UniqueId": "XdpModeDowngrade",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpNotSupported": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Xdp is not supported on this interface:%s",
-      "UniqueId": "XdpNotSupported",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "s",
-          "MacroVariableName": "arg3"
         }
       ],
       "macroName": "QuicTraceLogVerbose"
@@ -13291,22 +12387,6 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
-    "XdpRxRelease": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp][%p] Release %d from Rx queue (TODO:Check necesity here)",
-      "UniqueId": "XdpRxRelease",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "p",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
     "XdpSetIfnameFails": {
       "ModuleProperites": {},
       "TraceString": "[ xdp] Failed to set ifname %s on %s",
@@ -13350,54 +12430,6 @@
         },
         {
           "DefinationEncoding": "s",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpSkipOrEndofBuffer": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Skip or End of Buffer %d/%d",
-      "UniqueId": "XdpSkipOrEndofBuffer",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpSocketCreate": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Failed to create AF_XDP socket. ret:%d errno:%d",
-      "UniqueId": "XdpSocketCreate",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "d",
-          "MacroVariableName": "arg3"
-        }
-      ],
-      "macroName": "QuicTraceLogVerbose"
-    },
-    "XdpSocketNotFound": {
-      "ModuleProperites": {},
-      "TraceString": "[ xdp] Socket not found LocalAddr=%!ADDR! RemoteAddr=%!ADDR!",
-      "UniqueId": "XdpSocketNotFound",
-      "splitArgs": [
-        {
-          "DefinationEncoding": "!ADDR!",
-          "MacroVariableName": "arg2"
-        },
-        {
-          "DefinationEncoding": "!ADDR!",
           "MacroVariableName": "arg3"
         }
       ],
@@ -14064,11 +13096,6 @@
         "EncodingString": "[ api] Enter %u (%p)."
       },
       {
-        "UniquenessHash": "dddba4c1-201c-11ae-51de-155523e40b7e",
-        "TraceID": "ApiError",
-        "EncodingString": "[ api] Error %u"
-      },
-      {
         "UniquenessHash": "c69c6d33-2838-013a-936c-7fbc085570b4",
         "TraceID": "ApiEventNoHandler",
         "EncodingString": "[conn][%p] Event silently discarded (no handler)."
@@ -14144,11 +13171,6 @@
         "EncodingString": "[bind][%p] Rundown, Udp=%p LocalAddr=%!ADDR! RemoteAddr=%!ADDR!"
       },
       {
-        "UniquenessHash": "ed52dc79-5619-64e6-7bde-c177b24ff85d",
-        "TraceID": "BindingSendFailed",
-        "EncodingString": "[bind][%p] Send failed, 0x%x"
-      },
-      {
         "UniquenessHash": "8419ad0b-e226-53e3-837c-4eebd4cc6619",
         "TraceID": "BindingSendTestDrop",
         "EncodingString": "[bind][%p] Test dropped packet"
@@ -14162,11 +13184,6 @@
         "UniquenessHash": "2e3530fe-5082-ce8a-7275-87755eb70c41",
         "TraceID": "CertCapiParsedChain",
         "EncodingString": "[cert] Successfully parsed chain of %u certificate(s)"
-      },
-      {
-        "UniquenessHash": "827a6a52-50a7-a1f6-8caa-5f1aea644206",
-        "TraceID": "CertCapiSign",
-        "EncodingString": "[cert] QuicCertSign alg=0x%4.4x"
       },
       {
         "UniquenessHash": "6fb480dc-d71f-74f2-dc75-559a5591fe3d",
@@ -14264,11 +13281,6 @@
         "EncodingString": "[conn][%p] Connection close complete"
       },
       {
-        "UniquenessHash": "b4f3dc8d-17c8-39c5-5345-952616752980",
-        "TraceID": "CloseUserCanceled",
-        "EncodingString": "[conn][%p] Connection close using user canceled error"
-      },
-      {
         "UniquenessHash": "f96b231c-aa1b-08a4-7036-a60927e3eadd",
         "TraceID": "CloseWithoutShutdown",
         "EncodingString": "[strm][%p] Closing handle without fully shutting down"
@@ -14347,11 +13359,6 @@
         "UniquenessHash": "471ca3d0-42c2-3bea-6a0d-030e241233d6",
         "TraceID": "ConnBbr",
         "EncodingString": "[conn][%p] BBR: State=%u RState=%u CongestionWindow=%u BytesInFlight=%u BytesInFlightMax=%u MinRttEst=%lu EstBw=%lu AppLimited=%u"
-      },
-      {
-        "UniquenessHash": "3cb11d31-f785-9082-29ff-ca3a505762e4",
-        "TraceID": "ConnCancelTimer",
-        "EncodingString": "[conn][%p] Canceling %hhu"
       },
       {
         "UniquenessHash": "631f94ef-27ad-9be6-98cf-966dbce8bad9",
@@ -14557,106 +13564,6 @@
         "UniquenessHash": "c339eadc-2eef-8e45-4a51-1fc84a3c198e",
         "TraceID": "ConnPersistentCongestion",
         "EncodingString": "[conn][%p] Persistent congestion event"
-      },
-      {
-        "UniquenessHash": "28c17287-b016-ae68-60d9-69341d0d41ee",
-        "TraceID": "ConnPoolCreateSocket",
-        "EncodingString": "[conp] Failed to create socket, 0x%x"
-      },
-      {
-        "UniquenessHash": "9603502c-8cb9-1921-8d36-26287b5ce149",
-        "TraceID": "ConnPoolGetLocalAddress",
-        "EncodingString": "[conp] Failed to get local address, 0x%x"
-      },
-      {
-        "UniquenessHash": "412470bc-72b5-06e3-3c78-419cae4813e7",
-        "TraceID": "ConnPoolGetLocalAddresses",
-        "EncodingString": "[conp] Failed to get local address info, 0x%x"
-      },
-      {
-        "UniquenessHash": "c9af32e6-259c-e09d-f758-defdea772c3b",
-        "TraceID": "ConnPoolGetRssConfig",
-        "EncodingString": "[conp] Failed to get RSS config, 0x%x"
-      },
-      {
-        "UniquenessHash": "5d34108f-60e7-7db5-0739-37f6bc882994",
-        "TraceID": "ConnPoolInvalidParam",
-        "EncodingString": "[conp] Invalid parameter, 0x%x"
-      },
-      {
-        "UniquenessHash": "9e7c0260-bbaa-3080-9e51-0817142f0ad3",
-        "TraceID": "ConnPoolInvalidParamNeedRemoteAddress",
-        "EncodingString": "[conp] Neither ServerName nor ServerAddress were set, 0x%x"
-      },
-      {
-        "UniquenessHash": "ab5cf81d-9ef4-c6c2-fffc-81ed281bf136",
-        "TraceID": "ConnPoolLocalAddressNotFound",
-        "EncodingString": "[conp] Failed to find local address, 0x%x"
-      },
-      {
-        "UniquenessHash": "fa99b8b0-d616-8f5c-6e72-e488f84ffc15",
-        "TraceID": "ConnPoolMaxRetries",
-        "EncodingString": "[conp] Ran out of retries. MaxRetries %u, Iteration %u, Port %u, 0x%x"
-      },
-      {
-        "UniquenessHash": "a6d8565d-4daa-4ce4-0fd8-c0a96e1f3857",
-        "TraceID": "ConnPoolOpenConnection",
-        "EncodingString": "[conp] Failed to open connection[%u], 0x%x"
-      },
-      {
-        "UniquenessHash": "1bff1b11-bb91-55c2-5dbe-b556895ec49c",
-        "TraceID": "ConnPoolResolveAddress",
-        "EncodingString": "[conp] Failed to resolve address, 0x%x"
-      },
-      {
-        "UniquenessHash": "8b2978e4-1bea-604f-7025-4232fd0352a2",
-        "TraceID": "ConnPoolRssNotConfigured",
-        "EncodingString": "[conp] RSS not configured, 0x%x"
-      },
-      {
-        "UniquenessHash": "d627fb5b-c7f9-0a4f-4a74-eae0d6793911",
-        "TraceID": "ConnPoolRssNotSupported",
-        "EncodingString": "[conp] RSS not supported for UDP, 0x%x. RssHashTypes 0x%x"
-      },
-      {
-        "UniquenessHash": "0f1cace5-9a63-5f7c-fc34-b34d3139e2e0",
-        "TraceID": "ConnPoolRssSecretKeyTooLong",
-        "EncodingString": "[conp] RSS secret key too long (%u bytes), 0x%x"
-      },
-      {
-        "UniquenessHash": "33ae3aed-4b8f-97b5-c6ea-bd70a3911635",
-        "TraceID": "ConnPoolRssSecretKeyTooShort",
-        "EncodingString": "[conp] RSS secret key too short (%u bytes), 0x%x"
-      },
-      {
-        "UniquenessHash": "81b1615f-0fa3-850f-6636-b04a5258a184",
-        "TraceID": "ConnPoolServerNameTooLong",
-        "EncodingString": "[conp] ServerName too long (%llu bytes)"
-      },
-      {
-        "UniquenessHash": "783dface-e5d4-81d2-213a-a40abc4b00d9",
-        "TraceID": "ConnPoolSetCibirId",
-        "EncodingString": "[conp] Failed to set CIBIR ID on connection[%u], 0x%x"
-      },
-      {
-        "UniquenessHash": "f52999bc-8de3-798c-c4ed-0fa4ad686385",
-        "TraceID": "ConnPoolSetLocalAddress",
-        "EncodingString": "[conp] Failed to set local address on connection[%u], 0x%x"
-      },
-      {
-        "UniquenessHash": "57696af4-f367-3d05-7259-d55ac7dabf60",
-        "TraceID": "ConnPoolSetRemoteAddress",
-        "EncodingString": "[conp] Failed to set remote address on connection[%u], 0x%x"
-      },
-      {
-        "UniquenessHash": "13538c59-4bf3-962f-0ce7-0f65dcd761e4",
-        "TraceID": "ConnPoolSetShareBinding",
-        "EncodingString": "[conp] Failed to set share binding on connection[%u], 0x%x"
-      },
-      {
-        "UniquenessHash": "4a8d226c-314f-ad09-87bd-fbd785079e4d",
-        "TraceID": "ConnPoolStartConnection",
-        "EncodingString": "[conp] Failed to start connection[%u], 0x%x"
       },
       {
         "UniquenessHash": "1774df63-d849-a89c-4a88-bf2ff1002e15",
@@ -14884,11 +13791,6 @@
         "EncodingString": "[  dp] Failed to initialize datapath, status:%d"
       },
       {
-        "UniquenessHash": "b88fe9ef-f6ed-09b0-1711-28ec0fc2ab52",
-        "TraceID": "DatapathInitialize",
-        "EncodingString": "[data][%p] Datapath initialize"
-      },
-      {
         "UniquenessHash": "d68a3d43-333c-e62d-ec53-bb88a64aa2f4",
         "TraceID": "DataPathInitialized",
         "EncodingString": "[data] Initialized, DatapathFeatures=%u"
@@ -14974,11 +13876,6 @@
         "EncodingString": "[data][%p] Dropping datagram with empty payload."
       },
       {
-        "UniquenessHash": "60d31969-e1ac-0a1d-7419-9fe56e0f5404",
-        "TraceID": "DatapathRecvXdp",
-        "EncodingString": "[ xdp][%p] Recv %u bytes (segment=%hu) Src=%!ADDR! Dst=%!ADDR!"
-      },
-      {
         "UniquenessHash": "8c0dc882-517e-cd8f-df0b-0b892d83bb00",
         "TraceID": "DatapathResolveHostNameFailed",
         "EncodingString": "[%p] Couldn't resolve hostname '%s' to an IP address"
@@ -15002,11 +13899,6 @@
         "UniquenessHash": "798b4c99-cb62-f6d9-178d-daf707dc6c10",
         "TraceID": "DatapathSendTcpControl",
         "EncodingString": "[data][%p] Send %u bytes TCP control packet Flags=%hhu Dst=%!ADDR!, Src=%!ADDR!"
-      },
-      {
-        "UniquenessHash": "3bf92922-ac70-d758-6cbe-92b13f20cce6",
-        "TraceID": "DatapathSendXdp",
-        "EncodingString": "[ xdp][%p] Send %u bytes Dst=%!ADDR!, Src=%!ADDR!"
       },
       {
         "UniquenessHash": "4f1e0892-0852-480e-71db-5b9bb377aabc",
@@ -15384,11 +14276,6 @@
         "EncodingString": "[ xdp][rx  ] OOM for Rx"
       },
       {
-        "UniquenessHash": "eff0bf3a-6d97-e11d-d4a2-543e2e480bdb",
-        "TraceID": "FailSendTo",
-        "EncodingString": "[ xdp][tx  ] Faild sendto. errno:%d, Umem addr:%lld"
-      },
-      {
         "UniquenessHash": "f0f39cc3-a21d-f843-1018-5901295b6a1a",
         "TraceID": "FailTxAlloc",
         "EncodingString": "[ xdp][tx  ] OOM for Tx"
@@ -15744,11 +14631,6 @@
         "EncodingString": "[strm][%p] Ignoring recv flush (recv disabled)"
       },
       {
-        "UniquenessHash": "1537935d-ab2d-521e-a290-e59e29d2626d",
-        "TraceID": "IgnoreRecvFlushByReadPending",
-        "EncodingString": "[strm][%p] Ignoring recv flush (ReadPendingLenght=%llu)"
-      },
-      {
         "UniquenessHash": "1e752977-c5b3-6034-4b89-414f9c6ff50f",
         "TraceID": "IgnoreUnreachable",
         "EncodingString": "[conn][%p] Ignoring received unreachable event (inline)"
@@ -15839,11 +14721,6 @@
         "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED [%p, 0x%x]"
       },
       {
-        "UniquenessHash": "651766ae-e436-c010-d55a-bcb9ecd224be",
-        "TraceID": "IndicateQTIPSettingsBubbledDown",
-        "EncodingString": "[conn][%p] Bubbling down UseQTIP setting: %hhu"
-      },
-      {
         "UniquenessHash": "cb6ed5bc-5216-e56f-9e29-117ba277fde6",
         "TraceID": "IndicateReliableResetNegotiated",
         "EncodingString": "[conn][%p] Indicating QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED [IsNegotiated=%hhu]"
@@ -15899,19 +14776,9 @@
         "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE [Shutdown=%hhu, ShutdownByApp=%hhu, ClosedRemotely=%hhu, ErrorCode=0x%llx, CloseStatus=0x%x]"
       },
       {
-        "UniquenessHash": "5b61c178-ef08-2544-fe09-4192be82b795",
-        "TraceID": "InsertSocket",
-        "EncodingString": "[sock][%p] InsertSocket: LocalAddr=%!ADDR! RemoteAddr=%!ADDR!"
-      },
-      {
         "UniquenessHash": "a3160ae8-224d-49a6-5df1-cca3e643d016",
         "TraceID": "InterfaceFree",
         "EncodingString": "[ xdp][%p] Freeing Interface"
-      },
-      {
-        "UniquenessHash": "0acc6df5-0b99-f6ab-42de-fa7beb78db1c",
-        "TraceID": "InterfaceInit",
-        "EncodingString": "[ xdp][%p] Interface init done"
       },
       {
         "UniquenessHash": "e98e6411-dfab-d3a6-e7bd-d1782209846d",
@@ -16042,11 +14909,6 @@
         "UniquenessHash": "58367e27-574f-14e0-4661-81f93cdb9e18",
         "TraceID": "LibraryServerInit",
         "EncodingString": "[ lib] Shared server state initializing"
-      },
-      {
-        "UniquenessHash": "46c73e98-adfd-96b8-38c1-8ba4f06b8dc1",
-        "TraceID": "LibrarySetRetryConfigLengthInvalid",
-        "EncodingString": "[ lib] Config buffer insufficient: %u. Expected %u"
       },
       {
         "UniquenessHash": "486e116e-95bb-bdeb-5f27-de64f47dd51a",
@@ -16689,21 +15551,6 @@
         "EncodingString": "[perf] Performance Stop Cancelled"
       },
       {
-        "UniquenessHash": "221a79fd-6347-1c39-b203-268190b2e183",
-        "TraceID": "PerfRpsComplete",
-        "EncodingString": "[perf] RPS Client complete"
-      },
-      {
-        "UniquenessHash": "d09461bb-6b09-2766-23bd-bc4734886134",
-        "TraceID": "PerfRpsStart",
-        "EncodingString": "[perf] RPS Client start"
-      },
-      {
-        "UniquenessHash": "93872e3e-e3be-2983-e205-d6e666f739f6",
-        "TraceID": "PerfRpsTimeout",
-        "EncodingString": "[perf] RPS Client timeout"
-      },
-      {
         "UniquenessHash": "8260f5a0-7930-0280-7f31-39c627e51e33",
         "TraceID": "PerfTcpAppAccept",
         "EncodingString": "[perf][tcp][%p] App Accept"
@@ -16834,11 +15681,6 @@
         "EncodingString": "[perf] Print Buffer %d %s\\n"
       },
       {
-        "UniquenessHash": "3379ba23-5dc4-936c-5dd0-224fcad9d9d5",
-        "TraceID": "ProcessorInfoV2",
-        "EncodingString": "[ dll] Proc[%u] Group[%hu] Index[%u] Active=%hhu"
-      },
-      {
         "UniquenessHash": "c224289c-70bc-0be5-bc16-ea902175e280",
         "TraceID": "ProcessorInfoV3",
         "EncodingString": "[ dll] Proc[%u] Group[%hu] Index[%hhu] Active=%hhu"
@@ -16864,29 +15706,9 @@
         "EncodingString": "[ xdp][%p] Freeing Queue on Interface:%p"
       },
       {
-        "UniquenessHash": "6e24a520-c712-e682-29a3-004d35d51ded",
-        "TraceID": "QueueInit",
-        "EncodingString": "[ xdp][%p] Setting up Queue on Interface:%p"
-      },
-      {
         "UniquenessHash": "80596bbb-20e9-07e5-07f3-ebc7078fa612",
         "TraceID": "QueueRecvFlush",
         "EncodingString": "[strm][%p] Queuing recv flush"
-      },
-      {
-        "UniquenessHash": "d61a4398-ba19-c65b-995e-e71c9582edb4",
-        "TraceID": "QuicConnRecvDatagrams",
-        "EncodingString": "[conn][%p] Recv %u UDP datagrams, %u bytes"
-      },
-      {
-        "UniquenessHash": "6ac0022e-511b-ec8a-4ef3-15735ee7c35d",
-        "TraceID": "QuicConnRecvUdpDatagrams",
-        "EncodingString": "[conn][%p] Recv %u UDP datagrams, %u bytes"
-      },
-      {
-        "UniquenessHash": "f4ecfd1f-95a5-724a-b299-4f8f08ba6543",
-        "TraceID": "RawDatapathInitFail",
-        "EncodingString": "[ raw] Failed to initialize raw datapath, status:%d"
       },
       {
         "UniquenessHash": "4f370688-5822-225a-8c7e-ec4200d38f0a",
@@ -16937,11 +15759,6 @@
         "UniquenessHash": "1a6051bf-393a-b704-7237-8d9d0881efb3",
         "TraceID": "RecvStatelessReset",
         "EncodingString": "[conn][%p] Received stateless reset"
-      },
-      {
-        "UniquenessHash": "9727ad53-8a0f-e3b3-8def-c1fa820baaa9",
-        "TraceID": "RecvVerNeg",
-        "EncodingString": "[conn][%p] Received Version Negotation:"
       },
       {
         "UniquenessHash": "c13441c6-4ae4-4459-2078-3ac4175a374b",
@@ -17009,11 +15826,6 @@
         "EncodingString": "[conn][%p] Removing flags %x"
       },
       {
-        "UniquenessHash": "d01ebc42-ef1c-8e8f-878e-67fabbbaf89b",
-        "TraceID": "RemoveSocket",
-        "EncodingString": "[sock][%p] RemoveSocket: LocalAddr=%!ADDR! RemoteAddr=%!ADDR!"
-      },
-      {
         "UniquenessHash": "1f2558ac-412e-da8c-33d7-7c45995dbcf9",
         "TraceID": "ResetEarly",
         "EncodingString": "[strm][%p] Tried to reset at earlier final size!"
@@ -17042,16 +15854,6 @@
         "UniquenessHash": "ff41b02a-ac3e-3b07-30f1-3040e2416019",
         "TraceID": "RttUpdatedV2",
         "EncodingString": "[conn][%p] Updated Rtt=%u.%03u ms, Var=%u.%03u 1Way=%u.%03u ms"
-      },
-      {
-        "UniquenessHash": "e179b91c-9ba5-4a5d-24a6-0cbe7e3c5814",
-        "TraceID": "RxConsPeekFail",
-        "EncodingString": "[ xdp][rx  ] Failed to peek from Rx queue"
-      },
-      {
-        "UniquenessHash": "cbd9e457-c19c-dbd7-effe-4648f905fe33",
-        "TraceID": "RxConsPeekSucceed",
-        "EncodingString": "[ xdp][rx  ] Succeed peek %d from Rx queue"
       },
       {
         "UniquenessHash": "ea188c4d-44a9-c75a-c8cf-fae2224bd6ca",
@@ -17594,21 +16396,6 @@
         "EncodingString": "[sock] Failed to create socket, status:%d"
       },
       {
-        "UniquenessHash": "d0c18368-6f75-5e69-9d2f-76edf03adf47",
-        "TraceID": "SockStatus",
-        "EncodingString": "[sock] Allocated socket. IsServer: %d, UseQTIP: %d:"
-      },
-      {
-        "UniquenessHash": "de94c2aa-2080-519a-1813-9d205ab343f9",
-        "TraceID": "SockStatus2",
-        "EncodingString": "[sock] Allocated socket. IgnoreRawSocketFailure: %d"
-      },
-      {
-        "UniquenessHash": "9ea32e07-da06-1c05-2ed6-234e7b353ec6",
-        "TraceID": "SockStatus3",
-        "EncodingString": "[sock] Allocated socket. IsServer: %d, UseQTIP: %d"
-      },
-      {
         "UniquenessHash": "3811b30b-84d6-43cc-8312-918d88c99d3e",
         "TraceID": "StartAckDelayTimer",
         "EncodingString": "[conn][%p] Starting ACK_DELAY timer for %u ms"
@@ -17662,6 +16449,11 @@
         "UniquenessHash": "c3b546cc-e127-435d-8bf4-cf20ca3d2d5e",
         "TraceID": "StreamError",
         "EncodingString": "[strm][%p] ERROR, %s."
+      },
+      {
+        "UniquenessHash": "556a140f-9a69-1c56-aaee-8358e3ece719",
+        "TraceID": "StreamNotifyInsufficientRecvBuffer",
+        "EncodingString": "[strm][%p] Indicating QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED [BufferLengthNeeded=%llu]"
       },
       {
         "UniquenessHash": "638251a8-14f3-2929-34e2-e69cfdab2277",
@@ -17914,11 +16706,6 @@
         "EncodingString": "[conn][%p] Updated Stream Scheduling Scheme = %u"
       },
       {
-        "UniquenessHash": "62fa7337-1321-2cd0-f7cc-236d893ed747",
-        "TraceID": "VerNegItem",
-        "EncodingString": "[conn][%p]   Ver[%d]: 0x%x"
-      },
-      {
         "UniquenessHash": "0c7aa55b-0fac-8bf3-13f4-2a80e4a8b2ba",
         "TraceID": "VersionInfoChosenVersionZero",
         "EncodingString": "[conn][%p] Version Info Chosen Version is zero!"
@@ -18034,11 +16821,6 @@
         "EncodingString": "[ xdp] Failed to allocate umem"
       },
       {
-        "UniquenessHash": "d2086d2a-ac56-bbce-57f6-5c3823319f8f",
-        "TraceID": "XdpAttached",
-        "EncodingString": "[ xdp] XDP program already attached to %s"
-      },
-      {
         "UniquenessHash": "c124b808-c9ae-82fd-49fa-040aa1bc4796",
         "TraceID": "XdpAttachFails",
         "EncodingString": "[ xdp] Failed to attach XDP program to %s. error:%s"
@@ -18047,16 +16829,6 @@
         "UniquenessHash": "a4b84136-131d-0ec3-2ff5-23c3a752b330",
         "TraceID": "XdpAttachSucceeds",
         "EncodingString": "[ xdp] Successfully attach XDP program to %s by mode:%d"
-      },
-      {
-        "UniquenessHash": "d437d3dd-3834-5c47-d972-1a1d8c08ccd8",
-        "TraceID": "XdpBypassMapError",
-        "EncodingString": "[ xdp] Failed to open stack bypass map"
-      },
-      {
-        "UniquenessHash": "0376ea53-71bd-561b-8a1d-76beca2d2c12",
-        "TraceID": "XdpChainingBuffer",
-        "EncodingString": "[ xdp] Done chaining buffer %d/%d"
       },
       {
         "UniquenessHash": "bd03227b-bb34-4f00-287c-14b7b8948404",
@@ -18084,26 +16856,6 @@
         "EncodingString": "[ xdp] Failed to get RSS queue count for %s"
       },
       {
-        "UniquenessHash": "85daf4dc-93cf-8f55-f583-c708356db354",
-        "TraceID": "XdpFindProbramSectionError",
-        "EncodingString": "[ xdp] ERROR, finding program section '%s'"
-      },
-      {
-        "UniquenessHash": "3a56ae8d-b415-1527-5570-a2d90bb41c54",
-        "TraceID": "XdpGetRssConfigFailed",
-        "EncodingString": "[ xdp][%p] Failed to get RSS configuration on IfIndex %u, RssConfigSize %u, Result %d"
-      },
-      {
-        "UniquenessHash": "bee5b34c-ac00-38e2-c85c-23a75b110c9c",
-        "TraceID": "XdpGetRssConfigInterfaceOpenFailed",
-        "EncodingString": "[ xdp] Failed to open Xdp interface for index %u. Error %d"
-      },
-      {
-        "UniquenessHash": "259b761c-655a-62b3-8826-84d1cd8321d1",
-        "TraceID": "XdpGetRssConfigSizeFailed",
-        "EncodingString": "[ xdp][%p] Failed to get RSS configuration size on IfIndex %u, RssConfigSize %u, Result %d"
-      },
-      {
         "UniquenessHash": "0a2db04c-0b5e-388d-18a0-2842ccb8d3ed",
         "TraceID": "XdpInitialize",
         "EncodingString": "[ xdp][%p] XDP initialized, %u procs"
@@ -18119,24 +16871,9 @@
         "EncodingString": "[ixdp][%p] Initializing %u queues on interface"
       },
       {
-        "UniquenessHash": "83b58d1d-bb4b-653f-d379-3631b103ed34",
-        "TraceID": "XdpLoadBpfObjectError",
-        "EncodingString": "[ xdp] ERROR:, loading BPF-OBJ file:%s, %d: [%s]."
-      },
-      {
         "UniquenessHash": "7783db85-e3da-a62a-9eaa-9430fc3b40c4",
         "TraceID": "XdpLoadObject",
         "EncodingString": "[ xdp] Successfully loaded xdp object of %s"
-      },
-      {
-        "UniquenessHash": "35b81be4-4ed1-ea3e-5c07-8f184e975d2f",
-        "TraceID": "XdpModeDowngrade",
-        "EncodingString": "[ xdp][%p] Downgrading from DRV mode to SKB mode for interface:%s"
-      },
-      {
-        "UniquenessHash": "6a5bfc6f-444f-4971-09f2-49a362ebac82",
-        "TraceID": "XdpNotSupported",
-        "EncodingString": "[ xdp][%p] Xdp is not supported on this interface:%s"
       },
       {
         "UniquenessHash": "d6fd6cf6-d65c-5e75-31f2-2a34a36c3255",
@@ -18189,11 +16926,6 @@
         "EncodingString": "[ xdp][%p] XDP release"
       },
       {
-        "UniquenessHash": "6ae15185-3a2c-6110-2cfa-0a53a094e7b5",
-        "TraceID": "XdpRxRelease",
-        "EncodingString": "[ xdp][%p] Release %d from Rx queue (TODO:Check necesity here)"
-      },
-      {
         "UniquenessHash": "02a4f582-b4ac-f506-b60f-2627183d2bde",
         "TraceID": "XdpSetIfnameFails",
         "EncodingString": "[ xdp] Failed to set ifname %s on %s"
@@ -18207,21 +16939,6 @@
         "UniquenessHash": "f209f7d4-9287-cfed-6abd-bfcd201e5ee7",
         "TraceID": "XdpSetPortFails",
         "EncodingString": "[ xdp] Failed to set port %d on %s"
-      },
-      {
-        "UniquenessHash": "2bcd0dff-21b9-c403-d43c-d997d9a6ec6d",
-        "TraceID": "XdpSkipOrEndofBuffer",
-        "EncodingString": "[ xdp] Skip or End of Buffer %d/%d"
-      },
-      {
-        "UniquenessHash": "603ba4f2-6ee1-96ee-fb08-ae3c1f0c446b",
-        "TraceID": "XdpSocketCreate",
-        "EncodingString": "[ xdp] Failed to create AF_XDP socket. ret:%d errno:%d"
-      },
-      {
-        "UniquenessHash": "51039a96-82fb-435b-957c-2af13dab2dc7",
-        "TraceID": "XdpSocketNotFound",
-        "EncodingString": "[ xdp] Socket not found LocalAddr=%!ADDR! RemoteAddr=%!ADDR!"
       },
       {
         "UniquenessHash": "e81e1b15-4470-f033-d0b6-6c03f9a19011",

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -6003,6 +6003,8 @@ pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE: QUIC_
     8;
 pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_PEER_ACCEPTED: QUIC_STREAM_EVENT_TYPE = 9;
 pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_CANCEL_ON_LOSS: QUIC_STREAM_EVENT_TYPE = 10;
+pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED: QUIC_STREAM_EVENT_TYPE =
+    11;
 pub type QUIC_STREAM_EVENT_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6022,6 +6024,7 @@ pub union QUIC_STREAM_EVENT__bindgen_ty_1 {
     pub SHUTDOWN_COMPLETE: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_7,
     pub IDEAL_SEND_BUFFER_SIZE: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_8,
     pub CANCEL_ON_LOSS: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9,
+    pub RECEIVE_BUFFER_NEEDED: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6442,6 +6445,23 @@ const _: () = {
     ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9::ErrorCode"]
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9, ErrorCode) - 0usize];
 };
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10 {
+    pub BufferLengthNeeded: u64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10"]
+        [::std::mem::size_of::<QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10>() - 8usize];
+    ["Alignment of QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10"]
+        [::std::mem::align_of::<QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10>() - 8usize];
+    ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10::BufferLengthNeeded"][::std::mem::offset_of!(
+        QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10,
+        BufferLengthNeeded
+    )
+        - 0usize];
+};
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of QUIC_STREAM_EVENT__bindgen_ty_1"]
@@ -6466,6 +6486,8 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, IDEAL_SEND_BUFFER_SIZE) - 0usize];
     ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1::CANCEL_ON_LOSS"]
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, CANCEL_ON_LOSS) - 0usize];
+    ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1::RECEIVE_BUFFER_NEEDED"]
+        [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, RECEIVE_BUFFER_NEEDED) - 0usize];
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -6030,6 +6030,8 @@ pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE: QUIC_
     8;
 pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_PEER_ACCEPTED: QUIC_STREAM_EVENT_TYPE = 9;
 pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_CANCEL_ON_LOSS: QUIC_STREAM_EVENT_TYPE = 10;
+pub const QUIC_STREAM_EVENT_TYPE_QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED: QUIC_STREAM_EVENT_TYPE =
+    11;
 pub type QUIC_STREAM_EVENT_TYPE = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6049,6 +6051,7 @@ pub union QUIC_STREAM_EVENT__bindgen_ty_1 {
     pub SHUTDOWN_COMPLETE: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_7,
     pub IDEAL_SEND_BUFFER_SIZE: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_8,
     pub CANCEL_ON_LOSS: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9,
+    pub RECEIVE_BUFFER_NEEDED: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6469,6 +6472,23 @@ const _: () = {
     ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9::ErrorCode"]
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_9, ErrorCode) - 0usize];
 };
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10 {
+    pub BufferLengthNeeded: u64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10"]
+        [::std::mem::size_of::<QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10>() - 8usize];
+    ["Alignment of QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10"]
+        [::std::mem::align_of::<QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10>() - 8usize];
+    ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10::BufferLengthNeeded"][::std::mem::offset_of!(
+        QUIC_STREAM_EVENT__bindgen_ty_1__bindgen_ty_10,
+        BufferLengthNeeded
+    )
+        - 0usize];
+};
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of QUIC_STREAM_EVENT__bindgen_ty_1"]
@@ -6493,6 +6513,8 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, IDEAL_SEND_BUFFER_SIZE) - 0usize];
     ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1::CANCEL_ON_LOSS"]
         [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, CANCEL_ON_LOSS) - 0usize];
+    ["Offset of field: QUIC_STREAM_EVENT__bindgen_ty_1::RECEIVE_BUFFER_NEEDED"]
+        [::std::mem::offset_of!(QUIC_STREAM_EVENT__bindgen_ty_1, RECEIVE_BUFFER_NEEDED) - 0usize];
 };
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -626,7 +626,7 @@ QuicTestEcn(
 void QuicTestStreamAppProvidedBuffers(
     );
 
-void QuicTestStreamAppProvidedBuffersZeroWindow(
+void QuicTestStreamAppProvidedBuffersOutOfSpace(
     );
 
 //
@@ -1379,7 +1379,7 @@ typedef struct {
 #define IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS \
     QUIC_CTL_CODE(128, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_ZERO_WINDOW \
+#define IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_OUT_OF_SPACE \
     QUIC_CTL_CODE(129, METHOD_BUFFERED, FILE_WRITE_DATA)
 
 #define IOCTL_QUIC_RUN_TEST_KEY_UPDATE_DURING_HANDSHAKE \

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -2337,12 +2337,12 @@ TEST(Misc, StreamAppProvidedBuffers) {
     }
 }
 
-TEST(Misc, StreamAppProvidedBuffersZeroWindow) {
-    TestLogger Logger("StreamAppProvidedBuffersZeroWindow");
+TEST(Misc, StreamAppProvidedBuffersOutOfSpace) {
+    TestLogger Logger("QuicTestStreamAppProvidedBuffersOutOfSpace");
     if (TestingKernelMode) {
-        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_ZERO_WINDOW));
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_OUT_OF_SPACE));
     } else {
-        QuicTestStreamAppProvidedBuffersZeroWindow();
+        QuicTestStreamAppProvidedBuffersOutOfSpace();
     }
 }
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -1515,8 +1515,8 @@ QuicTestCtlEvtIoDeviceControl(
         QuicTestCtlRun(QuicTestStreamAppProvidedBuffers());
         break;
 
-    case IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_ZERO_WINDOW:
-        QuicTestCtlRun(QuicTestStreamAppProvidedBuffersZeroWindow());
+    case IOCTL_QUIC_RUN_STREAM_APP_PROVIDED_BUFFERS_OUT_OF_SPACE:
+        QuicTestCtlRun(QuicTestStreamAppProvidedBuffersOutOfSpace());
         break;
 
     case IOCTL_QUIC_RUN_CONNECTION_POOL_CREATE:

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -4604,12 +4604,29 @@ QuicTestStreamMultiReceive(
 struct AppBuffersSenderContext {
     MsQuicStream* SenderStream{};
     CxPlatEvent SenderStreamCreated{};
+    CxPlatEvent SenderStreamClosed{};
+    uint64_t PeerRecvAbortedError{};
 
     static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
         auto* SenderContext = (AppBuffersSenderContext *)Context;
         if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
-            SenderContext->SenderStream = new(std::nothrow) MsQuicStream(Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete);
+            SenderContext->SenderStream = new(std::nothrow) MsQuicStream(
+                Event->PEER_STREAM_STARTED.Stream,
+                CleanUpAutoDelete,
+                AppBuffersSenderContext::StreamCallback,
+                Context);
             SenderContext->SenderStreamCreated.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS StreamCallback(_In_ MsQuicStream* Stream, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto* SenderContext = (AppBuffersSenderContext *)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED) {
+            SenderContext->PeerRecvAbortedError = Event->PEER_RECEIVE_ABORTED.ErrorCode;
+            Stream->Shutdown(QUIC_STATUS_SUCCESS);
+        } else if (Event->Type == QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE) {
+            SenderContext->SenderStreamClosed.Set();
         }
         return QUIC_STATUS_SUCCESS;
     }
@@ -4633,16 +4650,21 @@ struct AppBuffersReceiverContext {
     uint32_t NumBuffersForThreshold{};
     uint64_t MoreBufferThreshold{};
 
+    // App buffers to provide when the ReceiveBufferNeeded notification is received
+    QUIC_BUFFER *BuffersForInsufficientRecvBuffer{};
+    uint32_t NumBuffersForInsufficientRecvBuffer{};
+    BOOLEAN ShutdownOnInsufficientRecvBuffer{};
+
     uint64_t ReceivedBytes{};
 
     // Event to signal when the sender stream get closed
     CxPlatEvent SenderStreamClosed{};
 
-    // Event to signal when at least
+    // Event to signal when at least ReceivedBytesThreshold bytes have been received
     CxPlatEvent ReceivedBytesThresholdReached{};
     uint64_t ReceivedBytesThreshold{};
 
-    // Accept a stream on the listener side (no need to keep the handle to it)
+    // Accept a stream on the listener side
     static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
         auto ReceiverContext = (AppBuffersReceiverContext*)Context;
 
@@ -4678,6 +4700,16 @@ struct AppBuffersReceiverContext {
                 ReceiverContext->ReceivedBytesThresholdReached.Set();
                 ReceiverContext->ReceivedBytesThreshold = 0;
             }
+        } else if (Event->Type == QUIC_STREAM_EVENT_RECEIVE_BUFFER_NEEDED) {
+            if (ReceiverContext->ShutdownOnInsufficientRecvBuffer) {
+                ReceiverContext->Stream->Shutdown(
+                    1, QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE | QUIC_STREAM_SHUTDOWN_FLAG_INLINE);
+            } else if (ReceiverContext->NumBuffersForInsufficientRecvBuffer > 0) {
+                ReceiverContext->Stream->ProvideReceiveBuffers(
+                    ReceiverContext->NumBuffersForInsufficientRecvBuffer,
+                    ReceiverContext->BuffersForInsufficientRecvBuffer);
+            }
+
         } else if (Event->Type == QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN) {
             ReceiverContext->SenderStreamClosed.Set();
         }
@@ -4720,12 +4752,17 @@ QuicTestStreamAppProvidedBuffers(
             QuicBuffers[i].Length = BufferSize / NumBuffers;
         }
 
+        // Prepare a receiver stream context
+        // - some initial receive buffer space will be provided when the stream is accepted
+        // - more receive buffer space will be provided after 0x1500 bytes are received
+        // - an event will be signaled when 0x1500 bytes are received to synchronize with the sender
         AppBuffersReceiverContext ReceiveContext;
         ReceiveContext.BuffersForStreamStarted = QuicBuffers;
         ReceiveContext.NumBuffersForStreamStarted = NumBuffers / 2;
         ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
         ReceiveContext.NumBuffersForThreshold = NumBuffers / 2;
         ReceiveContext.MoreBufferThreshold = 0x1500;
+        ReceiveContext.ReceivedBytesThreshold = 0x1500;
 
         // Setup a listener
         MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersReceiverContext::ConnCallback, &ReceiveContext);
@@ -4750,9 +4787,14 @@ QuicTestStreamAppProvidedBuffers(
         TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
         TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
 
-        // Send data
-        QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
-        TEST_QUIC_SUCCEEDED(ClientStream.Send(&Buffer, 1, QUIC_SEND_FLAG_FIN));
+        // Send data, waiting for the treshold to be  reached to ensure
+        // buffer space is provided in time.
+        QUIC_BUFFER Buffer1{BufferSize / 2, SendDataBuffer.get()};
+        QUIC_BUFFER Buffer2{BufferSize / 2, SendDataBuffer.get() + BufferSize / 2};
+
+        TEST_QUIC_SUCCEEDED(ClientStream.Send(&Buffer1, 1));
+        TEST_TRUE(ReceiveContext.ReceivedBytesThresholdReached.WaitTimeout(TestWaitTimeout));
+        TEST_QUIC_SUCCEEDED(ClientStream.Send(&Buffer2, 1, QUIC_SEND_FLAG_FIN));
 
         TEST_TRUE(ReceiveContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
         TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
@@ -4798,11 +4840,14 @@ QuicTestStreamAppProvidedBuffers(
             QuicBuffers[i].Length = BufferSize / NumBuffers;
         }
 
-        // Create and start a stream
+        // Create and start a receiver stream
+        // - more receive buffer space will be provided after 0x1500 bytes are received
+        // - an event will be signaled when 0x1500 bytes are received to synchronize with the sender
         AppBuffersReceiverContext ReceiveContext;
         ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
         ReceiveContext.NumBuffersForThreshold = NumBuffers / 2;
         ReceiveContext.MoreBufferThreshold = 0x1500;
+        ReceiveContext.ReceivedBytesThreshold = 0x1500;
 
         MsQuicStream ClientStream(
             Connection,
@@ -4822,9 +4867,15 @@ QuicTestStreamAppProvidedBuffers(
         auto* SenderStream = SenderContext.WaitForSenderStream();
         TEST_NOT_EQUAL(SenderStream, nullptr);
 
-        // Send data
-        QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
-        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer, 1, QUIC_SEND_FLAG_FIN));
+        //
+        // Send data, waiting for the treshold to be  reached to ensure
+        // buffer space is provided in time.
+        QUIC_BUFFER Buffer1{BufferSize / 2, SendDataBuffer.get()};
+        QUIC_BUFFER Buffer2{BufferSize / 2, SendDataBuffer.get() + BufferSize / 2};
+
+        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer1, 1));
+        TEST_TRUE(ReceiveContext.ReceivedBytesThresholdReached.WaitTimeout(TestWaitTimeout));
+        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer2, 1, QUIC_SEND_FLAG_FIN));
 
         TEST_TRUE(ReceiveContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
         TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
@@ -4833,7 +4884,7 @@ QuicTestStreamAppProvidedBuffers(
 }
 
 void
-QuicTestStreamAppProvidedBuffersZeroWindow(
+QuicTestStreamAppProvidedBuffersOutOfSpace(
     )
 {
     MsQuicRegistration Registration(true);
@@ -4849,7 +4900,7 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
         MsQuicCredentialConfig());
     TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
 
-    // Client side sending data
+    // Client side sending data - provide more buffer on insufficient receive buffer notification
     {
         // Create send and receive buffers
         const uint32_t BufferSize = 0x5000;
@@ -4867,16 +4918,16 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
             QuicBuffers[i].Length = BufferSize / NumBuffers;
         }
 
+        //
+        // Prepare a receiver stream context
+        // - some initial receive buffer space will be provided when the stream is accepted
+        // - more receive buffer space will be provided when the stream runs out of buffer space
+        //
         AppBuffersReceiverContext ReceiveContext;
         ReceiveContext.BuffersForStreamStarted = QuicBuffers;
         ReceiveContext.NumBuffersForStreamStarted = NumBuffers / 2;
-        ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
-        ReceiveContext.NumBuffersForThreshold = NumBuffers / 2;
-
-        // Setup the threshold so that more buffers are provided:
-        // - only when the receive window reaches zero bytes
-        // - but inline in the receive callback
-        ReceiveContext.MoreBufferThreshold = 0x2000;
+        ReceiveContext.BuffersForInsufficientRecvBuffer = QuicBuffers + NumBuffers / 2;
+        ReceiveContext.NumBuffersForInsufficientRecvBuffer = NumBuffers / 2;
 
         // Setup a listener
         MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersReceiverContext::ConnCallback, &ReceiveContext);
@@ -4901,7 +4952,8 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
         TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
         TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
 
-        // Send data
+        // Send all data at once. The receiver will provide more receive buffer inline in the
+        // insufficent receive buffer notification.
         QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
         TEST_QUIC_SUCCEEDED(ClientStream.Send(&Buffer, 1, QUIC_SEND_FLAG_FIN));
 
@@ -4910,7 +4962,7 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
         TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
     }
 
-    // Server side sending data
+    // Server side sending data - abort the stream on insufficient receive buffer notification
     {
         // Setup a listener
         AppBuffersSenderContext SenderContext{};
@@ -4961,9 +5013,8 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
         TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
 
         ReceiveContext.Stream = &ClientStream;
-        // Set the threshold to the amount of provided buffer space to wait until
-        // the maximum byte offset receivable is received.
-        ReceiveContext.ReceivedBytesThreshold = BufferSize / 2;
+        // The stream will be shutdown inline when it runs out of receive buffer space.
+        ReceiveContext.ShutdownOnInsufficientRecvBuffer = TRUE;
 
         // Provide some receive buffers before starting the stream
         TEST_QUIC_SUCCEEDED(ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers));
@@ -4975,18 +5026,14 @@ QuicTestStreamAppProvidedBuffersZeroWindow(
         TEST_NOT_EQUAL(SenderStream, nullptr);
 
         // Send data
+        // Don't send FIN so that the stream is deterministically closed after the sender gets the
+        // STOP_SENDING frame.
         QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
-        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer, 1, QUIC_SEND_FLAG_FIN));
+        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer, 1));
 
-        // Wait until enough data is received to fill the window completely
-        TEST_TRUE(ReceiveContext.ReceivedBytesThresholdReached.WaitTimeout(TestWaitTimeout));
-
-        // Provide more buffers out of a callback context and check the remaining data is received
-        TEST_QUIC_SUCCEEDED(ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers + NumBuffers / 2));
-
-        TEST_TRUE(ReceiveContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
-        TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
-        TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
+        TEST_TRUE(SenderContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
+        TEST_EQUAL(SenderContext.PeerRecvAbortedError, 1);
     }
 }
+
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES


### PR DESCRIPTION
## Description

Cherry-pick of #5313

When using app-provided buffers, the flow control window was constrained to the amount of buffer provided by the application.
Assuming the application mis-calculates the amount of buffer needed, this could cause a stream to be soft-locked: the receive window would be zero and the sender wait forever.

This changes this behavior:
- the flow control window is no longer bound by the amount of buffer provided
- if more data is received than there is buffer space, a `QUIC_STREAM_EVENT_INSUFFICIENT_RECEIVE_BUFFER` is sent to the app which can:
    - provide more buffer space inline
    - close abortively the receive side of the stream inline
  Otherwise, the connection is aborted.

## Testing

Test have been improved and adapted for the new behavior.

Instead of validating that when the sender queue more data than the receiver has buffer for, the receive window limits the amount of data sent (previous behavior), the updated tests validate that the receive buffer is no longer a limiting factor and that when more data is received than there is buffer available for:
- the notification is emmited
- the app can provide more buffer space
- the app can shutdown the stream inline

## Documentation

Documentation was updated
