### PR TITLE
Add /profile link flag to msquic.dll

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -240,7 +240,7 @@ set_property(TARGET msquic PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
 
 if(WIN32)
     SET_TARGET_PROPERTIES(msquic
-        PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
+        PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\" /PROFILE")
 elseif (CX_PLATFORM STREQUAL "linux")
     SET_TARGET_PROPERTIES(msquic
         PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/linux/exports.txt\"")


### PR DESCRIPTION
## Description

Add /profile link flag to Windows user mode builds. This flag puts extra debug information in the PDB to enable performance analysis of the binary and is required for shipping in some scenarios.

## Testing

Existing tests should cover this.

## Documentation

N/A
