### PR TITLE
Simplify Netperf API

### DIFF
--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -124,6 +124,7 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
 } elseif ($Command.Contains("Config_DumpCollection_Windows")) {
     $DumpDir = "C:/_work/quic/artifacts/crashdumps"
+    $WerDumpRegPath = "HKLM:\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\secnetperf.exe"
     New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
     New-Item -Path $WerDumpRegPath -Force -ErrorAction Ignore | Out-Null
     Set-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -Value $DumpDir | Out-Null

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -1,5 +1,9 @@
-param (
-    [string]$Command
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Command,
+
+    [Parameter(Mandatory = $false)]
+    [string] $WorkingDir = "."
 )
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
@@ -81,8 +85,8 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     Write-Host "Executing command: $(pwd)/artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats"
     ./artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats
 } elseif ($Command.Contains("Prepare_MachineForTest")) {
-    Write-Host "Executing command: Prepare_MachineForTest"
-    .\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates
+    Write-Host "Executing command: $WorkingDir\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates"
+    iex "$WorkingDir\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates"
 } elseif ($Command.Contains("Install_XDP")) {
     Write-Host "Executing command: Install_XDP"
     .\scripts\prepare-machine.ps1 -InstallXdpDriver

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -86,7 +86,7 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     ./artifacts/bin/windows/x64_Release_schannel/secnetperf -exec:$mode -io:$io -stats:$stats
 } elseif ($Command.Contains("Prepare_MachineForTest")) {
     Write-Host "Executing command: $WorkingDir\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates"
-    iex "$WorkingDir\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates"
+    Invoke-Expression "$WorkingDir\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates"
 } elseif ($Command.Contains("Install_XDP")) {
     Write-Host "Executing command: Install_XDP"
     .\scripts\prepare-machine.ps1 -InstallXdpDriver

--- a/scripts/quic_callback.ps1
+++ b/scripts/quic_callback.ps1
@@ -118,6 +118,12 @@ if ($Command.Contains("/home/secnetperf/_work/quic/artifacts/bin/linux/x64_Relea
     # if artifacts don't exist, make it
     New-Item -ItemType Directory "artifacts/logs/$artifactName/server" -ErrorAction Ignore | Out-Null
     .\scripts\log.ps1 -Stop -OutputPath "artifacts/logs/$artifactName/server" -RawLogOnly
+} elseif ($Command.Contains("Config_DumpCollection_Windows")) {
+    $DumpDir = "C:/_work/quic/artifacts/crashdumps"
+    New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
+    New-Item -Path $WerDumpRegPath -Force -ErrorAction Ignore | Out-Null
+    Set-ItemProperty -Path $WerDumpRegPath -Name DumpFolder -Value $DumpDir | Out-Null
+    Set-ItemProperty -Path $WerDumpRegPath -Name DumpType -Value 2 | Out-Null
 } else {
     throw "Invalid command: $Command"
 }

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -32,7 +32,7 @@ function Configure-DumpCollection {
     param ($Session)
     if ($isWindows) {
         NetperfSendCommand "Config_DumpCollection_Windows" $Session
-        NetperfWaitServerFinishExecution
+        NetperfWaitServerFinishExecution -Session $Session
         $DumpDir = Repo-Path "artifacts/crashdumps"
         New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
         New-Item -Path $WerDumpRegPath -Force -ErrorAction Ignore | Out-Null

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -133,15 +133,8 @@ function Prepare-MachineForTest {
     .\scripts\prepare-machine.ps1 -ForTest -InstallSigningCertificates
     Write-Host "Running prepare-machine.ps1 -ForTest -InstallSigningCertificates on peer"
 
-    if ($Session -eq "NOT_SUPPORTED") {
-        NetperfSendCommand "Prepare_MachineForTest"
-        NetperfWaitServerFinishExecution
-        return
-    }
-
-    Invoke-Command -Session $Session -ScriptBlock {
-        & "$Using:RemoteDir\scripts\prepare-machine.ps1" -ForTest -InstallSigningCertificates
-    }
+    NetperfSendCommand "Prepare_MachineForTest" $Session
+    NetperfWaitServerFinishExecution -Session $Session
 }
 
 # Download and install XDP on both local and remote machines.

--- a/scripts/secnetperf-helpers.psm1
+++ b/scripts/secnetperf-helpers.psm1
@@ -31,13 +31,8 @@ function Repo-Path {
 function Configure-DumpCollection {
     param ($Session)
     if ($isWindows) {
-        Invoke-Command -Session $Session -ScriptBlock {
-            $DumpDir = "C:/_work/quic/artifacts/crashdumps"
-            New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
-            New-Item -Path $Using:WerDumpRegPath -Force -ErrorAction Ignore | Out-Null
-            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpFolder -Value $DumpDir | Out-Null
-            Set-ItemProperty -Path $Using:WerDumpRegPath -Name DumpType -Value 2 | Out-Null
-        }
+        NetperfSendCommand "Config_DumpCollection_Windows" $Session
+        NetperfWaitServerFinishExecution
         $DumpDir = Repo-Path "artifacts/crashdumps"
         New-Item -Path $DumpDir -ItemType Directory -ErrorAction Ignore | Out-Null
         New-Item -Path $WerDumpRegPath -Force -ErrorAction Ignore | Out-Null

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -98,9 +98,6 @@ if ($psVersion.Major -lt 7) {
     $IsWindows = $true
 }
 
-Write-Host "Running tests with the following parameters:"
-Write-Host "$RemotePowershellSupported, $RunId"
-
 # Set up some important paths.
 $RemoteDir = "C:/_work/quic"
 if (!$isWindows) {

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -128,7 +128,8 @@ if ($isWindows -and $NoLogs) {
 
 $useXDP = (Is-XdpRequiredByIo $io) -or (Is-XdpRequiredByIo $serverio)
 
-$Session = InitNetperfLib "quic_callback.ps1" $RemoteDir
+$Session = InitNetperfLib "quic_callback.ps1" $RemoteDir $RemoteName $UserName
+Copy-RepoToPeer $Session
 
 if ($Session -ne "NOT_SUPPORTED") {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
@@ -151,8 +152,6 @@ if ($io -eq "wsk") {
     # Remove all the other kernel binaries since we don't need them any more.
     Remove-Item -Force -Recurse $KernelDir | Out-Null
 }
-
-Copy-RepoToPeer $Session
 
 # Create the logs directories on both machines.
 New-Item -ItemType Directory -Path ./artifacts/logs | Out-Null

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -90,7 +90,6 @@ function Is-XdpRequiredByIo {
     return ($Io -eq "xdp" -or $Io -eq "qtip")
 }
 
-$RemotePowershellSupported = $env:netperf_remote_powershell_supported
 $RunId = $env:netperf_run_id
 $SyncerSecret = $env:netperf_syncer_secret
 
@@ -131,50 +130,8 @@ if ($isWindows -and $NoLogs) {
 }
 
 $useXDP = (Is-XdpRequiredByIo $io) -or (Is-XdpRequiredByIo $serverio)
-if ($RemotePowershellSupported -eq $true) {
 
-    # Set up the connection to the peer over remote powershell.
-    Write-Host "Connecting to $RemoteName"
-    $Attempts = 0
-    while ($Attempts -lt 5) {
-        if ($environment -eq "azure") {
-            if ($isWindows) {
-                Write-Host "Attempting to connect..."
-                $Session = New-PSSession -ComputerName $RemoteName -ConfigurationName PowerShell.7
-                break
-            } else {
-                # On Azure in 1ES Linux environments, remote powershell is not supported (yet).
-                $Session = "NOT_SUPPORTED"
-                Write-Host "Remote PowerShell is not supported in Azure 1ES Linux environments"
-                break
-            }
-        }
-        try {
-            if ($isWindows) {
-                $username = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultUserName
-                $password = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultPassword | ConvertTo-SecureString -AsPlainText -Force
-                $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
-                $Session = New-PSSession -ComputerName $RemoteName -Credential $cred -ConfigurationName PowerShell.7
-            } else {
-                $Session = New-PSSession -HostName $RemoteName -UserName $UserName -SSHTransport
-            }
-            break
-        } catch {
-            Write-Host "Error $_"
-            $Attempts += 1
-            Start-Sleep -Seconds 10
-        }
-    }
-
-    if ($null -eq $Session) {
-        Write-GHError "Failed to create remote session"
-        exit 1
-    }
-
-} else {
-    $Session = "NOT_SUPPORTED"
-    Write-Host "Remote PowerShell is not supported in this environment"
-}
+$Session = InitNetperfLib "quic_callback.ps1" $RemoteDir
 
 if ($Session -ne "NOT_SUPPORTED") {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
@@ -198,20 +155,7 @@ if ($io -eq "wsk") {
     Remove-Item -Force -Recurse $KernelDir | Out-Null
 }
 
-
-if (!($Session -eq "NOT_SUPPORTED")) {
-    # Copy the artifacts to the peer.
-    Write-Host "Copying files to peer"
-    Invoke-Command -Session $Session -ScriptBlock {
-        if (Test-Path $Using:RemoteDir) {
-            Remove-Item -Force -Recurse $Using:RemoteDir | Out-Null
-        }
-        New-Item -ItemType Directory -Path $Using:RemoteDir -Force | Out-Null
-    }
-    Copy-Item -ToSession $Session ./artifacts -Destination "$RemoteDir/artifacts" -Recurse
-    Copy-Item -ToSession $Session ./scripts -Destination "$RemoteDir/scripts" -Recurse
-    Copy-Item -ToSession $Session ./src/manifest/MsQuic.wprp -Destination "$RemoteDir/scripts"
-}
+Copy-RepoToPeer $Session
 
 # Create the logs directories on both machines.
 New-Item -ItemType Directory -Path ./artifacts/logs | Out-Null
@@ -284,6 +228,8 @@ if ($isWindows -and !($environment -eq "azure")) {
     try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
     if (!$HasTestSigning) { Write-Host "Test Signing Not Enabled!" }
 }
+
+Configure-DumpCollection $Session
 
 # Install any dependent drivers.
 if ($useXDP -and $isWindows) { Install-XDP $Session $RemoteDir }

--- a/scripts/secnetperf.ps1
+++ b/scripts/secnetperf.ps1
@@ -129,7 +129,6 @@ if ($isWindows -and $NoLogs) {
 $useXDP = (Is-XdpRequiredByIo $io) -or (Is-XdpRequiredByIo $serverio)
 
 $Session = InitNetperfLib "quic_callback.ps1" $RemoteDir $RemoteName $UserName
-Copy-RepoToPeer $Session
 
 if ($Session -ne "NOT_SUPPORTED") {
     # Make sure nothing is running from a previous run. This only applies to non-azure / 1ES environments.
@@ -152,6 +151,8 @@ if ($io -eq "wsk") {
     # Remove all the other kernel binaries since we don't need them any more.
     Remove-Item -Force -Recurse $KernelDir | Out-Null
 }
+
+Copy-RepoToPeer $Session
 
 # Create the logs directories on both machines.
 New-Item -ItemType Directory -Path ./artifacts/logs | Out-Null


### PR DESCRIPTION
## Description

Attempt to address issues #5348 #5334 

The idea here is that for projects like MsQuic to leverage both lab-based and Azure-vm based perf testing, we have a standardized interface such that no internal implementation details leak.

Here is the proposed design:

For projects that only need to use the lab, they can still leverage remote powershell.
Every project that wants to leverage both Azure + Lab in their workflows needs to run:

- InitNetperfLib "project_callback.ps1"
- CopyRepoToPeer

Each time the client needs to orchestrate some remote commands to run on the peer, you always use:
- NetperfSendCommand -Command X
- NetperfWaitServerFinishExecution

And you add details to "project_callback.ps1" where:

if (command == X) {
   ...do XYZ...
}

### NOTE: 

Needs dependent Netperf PR: https://github.com/microsoft/netperf/pull/710 to merge first.

This pull request is a step in the direction to address the debt, but does not address all debt. Future PRs will be made to replace all instances of the secnetperf scripts to remove any leakage of implementation details.

## Testing

Netperf CI: https://github.com/microsoft/netperf/actions/runs/16973623322

## Documentation

Once more feedback comes, we can add this to the offical docs on netperf.