### PR TITLE
Windows: Allow customizing CompletionKey for IOCP usage

### DIFF
--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -131,7 +131,10 @@ To create an execution context, the app much first create an event queue object,
 On Windows, the following types are defined:
 
 ```c++
-typedef HANDLE QUIC_EVENTQ;
+typedef struct CXPLAT_EVENTQ {
+    HANDLE IoCompletionPort;
+    ULONG_PTR CompletionKey;
+} CXPLAT_EVENTQ;
 
 typedef OVERLAPPED_ENTRY CXPLAT_CQE;
 
@@ -149,22 +152,26 @@ typedef struct CXPLAT_SQE {
 } CXPLAT_SQE;
 ```
 
-You will also notice the definiton for `QUIC_SQE` (SQE stands for submission queue entry), which defines the format that all completion events must take so they may be generically processed from the event queue (more on this below).
+You will also notice the definiton for `CXPLAT_SQE` (SQE stands for submission queue entry), which defines the format that all completion events must take so they may be generically processed from the event queue (more on this below).
 
 Once the app has the event queue, it may create the execution context with the `ExecutionCreate` function:
 
 ```c++
 HANDLE IOCP = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
-QUIC_EXECUTION_CONFIG ExecConfig = { 0, &IOCP };
+ULONG_PTR completionKey = 0; // Optional
+CXPLAT_EVENTQ queueConfig = { IOCP, completionKey };
+QUIC_EXECUTION_CONFIG ExecConfig = { 0, &queueConfig };
 
 QUIC_EXECUTION* ExecContext = nullptr;
 QUIC_STATUS Status = MsQuic->ExecutionCreate(QUIC_GLOBAL_EXECUTION_CONFIG_FLAG_NONE, 0, 1, &ExecConfig, &ExecContext);
 ```
 
-The above code createa a new IOCP (for Windows), sets up an execution config, indicating an ideal processor of 0 and the pointer to the IOCP, and then calls MsQuic to create 1 execution context.
+The above code creates a new IOCP (for Windows), sets up an execution config, indicating an ideal processor of 0 and the pointer to the IOCP, and then calls MsQuic to create 1 execution context.
 An application may expand this code to create multiple execution contexts, depending on their needs.
 
 To drive this execution context, the app will need to to periodically call `ExecutionPoll` and use the platform specific function to drain completion events from the event queue.
+The return value of `ExecutionPoll` tells the application how long it should wait (in milliseconds) before calling `ExecutionPoll` again, even if no new IO has completed. This is used by MsQuic to implement its internal timeouts. 
+If the application operates a simple loop around `GetQueuedCompletionStatus(Ex)` as in the following example, then it may conveniently pass that directly as its timeout value.
 
 ```c
 bool AllDone = false;
@@ -175,7 +182,7 @@ while (!AllDone) {
     OVERLAPPED_ENTRY Overlapped[8];
     if (GetQueuedCompletionStatusEx(IOCP, Overlapped, ARRAYSIZE(Overlapped), &OverlappedCount, WaitTime, FALSE)) {
         for (ULONG i = 0; i < OverlappedCount; ++i) {
-            QUIC_SQE* Sqe = CONTAINING_RECORD(Overlapped[i].lpOverlapped, QUIC_SQE, Overlapped);
+            CXPLAT_SQE* Sqe = CONTAINING_RECORD(Overlapped[i].lpOverlapped, CXPLAT_SQE, Overlapped);
             Sqe->Completion(&Overlapped[i]);
         }
     }
@@ -185,8 +192,39 @@ while (!AllDone) {
 Above, you can see a simple loop that properly drives a single execution context on Windows.
 `OVERLAPPED_ENTRY` objects received from `GetQueuedCompletionStatusEx` are used to get the submission queue entry and then call its completion handler.
 
-In a real application, these completion events may come both from MsQuic and the application itself, therefore, this means **the application must use the same base format for its own submission entries**.
-This is necessary to be able to share the same event queue object.
+Applications may also perform their own IOs alongside those of MsQuic, pointing to the same IOCP, so that the same threads may efficiently service both MsQuic and non-MsQuic IOs together.
+
+The sample above makes the assumption that _all_ dequeued OVERLAPPED_ENTRY values are in fact pointing to `CXPLAT_SQE` objects (which embed the traditional Win32 `OVERLAPPED` structure).
+To simplify mixing MsQuic with non-MsQuic IO, the application may decide to use the same base format as `CXPLAT_SQE` for its own IOs and streamline the event loop as in the above example. This approach will work for all platforms and not only Windows user-mode.
+
+On Windows, if the application has its own structure embedding the `OVERLAPPED` for its own non-MsQuic IOs and cannot align with the same convention as `CXPLAT_SQE`, it may configure MsQuic to use a specific `CompletionKey`
+when posting packets to the IOCP. By inspecting this `CompletionKey`, the application may distinguish MsQuic-based IO (which means it is a `CXPLAT_SQE`), from non-MsQuic IO that may be in any other arbitrary shape.
+
+```c++
+HANDLE IOCP = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+ULONG_PTR completionKeyForMsQuic = 0x11223344;
+CXPLAT_EVENTQ queueConfig = { IOCP, completionKeyForMsQuic };
+QUIC_EXECUTION_CONFIG ExecConfig = { 0, &queueConfig };
+
+// [...]
+
+while (true) {
+    uint32_t WaitTime = MsQuic->ExecutionPoll(ExecContext);
+
+    ULONG OverlappedCount = 0;
+    OVERLAPPED_ENTRY Overlapped[8];
+    if (GetQueuedCompletionStatusEx(IOCP, Overlapped, ARRAYSIZE(Overlapped), &OverlappedCount, WaitTime, FALSE)) {
+        for (ULONG i = 0; i < OverlappedCount; ++i) {
+            if (Overlapped[i].lpCompletionKey == completionKeyForMsQuic) {
+                CXPLAT_SQE* Sqe = CONTAINING_RECORD(Overlapped[i].lpOverlapped, CXPLAT_SQE, Overlapped);
+                Sqe->Completion(&Overlapped[i]);
+            } else {
+                // This IO did not originate from MSQuic and is app-specific.
+            }
+        }
+    }
+}
+```
 
 # See Also
 

--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -382,7 +382,7 @@ QuicAddrToString(
 // Event Queue Abstraction
 //
 
-typedef HANDLE QUIC_EVENTQ;
+typedef struct CXPLAT_EVENTQ QUIC_EVENTQ;
 
 typedef OVERLAPPED_ENTRY QUIC_CQE;
 


### PR DESCRIPTION
## Description

Applications can mix their own arbitrary IOs with those of MsQuic on the same "event queues" (Windows IOCP, Linux epoll, etc).

The simplest way to accomplish this is to ensure that their non-MsQuic follow the same layout and convention as that of `CXPLAT_SQE`, which has some platform-specific state (`OVERLAPPED` in Windows, for example), and a callback called `CXPLAT_SQE::Completion` that should be invoked by the application.

However, it is not always possible for complex applications to follow MsQuic's convention for their own arbitrary IOs.

On Windows specifically, it is possible to let applications distinguish the origin of IO completion packets with the use of the `CompletionKey` that gets configured by `CreateIoCompletionPort` and passed back by `GetQueuedCompletionStatus/Ex`.

This PR changes the definition of `CXPLAT_EVENTQ` for Windows so that applications may tell MsQuic what value to use as `CompletionKey`. The value they provide is application-defined and is not interpreted by MsQuic.

## Testing

I adapted the Windows Execution sample.

## Documentation

Yes updated.

Fixes #5366 
