### PR TITLE
Fix incorrect cmake option name in build.ps1 and cmakepreset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,7 +34,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/linux",
             "cacheVariables": {
-                "QUIC_LINUX_LOG_ENCODER": "lttng",
+                "QUIC_LOGGING_TYPE": "lttng",
                 "QUIC_ENABLE_LOGGING": "on",
                 "QUIC_BUILD_TOOLS": "on",
                 "QUIC_BUILD_TEST": "on",

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -440,9 +440,6 @@ function CMake-Generate {
     $Arguments += " -DQUIC_TLS_LIB=" + $Tls
     $Arguments += " -DQUIC_OUTPUT_DIR=""$ArtifactsDir"""
 
-    if ($IsLinux) {
-        $LoggingType = "lttng"
-    }
     if (!$DisableLogs) {
         $Arguments += " -DQUIC_ENABLE_LOGGING=on"
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -441,7 +441,7 @@ function CMake-Generate {
     $Arguments += " -DQUIC_OUTPUT_DIR=""$ArtifactsDir"""
 
     if ($IsLinux) {
-        $Arguments += " -DQUIC_LINUX_LOG_ENCODER=lttng"
+        $LoggingType = "lttng"
     }
     if (!$DisableLogs) {
         $Arguments += " -DQUIC_ENABLE_LOGGING=on"


### PR DESCRIPTION
## Description

- QUIC_LINUX_LOG_ENCODER is an incorrect CMake options, should be modified to `QUIC_LOGGING_TYPE`.

## Testing

No new tests should be required.

## Documentation

No docs need be updated.
