### PR TITLE
Update CMakePresets.json to use same generators as build.ps1

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
             "name": "win-base",
             "description": "Base settings for all windows builds",
             "hidden": true,
-            "generator": "Ninja",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build/windows",
             "cacheVariables": {
                 "QUIC_ENABLE_LOGGING": "on",
@@ -31,7 +31,7 @@
             "name": "lin-base",
             "description": "Base settings for all Linux builds",
             "hidden": true,
-            "generator": "Ninja",
+            "generator": "Unix Makefiles",
             "binaryDir": "${sourceDir}/build/linux",
             "cacheVariables": {
                 "QUIC_LINUX_LOG_ENCODER": "lttng",


### PR DESCRIPTION
## Description

CMakePresets.json is used by Visual Studio Code (and other editors) to build projects. The MsQuic CMakePresets.json was using the Ninja generator, which is not installed by default in many environments. The build.ps1 script also uses different generators, which means that when switching between building via build.ps1 and CMakePresets, a clean build must be done.

This change updates the presets file to use the same generator as the build.ps1 script, thereby making the presets that much more useful for developers.

## Testing

Locally tested.

## Documentation

No, this is an optional quality of life feature.
