### PR TITLE
Allow CLOG to run on newer frameworks in test

### DIFF
--- a/scripts/log.ps1
+++ b/scripts/log.ps1
@@ -376,9 +376,19 @@ function Log-Decode {
 #                     Main Execution                         #
 ##############################################################
 
-if ($Start)  { Log-Start }
-if ($Cancel) { Log-Cancel }
-if ($Stop)   { Log-Stop }
-if ($Decode) { Log-Decode }
-if ($PerfRun) { Perf-Run }
-if ($PerfGraph) { Perf-Graph }
+#
+# Allow the CLOG sidecar to run on newer .NET versions.
+#
+$OriginalDOTNET_ROLL_FORWARD = $env:DOTNET_ROLL_FORWARD
+
+try {
+    $env:DOTNET_ROLL_FORWARD = "Major"
+    if ($Start)  { Log-Start }
+    if ($Cancel) { Log-Cancel }
+    if ($Stop)   { Log-Stop }
+    if ($Decode) { Log-Decode }
+    if ($PerfRun) { Perf-Run }
+    if ($PerfGraph) { Perf-Graph }
+} finally {
+    $env:DOTNET_ROLL_FORWARD = $OriginalDOTNET_ROLL_FORWARD
+}


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

CLOG by default requires exactly version 6.0 of the .NET framework, which is obsolete and not secure. Allow CLOG to run with newer version of the framework in the logging script, which is used by test infra.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tested locally.

## Documentation

_Is there any documentation impact for this change?_

No.