### PR TITLE
Fix unaligned memory access

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -2859,7 +2859,7 @@ static int SplitAddRecord(RECORD_ENTRY *Entry, size_t *Consumed)
 
     while (total_message_size < Entry->RecLen) {
         message_type = *idx;
-        message_size = *((uint32_t *)idx);
+        memcpy(&message_size, idx, sizeof(message_size));
 
         //
         //message size is just the lower 3 bytes of the TLS record


### PR DESCRIPTION
## Description

Casting an unaligned byte pointer to uint32_t can result in a crash on ARM architectures, and result in low-performance on x64 architectures. Discovered via UBSAN.

## Testing

Existing tests should exercise this scenario thoroughly

## Documentation

N/A
