### PR TITLE
QTIP: Configure XDP rules properly

### DIFF
--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1452,6 +1452,7 @@ CxPlatDpRawPlumbRulesOnSocket(
 
             memcpy(Rules[0].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
             memcpy(Rules[1].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+            RulesSize = 2;
 
             if (Socket->ReserveAuxTcpSock) {
                 Rules[2].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
@@ -1479,8 +1480,6 @@ CxPlatDpRawPlumbRulesOnSocket(
                 Rules[4].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
                 Rules[4].Redirect.Target = NULL;
                 RulesSize = 5;
-            } else {
-                RulesSize = 2;
             }
             CXPLAT_DBG_ASSERT(RulesSize <= RTL_NUMBER_OF(Rules));
         } else {
@@ -1489,6 +1488,7 @@ CxPlatDpRawPlumbRulesOnSocket(
             Rules[0].Action = XDP_PROGRAM_ACTION_REDIRECT;
             Rules[0].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
             Rules[0].Redirect.Target = NULL;
+            RulesSize = 1;
 
             if (Socket->ReserveAuxTcpSock) {
                 Rules[1].Match = XDP_MATCH_TCP_DST;
@@ -1497,8 +1497,6 @@ CxPlatDpRawPlumbRulesOnSocket(
                 Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
                 Rules[1].Redirect.Target = NULL;
                 RulesSize = 2;
-            } else {
-                RulesSize = 1;
             }
         }
         CXPLAT_LIST_ENTRY* Entry;

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1450,52 +1450,58 @@ CxPlatDpRawPlumbRulesOnSocket(
             Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
             Rules[1].Redirect.Target = NULL;
 
-            Rules[2].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
-            Rules[2].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[2].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-            Rules[2].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
-            Rules[2].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[2].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[2].Redirect.Target = NULL;
+            if (Socket->ReserveAuxTcpSock) {
+                Rules[2].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
+                Rules[2].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[2].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+                Rules[2].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
+                Rules[2].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[2].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[2].Redirect.Target = NULL;
 
-            Rules[3].Match = XDP_MATCH_TCP_QUIC_FLOW_DST_CID;
-            Rules[3].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[3].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-            Rules[3].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
-            Rules[3].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[3].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[3].Redirect.Target = NULL;
-
+                Rules[3].Match = XDP_MATCH_TCP_QUIC_FLOW_DST_CID;
+                Rules[3].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[3].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+                Rules[3].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
+                Rules[3].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[3].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[3].Redirect.Target = NULL;
+            }
 
             memcpy(Rules[0].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
             memcpy(Rules[1].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-            memcpy(Rules[2].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-            memcpy(Rules[3].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
 
-            Rules[4].Match = XDP_MATCH_TCP_CONTROL_DST;
-            Rules[4].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[4].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[4].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[4].Redirect.Target = NULL;
-            RulesSize = 5;
-
+            if (Socket->ReserveAuxTcpSock) {
+                memcpy(Rules[2].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+                memcpy(Rules[3].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+                Rules[4].Match = XDP_MATCH_TCP_CONTROL_DST;
+                Rules[4].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[4].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[4].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[4].Redirect.Target = NULL;
+                RulesSize = 5;
+            } else {
+                RulesSize = 2;
+            }
             CXPLAT_DBG_ASSERT(RulesSize <= RTL_NUMBER_OF(Rules));
         } else {
-            Rules[0].Match = XDP_MATCH_TCP_DST;
+            Rules[0].Match = XDP_MATCH_UDP_DST;
             Rules[0].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
             Rules[0].Action = XDP_PROGRAM_ACTION_REDIRECT;
             Rules[0].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
             Rules[0].Redirect.Target = NULL;
 
-            Rules[1].Match = XDP_MATCH_UDP_DST;
-            Rules[1].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[1].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[1].Redirect.Target = NULL;
-
-            RulesSize = 2;
+            if (Socket->ReserveAuxTcpSock) {
+                Rules[1].Match = XDP_MATCH_TCP_DST;
+                Rules[1].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[1].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[1].Redirect.Target = NULL;
+                RulesSize = 2;
+            } else {
+                RulesSize = 1;
+            }
         }
-
         CXPLAT_LIST_ENTRY* Entry;
         for (Entry = Xdp->Interfaces.Flink; Entry != &Xdp->Interfaces; Entry = Entry->Flink) {
             XDP_INTERFACE* Interface = CONTAINING_RECORD(Entry, XDP_INTERFACE, Link);

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1434,69 +1434,70 @@ CxPlatDpRawPlumbRulesOnSocket(
         XDP_RULE Rules[5] = {0};
         uint8_t RulesSize = 0;
         if (Socket->CibirIdLength) {
-            Rules[0].Match = XDP_MATCH_QUIC_FLOW_SRC_CID;
-            Rules[0].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[0].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-            Rules[0].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
-            Rules[0].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[0].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[0].Redirect.Target = NULL;
+            Rules[RulesSize].Match = XDP_MATCH_QUIC_FLOW_SRC_CID;
+            Rules[RulesSize].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+            Rules[RulesSize].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+            Rules[RulesSize].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
+            Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+            Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+            Rules[RulesSize].Redirect.Target = NULL;
+            memcpy(Rules[RulesSize].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+            RulesSize++;
 
-            Rules[1].Match = XDP_MATCH_QUIC_FLOW_DST_CID;
-            Rules[1].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[1].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-            Rules[1].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
-            Rules[1].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[1].Redirect.Target = NULL;
-
-            memcpy(Rules[0].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-            memcpy(Rules[1].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-            RulesSize = 2;
+            Rules[RulesSize].Match = XDP_MATCH_QUIC_FLOW_DST_CID;
+            Rules[RulesSize].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+            Rules[RulesSize].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+            Rules[RulesSize].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
+            Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+            Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+            Rules[RulesSize].Redirect.Target = NULL;
+            memcpy(Rules[RulesSize].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+            RulesSize++;
 
             if (Socket->ReserveAuxTcpSock) {
-                Rules[2].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
-                Rules[2].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-                Rules[2].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-                Rules[2].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
-                Rules[2].Action = XDP_PROGRAM_ACTION_REDIRECT;
-                Rules[2].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-                Rules[2].Redirect.Target = NULL;
+                Rules[RulesSize].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
+                Rules[RulesSize].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[RulesSize].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+                Rules[RulesSize].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetSrc;
+                Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[RulesSize].Redirect.Target = NULL;
+                memcpy(Rules[RulesSize].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+                RulesSize++;
 
-                Rules[3].Match = XDP_MATCH_TCP_QUIC_FLOW_DST_CID;
-                Rules[3].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
-                Rules[3].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
-                Rules[3].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
-                Rules[3].Action = XDP_PROGRAM_ACTION_REDIRECT;
-                Rules[3].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-                Rules[3].Redirect.Target = NULL;
+                Rules[RulesSize].Match = XDP_MATCH_TCP_QUIC_FLOW_DST_CID;
+                Rules[RulesSize].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[RulesSize].Pattern.QuicFlow.CidLength = Socket->CibirIdLength;
+                Rules[RulesSize].Pattern.QuicFlow.CidOffset = Socket->CibirIdOffsetDst;
+                Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[RulesSize].Redirect.Target = NULL;
+                memcpy(Rules[RulesSize].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+                RulesSize++;
 
-                memcpy(Rules[2].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-                memcpy(Rules[3].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-
-                Rules[4].Match = XDP_MATCH_TCP_CONTROL_DST;
-                Rules[4].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
-                Rules[4].Action = XDP_PROGRAM_ACTION_REDIRECT;
-                Rules[4].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-                Rules[4].Redirect.Target = NULL;
-                RulesSize = 5;
+                Rules[RulesSize].Match = XDP_MATCH_TCP_CONTROL_DST;
+                Rules[RulesSize].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[RulesSize].Redirect.Target = NULL;
+                RulesSize++;
             }
             CXPLAT_DBG_ASSERT(RulesSize <= RTL_NUMBER_OF(Rules));
         } else {
-            Rules[0].Match = XDP_MATCH_UDP_DST;
-            Rules[0].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
-            Rules[0].Action = XDP_PROGRAM_ACTION_REDIRECT;
-            Rules[0].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-            Rules[0].Redirect.Target = NULL;
-            RulesSize = 1;
+            Rules[RulesSize].Match = XDP_MATCH_UDP_DST;
+            Rules[RulesSize].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
+            Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+            Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+            Rules[RulesSize].Redirect.Target = NULL;
+            RulesSize++;
 
             if (Socket->ReserveAuxTcpSock) {
-                Rules[1].Match = XDP_MATCH_TCP_DST;
-                Rules[1].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
-                Rules[1].Action = XDP_PROGRAM_ACTION_REDIRECT;
-                Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
-                Rules[1].Redirect.Target = NULL;
-                RulesSize = 2;
+                Rules[RulesSize].Match = XDP_MATCH_TCP_DST;
+                Rules[RulesSize].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
+                Rules[RulesSize].Action = XDP_PROGRAM_ACTION_REDIRECT;
+                Rules[RulesSize].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+                Rules[RulesSize].Redirect.Target = NULL;
+                RulesSize++;
             }
         }
         CXPLAT_LIST_ENTRY* Entry;

--- a/src/platform/datapath_raw_xdp_win.c
+++ b/src/platform/datapath_raw_xdp_win.c
@@ -1450,6 +1450,9 @@ CxPlatDpRawPlumbRulesOnSocket(
             Rules[1].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
             Rules[1].Redirect.Target = NULL;
 
+            memcpy(Rules[0].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+            memcpy(Rules[1].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+
             if (Socket->ReserveAuxTcpSock) {
                 Rules[2].Match = XDP_MATCH_TCP_QUIC_FLOW_SRC_CID;
                 Rules[2].Pattern.QuicFlow.UdpPort = Socket->LocalAddress.Ipv4.sin_port;
@@ -1466,14 +1469,10 @@ CxPlatDpRawPlumbRulesOnSocket(
                 Rules[3].Action = XDP_PROGRAM_ACTION_REDIRECT;
                 Rules[3].Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
                 Rules[3].Redirect.Target = NULL;
-            }
 
-            memcpy(Rules[0].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-            memcpy(Rules[1].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
-
-            if (Socket->ReserveAuxTcpSock) {
                 memcpy(Rules[2].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
                 memcpy(Rules[3].Pattern.QuicFlow.CidData, Socket->CibirId, Socket->CibirIdLength);
+
                 Rules[4].Match = XDP_MATCH_TCP_CONTROL_DST;
                 Rules[4].Pattern.Port = Socket->LocalAddress.Ipv4.sin_port;
                 Rules[4].Action = XDP_PROGRAM_ACTION_REDIRECT;


### PR DESCRIPTION
## Description

As part of the change to have listeners support both QTIP and QUIC/UDP, we configure the XDP rules to listen to both 
UDP and TCP packets bound to the listener port. 

But the problem is, we always set these rules, even in cases where XDP is enabled but not QTIP. What that means is we don't create an auxiliary TCP socket, so other applications bound to the same TCP port as the msquic listener will have their traffic stolen. 

## Testing

CI

## Documentation

N/A
