### PR TITLE
Fix posix refcount bounce protection

### DIFF
--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -317,7 +317,7 @@ CxPlatRefIncrement(
     _Inout_ CXPLAT_REF_COUNT* RefCount
     )
 {
-    if (__atomic_add_fetch(RefCount, 1, __ATOMIC_SEQ_CST)) {
+    if (__atomic_add_fetch(RefCount, 1, __ATOMIC_SEQ_CST) > 1) {
         return;
     }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The posix refcount implementation has an off-by-one bug: unlike the Windows platforms, it allows reference counts to bounce from zero. This is unsafe.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.