### PR TITLE
Disable all compiler optimization in sanitizer builds, too.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ else() #!WIN32
     if (QUIC_SANITIZER_ACTIVE)
         message(STATUS "Configuring sanitizers: ASAN:${QUIC_ENABLE_ASAN} LSAN:${QUIC_ENABLE_LSAN} UBSAN:${QUIC_ENABLE_UBSAN} EXTRA:${QUIC_ENABLE_EXTRA_SANITIZERS}")
         # Append common flags for all sanitizer options
-        list(APPEND QUIC_COMMON_FLAGS -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        list(APPEND QUIC_COMMON_FLAGS -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls)
 
         # Clang/LLVM doesn't support this flag, but GCC does.
         check_c_compiler_flag(-fno-var-tracking-assignments HAS_NO_VAR_TRACKING)


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We already turned off [compiler optimizations](https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-O0) in debug builds, but we left behind `-Og` (roughly equal to `-O1`) in sanitizer builds, partly because the compiler optimizations were masking bugs. Try to get a CI to pass with `-O0`, which disables all optimizations, to make it easier to debug.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.