### PR TITLE
Optimize timediff function

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,7 +34,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/linux",
             "cacheVariables": {
-                "QUIC_LINUX_LOG_ENCODER": "lttng",
+                "QUIC_LOGGING_TYPE": "lttng",
                 "QUIC_ENABLE_LOGGING": "on",
                 "QUIC_BUILD_TOOLS": "on",
                 "QUIC_BUILD_TEST": "on",

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -440,9 +440,6 @@ function CMake-Generate {
     $Arguments += " -DQUIC_TLS_LIB=" + $Tls
     $Arguments += " -DQUIC_OUTPUT_DIR=""$ArtifactsDir"""
 
-    if ($IsLinux) {
-        $LoggingType = "lttng"
-    }
     if (!$DisableLogs) {
         $Arguments += " -DQUIC_ENABLE_LOGGING=on"
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -441,7 +441,7 @@ function CMake-Generate {
     $Arguments += " -DQUIC_OUTPUT_DIR=""$ArtifactsDir"""
 
     if ($IsLinux) {
-        $Arguments += " -DQUIC_LINUX_LOG_ENCODER=lttng"
+        $LoggingType = "lttng"
     }
     if (!$DisableLogs) {
         $Arguments += " -DQUIC_ENABLE_LOGGING=on"

--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -745,11 +745,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 QUIC_INLINE

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -696,11 +696,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 //

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -1001,11 +1001,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 //


### PR DESCRIPTION
## Description

- 1. in any cases, `T2 + (0xFFFFFFFF - T1) + 1` is equal to `T2 - T1`;
- 2. subtraction (`T2 - T1`) can handle wraparound automatically in the ring 2^32;
- 3. removed if-else in TimeDiff function improves the performance;

## Testing

No new testing required.

## Documentation

No docs need to be updated.
