### PR TITLE
Removed unnecessary if-else in TimeDiff functions

### DIFF
--- a/src/inc/quic_platform_posix.h
+++ b/src/inc/quic_platform_posix.h
@@ -745,11 +745,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 QUIC_INLINE

--- a/src/inc/quic_platform_winkernel.h
+++ b/src/inc/quic_platform_winkernel.h
@@ -696,11 +696,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 //

--- a/src/inc/quic_platform_winuser.h
+++ b/src/inc/quic_platform_winuser.h
@@ -1001,11 +1001,8 @@ CxPlatTimeDiff32(
     _In_ uint32_t T2      // Second time measured
     )
 {
-    if (T2 > T1) {
-        return T2 - T1;
-    } else { // Wrap around case.
-        return T2 + (0xFFFFFFFF - T1) + 1;
-    }
+    // Subtraction handles wraparound automatically in the ring 2^32
+    return T2 - T1;
 }
 
 //


### PR DESCRIPTION
## Description

- 1. in any cases, `T2 + (0xFFFFFFFF - T1) + 1` is equal to `T2 - T1`;
- 2. subtraction (`T2 - T1`) can handle wraparound automatically in the ring 2^32;
- 3. removed if-else in TimeDiff function improves the performance;

## Testing

No new testing required.

## Documentation

No docs need to be updated.
