### PR TITLE
Fix do the 1way delay caculation only when feature is enabled

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -826,7 +826,7 @@ QuicConnUpdateRtt(
         Path->SmoothedRtt = (7 * Path->SmoothedRtt + LatestRtt) / 8;
     }
 
-    if (OurSendTimestamp != UINT64_MAX) {
+    if (Connection->Settings.OneWayDelayEnabled && OurSendTimestamp != UINT64_MAX) {
         if (Connection->Stats.Timing.PhaseShift == 0 || NewMinRtt) {
             Connection->Stats.Timing.PhaseShift =
                 (int64_t)PeerSendTimestamp - (int64_t)OurSendTimestamp - (int64_t)LatestRtt / 2;


### PR DESCRIPTION
## Description

`QuicConnUpdateRtt` tries to calculate `Path`'s OneWayDelay even when this feature is in disabled state; it has the following minor impacts:
- Misleading OneWayDelay value in trace log (see log details below)
- Unnecessary calculation on an invalid Packet's  `SendTimestamp` (SendTimestamp is fixed to 0 when OneWayDelay is disabled)

Expected behavior:
- Skip OneWayDelay calculation when it's disabled;
- in trace log，1Way should be shown as 0  when it's disabled.

Before fix (with OneWayDelay disabled):
```log
  685,51: [0][71.7b][10:01:07.062688][conn][0x7daca4065da0] Updated Rtt=143.229 ms, Var=71.614 1Way=71.614 ms
  1866,51: [0][71.7b][10:01:07.204465][conn][0x7daca4065da0] Updated Rtt=142.849 ms, Var=54.469 1Way=70.97 ms
  2006,51: [0][71.7b][10:01:07.204575][conn][0x7daca4065da0] Updated Rtt=142.525 ms, Var=41.499 1Way=70.91 ms
  2528,51: [0][71.7b][10:01:07.205713][conn][0x7daca4065da0] Updated Rtt=142.223 ms, Var=31.727 1Way=70.57 ms
  2723,51: [2][71.7b][10:01:07.216949][conn][0x7daca4065da0] Updated Rtt=141.980 ms, Var=24.279 1Way=69.921 ms
  3749,51: [6][71.7b][10:01:07.344662][conn][0x7daca4065da0] Updated Rtt=141.746 ms, Var=18.676 1Way=70.56 ms
  4234,51: [6][71.7b][10:01:07.345034][conn][0x7daca4065da0] Updated Rtt=141.572 ms, Var=14.353 1Way=70.39 ms
  4325,51: [6][71.7b][10:01:07.345904][conn][0x7daca4065da0] Updated Rtt=141.391 ms, Var=11.125 1Way=69.887 ms
  4741,51: [6][71.7b][10:01:07.347169][conn][0x7daca4065da0] Updated Rtt=141.258 ms, Var=8.609 1Way=69.619 ms
  5460,51: [6][71.7b][10:01:07.357118][conn][0x7daca4065da0] Updated Rtt=141.117 ms, Var=6.737 1Way=68.117 ms
  6117,51: [6][71.7b][10:01:07.484959][conn][0x7daca4065da0] Updated Rtt=141.1 ms, Var=5.283 1Way=50.832 ms
  6627,51: [6][71.7b][10:01:07.485265][conn][0x7daca4065da0] Updated Rtt=140.906 ms, Var=4.151 1Way=35.675 ms
  7291,51: [6][71.7b][10:01:07.487110][conn][0x7daca4065da0] Updated Rtt=140.808 ms, Var=3.309 1Way=22.166 ms
  7631,51: [6][71.7b][10:01:07.487251][conn][0x7daca4065da0] Updated Rtt=140.724 ms, Var=2.649 1Way=10.330 ms
  8091,51: [6][71.7b][10:01:07.487549][conn][0x7daca4065da0] Updated Rtt=140.675 ms, Var=2.83 1Way=3917010173.912 ms
  8123,51: [6][71.7b][10:01:07.487568][conn][0x7daca4065da0] Updated Rtt=140.627 ms, Var=1.657 1Way=206158421.87 ms
  8158,51: [6][71.7b][10:01:07.487576][conn][0x7daca4065da0] Updated Rtt=140.577 ms, Var=1.342 1Way=3401614081.356 ms
  8199,51: [6][71.7b][10:01:07.487584][conn][0x7daca4065da0] Updated Rtt=140.524 ms, Var=1.112 1Way=2439541400.81 ms
  8229,51: [6][71.7b][10:01:07.487591][conn][0x7daca4065da0] Updated Rtt=140.474 ms, Var=0.933 1Way=3745211451.961 ms
  ```


## Testing

Any stream/Datagram sending/receiving tests can repeat this;

## Documentation

No docs need to be updated.
