### PR TITLE
Enable interop test logging in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,7 +308,7 @@ jobs:
       shell: pwsh
     - name: Interop
       shell: pwsh
-      run: scripts/interop.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -GHA -GenerateXmlResults
+      run: scripts/interop.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -GHA -GenerateXmlResults -LogProfile ${{ !inputs.log_level && 'Full.Light' || inputs.log_level }}
     - name: Upload results
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: failure() || cancelled()


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The interop tests do not capture logs - use the existing workflow log param to enable logging by default.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.