### PR TITLE
Add linker options for hotpatching on x64 kernel driver

### DIFF
--- a/src/bin/winkernel/msquic.kernel.vcxproj
+++ b/src/bin/winkernel/msquic.kernel.vcxproj
@@ -119,9 +119,14 @@
       <PreprocessorDefinitions>VER_BUILD_ID=$(QUIC_VER_BUILD_ID);VER_SUFFIX=$(QUIC_VER_SUFFIX);VER_GIT_HASH=$(QUIC_VER_GIT_HASH);QUIC_EVENTS_MANIFEST_ETW;QUIC_LOGS_MANIFEST_ETW;QUIC_TELEMETRY_ASSERTS=1;SECURITY_KERNEL;SECURITY_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+  <!-- x64 Release Hotpatch linker flags to allow hotpatching -->
+  <PropertyGroup>
+    <AllowHotpatchLinkOptionsX64>/hotpatchcompatible /profile /incremental:no /FUNCTIONPADMIN:6</AllowHotpatchLinkOptionsX64>
+  </PropertyGroup>
+  <!-- Hotpatch flags appended last to prevent override -->
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalOptions>%(AdditionalOptions) /FORCE:PGOREPRO /USEPROFILE:PGD=$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\msquic.pgd /hotpatchcompatible /profile /incremental:no /FUNCTIONPADMIN:6</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /FORCE:PGOREPRO /USEPROFILE:PGD=$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\msquic.pgd $(AllowHotpatchLinkOptionsX64)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
Add hotpatch support for Windows x64 kernel driver

This PR enables runtime hotpatching capabilities for the MSQuic kernel driver (msquic.sys) in Release|x64 builds by adding the necessary linker flags to msquic.kernel.vcxproj.

Background
Currently, production releases of msquic.sys do not support runtime hotpatching due to missing linker options and function padding required for x64 hotpatch operations. This limitation prevents in-memory updates and affects compatibility with components such as SMBDirect that depend on hotpatch-enabled drivers.

Changes
This PR adds the following linker flags to the Release|x64 configuration:

- /hotpatchcompatible /profile /incremental:no - Generates PDB records for Vulcan compatibility and enables hotpatch-compatible linking
- /FUNCTIONPADMIN:6 - Adds 6-byte function padding required for x64 hotpatching trampolines used by hpiload during patch application

Impact

- Production Deployments: Enables in-memory hotpatching for production MSQuic kernel driver updates
- Component Compatibility: Ensures compatibility with SMBDirect and other components requiring hotpatch-enabled drivers
- Operational Benefits: Reduces downtime by supporting runtime driver updates without system restarts

Technical Details

- The 6-byte padding on x64 functions allows the hotpatch loader (hpiload) to insert trampolines that redirect execution from the baseline binary to the patch binary at runtime, enabling seamless driver updates.

## Testing

Completed Verification
✅ Visual Studio Build: Confirmed that locally built msquic.sys for x64 Release configuration contains all required hotpatch prerequisites.
✅ Hotpatch Loading: Successfully loaded and applied a hotpatch to the driver in memory during testing.

✅ GitHub Actions Pipeline: Verify that CI/CD-generated msquic.sys artifact maintain hotpatch compatibility
✅ Release Artifact Testing: Confirm that market-ready msquic.sys binary produced by GitHub pipelines support hotpatch operations

Validation Plan
1. Download Release-winkernel-windows-2022-x64-schannel artifact from GitHub Actions
✅https://github.com/microsoft/msquic/actions/runs/17618956151/job/50059433726?pr=5437
2. Verify binary contains required function padding and hotpatch metadata
✅https://github.com/microsoft/msquic/actions/runs/17618956151/artifacts/3976994659
4. Perform runtime hotpatch loading test with CI-generated binary
✅Successfully loaded and applied a hotpatch to the driver in memory during testing.

## Documentation

No user-facing documentation changes required. This is an internal build configuration change that enables existing Windows hotpatch infrastructure. The functionality is transparent to end users and does not modify MSQuic APIs or behavior. 
