### PR TITLE
Add linker options for hotpatching on x64 user-mode driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,12 @@ if(WIN32)
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
     endif()
 
+    # Add hotpatch support for Release x64 builds
+    if(CMAKE_GENERATOR_PLATFORM STREQUAL "x64" OR SYSTEM_PROCESSOR STREQUAL "x64")
+        message(STATUS "Configuring hotpatch support for x64 Release builds")
+        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /hotpatchcompatible /profile /incremental:no /functionpadmin:6")
+    endif()
+
 else() #!WIN32
     # Custom build flags.
 


### PR DESCRIPTION
## Description

Enable hotpatching capabilities for msquic.dll in Release|x64 builds. To produce MSQuic artifacts with runtime hotpatching support enabled across both SChannel and OpenSSL binaries.

- Enables function padding for Release|x64 configuration
- Supports runtime hotpatching for production deployments
- Applied to both SChannel and OpenSSL build paths

These linker flags modifications meaning:
- /hotpatchcompatible /profile /incremental:no This adds records to the PDB which lets vulcan understand the binary.
- /FUNCTIONPADMIN:6 This adds padding needed for hotpatching on x64 binaries. The 6 bytes of padding on x64 are used by hpiload at patch load time to trampoline from the baseline binary to the patch binary.

Key points:
- Project Generation Impact: Modifies CMakeLists.txt to generate Visual Studio project files with conditional hotpatch support
- Dual Binary Coverage: Applied uniformly to both SChannel (build/windows/x64_schannel/) and OpenSSL (build/windows/x64_openssl/) project generation paths
- Configuration Specificity: Hotpatch flags integrated exclusively into Release|x64 configuration within generated .vcxproj files
- Build System Integration: Leverages CMake's CMAKE_SHARED_LINKER_FLAGS_RELEASE to ensure consistent flag application across binaries
- CI/CD Compatibility: Source-controlled approach enables automatic project generation with hotpatch support in GitHub CI pipelines
- Production Targeting: Conditional logic ensures hotpatch overhead limited to production Release x64 builds

Generated project paths:
- SChannel Build Path: build/windows/x64_schannel/src/bin/msquic.vcxproj
- OpenSSL Build Path: build/windows/x64_openssl/src/bin/msquic.vcxproj

## Testing

Completed Verification
✅ Visual Studio Build: Confirmed that locally built msquic.dll for x64 Release configuration contains all required hotpatch prerequisites for SChannel and OpenSSL binaries.
⏳ Hotpatch Loading: Successfully loaded and applied a hotpatch to the driver in memory during testing.

⏳ GitHub Actions Pipeline: Verify that CI/CD-generated msquic.dll artifacts maintain hotpatch compatibility
⏳ Release Artifact Testing: Confirm that market-ready msquic.dll binaries produced by GitHub pipelines support hotpatch operations

Validation Plan

Download Release-winuser-windows-2022-x64-schannel artifact from GitHub Actions
Download Release-winuser-windows-2022-x64-openssl artifact from GitHub Actions
Verify binaries contains required function padding and hotpatch metadata
Perform runtime hotpatch loading test with CI-generated binaries

## Documentation

No user-facing documentation changes required. This is an internal build configuration change that enables existing Windows hotpatch infrastructure. The functionality is transparent to end users and does not modify MSQuic APIs or behavior.
