### PR TITLE
Cherry-pick: modified cmake to disable xdp for arm architecture (#5343)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,12 @@ else()
             set(QUIC_LOGGING_TYPE "lttng")
             message(STATUS "Choosing lttng as default logging type for platform")
         endif()
+        
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)$")
+            set(QUIC_LINUX_XDP_ENABLED OFF CACHE BOOL "XDP not supported on ARM architectures" FORCE)
+        else()
+            option(QUIC_LINUX_XDP_ENABLED "Enables XDP support" OFF)
+        endif()
 
     elseif(CX_PLATFORM STREQUAL "darwin")
         check_function_exists(sysctl HAS_SYSCTL)


### PR DESCRIPTION
## Description

Cherry-pick this change to fix the build/release pipeline for 2.4

## Testing

CI

## Documentation

N/A
