### PR TITLE
CI: validate Rust crate size under 10MB in cargo workflow

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -103,7 +103,9 @@ jobs:
     - name: Cargo Publish (dry run)
       run: cargo publish --dry-run --allow-dirty --no-verify
     - name: Validate crate size (< 10MB)
-      if: matrix.os == 'ubuntu-latest'
+      # Temporary: skip size check for OpenSSL TLS builds which currently exceed 10MiB.
+      # We still validate for other TLS configs (e.g., quictls) on ubuntu-latest.
+      if: matrix.os == 'ubuntu-latest' && matrix.vec.tls != 'openssl'
       shell: bash
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary
Add a CI check to ensure the Rust crate archive stays under the crates.io 10MB limit.

## Motivation
As noted in #5243, crates.io rejects packages over 10MB. We’re close to the limit, and without CI validation we might only discover this at release time.

## Changes
- Workflow: `.github/workflows/cargo.yml`
  - After `cargo publish --dry-run`, run `cargo package` to produce the `.crate` tarball under `target/package`.
  - On `ubuntu-latest`, compute the `.crate` size and fail the job if it exceeds 10MB.

## Notes
- Limited to `ubuntu-latest` to avoid shell differences across OS runners; behavior is OS-independent because crates package source files.
- Keeps the check in the existing cargo workflow so it runs on PRs and pushes.

Fixes #5243

Update: Per maintainer feedback, temporarily exempt OpenSSL TLS builds from the crate size check. The validation still runs on ubuntu-latest for non-OpenSSL TLS configurations (e.g., quictls). Once package contents are reduced to consistently stay <10MiB, we can re-enable the check for OpenSSL as well.
