### PR TITLE
Range compaction

### DIFF
--- a/src/core/range.h
+++ b/src/core/range.h
@@ -379,6 +379,19 @@ QuicRangeGetMaxSafe(
     _Out_ uint64_t* Value
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicRangeCompact(
+    _Inout_ QUIC_RANGE* Range
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Success_(return != FALSE)
+BOOLEAN
+QuicRangeShrink(
+    _Inout_ QUIC_RANGE* Range,
+    _In_ uint32_t NewAllocLength
+    );
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
## Description

This Pull Request adds range compaction and shrinking functionality to optimize memory usage in the QUIC range management system. The key changes include:

- **New Functions**:
  - `QuicRangeCompact`: Merges overlapping or adjacent subranges to reduce fragmentation and improve search performance.
  - `QuicRangeShrink`: Dynamically reduces the allocation size of the subranges array when usage is significantly below allocated capacity.
  - `QuicRangeCalculateShrinkLength`: Helper function to determine optimal shrink thresholds based on configurable parameters.

- **Integration**: Modified existing range operations (`QuicRangeAddRange`, `QuicRangeRemoveRange`, `QuicRangeSetMin`, `QuicRangeRemoveSubranges`) to automatically compact ranges after modifications that could create adjacent subranges.

These optimizations are particularly beneficial for long-running, highly fragmented QUIC connections where range operations accumulate over time, helping to maintain efficient memory usage and performance.

Remediates the problem in #5450, but still does not prevent worst case mentioned.

## Testing

Existing unit tests for range operations (in `src/test/`) should continue to pass and provide coverage for basic functionality. Additional tests are recommended for:
- Compaction logic with various overlap scenarios
- Shrink behavior at different usage thresholds
- Edge cases like single subrange compaction and allocation failure handling

## Documentation

No user-facing documentation impact, as these are internal implementation optimizations. If any public APIs are indirectly affected, ensure API documentation remains accurate.