### PR TITLE
Added /profile flag only in case of pipeline build

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -239,13 +239,11 @@ endif()
 set_property(TARGET msquic PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
 
 if(WIN32)
+    set(MSQUIC_LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
     if(QUIC_CI)
-        SET_TARGET_PROPERTIES(msquic
-            PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\" /PROFILE")
-    else()
-        SET_TARGET_PROPERTIES(msquic
-            PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
+        string(APPEND MSQUIC_LINK_FLAGS " /PROFILE")
     endif()
+    SET_TARGET_PROPERTIES(msquic PROPERTIES LINK_FLAGS "${MSQUIC_LINK_FLAGS}")
 elseif (CX_PLATFORM STREQUAL "linux")
     SET_TARGET_PROPERTIES(msquic
         PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/linux/exports.txt\"")


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
Using /profile disables the incremental linking, to avoid it in local build, using /profile flag in case of pipleine build only.  fixes #5360 
## Testing
I ran MaxDep locally and verified.
_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
