### PR TITLE
ensure msquic doesn't unload while registration cleanup is pending

### DIFF
--- a/src/core/library.h
+++ b/src/core/library.h
@@ -221,6 +221,10 @@ typedef struct QUIC_LIBRARY {
     //
     CXPLAT_LIST_ENTRY RegistrationCloseCleanupList;
 
+    //
+    // Rundown protection for the registration close cleanup worker.
+    //
+    CXPLAT_RUNDOWN_REF RegistrationCloseCleanupRundown;
 
     //
     // Per-partition storage. Count of `PartitionCount`.

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -84,6 +84,10 @@ CXPLAT_THREAD_CALLBACK(RegistrationCloseWorker, Context)
     if (Registration->CloseCompleteHandler != NULL) {
         BOOLEAN WakeCleanupWorker;
 
+        CXPLAT_FRE_ASSERTMSG(
+            CxPlatRundownAcquire(&MsQuicLib.RegistrationCloseCleanupRundown),
+            "The library is being unloaded while a registration is not fully closed!");
+
         QuicRegistrationClose(Registration);
 
         Registration->CloseCompleteHandler(Registration->CloseCompleteContext);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

This PR fixes a race condition missed in PR #5376: during library uninitialization, the internal registration cleanup worker thread was not guaranteed to have flushed all registrations that had been closed to the app, causing leaks. These were caught by sanitizer in another environment; it's not clear why sanitizer has not caught the bug within the MsQuic CI, which should be executing similar code.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

We have code coverage of the scenario and sanitizer; we simply just don't hit this internal race condition.

## Documentation

_Is there any documentation impact for this change?_

No.