### PR TITLE
Ensure contexts outlive their objects in app-provided receive buffers tests

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -4650,9 +4650,13 @@ struct AppBuffersReceiverContext {
 };
 
 void
-QuicTestStreamAppProvidedBuffers(
+QuicTestStreamAppProvidedBuffers_ClientSend(
     )
 {
+    // Declare all contexts before the registration to ensure they outlive all MsQuic objects.
+    AppBuffersReceiverContext ReceiveContext;
+
+    // MsQuic basic initialization
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
@@ -4688,7 +4692,6 @@ QuicTestStreamAppProvidedBuffers(
         // - some initial receive buffer space will be provided when the stream is accepted
         // - more receive buffer space will be provided after 0x1500 bytes are received
         // - an event will be signaled when 0x1500 bytes are received to synchronize with the sender
-        AppBuffersReceiverContext ReceiveContext;
         ReceiveContext.BuffersForStreamStarted = QuicBuffers;
         ReceiveContext.NumBuffersForStreamStarted = NumBuffers / 2;
         ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
@@ -4732,93 +4735,123 @@ QuicTestStreamAppProvidedBuffers(
         TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
         TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
     }
-
-    // Server side sending data
-    {
-        // Setup a listener
-        AppBuffersSenderContext SenderContext{};
-        MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersSenderContext::ConnCallback, &SenderContext);
-        TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
-        TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
-        QuicAddr ServerLocalAddr;
-        TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
-
-        // Setup a client connection
-        MsQuicConnection Connection(Registration);
-        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
-
-        TEST_QUIC_SUCCEEDED(Connection.Start(
-            ClientConfiguration,
-            ServerLocalAddr.GetFamily(),
-            QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()),
-            ServerLocalAddr.GetPort()));
-        TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
-        TEST_TRUE(Connection.HandshakeComplete);
-
-        // Create send and receive buffers
-        const uint32_t BufferSize = 0x5000;
-        const uint32_t NumBuffers = 0x10;
-        UniquePtr<uint8_t[]> SendDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
-        TEST_TRUE(SendDataBuffer);
-        for (auto i = 0u; i < BufferSize; ++i) {
-            SendDataBuffer[i] = static_cast<uint8_t>(i);
-        }
-
-        UniquePtr<uint8_t[]> ReceiveDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
-        TEST_TRUE(ReceiveDataBuffer);
-        QUIC_BUFFER QuicBuffers[NumBuffers]{};
-        for (auto i = 0u; i < NumBuffers; ++i) {
-            QuicBuffers[i].Buffer = ReceiveDataBuffer.get() + i * BufferSize / NumBuffers;
-            QuicBuffers[i].Length = BufferSize / NumBuffers;
-        }
-
-        // Create and start a receiver stream
-        // - more receive buffer space will be provided after 0x1500 bytes are received
-        // - an event will be signaled when 0x1500 bytes are received to synchronize with the sender
-        AppBuffersReceiverContext ReceiveContext;
-        ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
-        ReceiveContext.NumBuffersForThreshold = NumBuffers / 2;
-        ReceiveContext.MoreBufferThreshold = 0x1500;
-        ReceiveContext.ReceivedBytesThreshold = 0x1500;
-
-        MsQuicStream ClientStream(
-            Connection,
-            QUIC_STREAM_OPEN_FLAG_APP_OWNED_BUFFERS,
-            CleanUpManual,
-            AppBuffersReceiverContext::StreamCallback,
-            &ReceiveContext);
-        TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
-
-        ReceiveContext.Stream = &ClientStream;
-        // Provide some receive buffers before starting the stream
-        ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers);
-
-        TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
-        TEST_QUIC_SUCCEEDED(ClientStream.Shutdown(QUIC_STATUS_SUCCESS, QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL));
-
-        auto* SenderStream = SenderContext.WaitForSenderStream();
-        TEST_NOT_EQUAL(SenderStream, nullptr);
-
-        //
-        // Send data, waiting for the treshold to be  reached to ensure
-        // buffer space is provided in time.
-        QUIC_BUFFER Buffer1{BufferSize / 2, SendDataBuffer.get()};
-        QUIC_BUFFER Buffer2{BufferSize / 2, SendDataBuffer.get() + BufferSize / 2};
-
-        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer1, 1));
-        TEST_TRUE(ReceiveContext.ReceivedBytesThresholdReached.WaitTimeout(TestWaitTimeout));
-        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer2, 1, QUIC_SEND_FLAG_FIN));
-
-        TEST_TRUE(ReceiveContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
-        TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
-        TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
-    }
 }
 
 void
-QuicTestStreamAppProvidedBuffersOutOfSpace(
+QuicTestStreamAppProvidedBuffers_ServerSend(
     )
 {
+    // Declare all contexts before the registration to ensure they outlive all MsQuic objects.
+    AppBuffersSenderContext SenderContext{};
+    AppBuffersReceiverContext ReceiveContext;
+
+    // MsQuic basic initialization
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings().SetPeerUnidiStreamCount(1).SetPeerBidiStreamCount(1).SetStreamRecvWindowDefault(0x2000),
+        ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings().SetPeerUnidiStreamCount(1).SetPeerBidiStreamCount(1).SetStreamRecvWindowDefault(0x2000),
+        MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    // Setup a listener
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersSenderContext::ConnCallback, &SenderContext);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    // Setup a client connection
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+
+    TEST_QUIC_SUCCEEDED(Connection.Start(
+        ClientConfiguration,
+        ServerLocalAddr.GetFamily(),
+        QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()),
+        ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+
+    // Create send and receive buffers
+    const uint32_t BufferSize = 0x5000;
+    const uint32_t NumBuffers = 0x10;
+    UniquePtr<uint8_t[]> SendDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
+    TEST_TRUE(SendDataBuffer);
+    for (auto i = 0u; i < BufferSize; ++i) {
+        SendDataBuffer[i] = static_cast<uint8_t>(i);
+    }
+
+    UniquePtr<uint8_t[]> ReceiveDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
+    TEST_TRUE(ReceiveDataBuffer);
+    QUIC_BUFFER QuicBuffers[NumBuffers]{};
+    for (auto i = 0u; i < NumBuffers; ++i) {
+        QuicBuffers[i].Buffer = ReceiveDataBuffer.get() + i * BufferSize / NumBuffers;
+        QuicBuffers[i].Length = BufferSize / NumBuffers;
+    }
+
+    // Create and start a receiver stream
+    // - more receive buffer space will be provided after 0x1500 bytes are received
+    // - an event will be signaled when 0x1500 bytes are received to synchronize with the sender
+    ReceiveContext.BuffersForThreshold = QuicBuffers + NumBuffers / 2;
+    ReceiveContext.NumBuffersForThreshold = NumBuffers / 2;
+    ReceiveContext.MoreBufferThreshold = 0x1500;
+    ReceiveContext.ReceivedBytesThreshold = 0x1500;
+
+    MsQuicStream ClientStream(
+        Connection,
+        QUIC_STREAM_OPEN_FLAG_APP_OWNED_BUFFERS,
+        CleanUpManual,
+        AppBuffersReceiverContext::StreamCallback,
+        &ReceiveContext);
+    TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
+
+    ReceiveContext.Stream = &ClientStream;
+    // Provide some receive buffers before starting the stream
+    ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers);
+
+    TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+    TEST_QUIC_SUCCEEDED(ClientStream.Shutdown(QUIC_STATUS_SUCCESS, QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL));
+
+    auto* SenderStream = SenderContext.WaitForSenderStream();
+    TEST_NOT_EQUAL(SenderStream, nullptr);
+
+    //
+    // Send data, waiting for the treshold to be  reached to ensure
+    // buffer space is provided in time.
+    QUIC_BUFFER Buffer1{BufferSize / 2, SendDataBuffer.get()};
+    QUIC_BUFFER Buffer2{BufferSize / 2, SendDataBuffer.get() + BufferSize / 2};
+
+    TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer1, 1));
+    TEST_TRUE(ReceiveContext.ReceivedBytesThresholdReached.WaitTimeout(TestWaitTimeout));
+    TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer2, 1, QUIC_SEND_FLAG_FIN));
+
+    TEST_TRUE(ReceiveContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
+    TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
+    TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
+}
+
+void
+QuicTestStreamAppProvidedBuffers(
+    )
+{
+    QuicTestStreamAppProvidedBuffers_ClientSend();
+    QuicTestStreamAppProvidedBuffers_ServerSend();
+}
+
+void
+QuicTestStreamAppProvidedBuffersOutOfSpace_ClientSend(
+    )
+{
+    // Declare all contexts before the registration to ensure they outlive all MsQuic objects.
+    AppBuffersReceiverContext ReceiveContext;
+
+    // MsQuic basic initialization
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
@@ -4855,7 +4888,6 @@ QuicTestStreamAppProvidedBuffersOutOfSpace(
         // - some initial receive buffer space will be provided when the stream is accepted
         // - more receive buffer space will be provided when the stream runs out of buffer space
         //
-        AppBuffersReceiverContext ReceiveContext;
         ReceiveContext.BuffersForStreamStarted = QuicBuffers;
         ReceiveContext.NumBuffersForStreamStarted = NumBuffers / 2;
         ReceiveContext.BuffersForInsufficientRecvBuffer = QuicBuffers + NumBuffers / 2;
@@ -4893,79 +4925,106 @@ QuicTestStreamAppProvidedBuffersOutOfSpace(
         TEST_EQUAL(ReceiveContext.ReceivedBytes, BufferSize);
         TEST_EQUAL(0, memcmp(SendDataBuffer.get(), ReceiveDataBuffer.get(), BufferSize));
     }
+}
 
+void
+QuicTestStreamAppProvidedBuffersOutOfSpace_ServerSend(
+    )
+{
     // Server side sending data - abort the stream on insufficient receive buffer notification
-    {
-        // Setup a listener
-        AppBuffersSenderContext SenderContext{};
-        MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersSenderContext::ConnCallback, &SenderContext);
-        TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
-        TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
-        QuicAddr ServerLocalAddr;
-        TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-        // Setup a client connection
-        MsQuicConnection Connection(Registration);
-        TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    // Declare all contexts before the registration to ensure they outlive all MsQuic objects.
+    AppBuffersSenderContext SenderContext{};
+    AppBuffersReceiverContext ReceiveContext;
 
-        TEST_QUIC_SUCCEEDED(Connection.Start(
-            ClientConfiguration,
-            ServerLocalAddr.GetFamily(),
-            QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()),
-            ServerLocalAddr.GetPort()));
-        TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
-        TEST_TRUE(Connection.HandshakeComplete);
+    // MsQuic basic initialization
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
-        // Create send and receive buffers
-        const uint32_t BufferSize = 0x5000;
-        const uint32_t NumBuffers = 0x10;
-        UniquePtr<uint8_t[]> SendDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
-        TEST_TRUE(SendDataBuffer);
-        for (auto i = 0u; i < BufferSize; ++i) {
-            SendDataBuffer[i] = static_cast<uint8_t>(i);
-        }
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings().SetPeerUnidiStreamCount(1).SetPeerBidiStreamCount(1).SetStreamRecvWindowDefault(0x2000),
+        ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
 
-        UniquePtr<uint8_t[]> ReceiveDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
-        TEST_TRUE(ReceiveDataBuffer);
-        QUIC_BUFFER QuicBuffers[NumBuffers]{};
-        for (auto i = 0u; i < NumBuffers; ++i) {
-            QuicBuffers[i].Buffer = ReceiveDataBuffer.get() + i * BufferSize / NumBuffers;
-            QuicBuffers[i].Length = BufferSize / NumBuffers;
-        }
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest",
+        MsQuicSettings().SetPeerUnidiStreamCount(1).SetPeerBidiStreamCount(1).SetStreamRecvWindowDefault(0x2000),
+        MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
 
-        // Create and start a stream
-        AppBuffersReceiverContext ReceiveContext;
+    // Setup a listener
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AppBuffersSenderContext::ConnCallback, &SenderContext);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-        MsQuicStream ClientStream(
-            Connection,
-            QUIC_STREAM_OPEN_FLAG_APP_OWNED_BUFFERS,
-            CleanUpManual,
-            AppBuffersReceiverContext::StreamCallback,
-            &ReceiveContext);
-        TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
+    // Setup a client connection
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
 
-        ReceiveContext.Stream = &ClientStream;
-        // The stream will be shutdown inline when it runs out of receive buffer space.
-        ReceiveContext.ShutdownOnInsufficientRecvBuffer = TRUE;
+    TEST_QUIC_SUCCEEDED(Connection.Start(
+        ClientConfiguration,
+        ServerLocalAddr.GetFamily(),
+        QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()),
+        ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
 
-        // Provide some receive buffers before starting the stream
-        TEST_QUIC_SUCCEEDED(ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers));
-
-        TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
-        TEST_QUIC_SUCCEEDED(ClientStream.Shutdown(QUIC_STATUS_SUCCESS, QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL));
-
-        auto* SenderStream = SenderContext.WaitForSenderStream();
-        TEST_NOT_EQUAL(SenderStream, nullptr);
-
-        // Send data
-        // Don't send FIN so that the stream is deterministically closed after the sender gets the
-        // STOP_SENDING frame.
-        QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
-        TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer, 1));
-
-        TEST_TRUE(SenderContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
-        TEST_EQUAL(SenderContext.PeerRecvAbortedError, 1);
+    // Create send and receive buffers
+    const uint32_t BufferSize = 0x5000;
+    const uint32_t NumBuffers = 0x10;
+    UniquePtr<uint8_t[]> SendDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
+    TEST_TRUE(SendDataBuffer);
+    for (auto i = 0u; i < BufferSize; ++i) {
+        SendDataBuffer[i] = static_cast<uint8_t>(i);
     }
+
+    UniquePtr<uint8_t[]> ReceiveDataBuffer{new(std::nothrow) uint8_t[BufferSize]};
+    TEST_TRUE(ReceiveDataBuffer);
+    QUIC_BUFFER QuicBuffers[NumBuffers]{};
+    for (auto i = 0u; i < NumBuffers; ++i) {
+        QuicBuffers[i].Buffer = ReceiveDataBuffer.get() + i * BufferSize / NumBuffers;
+        QuicBuffers[i].Length = BufferSize / NumBuffers;
+    }
+
+    // Create and start a stream
+    MsQuicStream ClientStream(
+        Connection,
+        QUIC_STREAM_OPEN_FLAG_APP_OWNED_BUFFERS,
+        CleanUpManual,
+        AppBuffersReceiverContext::StreamCallback,
+        &ReceiveContext);
+    TEST_QUIC_SUCCEEDED(ClientStream.GetInitStatus());
+
+    ReceiveContext.Stream = &ClientStream;
+    // The stream will be shutdown inline when it runs out of receive buffer space.
+    ReceiveContext.ShutdownOnInsufficientRecvBuffer = TRUE;
+
+    // Provide some receive buffers before starting the stream
+    TEST_QUIC_SUCCEEDED(ClientStream.ProvideReceiveBuffers(NumBuffers / 2, QuicBuffers));
+
+    TEST_QUIC_SUCCEEDED(ClientStream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+    TEST_QUIC_SUCCEEDED(ClientStream.Shutdown(QUIC_STATUS_SUCCESS, QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL));
+
+    auto* SenderStream = SenderContext.WaitForSenderStream();
+    TEST_NOT_EQUAL(SenderStream, nullptr);
+
+    // Send data
+    // Don't send FIN so that the stream is deterministically closed after the sender gets the
+    // STOP_SENDING frame.
+    QUIC_BUFFER Buffer{BufferSize, SendDataBuffer.get()};
+    TEST_QUIC_SUCCEEDED(SenderStream->Send(&Buffer, 1));
+
+    TEST_TRUE(SenderContext.SenderStreamClosed.WaitTimeout(TestWaitTimeout));
+    TEST_EQUAL(SenderContext.PeerRecvAbortedError, 1);
+}
+
+void
+QuicTestStreamAppProvidedBuffersOutOfSpace(
+    )
+{
+    QuicTestStreamAppProvidedBuffersOutOfSpace_ClientSend();
+    QuicTestStreamAppProvidedBuffersOutOfSpace_ServerSend();
 }
 
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES


### PR DESCRIPTION
## Description

The app-provided receive buffers failed spuriously because the stream context (especially the sender stream context) deletion was racing with the stream final callbacks.

This fixes the problem by moving the context declaration before the registration, using the registration wait on close to ensure all contexts will outlive their objects.
To allow this, the test cases are split in their own functions (which is a good thing to keep test cases fully independent anyways).

Fixes #5356

## Testing

N/A

## Documentation

N/A
