### PR TITLE
Only create issues on Merge Events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,7 +330,7 @@ jobs:
 
   Create-Or-Update-Issue:
     needs: [Complete]
-    if: failure()
+    if: ${{ failure() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
     - name: Download BVT Failures
@@ -406,6 +406,16 @@ jobs:
             if (!dedup.has(it.title)) dedup.set(it.title, it);
           }
           const issuesToFile = [...dedup.values()];
+
+          if (issuesToFile.length > 5) {
+            await github.rest.issues.create({
+              owner, repo,
+              title: "Too Many CI Failures...",
+              body: run_url,
+              labels: ['bvt', 'ci-failure'] // tweak/remove labels as you wish
+            });
+            process.exit(0);
+          }
 
           // --- Fetch all open issues once (pagination safe) ---
           const openIssues = await github.paginate(


### PR DESCRIPTION
## Description

Improvement to the auto-issue filer. 

Right now, it would create issues even on pull requests, which would be a WIP. 

In theory, if a PR had 100+ failures, then it would log 100+ issues. This would be bad.

## Testing

CI

## Documentation

No
