### PR TITLE
Make codecov informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,13 @@ coverage:
   status:
     project:
       default:
+        informational: true
         target: auto
         threshold: 2%
     patch:
-      target: 80%
-      threshold: 2%
+      default:
+        informational: true
+        target: 80%
 ignore:
   - "**/*.md"
-  - "docs"
+  - "docs/**/*"


### PR DESCRIPTION
## Description

The code coverage CI validation is very often failing without a clear reason.
For instance, this should be included in the 2% threshold allowance, but is however marked as failing.
<img width="1333" height="106" alt="image" src="https://github.com/user-attachments/assets/67d4d0ad-d981-4dd4-a430-a700f47208f3" />

This introduces noise in the CI and show failing overall CI result that we simply ignore.
This PR makes the code coverage informational only, since this is already how we treat it in practice.

- Make codecov informational
- Fix config to follow the codecov documentation

## Testing
n/a

## Documentation
n/a