### PR TITLE
Leverage Netperf Lab to Collect CI MEMORY dumps

### DIFF
--- a/.github/workflows/netperf-kernel-bvt.yml
+++ b/.github/workflows/netperf-kernel-bvt.yml
@@ -1,0 +1,32 @@
+name: Netperf Kernel BVT
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        description: 'Git Ref'
+        type: string
+      filter:
+        required: false
+        description: 'Custom Test Filter'
+        default: '-*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*'
+        type: string
+
+permissions: read-all
+
+jobs:
+  run:
+    name: Run Perf
+    runs-on: windows-latest
+    steps:
+    - name: Run NetPerf Workflow
+      timeout-minutes: 120
+      shell: pwsh
+      run: |
+        $url = "https://raw.githubusercontent.com/microsoft/netperf/main/run-workflow.ps1"
+        if ('${{ secrets.NET_PERF_TRIGGER }}' -eq '') {
+            Write-Host "Not able to run because no secrets are available!"
+            return
+        }
+        iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} msquic-kernel-bvt 'N/A' ${{ inputs.ref }} 'N/A'"

--- a/.github/workflows/netperf-kernel-bvt.yml
+++ b/.github/workflows/netperf-kernel-bvt.yml
@@ -17,10 +17,10 @@ permissions: read-all
 
 jobs:
   run:
-    name: Run Perf
+    name: Run Kernel BVT on Netperf
     runs-on: windows-latest
     steps:
-    - name: Run NetPerf Workflow
+    - name: Run Kernel BVT on Netperf
       timeout-minutes: 120
       shell: pwsh
       run: |
@@ -29,4 +29,5 @@ jobs:
             Write-Host "Not able to run because no secrets are available!"
             return
         }
-        iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} msquic-kernel-bvt 'N/A' ${{ inputs.ref }} 'N/A'"
+        # Params: token, type, sha, ref, pr, run_id, logs, filter
+        iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} msquic-kernel-bvt 'N/A' ${{ inputs.ref }} 'N/A' 'N/A' 'N/A' ${{ inputs.filter }}"


### PR DESCRIPTION
Netperf, in addition to measuring performance data on MsQuic, should also be able to run MsQuic functional CI (a subset) in Kernel mode and collect crash dumps for analysis.

Fixes #5273 
We can leverage this pattern for the XDP-for-windows project too.

Validation: 
https://github.com/microsoft/netperf/actions/runs/18208239591,

which ran on MsQuic Ref: https://github.com/microsoft/msquic/compare/main...jackhe/bugcheck-on-purpose

<img width="589" height="306" alt="image" src="https://github.com/user-attachments/assets/4ae7cfce-fc34-4d1e-bac2-6717d7ff6f6e" />

<img width="1888" height="1506" alt="image" src="https://github.com/user-attachments/assets/346b4a82-91f9-477d-80f9-22fbd2929ed3" />


Here is another run which doesn't run on an MsQuic version that does not bugcheck:

https://github.com/microsoft/netperf/actions/runs/18206803000