### PR TITLE
CP: Do not send CONNECTION_CLOSE frames in draining state.

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1526,6 +1526,7 @@ QuicConnTryClose(
         if (!SilentClose) {
             //
             // Enter 'draining period' to flush out any leftover packets.
+            // During that time, no packet should be sent.
             //
             QuicConnTimerSet(
                 Connection,
@@ -1546,7 +1547,8 @@ QuicConnTryClose(
         if (!SilentClose) {
             //
             // Enter 'closing period' to wait for a (optional) connection close
-            // response.
+            // response. During that time, the connection close will be re-transmitted
+            // when packets are received.
             //
             uint64_t Pto =
                 QuicLossDetectionComputeProbeTimeout(
@@ -4436,14 +4438,17 @@ QuicConnRecvFrames(
     BOOLEAN UpdatedFlowControl = FALSE;
     QUIC_ENCRYPT_LEVEL EncryptLevel = QuicKeyTypeToEncryptLevel(Packet->KeyType);
     BOOLEAN Closed = Connection->State.ClosedLocally || Connection->State.ClosedRemotely;
+    const BOOLEAN ClosingState = Connection->State.ClosedLocally && !Connection->State.ClosedRemotely;
     const uint8_t* Payload = Packet->AvailBuffer + Packet->HeaderLength;
     uint16_t PayloadLength = Packet->PayloadLength;
     uint64_t RecvTime = CxPlatTimeUs64();
 
     //
     // In closing state, respond to any packet with a new close frame (rate-limited).
+    // Note this excludes the draining state (i.e., ClosedRemotely == TRUE)
+    // in which we should be silent.
     //
-    if (Closed && !Connection->State.ShutdownComplete) {
+    if (ClosingState && !Connection->State.ShutdownComplete) {
         if (RecvTime - Connection->LastCloseResponseTimeUs >= QUIC_CLOSING_RESPONSE_MIN_INTERVAL) {
             QuicSendSetSendFlag(
                 &Connection->Send,


### PR DESCRIPTION
## Description

Cherry-pick #5477 

Some spurious test failures show a pattern when the two peers entered a loop of sending CONNECTION_CLOSE frames to each other. This regression was introduced by #5107.

According to RFC 9000:
- When a peer sends a CONNECTION_CLOSE frame, it enters the "closing" state and should answer any incoming packet on the connection with a new CONNECTION_CLOSE frame (subject to rate limiting), to ensure the peer get the CONNECTION_CLOSE.
- When a peer receives a CONNECTION_CLOSE frame, it enters the "draining" state and should not send any more packets.

(The RFC is not explicit about what happens when a peer in the "closing" state receives a CONNECTION_CLOSE, but since it means both peers are closing the connection, it can stop sending additional CONNECTION_CLOSE).

However, #5107 was re-sending CONNECTION_CLOSE frame both in "closing" and "draining" state. This PR fixes it.

## Testing

CI. The issue is timing dependent and can't be reliably reproduced.

## Documentation

N/A
