### PR TITLE
Add io_uring assert to detect send-after-shutdown

### DIFF
--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -206,6 +206,7 @@ CxPlatSocketIoStart(
     _In_ CXPLAT_SOCKET_CONTEXT* SocketContext
     )
 {
+    CXPLAT_DBG_ASSERT(!SocketContext->Shutdown);
     SocketContext->IoCount++;
 }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Add diagnostics to try to detect #5490 closer to the root cause. Debugging details are in the bug, but it looks like the crash occurs when a send IO completes after the socket is torn down. I'm not certain this newly-asserted code path _is_ happening, but with the assert added we can rule it out or confirm it.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds and spins locally.

## Documentation

_Is there any documentation impact for this change?_

No.