### PR TITLE
separate io_uring flags into locked bitfield

### DIFF
--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -805,18 +805,20 @@ typedef struct QUIC_CACHEALIGN CXPLAT_SOCKET_CONTEXT {
     BOOLEAN IoStarted : 1;
 
 #ifdef CXPLAT_USE_IO_URING
-    //
-    // Indicates if the socket has started shutting down.
-    //
-    BOOLEAN Shutdown : 1;
+    struct {
+        //
+        // Indicates if the socket has started shutting down.
+        //
+        BOOLEAN Shutdown : 1;
 
 #if DEBUG
-    //
-    // Indicates if the socket socket has a multi recv outstanding.
-    //
-    BOOLEAN MultiRecvStarted : 1;
-#endif
-#endif
+        //
+        // Indicates if the socket socket has a multi recv outstanding.
+        //
+        BOOLEAN MultiRecvStarted : 1;
+#endif // DEBUG
+    } LockedFlags;
+#endif // CXPLAT_USE_IO_URING
 
 #if DEBUG
     uint8_t Uninitialized : 1;


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

One of the recent stress failures can be explained by a race between `CxPlatSocketContextUninitialize` setting `Uninitialized` and the io_uring data path reading/writing to `Shutdown` or `MultiRecvStarted`.

Split out the io_uring fields used on the data path under lock into a separate bitfield struct.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally.

## Documentation

_Is there any documentation impact for this change?_

No.