### PR TITLE
Add CET Shadow stack compatibility (#5496)

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -239,8 +239,21 @@ endif()
 set_property(TARGET msquic PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
 
 if(WIN32)
-    SET_TARGET_PROPERTIES(msquic
-        PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
+    set(MSQUIC_LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/msquic.def\"")
+
+    # Indicate CET Shadow Stack support for supported architectures
+    if (${SYSTEM_PROCESSOR} STREQUAL "x64" OR
+        ${SYSTEM_PROCESSOR} STREQUAL "AMD64" OR
+        ${SYSTEM_PROCESSOR} STREQUAL "x86" OR
+        ${SYSTEM_PROCESSOR} STREQUAL "win32")
+
+        string(APPEND MSQUIC_LINK_FLAGS " /CETCOMPAT")
+    endif()
+
+    if(QUIC_CI)
+        string(APPEND MSQUIC_LINK_FLAGS " /PROFILE")
+    endif()
+    SET_TARGET_PROPERTIES(msquic PROPERTIES LINK_FLAGS "${MSQUIC_LINK_FLAGS}")
 elseif (CX_PLATFORM STREQUAL "linux")
     SET_TARGET_PROPERTIES(msquic
         PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/linux/exports.txt\"")


### PR DESCRIPTION
## Description

Fixes #5495 by adding the linker flag /CETCOMPAT, to advertise CET Shadow stacks supports.
Cherry-pick of #5496.

## Testing

CI

## Documentation

N/A
