### PR TITLE
Wait on connection close completion in connect and ping tests

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -610,11 +610,16 @@ QuicTestConnectAndPing(
             TEST_FAILURE("Wait for server streams to complete timed out after %u ms.", TimeoutMs);
             return;
         }
-    } // All client connections are closed at the end of this scope
 
-    // Wait for the connections to be fully completed
+        // Shutdown all client connections (they are set with auto-close)
+        for (uint32_t i = 0; i < ConnectionCount; ++i) {
+            Connections.get()[i]->Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+        }
+    }
+
+    // Wait for the connections to be fully shutdown.
     // It is important to wait to ensure all server connections are closed by the client (and not
-    // by the registration close call), since we validate the connection shutdown reason code.
+    // by the registration close call), to avoid an unexpected "SHUTDOWN_BY_PEER".
     if (!CxPlatEventWaitWithTimeout(ClientStats.ConnectionCompletionEvent, TimeoutMs)) {
         TEST_FAILURE("Wait for clients connections to complete timed out after %u ms.", TimeoutMs);
         return;


### PR DESCRIPTION
## Description

Some spurious failure in the AppData/WithSendArgs1.Send happened because of a race condition between:
- a server connection being shut down and closed by receiving a CONNECTION_CLOSE from its peer
- a server connection being shut down and closed upon the registration close call

Those two path result in a different app close reason code, and the test validates those reasons.

## Testing

CI. Hard to validate since the issue was a rare race condition happening mainly in the OS build CI.

## Documentation

N/A
