### PR TITLE
Change the format specifier (#5523)

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1288,7 +1288,7 @@ QuicLibrarySetGlobalParam(
 
         QuicTraceLogInfo(
             LibraryDscpRecvEnabledSet,
-            "[ lib] Setting Dscp on recv = %d", MsQuicLib.EnableDscpOnRecv);
+            "[ lib] Setting Dscp on recv = %u", MsQuicLib.EnableDscpOnRecv);
 
         Status = QUIC_STATUS_SUCCESS;
         break;

--- a/src/generated/linux/library.c.clog.h
+++ b/src/generated/linux/library.c.clog.h
@@ -209,10 +209,10 @@ tracepoint(CLOG_LIBRARY_C, LibraryExecutionConfigSet );\
 
 /*----------------------------------------------------------
 // Decoder Ring for LibraryDscpRecvEnabledSet
-// [ lib] Setting Dscp on recv = %d
+// [ lib] Setting Dscp on recv = %u
 // QuicTraceLogInfo(
             LibraryDscpRecvEnabledSet,
-            "[ lib] Setting Dscp on recv = %d", MsQuicLib.EnableDscpOnRecv);
+            "[ lib] Setting Dscp on recv = %u", MsQuicLib.EnableDscpOnRecv);
 // arg2 = arg2 = MsQuicLib.EnableDscpOnRecv = arg2
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_LibraryDscpRecvEnabledSet

--- a/src/generated/linux/library.c.clog.h.lttng.h
+++ b/src/generated/linux/library.c.clog.h.lttng.h
@@ -178,17 +178,17 @@ TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryExecutionConfigSet,
 
 /*----------------------------------------------------------
 // Decoder Ring for LibraryDscpRecvEnabledSet
-// [ lib] Setting Dscp on recv = %d
+// [ lib] Setting Dscp on recv = %u
 // QuicTraceLogInfo(
             LibraryDscpRecvEnabledSet,
-            "[ lib] Setting Dscp on recv = %d", MsQuicLib.EnableDscpOnRecv);
+            "[ lib] Setting Dscp on recv = %u", MsQuicLib.EnableDscpOnRecv);
 // arg2 = arg2 = MsQuicLib.EnableDscpOnRecv = arg2
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_LIBRARY_C, LibraryDscpRecvEnabledSet,
     TP_ARGS(
-        int, arg2), 
+        unsigned int, arg2), 
     TP_FIELDS(
-        ctf_integer(int, arg2, arg2)
+        ctf_integer(unsigned int, arg2, arg2)
     )
 )
 

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -6200,11 +6200,11 @@
     },
     "LibraryDscpRecvEnabledSet": {
       "ModuleProperites": {},
-      "TraceString": "[ lib] Setting Dscp on recv = %d",
+      "TraceString": "[ lib] Setting Dscp on recv = %u",
       "UniqueId": "LibraryDscpRecvEnabledSet",
       "splitArgs": [
         {
-          "DefinationEncoding": "d",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg2"
         }
       ],
@@ -14837,9 +14837,9 @@
         "EncodingString": "[ lib] CID Length = %hhu"
       },
       {
-        "UniquenessHash": "4ee2132f-243f-586f-f776-403103dc21a7",
+        "UniquenessHash": "bce1fded-91be-da6e-29d8-3f52455fa16a",
         "TraceID": "LibraryDscpRecvEnabledSet",
-        "EncodingString": "[ lib] Setting Dscp on recv = %d"
+        "EncodingString": "[ lib] Setting Dscp on recv = %u"
       },
       {
         "UniquenessHash": "2cbc406b-c1c0-ba4d-eee8-669f30330f4a",


### PR DESCRIPTION
## Description

Cherry-pick #5523

The msquic pipeline in undock using UCRT compiler is failing due to format specifier mismatch. BOOLEAN is typedef'd as unsigned char, but the format string uses %d which expects a signed integer. When an unsigned char is passed to a function that expects a signed type, the compiler generates a C6340 warning.

## Testing
The new changes are tested on the undock pipeline and its passing.

## Documentation
No