### PR TITLE
Enable central package transitive pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />


### PR DESCRIPTION
## Description

Enable NuGet’s Transitive Pinning to effectively promote a transitive dependency to a top-level dependency implicitly on your behalf when necessary.

See https://microsoft.visualstudio.com/undock/_git/msquic/pullrequest/14056823

## Testing

C/I

## Documentation

N/A
