### PR TITLE
Update Actions Permissions So We Can Create Issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,9 @@ concurrency:
   group: bvt-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   build-windows-kernel:


### PR DESCRIPTION
## Description

Update the permissions on the workflow so issues can be created.

We saw an HTTP 403 error the last time it ran: 
https://github.com/microsoft/msquic/actions/runs/18658444843/job/53199881918

<img width="533" height="344" alt="image" src="https://github.com/user-attachments/assets/a61590f3-b529-451f-894a-b582af14ed07" />

## Testing

CI

## Documentation

No