### PR TITLE
Fix double deref in connection pool error path

### DIFF
--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -714,8 +714,8 @@ CleanUpConnections:
         //
         // Close every connection that was created.
         // The application will receive the shutdown notification.
-        // Wait for the task to be complete so that when this function returns to the app,
-        // all connections are closed (since the shutdown notification is visible).
+        // Wait for the task to complete so that when this function returns to the app,
+        // all connections are already closed (since the shutdown notification is visible).
         //
         for (uint32_t i = 0; i < CreatedConnections; i++) {
             QuicConnPoolQueueConnectionClose(Connections[i], TRUE);


### PR DESCRIPTION
## Description

When creating a connection pool, if a `QuicConnStart` fails:
- the connection was marked as `ExternalOwner` to prevent it from sending notification to the app
    - but this also mean that the closing logic will take care of releasing the owner refcount, since the application is not the owner yet
- the connection was closed using `MsQuicConnectionClose`, which release the refcount of the application

This caused a double release, triggering an assertion.

We should not call APIs from internal call (it makes logging confusing and breaks some assumptions), so queue the connection close manually instead.

Fixes #5550.

## Testing

C/I.
Need to consider if there is a simply way to deterministically test the connection pool failure paths.

## Documentation

N/A
