### PR TITLE
Separate the dependabot entries for Docker Images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       - "dependencies"
       - "Language: Rust"
 
+# The docker entries are split out so they can update separately.
+# When combined, dependabot seems to only update when both meet the criteria,
+# which is impossible, since they're different versions.
   - package-ecosystem: "docker"
     directories:
       - "/.docker/ubuntu-22.04"


### PR DESCRIPTION
## Description

It appears as though when the docker entries are together, they are only updated together.  This change separates the Ubuntu 22.04 and Ubuntu 24.04 dependabot entries so they will hopefully update separately.

## Testing

Running the dependabot CLI with this change seems to correctly update the docker images.

## Documentation

Added a comment to the file explaining why the split exists
