### PR TITLE
Build for Android Arm/Arm64 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ['Debug', 'Release']
-        plat: [linux]
+        plat: [android, linux]
         os: ['ubuntu-22.04', 'ubuntu-24.04']
         arch: [arm, arm64]
         tls: [quictls, openssl]


### PR DESCRIPTION
Arm and Arm64 android builds feel much more applicable than the x86_64 android builds that CI already produces. Since it was a simple change to make to the CI workflow, I figured I'd send the proposal to add them to the CI flow along with the PR to actually add it. It's up to you whether the extra CI work makes sense, though.

The Build workflow that I modified here completed successfully when I [ran it myself](<https://github.com/kitlith/msquic/actions/runs/19561650233>), though I was unable to complete the rest of the CI run due to not having access to `macos-latest-xlarge` instances.