### PR TITLE
Refactor dependabot.yml to use single directory entries for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,7 @@ updates:
     allow:
       - dependency-name: "ubuntu"
         dependency-type: "direct"
+        update-types: ["version-update:semver-digest"]
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"
@@ -52,3 +53,4 @@ updates:
     allow:
       - dependency-name: "ubuntu"
         dependency-type: "direct"
+        update-types: ["version-update:semver-digest"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        versions: ["> 22.04"]
+        versions: [">= 22.10"]
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"
@@ -51,4 +51,4 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        versions: ["> 24.04"]
+        versions: [">= 24.10"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-    ignore:
+    allow:
       - dependency-name: "ubuntu"
-        versions: [">=22.10"]
+        dependency-type: "direct"
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,10 @@ updates:
       day: "saturday"
     allow:
       - dependency-name: "ubuntu"
-        dependency-type: "direct"
         update-types: ["version-update:semver-digest"]
+    ignore:
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"
@@ -52,5 +54,7 @@ updates:
       day: "saturday"
     allow:
       - dependency-name: "ubuntu"
-        dependency-type: "direct"
         update-types: ["version-update:semver-digest"]
+    ignore:
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        versions: ["> 22.04"]
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"
@@ -51,4 +51,4 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        versions: ["> 24.04"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        versions: [">= 22.10"]
+        versions: [">=22.10"]
 
   - package-ecosystem: "docker"
     directory: "/.docker/ubuntu-24.04"
@@ -51,4 +51,4 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        versions: [">= 24.10"]
+        versions: [">=24.10"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-    ignore:
+    allow:
       - dependency-name: "ubuntu"
-        versions: [">=24.10"]
+        dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,7 @@ updates:
 # When combined, dependabot seems to only update when both meet the criteria,
 # which is impossible, since they're different versions.
   - package-ecosystem: "docker"
-    directories:
-      - "/.docker/ubuntu-22.04"
+    directory: "/.docker/ubuntu-22.04"
     schedule:
       interval: "weekly"
       day: "saturday"
@@ -46,8 +45,7 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
-    directories:
-      - "/.docker/ubuntu-24.04"
+    directory: "/.docker/ubuntu-24.04"
     schedule:
       interval: "weekly"
       day: "saturday"


### PR DESCRIPTION
## Description

Updated dependabot configuration to use single directory entries for Ubuntu Docker images.

## Testing

Running the dependabot tool 

## Documentation

N/A
