### PR TITLE
Fail test passes when a test succeeds only after a retry

### DIFF
--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -939,13 +939,11 @@ try {
         Log "Output can be found in $($LogDir)"
         $ConsistentFailure = $TestsFailed - $TestsRetried
         $PassedWithRetry = $TestsRetried - $ConsistentFailure
-        if ($ErrorsAsWarnings -or
-            (($IsolationMode -eq "Isolated") -and ($TestsFailed -ne 0) -and ($TestsFailed -eq $TestsRetried))) {
-            if ($TestsFailed -eq $TestsRetried) {
-                Write-Warning "$($TestsRetried) test(s) passed with retry, $($global:CrashedProcessCount) test(s) crashed."
-            } else { # for $ErrorsAsWarning
-                Write-Warning "$($ConsistentFailure) test(s) failed with retry, $($PassedWithRetry) test(s) passed with retry, $($global:CrashedProcessCount) test(s) crashed."
-            }
+        if ($ErrorsAsWarnings) {
+            Write-Warning "$($ConsistentFailure) test(s) failed with retry, $($PassedWithRetry) test(s) passed with retry, $($global:CrashedProcessCount) test(s) crashed."
+        } elseif (($IsolationMode -eq "Isolated") -and ($TestsFailed -ne 0) -and ($TestsFailed -eq $TestsRetried)) {
+            Write-Error "$($TestsRetried) test(s) failed but succeeded on retry, $($global:CrashedProcessCount) test(s) crashed."
+            $LastExitCode = 1
         } else {
             Write-Error "$($ConsistentFailure) test(s) failed with retry, $($PassedWithRetry) test(s) passed with retry, $($global:CrashedProcessCount) test(s) crashed."
             $LastExitCode = 1


### PR DESCRIPTION
## Description

Retries have been added automatically to every test on failure, which might be hiding infrequent issues.
This change makes the test pass fail if it takes a retry for the CI to succeed.

This will let us know how frequently the retry was needed to avoid spurious issues and how often it was hiding real infrequent issues. If the failure rate does not dramatically increase, the entire retry logic should be removed.

## Testing

CI

## Documentation

N/A
