### PR TITLE
Fix GCC multichar warning with push/pop pragma (#5632)

### DIFF
--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -138,6 +138,7 @@ constexpr _Ty&& CxPlatForward(
 }
 
 #ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmultichar" // Multi-character constant used intentionally for the tag
 #endif
 template<typename T, uint32_t Tag = 'lPxC', bool Paged = false>
@@ -162,6 +163,9 @@ public:
         }
     }
 };
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef CXPLAT_HASH_MIN_SIZE
 


### PR DESCRIPTION
## Description
Fixes the `-Wmultichar` warning that appears on some build configurations (particularly Alpine Linux) by properly scoping the pragma suppression with `push`/`pop` directives.

Fixes #5632