### PR TITLE
increase spinquic watchdog timeout

### DIFF
--- a/src/tools/spin/spinquic.cpp
+++ b/src/tools/spin/spinquic.cpp
@@ -167,7 +167,7 @@ public:
 // The amount of extra time (in milliseconds) to give the watchdog before
 // actually firing.
 //
-#define WATCHDOG_WIGGLE_ROOM 20000
+#define WATCHDOG_WIGGLE_ROOM 30000
 
 class SpinQuicWatchdog {
     CXPLAT_THREAD WatchdogThread;


### PR DESCRIPTION
## Description

As discussed in issue #5491 , from logs, the watchdog assert is firing.
For now, let's increase it by 100%.

## Testing

CI

## Documentation

N/A
