### PR TITLE
Synchronize rust test certificate creation

### DIFF
--- a/src/rs/server_client_test.rs
+++ b/src/rs/server_client_test.rs
@@ -54,6 +54,11 @@ pub fn get_test_cred() -> Credential {
     let cert_path = cert_dir.join(cert);
 
     CREATE_TEST_CERTS.call_once(|| {
+        // Nothing to do if certs are already present
+        if key_path.exists() && cert_path.exists() {
+            return;
+        }
+
         // Remove any pre-existing files
         let _ = std::fs::remove_dir_all(&cert_dir);
 


### PR DESCRIPTION
## Description

#5618 added a second test relying on test certificate, causing the test certificate creation to race between the two tests.

This synchronizes the certificate creation and ensure it runs only once per executable invocation (and not at all if certificates are already present)

## Testing

CI

## Documentation

N/A
