### PR TITLE
Fix invalid handle access for RegistrationCloseCleanup Events

### DIFF
--- a/src/core/library.c
+++ b/src/core/library.c
@@ -607,11 +607,6 @@ Error:
             CxPlatThreadDelete(&MsQuicLib.RegistrationCloseCleanupWorker);
             MsQuicLib.RegistrationCloseCleanupWorker = 0;
         }
-        if (PlatformInitialized) {
-            CxPlatRundownUninitialize(&MsQuicLib.RegistrationCloseCleanupRundown);
-            CxPlatEventUninitialize(MsQuicLib.RegistrationCloseCleanupEvent);
-            CxPlatLockUninitialize(&MsQuicLib.RegistrationCloseCleanupLock);
-        }
         if (MsQuicLib.Storage != NULL) {
             CxPlatStorageClose(MsQuicLib.Storage);
             MsQuicLib.Storage = NULL;
@@ -621,6 +616,9 @@ Error:
             MsQuicLib.DefaultCompatibilityList = NULL;
         }
         if (PlatformInitialized) {
+            CxPlatRundownUninitialize(&MsQuicLib.RegistrationCloseCleanupRundown);
+            CxPlatEventUninitialize(MsQuicLib.RegistrationCloseCleanupEvent);
+            CxPlatLockUninitialize(&MsQuicLib.RegistrationCloseCleanupLock);
             CxPlatDispatchRwLockUninitialize(&MsQuicLib.StatelessRetry.Lock);
             CxPlatUninitialize();
         }


### PR DESCRIPTION
## Description

When MsQuic is first initialized, there may not be enough memory to allocate the datapath layer.

This happens so rarely that there is little to no coverage for error handling when this happens.

But when it happens, you skip directly to the exit condition, and that tries free-ing memory that was never initialized.

So fix up the logic so cleanup only happens if initialized.

Fixes: https://github.com/microsoft/msquic/issues/5491

## Testing

Stress tests.

## Documentation

No
