### PR TITLE
Fix race between causing spurious failure in the ConnectTcp datapath test

### DIFF
--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2661,6 +2661,7 @@ CxPlatDataPathSocketProcessAcceptCompletion(
         //
         AcceptSocketProc->IoStarted = TRUE;
         if (!CxPlatRundownAcquire(&AcceptSocketProc->RundownRef)) {
+            AcceptSocketProc = NULL;
             goto Error;
         }
 


### PR DESCRIPTION
## Description

`CxPlatDataPathSocketProcessAcceptCompletion` can race with `CxPlatSocketDelete` if the test code delete the socket right after it receive the "accept" callback.

`CxPlatSocketDelete` doesn't wait on the rundown ref when `IoStarted` is not true (I don't know why, and I wonder if we couldn't simply remove that special case, but that is out of scope of this PR).

This would allow a socket to be already in the "uninitialzed" state when then end of `CxPlatDataPathSocketProcessAcceptCompletion` tries to post the first receive SQE on it.

Fixes #5679

## Testing

CI. The failure was observed regularly on recent PR CI runs but is not consistent, so we may have to keep an eye for a time.

## Documentation

N/A
