### PR TITLE
Docs: CA cert files are only supported in OpenSSL.

### DIFF
--- a/docs/api/QUIC_CREDENTIAL_CONFIG.md
+++ b/docs/api/QUIC_CREDENTIAL_CONFIG.md
@@ -160,6 +160,7 @@ Obtain the peer certificate using a faster in-process API call. Only available o
 `QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE`
 
 Enable CA certificate file provided in the `CaCertificateFile` member.
+Only valid for OpenSSL.
 
 `QUIC_CREDENTIAL_FLAG_DISABLE_AIA`
 


### PR DESCRIPTION
## Description

Added a note saying that `QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE` is only supported in OpenSSL.  It's supported in QuicTLS too, but that isn't mentioned for the other options.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

This is a documentation change.