### PR TITLE
Add compiler toggle for xdp on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ option(QUIC_EXTERNAL_TOOLCHAIN "Enable if system libs and include paths are conf
 option(QUIC_PGO "Enables profile guided optimizations" OFF)
 option(QUIC_LINUX_IOURING_ENABLED "Enables io_uring support" OFF)
 option(QUIC_LINUX_XDP_ENABLED "Enables XDP support" OFF)
+option(QUIC_WINDOWS_XDP_ENABLED "Enables Windows XDP support" OFF)
 option(QUIC_SOURCE_LINK "Enables source linking on MSVC" ON)
 option(QUIC_EMBED_GIT_HASH "Embed git commit hash in the binary" ON)
 option(QUIC_PDBALTPATH "Enable PDBALTPATH setting on MSVC" ON)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ find = []
 # This feature enables openssl on windows, and has no effect on linux.
 openssl = []
 quictls = []
+# Enable Windows XDP datapath support when building from source.
+windows-xdp = []
 static = ["src"]
 preview-api = []
 # Overwrite generated binding by reruning the bindgen

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -57,6 +57,10 @@ fn cmake_build() {
         config.define("QUIC_TLS_LIB", "quictls");
     }
 
+    if cfg!(all(windows, feature = "windows-xdp")) {
+        config.define("QUIC_WINDOWS_XDP_ENABLED", "on");
+    }
+
     if cfg!(feature = "static") {
         config.define("QUIC_BUILD_SHARED", "off");
     }

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -20,7 +20,12 @@ if("${CX_PLATFORM}" STREQUAL "windows")
        ${SYSTEM_PROCESSOR} STREQUAL "arm64ec")
         set(SOURCES ${SOURCES} datapath_raw_dummy.c)
     else()
-        set(SOURCES ${SOURCES} datapath_raw.c datapath_raw_win.c datapath_raw_socket.c datapath_raw_socket_win.c datapath_raw_xdp_win.c)
+        set(SOURCES ${SOURCES} datapath_raw.c datapath_raw_win.c datapath_raw_socket.c datapath_raw_socket_win.c)
+        if(QUIC_WINDOWS_XDP_ENABLED)
+            list(APPEND SOURCES datapath_raw_xdp_win.c)
+        else()
+            list(APPEND SOURCES datapath_raw_dummy.c)
+        endif()
     endif()
 else()
     set(SOURCES ${SOURCES} platform_posix.c storage_posix.c cgroup.c datapath_unix.c)
@@ -124,11 +129,15 @@ target_link_libraries(msquic_platform PRIVATE warnings main_binary_link_args)
 set_property(TARGET msquic_platform PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}libraries")
 
 if ("${CX_PLATFORM}" STREQUAL "windows")
-    target_include_directories(
-        msquic_platform
-        PRIVATE
-        ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES}
-        ${PROJECT_SOURCE_DIR}/submodules/xdp-for-windows/published/external)
+    if(QUIC_WINDOWS_XDP_ENABLED)
+        target_include_directories(
+            msquic_platform
+            PRIVATE
+            ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES}
+            ${PROJECT_SOURCE_DIR}/submodules/xdp-for-windows/published/external)
+    else()
+        target_include_directories(msquic_platform PRIVATE ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES})
+    endif()
 elseif(QUIC_LINUX_XDP_ENABLED)
     include_directories(/usr/include/libnl3)
     target_include_directories(msquic_platform PRIVATE ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES})


### PR DESCRIPTION
XDP for windows [requires windows server](https://github.com/microsoft/xdp-for-windows/blob/main/docs/usage.md#prerequisites), add a toggle so msquic can be built without xdp.