### PR TITLE
Double wait time in flaky drop test

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3005,7 +3005,7 @@ QuicTestNthPacketDrop(
         CONTINUE_ON_FAIL(Stream.GetInitStatus());
 
         CONTINUE_ON_FAIL(Stream.Send(&Buffer, 1, QUIC_SEND_FLAG_START | QUIC_SEND_FLAG_FIN));
-        TEST_TRUE(RecvContext.ServerStreamShutdown.WaitTimeout(2000));
+        TEST_TRUE(RecvContext.ServerStreamShutdown.WaitTimeout(4000));
         if (RecvContext.Failure || !LossHelper.Dropped() ||
             CxPlatTimeDiff64(StartTime, CxPlatTimeUs64()) > S_TO_US(TimeOutS)) {
             StopRunning = true;


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The QuicTestNthPacketDrop test hit 

```DataTest.cpp(3006): error: RecvContext.ServerStreamShutdown.WaitTimeout(2000) not true```

but after looking at the logs, it was making fairly steady progress over two seconds, as far as I can tell. I suspect we just randomly tripped across the existing 2 second limit due to bad luck, so doubled the limit, which is not integral to the test itself.

Resolves #5676

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally.

## Documentation

_Is there any documentation impact for this change?_

N/A.