### PR TITLE
Fix hang in ExecutionDelete

### DIFF
--- a/src/platform/platform_worker.c
+++ b/src/platform/platform_worker.c
@@ -692,7 +692,9 @@ CxPlatWorkerPoolWorkerDrainEvents(
     _In_ CXPLAT_WORKER* Worker
     )
 {
+#if DEBUG
     uint32_t Iterations = 0;
+#endif
     do {
         Worker->State.TimeNow = CxPlatTimeUs64();
         Worker->State.ThreadID = CxPlatCurThreadID();
@@ -715,8 +717,9 @@ CxPlatWorkerPoolWorkerDrainEvents(
         Worker->State.NoWorkCount = 1;
         CxPlatProcessEvents(Worker);
 
-        ++Iterations;
-        CXPLAT_DBG_ASSERTMSG(Iterations < 10, "Is the library still active?");
+#if DEBUG
+        CXPLAT_DBG_ASSERTMSG(++Iterations < 10, "Is the library still active?");
+#endif
     } while (Worker->State.NoWorkCount == 0);
 }
 


### PR DESCRIPTION
## Description

In external execution mode, when cleaning up the last socket (binding) and registration and calling `ExecutionDelete`, it's possible the worker pool will attempt to be deleted by `ExecutionDelete` before the asynchronous shut down callbacks have had time to run. This will result in a hang because the ref count on the worker pool is non-zero, since there's still cleanup work to do. However, the caller, by calling `ExecutionDelete` has indicated that they have stopped the execution engine, so that remaining cleanup work won't get a chance to run.

## Testing

Tested the fix with the partner scenario

## Documentation

No documentation change.
