### PR TITLE
[CP] Persists the virtual buffer size when switching to app owned buffers #5690

### DIFF
--- a/docs/Streams.md
+++ b/docs/Streams.md
@@ -167,6 +167,7 @@ There is no guarantee the `QUIC_BUFFER`s indicated in a receive notification wil
 
 The application is responsible for tracking the amount of data received and when a buffer it provided has been fully used.
 The application regains full ownership of a buffer after it get a receive notification for all bytes in the buffer and accept them by calling [StreamReceiveComplete](api/StreamReceiveComplete.md).
+MsQuic will not re-use a buffer for subsequent receives once it has been fully written, unless the app submits the same buffer again.
 If the application accepts all the buffer's bytes **inline** from the receive notification, by returning `QUIC_STATUS_SUCCESS` and setting `TotalBufferLength` appropriately,
 it can free or reuse the buffer while in the notification handler.
 

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -977,13 +977,13 @@ QuicStreamSwitchToAppOwnedBuffers(
     )
 {
     //
-    // Preserve the initial receive window size.
-    // It should not have evolved yet since the stream creation.
+    // Preserve the initial receive window size: it should not have changed
+    // since the stream's creation.
     //
     const uint32_t InitialControlFlow = Stream->RecvBuffer.VirtualBufferLength;
     CXPLAT_DBG_ASSERT(
         InitialControlFlow == Stream->Connection->Settings.StreamRecvWindowBidiRemoteDefault ||
-        InitialControlFlow == Stream->Connection->Settings.StreamRecvWindowBidiLocalDefault);
+        InitialControlFlow == Stream->Connection->Settings.StreamRecvWindowUnidiDefault);
 
     //
     // Reset the current receive buffer


### PR DESCRIPTION
## Description

When an endpoint receives a new stream indication, it can provide some receive buffers inline to convert the stream to app-owned buffer mode.
When doing so, the receive buffer struct of the stream is reinitialized, and the virtual buffer length (which correspond to the stream receive window) was set to zero.

This is incorrect since we introduced the "more buffer needed" notification and the receive window is no longer tied to the amount of buffer provided.

This would result in a receive failure with data received outside of the virtual size.

When converting the receive buffer to app-buffer mode, the virtual size is now preserved.

Fixes #5672.

## Testing

Test not backported as they rely on changes present only in main

## Documentation

Clarify documentation about the app provided receive buffer ownership.
