### PR TITLE
Disable RSC for QTIP

### DIFF
--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -290,10 +290,9 @@ CxPlatDpRawParseIPv4(
     if (Length < IPTotalLength) {
         QuicTraceEvent(
             DatapathErrorStatus,
-            "[data][%p] ERROR, bytes received < bytes advertised in the header: %u < %u, %s.",
+            "[data][%p] ERROR, %u, %s.",
             Datapath,
             Length,
-            IPTotalLength,
             "unexpected IPv4 packet size");
         return;
     }


### PR DESCRIPTION
## Description

Upon investigation of https://github.com/microsoft/msquic/issues/5718, it turns out that we are dropping packets at the XDP layer due to bytes received being less than the bytes reported in the header. Let's try disabling this in the CI.

## Testing

No.

## Documentation

No.
