### PR TITLE
Add dependabot groups for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
     groups:
       actions:
         patterns:
@@ -17,10 +18,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-    groups:
-      actions:
-        patterns:
-          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I noticed eBPF's dependabot produces a [single PR](https://github.com/microsoft/ebpf-for-windows/pull/4913) for a batch of updates, which reduces overhead, among other things. Try the same [thing](https://github.com/microsoft/ebpf-for-windows/blob/2095c51aac6db0fe819006a97fdc3bcb90c41846/.github/dependabot.yml#L17-L20) in MsQuic for actions and change its cadence back to weekly.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

N/A.