### PR TITLE
Treat SEC_E_INTERNAL_ERROR as SEC_E_NO_CREDENTIAL when querying certi…

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2311,10 +2311,14 @@ CxPlatTlsWriteDataToSchannel(
             if ((SecStatus == SEC_E_NO_CREDENTIALS || SecStatus == SEC_E_INTERNAL_ERROR) &&
                 (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_DEFER_CERTIFICATE_VALIDATION)) {
                 //
-                // Ignore this case.
+                // Certificate validation is being deferred to the application:
+                // indicate no certificate is present but let the application decide if this is a
+                // failure.
+                // SEC_E_INTERNAL_ERROR can be returned on SECPKG_ATTR_REMOTE_CERT_CONTEXT if no
+                // certificate is found, normalize to SEC_E_NO_CREDENTIALS.
                 //
                 PeerCertBlob.Type = QUIC_CERT_BLOB_NONE;
-                CertValidationResult.hrVerifyChainStatus = SecStatus;
+                CertValidationResult.hrVerifyChainStatus = SEC_E_NO_CREDENTIALS;
             } else if (SecStatus == SEC_E_OK &&
                 !(TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION) &&
                 (TlsContext->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_REQUIRE_CLIENT_AUTHENTICATION ||


### PR DESCRIPTION
## Description

`SECPKG_ATTR_REMOTE_CERTIFICATES` can result in a `SEC_E_INTERNAL_ERROR` when the certificate is not found.
Schannel intentionally preserve this behavior to keep their error behavior unchanged.

When this happens, MsQuic would close the connection immediately, even when TLS was configured to require client certificate validation but defer the validation to the app (which could let the app accept a connection even if no certificate is provided).

This PR treats `SEC_E_INTERNAL_ERROR` the same way as `SECPKG_ATTR_REMOTE_CERTIFICATES`.

## Testing

CI. Partner validation pending.


## Documentation

N/A
