### PR TITLE
update ETW to disambiguate datapath sends

### DIFF
--- a/src/generated/linux/datapath_raw.c.clog.h
+++ b/src/generated/linux/datapath_raw.c.clog.h
@@ -68,11 +68,11 @@ tracepoint(CLOG_DATAPATH_RAW_C, DatapathRecv , arg2, arg3, arg4, arg5_len, arg5,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for DatapathSend
-// [data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!
+// Decoder Ring for RawDatapathSend
+// [data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!
 // QuicTraceEvent(
-        DatapathSend,
-        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        RawDatapathSend,
+        "[data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Socket,
         SendData->Buffer.Length,
         1,
@@ -86,9 +86,9 @@ tracepoint(CLOG_DATAPATH_RAW_C, DatapathRecv , arg2, arg3, arg4, arg5_len, arg5,
 // arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress) = arg6
 // arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress) = arg7
 ----------------------------------------------------------*/
-#ifndef _clog_10_ARGS_TRACE_DatapathSend
-#define _clog_10_ARGS_TRACE_DatapathSend(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg6_len, arg7, arg7_len)\
-tracepoint(CLOG_DATAPATH_RAW_C, DatapathSend , arg2, arg3, arg4, arg5, arg6_len, arg6, arg7_len, arg7);\
+#ifndef _clog_10_ARGS_TRACE_RawDatapathSend
+#define _clog_10_ARGS_TRACE_RawDatapathSend(uniqueId, encoded_arg_string, arg2, arg3, arg4, arg5, arg6, arg6_len, arg7, arg7_len)\
+tracepoint(CLOG_DATAPATH_RAW_C, RawDatapathSend , arg2, arg3, arg4, arg5, arg6_len, arg6, arg7_len, arg7);\
 
 #endif
 

--- a/src/generated/linux/datapath_raw.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw.c.clog.h.lttng.h
@@ -64,11 +64,11 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_C, DatapathRecv,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for DatapathSend
-// [data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!
+// Decoder Ring for RawDatapathSend
+// [data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!
 // QuicTraceEvent(
-        DatapathSend,
-        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        RawDatapathSend,
+        "[data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Socket,
         SendData->Buffer.Length,
         1,
@@ -82,7 +82,7 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_C, DatapathRecv,
 // arg6 = arg6 = CASTED_CLOG_BYTEARRAY(sizeof(Route->RemoteAddress), &Route->RemoteAddress) = arg6
 // arg7 = arg7 = CASTED_CLOG_BYTEARRAY(sizeof(Route->LocalAddress), &Route->LocalAddress) = arg7
 ----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_C, DatapathSend,
+TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_C, RawDatapathSend,
     TP_ARGS(
         const void *, arg2,
         unsigned int, arg3,

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -3822,6 +3822,15 @@
               template="tid_DATA_SEND_TCP_CONTROL"
               value="9225"
               />
+          <event
+              keywords="ut:UDP ut:DataFlow"
+              level="win:Verbose"
+              message="$(string.Etw.RawDatapathSend)"
+              opcode="Datapath"
+              symbol="QuicRawDatapathSend"
+              template="tid_DATA_SEND"
+              value="9226"
+              />
           <!-- 10240 - 11263 | Logs (not events) -->
           <event
               keywords="ut:Log"
@@ -4461,6 +4470,10 @@
         <string
             id="Etw.DatapathSend"
             value="[data][%1] Send %2 bytes in %3 buffers (segment=%4) Dst=%6 Src=%8"
+            />
+        <string
+            id="Etw.RawDatapathSend"
+            value="[data][%1] Raw send %2 bytes in %3 buffers (segment=%4) Dst=%6 Src=%8"
             />
         <string
             id="Etw.DatapathRecv"

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -9086,6 +9086,38 @@
       ],
       "macroName": "QuicTraceLogStreamVerbose"
     },
+    "RawDatapathSend": {
+      "ModuleProperites": {},
+      "TraceString": "[data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+      "UniqueId": "RawDatapathSend",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "p",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg3"
+        },
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg4"
+        },
+        {
+          "DefinationEncoding": "hu",
+          "MacroVariableName": "arg5"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg6"
+        },
+        {
+          "DefinationEncoding": "!ADDR!",
+          "MacroVariableName": "arg7"
+        }
+      ],
+      "macroName": "QuicTraceEvent"
+    },
     "RawSockCreateFail": {
       "ModuleProperites": {},
       "TraceString": "[sock] Failed to create raw socket, status:%d",
@@ -16019,6 +16051,11 @@
         "UniquenessHash": "80596bbb-20e9-07e5-07f3-ebc7078fa612",
         "TraceID": "QueueRecvFlush",
         "EncodingString": "[strm][%p] Queuing recv flush"
+      },
+      {
+        "UniquenessHash": "5ddc6267-3f4c-743c-9a00-f3cc7d7444f5",
+        "TraceID": "RawDatapathSend",
+        "EncodingString": "[data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!"
       },
       {
         "UniquenessHash": "4f370688-5822-225a-8c7e-ec4200d38f0a",

--- a/src/platform/datapath_raw.c
+++ b/src/platform/datapath_raw.c
@@ -345,8 +345,8 @@ RawSocketSend(
     }
 
     QuicTraceEvent(
-        DatapathSend,
-        "[data][%p] Send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
+        RawDatapathSend,
+        "[data][%p] Raw send %u bytes in %hhu buffers (segment=%hu) Dst=%!ADDR!, Src=%!ADDR!",
         Socket,
         SendData->Buffer.Length,
         1,


### PR DESCRIPTION
## Description

While parsing the logs, it was ambiguous sometimes whether or not we are sending from the raw datapath or not. 
Let's update that.

## Testing

CI 

## Documentation

No