### PR TITLE
[CP] Add linker options for hotpatching on ARM64 kernel driver (#5444)

### DIFF
--- a/src/bin/winkernel/msquic.kernel.vcxproj
+++ b/src/bin/winkernel/msquic.kernel.vcxproj
@@ -124,6 +124,16 @@
       <AdditionalOptions>%(AdditionalOptions) /FORCE:PGOREPRO /USEPROFILE:PGD=$(SolutionDir)artifacts\bin\winkernel\$(Platform)_$(Configuration)_schannel\msquic.pgd</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
+  <!-- ARM64 Release Hotpatch linker flags to allow hotpatching -->
+  <PropertyGroup>
+    <AllowHotpatchLinkOptionsARM64>/hotpatchcompatible /profile /incremental:no /PDBINJECT:MAPFILE</AllowHotpatchLinkOptionsARM64>
+  </PropertyGroup>
+   <!-- Hotpatch flags appended last to prevent override -->
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Link>
+      <AdditionalOptions>%(AdditionalOptions) $(AllowHotpatchLinkOptionsARM64)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>


### PR DESCRIPTION
## Cherry-pick Information
Related PR on main: #5444
Cherry-picked from main commit 6b8451f01ef4960c45ff99405817ba71b112eaf3

## Description
Add linker options for hotpatching on ARM64 kernel driver.

Enables runtime hotpatching capabilities for the MSQuic kernel driver (msquic.sys) in Release|ARM64 builds by adding the necessary linker flags to msquic.kernel.vcxproj.

Background
Currently, ARM64 releases of msquic.sys do not support runtime hotpatching due to missing linker options required for ARM64 hotpatch operations. This limitation prevents in-memory updates for ARM64 deployments and affects compatibility with ARM64 systems that depend on hotpatch-enabled drivers.

Changes
Adds the following linker flags to the Release|ARM64 configuration:

/hotpatchcompatible /profile /incremental:no - Generates PDB records for Vulcan compatibility and enables hotpatch-compatible
/PDBINJECT:MAPFILE - Injects map file information into PDB for ARM64-native hotpatch methodology (replaces x64's /FUNCTIONPADMIN:6)

Impact
- Production Deployments: Enables in-memory hotpatching for production MSQuic kernel driver updates on ARM64 systems
- Component Compatibility: Ensures compatibility with ARM64 components requiring hotpatch-enabled drivers  
- Operational Benefits: Reduces downtime by supporting runtime driver updates without system restarts on ARM64 platforms

Technical Details
ARM64 hotpatching uses map file injection rather than function padding. The /PDBINJECT:MAPFILE flag creates a function layout map that enables the hotpatch loader to create proper trampolines for ARM64 instruction sets, allowing seamless redirection from baseline to patch binary at runtime.

## Testing

Completed Verification
✅ Visual Studio Build: Confirmed that locally built msquic.sys for ARM64 Release configuration contains all required hotpatch prerequisites.
⏳ Hotpatch Loading: Successfully loaded and applied a hotpatch to the driver in memory during testing.

⏳ GitHub Actions Pipeline: Verify that CI/CD-generated msquic.sys artifact maintain hotpatch compatibility
⏳ Release Artifact Testing: Confirm that market-ready msquic.sys binary produced by GitHub pipelines support hotpatch operations

Validation Plan

Download Release-winkernel-windows-2022-ARM64-schannel artifact from GitHub Actions
✅ Verify binary contains required hotpatch metadata
Perform runtime hotpatch loading test with CI-generated binary

## Documentation

No user-facing documentation changes required. This is an internal build configuration change that enables existing Windows hotpatch infrastructure. The functionality is transparent to end users and does not modify MSQuic APIs or behavior.