### PR TITLE
Ignore all Ubuntu Docker dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,6 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directories:
@@ -58,4 +57,3 @@ updates:
       day: "saturday"
     ignore:
       - dependency-name: "ubuntu"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## Description

ADO policy should dictate the source of truth for the SHA version, not Github.
Let's disable it completely and use the reverse mirror script in #5775 


## Testing

No 

## Documentation

No