### PR TITLE
Update setup perl action

### DIFF
--- a/.github/workflows/build-reuse-win.yml
+++ b/.github/workflows/build-reuse-win.yml
@@ -83,7 +83,7 @@ jobs:
         repository: ${{ inputs.repo}}
         ref: ${{ inputs.ref }}
     - name: Install Perl
-      uses: shogo82148/actions-setup-perl@fa3bdcb0144a50651e317f30949bb4491e74a6e4
+      uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8
       with:
         perl-version: '5.34'
     - name: Install NASM

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -40,7 +40,7 @@ jobs:
       shell: pwsh
     - name: Install Perl
       if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@fa3bdcb0144a50651e317f30949bb4491e74a6e4
+      uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8
       with:
         perl-version: '5.34'
     - name: Install NASM

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Install Perl
       if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@fa3bdcb0144a50651e317f30949bb4491e74a6e4
+      uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8
       with:
         perl-version: '5.34'
     - name: Install NASM


### PR DESCRIPTION
## Description

The build CI started to fail with errors like:

```
Run shogo82148/actions-setup-perl@fa3bdcb0144a50651e317f30949bb4491e74a6e4
install perl
  verifying download: D:\a\_temp\d7077245-f8e5-4d0c-bca6-93c64dc8f837
  Warning: failed to verify attestation: TypeError: Cannot read properties of null (reading 'mediaType'), continue to next attestation
  Warning: failed to verify attestation: TypeError: Cannot read properties of null (reading 'mediaType'), continue to next attestation
Error: Error: failed to verify D:\a\_temp\d7077245-f8e5-4d0c-bca6-93c64dc8f837
```

https://github.com/microsoft/msquic/actions/runs/22020983438/job/63904220521?pr=5794

This has been fixed in https://github.com/shogo82148/actions-setup-perl/issues/2481.

Update the action to fix the CI.

## Testing

CI

## Documentation

N/A
