### PR TITLE
Fix memory leak in ServerSendIp error paths

### DIFF
--- a/src/tools/ip/server/quicipserver.cpp
+++ b/src/tools/ip/server/quicipserver.cpp
@@ -81,11 +81,13 @@ ServerSendIp(
 
     if (QUIC_FAILED(Status = MsQuic->StreamOpen(Connection, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL, ServerStreamCallback, nullptr, &Stream))) {
         printf("StreamOpen failed, 0x%x!\n", Status);
+        CXPLAT_FREE(SendBufferRaw, QUIC_POOL_TOOL);
         return;
     }
 
     if (QUIC_FAILED(Status = MsQuic->StreamStart(Stream, QUIC_STREAM_START_FLAG_NONE))) {
         printf("StreamStart failed, 0x%x!\n", Status);
+        CXPLAT_FREE(SendBufferRaw, QUIC_POOL_TOOL);
         MsQuic->StreamClose(Stream);
         return;
     }


### PR DESCRIPTION
## Description

Fixes #5255.

Adds missing CXPLAT_FREE(SendBufferRaw, QUIC_POOL_TOOL) calls in early
error-return paths in ServerSendIp() to prevent a potential memory leak
when StreamOpen or StreamStart fails.

This change only affects test tooling code in:
src/tools/ip/server/quicipserver.cpp

## Testing

No new tests added.

The affected code is part of test tooling, and the failure paths
require StreamOpen or StreamStart to fail, which would require
fault injection or specific runtime conditions to exercise reliably.

Built successfully locally on Linux (GitHub Codespaces).

## Documentation

None.