### PR TITLE
Disable the scorecard analysis run temporarily

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -1,10 +1,10 @@
 name: Scorecards supply-chain security
 
-on: workflow_dispatch
-#  push:
-#    branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -32,9 +32,6 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
## Description

The Scorecard analysis workflow systematically fails because of an error 401. It generates noise and makes it harder to check if something else went wrong in the CI run: the main branch always shows a failed status (https://github.com/microsoft/msquic/commits/main/).

This PR disable the run.
Fixing the permission is already tracked by #5479

## Testing

CI

## Documentation

N/A
