### PR TITLE
Add the `/utf-8` flag to the compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ include(GNUInstallDirs)
 
 if (WIN32)
     set(QUIC_WARNING_FLAGS /WX /W4 /sdl /wd4206 CACHE INTERNAL "")
-    set(QUIC_COMMON_FLAGS "")
+    set(QUIC_COMMON_FLAGS /utf-8)
 
     include(CheckCCompilerFlag)
 


### PR DESCRIPTION
## Description

Some files include non-ASCII (UTF-8) characters. So, we have to make sure that source files are interpreted as UTF-8 by adding the `/utf-8` flag to the compiler options for Windows builds.

## Testing

CI

## Documentation

No