### PR TITLE
Fix memory leak in stdout logging

### DIFF
--- a/src/generated/stdout/quic_trace.c
+++ b/src/generated/stdout/quic_trace.c
@@ -65,8 +65,9 @@ char * casted_clog_bytearray(const uint8_t * const data,
 }
 
 
-void clog_stdout(struct clog_param * head, const char * const format, ...)
+void clog_stdout(struct clog_param ** head_ptr, const char * const format, ...)
 {
+    struct clog_param * head = *head_ptr;
     char * reformat;
 
     if (strstr(format, "%!") == 0) {

--- a/src/inc/quic_trace.h
+++ b/src/inc/quic_trace.h
@@ -165,10 +165,10 @@ extern
     "C"
 #endif
 void //__attribute__((no_instrument_function, format(printf, 2, 3)))
-clog_stdout(struct clog_param * head, const char * format, ...);
+clog_stdout(struct clog_param ** head, const char * format, ...);
 #else
 QUIC_INLINE void //__attribute__((no_instrument_function, format(printf, 2, 3)))
-clog_stdout(struct clog_param * head, const char * format, ...)
+clog_stdout(struct clog_param ** head, const char * format, ...)
 {
     UNREFERENCED_PARAMETER(head);
     UNREFERENCED_PARAMETER(format);
@@ -178,7 +178,7 @@ clog_stdout(struct clog_param * head, const char * format, ...)
 #define clog(Fmt, ...)                                                         \
     do {                                                                       \
         struct clog_param * __head = 0;                                        \
-        clog_stdout(__head, (Fmt), ##__VA_ARGS__);                             \
+        clog_stdout(&__head, (Fmt), ##__VA_ARGS__);                            \
     } while (0)
 
 #endif


### PR DESCRIPTION
The clog_stdout function receives the clog_param list head by value. If argument evaluation is from left to right, then the linked list built by casted_clog_bytearray during format argument expansion is never visible to clog_stdout for cleanup. The fix here is to change the parameter to a pointer-to-pointer so that clog_stdout always gets the updated list head.

Related issue: https://github.com/microsoft/msquic/issues/5790

## Root Cause

The `clog` macro expands to:

```c
do {
    struct clog_param * __head = 0;
    clog_stdout(__head, (Fmt), ##__VA_ARGS__);
} while (0)
```

The `__VA_ARGS__` may contain calls to `casted_clog_bytearray(&__head, ...)`, which allocate `clog_param` nodes and link them into the `__head` list. However, `clog_stdout` receives `__head` **by value**. The C standard leaves function argument evaluation order **unspecified**, so a compiler may evaluate `__head` (first argument) *before* the `casted_clog_bytearray` calls in subsequent arguments update it. When that happens, `clog_stdout` receives `NULL` and never frees the allocated param chain.

## Fix
Pass `&__head` (a stable stack address) instead of the value of `__head`. Inside `clog_stdout`, dereference the pointer to get the current head. Since `&__head` is always the same address regardless of evaluation order, `clog_stdout` reads `*head_ptr` inside its body — after all arguments are fully evaluated — and correctly gets the head of the linked list.

## Reproduction

### Test program
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

struct clog_param { char * str; struct clog_param * next; };

static char * fake_bytearray(const char * data, struct clog_param ** head) {
    struct clog_param * p = (struct clog_param *)malloc(sizeof(*p));
    p->str = strdup(data);
    p->next = *head;
    *head = p;
    return p->str;
}

// OLD: takes head by value (leaks when head is evaluated before bytearray calls)
static void clog_old(struct clog_param * head, const char * fmt, ...) {
    (void)fmt;
    while (head) { struct clog_param *n = head->next; free(head->str); free(head); head = n; }
}

// NEW: takes head by pointer (always correct)
static void clog_new(struct clog_param ** head_ptr, const char * fmt, ...) {
    struct clog_param * head = *head_ptr;
    (void)fmt;
    while (head) { struct clog_param *n = head->next; free(head->str); free(head); head = n; }
}

int main(void) {
    // Simulate left-to-right evaluation (OLD version leaks)
    printf("=== OLD version (leaks) ===\n");
    for (int i = 0; i < 5; i++) {
        struct clog_param * __head = 0;
        struct clog_param * saved_head = __head; // snapshot before bytearray calls
        char * s1 = fake_bytearray("hello", &__head);
        char * s2 = fake_bytearray("world", &__head);
        clog_old(saved_head, "test %s %s", s1, s2);
    }

    // NEW version: always works regardless of evaluation order
    printf("=== NEW version (no leaks) ===\n");
    for (int i = 0; i < 5; i++) {
        struct clog_param * __head = 0;
        char * s1 = fake_bytearray("hello", &__head);
        char * s2 = fake_bytearray("world", &__head);
        clog_new(&__head, "test %s %s", s1, s2);
    }

    printf("Done.\n");
    return 0;
}
```

### Build and run
```bash
gcc -O0 -g -fsanitize=address,leak -o /tmp/test_clog_leak /tmp/test_clog_leak.c
/tmp/test_clog_leak
```

### Result
```
=== OLD version (leaks) ===
=== NEW version (no leaks) ===
Done.

=================================================================
==82669==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 5 object(s) allocated from:
    #0 0x71ab80abf91f in __interceptor_malloc asan_malloc_linux.cpp:69
    #1 0x5ac3e0af12c6 in fake_bytearray /tmp/test_clog_leak.c:8
    #2 0x5ac3e0af16d8 in main /tmp/test_clog_leak.c:37

Indirect leak of 80 byte(s) in 5 object(s) allocated from:
    #0 0x71ab80abf91f in __interceptor_malloc asan_malloc_linux.cpp:69
    #1 0x5ac3e0af12c6 in fake_bytearray /tmp/test_clog_leak.c:8
    #2 0x5ac3e0af16bb in main /tmp/test_clog_leak.c:36

Indirect leak of 30 byte(s) in 5 object(s) allocated from:
    #0 0x71ab80a73668 in __interceptor_strdup asan_interceptors.cpp:439
    #1 0x5ac3e0af12d6 in fake_bytearray /tmp/test_clog_leak.c:9
    #2 0x5ac3e0af16d8 in main /tmp/test_clog_leak.c:37

Indirect leak of 30 byte(s) in 5 object(s) allocated from:
    #0 0x71ab80a73668 in __interceptor_strdup asan_interceptors.cpp:439
    #1 0x5ac3e0af12d6 in fake_bytearray /tmp/test_clog_leak.c:9
    #2 0x5ac3e0af16bb in main /tmp/test_clog_leak.c:36

SUMMARY: AddressSanitizer: 220 byte(s) leaked in 20 allocation(s).
```

All 20 leaked allocations come from the OLD code path. The NEW code path produces zero leaks.

### Why the leak may not reproduce on all compilers
GCC on x86-64 typically evaluates function arguments **right-to-left**, so `__head` happens to be read *after* the `casted_clog_bytearray` calls update it — masking the bug. The test above explicitly simulates left-to-right evaluation to guarantee reproduction. The original leak was observed with a different toolchain (clang in a meru-common build) that evaluated arguments left-to-right.

### Argument evaluation order demo
```c
// Proves GCC evaluates right-to-left on this platform:
//   modify(2) runs first, then modify(1), then __head is read last
//   so __head already has the updated value — no leak on GCC
#include <stdio.h>
struct param { struct param * next; };
static struct param * modify(struct param ** head, int id) {
    struct param * p = __builtin_malloc(sizeof(*p));
    p->next = *head; *head = p;
    printf("  modify(%d): *head = %p\n", id, (void*)*head);
    return p;
}
static void func(struct param * head, const char * fmt, ...) {
    printf("  func: head = %p\n", (void*)head);
    while (head) { struct param *n = head->next; __builtin_free(head); head = n; }
}
int main(void) {
    struct param * __head = 0;
    func(__head, "test", modify(&__head, 1), modify(&__head, 2));
    return 0;
}
```

Output on GCC 12 x86-64:
```
  modify(2): *head = 0x502000000010
  modify(1): *head = 0x502000000030
  func: head = 0x502000000030    <-- correct, no leak with gcc
```

On clang or other compilers that evaluate left-to-right, `func` would receive `head = (nil)` — causing the leak.

