### PR TITLE
forwarder: handle OOM/null paths in stream and connection callbacks

### DIFF
--- a/src/tools/forwarder/forwarder.cpp
+++ b/src/tools/forwarder/forwarder.cpp
@@ -66,6 +66,9 @@ struct ForwardedSend {
     static ForwardedSend* New(QUIC_STREAM_EVENT* Event) {
         if (BufferedMode) {
             auto SendContext = (ForwardedSend*)malloc(sizeof(ForwardedSend) + (size_t)Event->RECEIVE.TotalBufferLength);
+            if (!SendContext) {
+                return nullptr;
+            }
             SendContext->TotalLength = Event->RECEIVE.TotalBufferLength;
             SendContext->Buffers[0].Buffer = (uint8_t*)SendContext + sizeof(ForwardedSend);
             SendContext->Buffers[0].Length = 0;
@@ -79,6 +82,9 @@ struct ForwardedSend {
             return SendContext;
         }
         auto SendContext = new(std::nothrow) ForwardedSend;
+        if (!SendContext) {
+            return nullptr;
+        }
         SendContext->TotalLength = Event->RECEIVE.TotalBufferLength;
         for (uint32_t i = 0; i < Event->RECEIVE.BufferCount; ++i) {
             SendContext->Buffers[i].Length = Event->RECEIVE.Buffers[i].Length;
@@ -110,6 +116,9 @@ QUIC_STATUS StreamCallback(
             return QUIC_STATUS_SUCCESS;
         }
         auto SendContext = ForwardedSend::New(Event);
+        if (!SendContext) {
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
         QUIC_SEND_FLAGS Flags = QUIC_SEND_FLAG_START;
         if (Event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN)   { Flags |= QUIC_SEND_FLAG_FIN; }
         if (Event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_0_RTT) { Flags |= QUIC_SEND_FLAG_ALLOW_0_RTT; }
@@ -119,7 +128,11 @@ QUIC_STATUS StreamCallback(
             ForwardedSend::Delete(SendContext);
             return QUIC_STATUS_SUCCESS;
         }
-        CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(Status));
+        if (QUIC_FAILED(Status)) {
+            ForwardedSend::Delete(SendContext);
+            CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(Status));
+            return QUIC_STATUS_SUCCESS;
+        }
         return BufferedMode ? QUIC_STATUS_SUCCESS : QUIC_STATUS_PENDING;
     }
     case QUIC_STREAM_EVENT_SEND_COMPLETE: {
@@ -171,7 +184,16 @@ QUIC_STATUS ConnectionCallback(
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
         //printf("c[%p] Peer stream started\n", Connection);
         auto PeerStream = new(std::nothrow) MsQuicStream(*PeerConn, Event->PEER_STREAM_STARTED.Flags, CleanUpAutoDelete, StreamCallback);
+        if (!PeerStream) {
+            MsQuic->StreamClose(Event->PEER_STREAM_STARTED.Stream);
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
         auto LocalStream = new(std::nothrow) MsQuicStream(Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete, StreamCallback, PeerStream);
+        if (!LocalStream) {
+            delete PeerStream;
+            MsQuic->StreamClose(Event->PEER_STREAM_STARTED.Stream);
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
         PeerStream->Context = LocalStream;
         //printf("s[%p] Started -> [%p]\n", LocalStream, PeerStream);
         break;
@@ -194,7 +216,14 @@ QUIC_STATUS ListenerCallback(
 {
     if (Event->Type == QUIC_LISTENER_EVENT_NEW_CONNECTION) {
         auto BackEndConn = new(std::nothrow) MsQuicConnection(*Registration, CleanUpAutoDelete, ConnectionCallback);
+        if (!BackEndConn) {
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
         auto FrontEndConn = new(std::nothrow) MsQuicConnection(Event->NEW_CONNECTION.Connection, CleanUpAutoDelete, ConnectionCallback, BackEndConn);
+        if (!FrontEndConn) {
+            delete BackEndConn;
+            return QUIC_STATUS_OUT_OF_MEMORY;
+        }
         BackEndConn->Context = FrontEndConn;
         //printf("c[%p] Created -> [%p]\n", FrontEndConn, BackEndConn);
         CXPLAT_FRE_ASSERT(QUIC_SUCCEEDED(BackEndConn->Start(*BackEndConfiguration, BackEndTarget, BackEndPort)));


### PR DESCRIPTION
## Summary
- add missing null checks for `ForwardedSend` allocations in `StreamCallback`
- free `SendContext` before asserting on unexpected `StreamSend` failures to avoid leak-on-assert path
- guard `MsQuicStream` and `MsQuicConnection` allocations in forwarder callbacks
- close/release stream/connection resources on OOM paths

Fixes #5806

## Testing
- Not run in this environment (toolchain/build deps unavailable).
- Change is limited to low-risk OOM/error-path guards in `src/tools/forwarder/forwarder.cpp`.
