### PR TITLE
Add rust build link dependencies

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -95,13 +95,7 @@ fn cmake_build() {
             // These are excluded from the monolithic archive (via the inc/base_link
             // EXCLUDE_LIST in CMake) and must be linked explicitly by the consumer.
             for lib in [
-                "ws2_32",
-                "ntdll",
-                "bcrypt",
-                "ncrypt",
-                "crypt32",
-                "iphlpapi",
-                "advapi32",
+                "ws2_32", "ntdll", "bcrypt", "ncrypt", "crypt32", "iphlpapi", "advapi32",
                 "schannel",
             ] {
                 println!("cargo:rustc-link-lib={lib}");


### PR DESCRIPTION
## Description

Fixes the Rust CI failures

### AI diagnostic

  Root Cause: Accidental Transitive Dependency

  Cargo.lock is .gitignore'd, so every CI run resolves the latest compatible dependency versions. Between Mar 5 and Mar 6:

   1. socket2 updated 0.6.2 →
    0.6.3, which bumped windows-sys from 0.60.2 → 0.61.2
   2. windows-sys
    0.60.x depended on windows_x86_64_msvc — a crate that ships actual .lib import library files (advapi32.lib, crypt32.lib, iphlpapi.lib, etc.) and makes them available to the linker
   3. windows-sys
    0.61.x switched to windows-link with raw-dylib, which generates import stubs inline — dropping windows_x86_64_msvc entirely
   4. The msquic build.rs never declared its Windows system library dependencies — they were accidentally satisfied by windows_x86_64_msvc's import libraries being on the linker search path
   5. With that crate gone, msquic.lib's references to advapi32, crypt32, etc. became unresolved


## Testing

CI

## Documentation

N/A
