### PR TITLE
Remove user32 linker dependency from Rust build

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -100,7 +100,6 @@ fn cmake_build() {
             ] {
                 println!("cargo:rustc-link-lib={lib}");
             }
-
         }
     }
 }


### PR DESCRIPTION
## Description

Removed unused linker dependency

## Testing

CI

## Documentation

N/A
