### PR TITLE
Fix overlapping recv buffer writes overwriting existing data

### DIFF
--- a/src/core/recv_buffer.c
+++ b/src/core/recv_buffer.c
@@ -597,6 +597,10 @@ QuicRecvBufferCopyIntoChunks(
         WriteBuffer += Diff;
     }
 
+    if (WriteLength == 0) {
+        return;
+    }
+
     const uint64_t RelativeOffset = WriteOffset - RecvBuffer->BaseOffset;
 
     //
@@ -611,10 +615,17 @@ QuicRecvBufferCopyIntoChunks(
         WriteLength -= (uint16_t)CopyLength;
     }
     CXPLAT_DBG_ASSERT(WriteLength == 0); // Should always have enough room to copy everything
+}
 
-    //
-    // Update the amount of data readable in the first chunk.
-    //
+//
+// Updates ReadLength based on the current state of WrittenRanges.
+//
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicRecvBufferUpdateReadLength(
+    _In_ QUIC_RECV_BUFFER* RecvBuffer
+    )
+{
     QUIC_SUBRANGE* FirstRange = QuicRangeGet(&RecvBuffer->WrittenRanges, 0);
     if (FirstRange->Low == 0) {
         RecvBuffer->ReadLength = (uint32_t)CXPLAT_MIN(
@@ -712,6 +723,51 @@ QuicRecvBufferWrite(
     }
 
     //
+    // Copy only NEW bytes (not already in WrittenRanges) to avoid overwriting
+    // previously received data. Walk the existing written ranges to find gaps
+    // within [WriteOffset, WriteOffset+WriteLength), and copy only those gaps.
+    // This must happen before QuicRangeAddRange modifies the ranges.
+    //
+    {
+        uint64_t GapStart = WriteOffset;
+        const uint64_t WriteEnd = (uint64_t)WriteOffset + WriteLength;
+
+        for (uint32_t idx = 0;
+             idx < QuicRangeSize(&RecvBuffer->WrittenRanges) && GapStart < WriteEnd;
+             idx++) {
+            QUIC_SUBRANGE* Sub = QuicRangeGet(&RecvBuffer->WrittenRanges, idx);
+            uint64_t SubEnd = Sub->Low + Sub->Count;
+
+            if (SubEnd <= GapStart) continue; // Before current position
+            if (Sub->Low >= WriteEnd) break;  // Past write region
+
+            //
+            // Copy the gap before this existing subrange.
+            //
+            if (GapStart < Sub->Low) {
+                uint64_t GapEnd = CXPLAT_MIN(Sub->Low, WriteEnd);
+                QuicRecvBufferCopyIntoChunks(
+                    RecvBuffer,
+                    GapStart,
+                    (uint16_t)(GapEnd - GapStart),
+                    WriteBuffer + (GapStart - WriteOffset));
+            }
+            GapStart = SubEnd;
+        }
+
+        //
+        // Copy any remaining gap after all overlapping subranges.
+        //
+        if (GapStart < WriteEnd) {
+            QuicRecvBufferCopyIntoChunks(
+                RecvBuffer,
+                GapStart,
+                (uint16_t)(WriteEnd - GapStart),
+                WriteBuffer + (GapStart - WriteOffset));
+        }
+    }
+
+    //
     // Set the write offset/length as a valid written range.
     //
     BOOLEAN WrittenRangesUpdated;
@@ -742,9 +798,9 @@ QuicRecvBufferWrite(
     *NewDataReady = UpdatedRange->Low == 0;
 
     //
-    // Write the data into the chunks now that everything has been validated.
+    // Update ReadLength now that WrittenRanges has been updated.
     //
-    QuicRecvBufferCopyIntoChunks(RecvBuffer, WriteOffset, WriteLength, WriteBuffer);
+    QuicRecvBufferUpdateReadLength(RecvBuffer);
 
     QuicRecvBufferValidate(RecvBuffer);
     return QUIC_STATUS_SUCCESS;

--- a/src/core/unittest/RecvBufferTest.cpp
+++ b/src/core/unittest/RecvBufferTest.cpp
@@ -159,6 +159,32 @@ struct RecvBuffer {
         Dump();
         return Status;
     }
+    QUIC_STATUS WriteRaw(
+        _In_ uint64_t WriteOffset,
+        _In_ uint16_t WriteLength,
+        _In_reads_bytes_(WriteLength) const uint8_t* Buffer,
+        _Inout_ uint64_t* WriteQuota,
+        _Out_ BOOLEAN* NewDataReady
+        ) {
+        printf("WriteRaw: Offset=%llu, Length=%u\n", (unsigned long long)WriteOffset, WriteLength);
+        uint64_t SizeNeeded = 0;
+        uint64_t QuotaConsumed = 0;
+        auto Status =
+            QuicRecvBufferWrite(
+                &RecvBuf,
+                WriteOffset,
+                WriteLength,
+                Buffer,
+                *WriteQuota,
+                &QuotaConsumed,
+                NewDataReady,
+                &SizeNeeded);
+        if (QUIC_SUCCEEDED(Status)) {
+            *WriteQuota = QuotaConsumed;
+        }
+        Dump();
+        return Status;
+    }
     void Read(
         _Out_ uint64_t* BufferOffset,
         _Inout_ uint32_t* BufferCount,
@@ -482,6 +508,141 @@ TEST_P(WithMode, OverwritePartial)
     ASSERT_TRUE(RecvBuf.HasUnreadData());
     ASSERT_EQ(5ull, InOutWriteLength); // Only 5 newly written bytes
     ASSERT_EQ(35ull, RecvBuf.GetTotalLength());
+}
+
+TEST_P(WithMode, OverlapDoesNotOverwriteExistingData)
+{
+    RecvBuffer RecvBuf;
+    ASSERT_EQ(QUIC_STATUS_SUCCESS, RecvBuf.Initialize(GetParam()));
+    uint64_t InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    BOOLEAN NewDataReady = FALSE;
+
+    //
+    // Write 30 bytes at offset 0 with standard pattern (byte[i] = i).
+    //
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(0, 30, &InOutWriteLength, &NewDataReady));
+    ASSERT_TRUE(NewDataReady);
+
+    //
+    // Write 20 bytes at offset 20 with different data (all 0xFF).
+    // Overlapping region [20,30) should NOT be overwritten.
+    // New region [30,40) should be written with 0xFF.
+    //
+    uint8_t OverlapBuffer[20];
+    memset(OverlapBuffer, 0xFF, sizeof(OverlapBuffer));
+    InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.WriteRaw(20, 20, OverlapBuffer, &InOutWriteLength, &NewDataReady));
+    ASSERT_TRUE(NewDataReady);
+    ASSERT_EQ(10ull, InOutWriteLength); // Only 10 new bytes [30,40)
+    ASSERT_EQ(40ull, RecvBuf.GetTotalLength());
+
+    //
+    // Read and validate byte-by-byte.
+    //
+    uint64_t ReadOffset;
+    QUIC_BUFFER ReadBuffers[3];
+    uint32_t BufferCount = ARRAYSIZE(ReadBuffers);
+    QuicRecvBufferRead(&RecvBuf.RecvBuf, &ReadOffset, &BufferCount, ReadBuffers);
+    ASSERT_EQ(0ull, ReadOffset);
+
+    uint32_t ByteIdx = 0;
+    for (uint32_t b = 0; b < BufferCount; ++b) {
+        for (uint32_t i = 0; i < ReadBuffers[b].Length; ++i) {
+            if (ByteIdx < 30) {
+                //
+                // Original data [0,30) must be preserved (byte[i] = i).
+                //
+                ASSERT_EQ((uint8_t)ByteIdx, ReadBuffers[b].Buffer[i])
+                    << "Byte at offset " << ByteIdx << " was overwritten";
+            } else {
+                //
+                // New data [30,40) should be 0xFF from second write.
+                //
+                ASSERT_EQ(0xFF, ReadBuffers[b].Buffer[i])
+                    << "Byte at offset " << ByteIdx << " should be 0xFF";
+            }
+            ByteIdx++;
+        }
+    }
+    ASSERT_EQ(40u, ByteIdx);
+}
+
+TEST_P(WithMode, OverlapFillGapPreservesExistingData)
+{
+    RecvBuffer RecvBuf;
+    ASSERT_EQ(QUIC_STATUS_SUCCESS, RecvBuf.Initialize(GetParam()));
+    uint64_t InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    BOOLEAN NewDataReady = FALSE;
+
+    //
+    // Write [0,10) with standard pattern (byte[i] = i).
+    //
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(0, 10, &InOutWriteLength, &NewDataReady));
+    ASSERT_TRUE(NewDataReady);
+
+    //
+    // Write [20,30) with standard pattern (byte[i] = i).
+    //
+    InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.Write(20, 10, &InOutWriteLength, &NewDataReady));
+    ASSERT_FALSE(NewDataReady); // Gap at [10,20), not contiguous from 0
+
+    //
+    // Write [5,25) with all 0xFF. This fills the gap [10,20) and overlaps
+    // with [5,10) and [20,25). Only the gap [10,20) should be written.
+    //
+    uint8_t OverlapBuffer[20];
+    memset(OverlapBuffer, 0xFF, sizeof(OverlapBuffer));
+    InOutWriteLength = DEF_TEST_BUFFER_LENGTH;
+    ASSERT_EQ(
+        QUIC_STATUS_SUCCESS,
+        RecvBuf.WriteRaw(5, 20, OverlapBuffer, &InOutWriteLength, &NewDataReady));
+    ASSERT_TRUE(NewDataReady); // Now contiguous [0,30)
+    ASSERT_EQ(30ull, RecvBuf.GetTotalLength());
+
+    //
+    // Read and validate byte-by-byte.
+    //
+    uint64_t ReadOffset;
+    QUIC_BUFFER ReadBuffers[3];
+    uint32_t BufferCount = ARRAYSIZE(ReadBuffers);
+    QuicRecvBufferRead(&RecvBuf.RecvBuf, &ReadOffset, &BufferCount, ReadBuffers);
+    ASSERT_EQ(0ull, ReadOffset);
+
+    uint32_t ByteIdx = 0;
+    for (uint32_t b = 0; b < BufferCount; ++b) {
+        for (uint32_t i = 0; i < ReadBuffers[b].Length; ++i) {
+            if (ByteIdx < 10) {
+                //
+                // Original [0,10) preserved.
+                //
+                ASSERT_EQ((uint8_t)ByteIdx, ReadBuffers[b].Buffer[i])
+                    << "Byte at offset " << ByteIdx << " was overwritten";
+            } else if (ByteIdx < 20) {
+                //
+                // Gap [10,20) filled with 0xFF from third write.
+                //
+                ASSERT_EQ(0xFF, ReadBuffers[b].Buffer[i])
+                    << "Byte at offset " << ByteIdx << " should be 0xFF (gap fill)";
+            } else {
+                //
+                // Original [20,30) preserved.
+                //
+                ASSERT_EQ((uint8_t)ByteIdx, ReadBuffers[b].Buffer[i])
+                    << "Byte at offset " << ByteIdx << " was overwritten";
+            }
+            ByteIdx++;
+        }
+    }
+    ASSERT_EQ(30u, ByteIdx);
 }
 
 TEST_P(WithMode, WriteTooMuch)


### PR DESCRIPTION
## Summary

Fixes #5824 - Overlapping CRYPTO frames overwrite previously received data.

## Problem

When `QuicRecvBufferWrite` receives data that partially overlaps with already-received bytes, it copies the **entire** write range into the buffer, overwriting previously received data. While full duplicates are correctly handled (`WrittenRangesUpdated == FALSE` -> early return), partial overlaps blindly copy all bytes, including the overlapping portion.

**Example:** If bytes [0,100) are received, then a retransmission covering [50,150) arrives, bytes [50,100) are overwritten.

## Fix

Before calling `QuicRangeAddRange`, the code now walks the existing `WrittenRanges` to identify **gap segments** (not-yet-written bytes) within the write region, and copies only those gaps. Already-received data is never overwritten.

Also refactors `QuicRecvBufferCopyIntoChunks` to separate the raw byte copy from the `ReadLength` update, since the copy now happens before `WrittenRanges` is updated while `ReadLength` must be updated after.

## Testing

Adds two new parametric tests across all 4 recv buffer modes (SINGLE, CIRCULAR, MULTIPLE, APP_OWNED):

- **OverlapDoesNotOverwriteExistingData** - writes 30 bytes, then overlapping 20 bytes with different content; verifies original data is preserved.
- **OverlapFillGapPreservesExistingData** - creates a gap between two ranges, fills it with an overlapping write; verifies both original ranges are preserved and only the gap is filled.

All 108 RecvBuffer unit tests pass.