### PR TITLE
Fix SAL annotation placement on function templates

### DIFF
--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -389,8 +389,8 @@ const uint64_t SizeMult[] = { 1000 * 1000 * 1000, 1000 * 1000, 1000, 1 };
 const char* CountUnits[] = { "cpu" };
 uint64_t CountMult[] = { 1 };
 
-_Success_(return != false)
 template <typename T>
+_Success_(return != false)
 bool
 TryGetVariableUnitValue(
     _In_ int argc,
@@ -448,8 +448,8 @@ TryGetVariableUnitValue(
     return true;
 }
 
-_Success_(return != false)
 template <typename T>
+_Success_(return != false)
 bool
 TryGetVariableUnitValue(
     _In_ int argc,
@@ -466,8 +466,8 @@ TryGetVariableUnitValue(
 /// <summary>
 /// Explicit template instantiation
 /// </summary>
-_Success_(return != false)
 template
+_Success_(return != false)
 bool
 TryGetVariableUnitValue<uint32_t>(
     _In_ int argc,
@@ -477,8 +477,8 @@ TryGetVariableUnitValue<uint32_t>(
     _Out_opt_ bool* isTimed
     );
 
-_Success_(return != false)
 template
+_Success_(return != false)
 bool
 TryGetVariableUnitValue<uint64_t>(
     _In_ int argc,

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -343,8 +343,8 @@ void QuicTestValidateConfiguration()
 
 namespace
 {
-    _Function_class_(QUIC_LISTENER_CALLBACK)
     template<typename T>
+    _Function_class_(QUIC_LISTENER_CALLBACK)
     QUIC_STATUS
     QUIC_API
     DummyListenerCallback(


### PR DESCRIPTION
## Description
SAL annotations (`_Success_`, `_Function_class_`) placed before the `template` keyword cause MSVC compilation errors (C2059) when TVS / static analysis is enabled. The `template` head must always come first; annotations go between it and the return type.

Fixed 5 occurrences:
- `src/perf/lib/SecNetPerfMain.cpp`: 4 instances of `_Success_` before `template`  
- `src/test/lib/ApiTest.cpp`: 1 instance of `_Function_class_` before `template`  

## Testing
Existing tests cover this change. No new tests needed — this is a compilation fix only (no behavioral change).

## Documentation
No documentation impact.