### PR TITLE
[CP] Fix SAL annotation placement on function templates (#5895)

### DIFF
--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -339,8 +339,8 @@ void QuicTestValidateConfiguration()
 
 namespace
 {
-    _Function_class_(QUIC_LISTENER_CALLBACK)
     template<typename T>
+    _Function_class_(QUIC_LISTENER_CALLBACK)
     QUIC_STATUS
     QUIC_API
     DummyListenerCallback(


### PR DESCRIPTION
Cherry-pick of #5895

## Description
SAL annotations (`_Success_`, `_Function_class_`) placed before the `template` keyword cause MSVC compilation errors (C2059) when TVS / static analysis is enabled. The `template` head must always come first; annotations go between it and the return type.

Fixed 5 occurrences:
- `src/perf/lib/SecNetPerfMain.cpp`: 4 instances of `_Success_` before `template`  
- `src/test/lib/ApiTest.cpp`: 1 instance of `_Function_class_` before `template`  

## Testing
Existing tests cover this change. No new tests needed — this is a compilation fix only (no behavioral change).

## Documentation
No documentation impact.