### PR TITLE
Fix client Initial key discard to trigger on any Handshake packet send

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -941,16 +941,6 @@ QuicCryptoWriteFrames(
         return TRUE;
     }
 
-    if (QuicConnIsClient(Connection) &&
-        Builder->Key == Crypto->TlsState.WriteKeys[QUIC_PACKET_KEY_HANDSHAKE]) {
-        CXPLAT_DBG_ASSERT(Builder->Key);
-        //
-        // Per spec, client MUST discard Initial keys when it starts
-        // encrypting packets with handshake keys.
-        //
-        QuicCryptoDiscardKeys(Crypto, QUIC_PACKET_KEY_INITIAL);
-    }
-
     uint8_t PrevFrameCount = Builder->Metadata->FrameCount;
 
     uint16_t AvailableBufferLength =

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -997,6 +997,18 @@ QuicPacketBuilderFinalize(
         Builder->Path,
         Builder->Metadata);
 
+    //
+    // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it first
+    // sends a Handshake packet. This fires on ANY Handshake packet (including
+    // ACK-only) so that Initial bytes in flight are released from congestion
+    // control. The next iteration of the send loop will then have CC allowance
+    // to write the CRYPTO frame with the TLS Finished.
+    //
+    if (QuicConnIsClient(Connection) &&
+        Builder->Key->Type == QUIC_PACKET_KEY_HANDSHAKE) {
+        QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
+    }
+
     Builder->Metadata->FrameCount = 0;
 
     if (Builder->Metadata->Flags.IsAckEliciting) {

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -999,10 +999,9 @@ QuicPacketBuilderFinalize(
 
     //
     // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it first
-    // sends a Handshake packet. This fires on ANY Handshake packet (including
-    // ACK-only) so that Initial bytes in flight are released from congestion
-    // control. The next iteration of the send loop will then have CC allowance
-    // to write the CRYPTO frame with the TLS Finished.
+    // sends a Handshake packet. It must be done on ANY Handshake packet, to
+    // ensure the congestion control state is cleared and Initial bytes in flight
+    // are not limiting Handshake packets.
     //
     if (QuicConnIsClient(Connection) &&
         Builder->Key->Type == QUIC_PACKET_KEY_HANDSHAKE) {

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -3322,10 +3322,8 @@ more_handshake:
 Exit:
 
     //
-    // Set buffer offsets unconditionally (not gated on !ERROR) because write
-    // keys may be installed asynchronously via the secrets callback before
-    // this exit code runs. On error, the connection is torn down before
-    // these offsets are consumed.
+    // Always set buffer offsets if keys have been installed to preserve code invariants.
+    // On error, the connection will be torn down anyway.
     //
     if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
         State->BufferOffsetHandshake == 0) {

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -3321,25 +3321,29 @@ more_handshake:
 
 Exit:
 
-    if (!(TlsContext->ResultFlags & CXPLAT_TLS_RESULT_ERROR)) {
-        if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
-            State->BufferOffsetHandshake == 0) {
-            State->BufferOffsetHandshake = State->BufferTotalLength;
-            QuicTraceLogConnInfo(
-                OpenSslHandshakeDataStart,
-                TlsContext->Connection,
-                "Writing Handshake data starts at %u",
-                State->BufferOffsetHandshake);
-        }
-        if (State->WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL &&
-            State->BufferOffset1Rtt == 0) {
-            State->BufferOffset1Rtt = State->BufferTotalLength;
-            QuicTraceLogConnInfo(
-                OpenSsl1RttDataStart,
-                TlsContext->Connection,
-                "Writing 1-RTT data starts at %u",
-                State->BufferOffset1Rtt);
-        }
+    //
+    // Set buffer offsets unconditionally (not gated on !ERROR) because write
+    // keys may be installed asynchronously via the secrets callback before
+    // this exit code runs. On error, the connection is torn down before
+    // these offsets are consumed.
+    //
+    if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
+        State->BufferOffsetHandshake == 0) {
+        State->BufferOffsetHandshake = State->BufferTotalLength;
+        QuicTraceLogConnInfo(
+            OpenSslHandshakeDataStart,
+            TlsContext->Connection,
+            "Writing Handshake data starts at %u",
+            State->BufferOffsetHandshake);
+    }
+    if (State->WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL &&
+        State->BufferOffset1Rtt == 0) {
+        State->BufferOffset1Rtt = State->BufferTotalLength;
+        QuicTraceLogConnInfo(
+            OpenSsl1RttDataStart,
+            TlsContext->Connection,
+            "Writing 1-RTT data starts at %u",
+            State->BufferOffset1Rtt);
     }
 
     return TlsContext->ResultFlags;

--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -2145,25 +2145,29 @@ CxPlatTlsProcessData(
 
 Exit:
 
-    if (!(TlsContext->ResultFlags & CXPLAT_TLS_RESULT_ERROR)) {
-        if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
-            State->BufferOffsetHandshake == 0) {
-            State->BufferOffsetHandshake = State->BufferTotalLength;
-            QuicTraceLogConnInfo(
-                OpenSslHandshakeDataStart,
-                TlsContext->Connection,
-                "Writing Handshake data starts at %u",
-                State->BufferOffsetHandshake);
-        }
-        if (State->WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL &&
-            State->BufferOffset1Rtt == 0) {
-            State->BufferOffset1Rtt = State->BufferTotalLength;
-            QuicTraceLogConnInfo(
-                OpenSsl1RttDataStart,
-                TlsContext->Connection,
-                "Writing 1-RTT data starts at %u",
-                State->BufferOffset1Rtt);
-        }
+    //
+    // Set buffer offsets unconditionally (not gated on !ERROR) because write
+    // keys may be installed asynchronously via the secrets callback before
+    // this exit code runs. On error, the connection is torn down before
+    // these offsets are consumed.
+    //
+    if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
+        State->BufferOffsetHandshake == 0) {
+        State->BufferOffsetHandshake = State->BufferTotalLength;
+        QuicTraceLogConnInfo(
+            OpenSslHandshakeDataStart,
+            TlsContext->Connection,
+            "Writing Handshake data starts at %u",
+            State->BufferOffsetHandshake);
+    }
+    if (State->WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL &&
+        State->BufferOffset1Rtt == 0) {
+        State->BufferOffset1Rtt = State->BufferTotalLength;
+        QuicTraceLogConnInfo(
+            OpenSsl1RttDataStart,
+            TlsContext->Connection,
+            "Writing 1-RTT data starts at %u",
+            State->BufferOffset1Rtt);
     }
 
     return TlsContext->ResultFlags;

--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -2146,10 +2146,8 @@ CxPlatTlsProcessData(
 Exit:
 
     //
-    // Set buffer offsets unconditionally (not gated on !ERROR) because write
-    // keys may be installed asynchronously via the secrets callback before
-    // this exit code runs. On error, the connection is torn down before
-    // these offsets are consumed.
+    // Always set buffer offsets if keys have been installed to preserve code invariants.
+    // On error, the connection will be torn down anyway.
     //
     if (State->WriteKeys[QUIC_PACKET_KEY_HANDSHAKE] != NULL &&
         State->BufferOffsetHandshake == 0) {


### PR DESCRIPTION
## Description

Fixes #5664, #5899

Fix a circular dependency in client Initial key discard that causes RandomLoss handshake test failures.

**Root cause**: Per RFC 9001 §4.9.1, a client MUST discard Initial keys and clear the congestion control and recovery states when it first sends a Handshake packet. MsQuic only discarded Initial keys inside `QuicCryptoWriteFrames` — which only runs when writing CRYPTO frames to a HANDSHAKE packet, not for every HANDSHAKE packet.

If the INITIAL data is big and there is packet loss on the network, it is possible for that the number of INITIAL bytes in flight from the client perspective is higher than the congestion window.
When the client receives the server's Handshake flight and TLS produces the Finished message, the send path tries to flush it as a HANDSHAKE CRYPTO frame. However, CRYPTO frames are subject to congestion control (per RFC 9002 §3 — only ACK and CONNECTION_CLOSE bypass CC).
This result in a HANDSHAKE packet containing only an ACK frame (which bypasses CC) — but no CRYPTO frame carrying the Finished.

This creates a deadlock:
- The client can't send the CRYPTO frame that would cause it to discard the INTIAL packet pending retransmission
- The server received a HANDSHAKE packet and drop every retransmitted INTIAL packet from the client

Eventually, the connection times out.

**Fix**: Move the client Initial key discard from `QuicCryptoWriteFrames` (crypto.c) to `QuicPacketBuilderFinalize` (packet_builder.c), so it triggers on ANY Handshake packet send (including ACK-only). This breaks the circular dependency: the ACK-only HANDSHAKE packet triggers the discard → Initial BytesInFlight released → CC unblocks → queued flush sends the Finished.

## Testing

Existing tests cover this change — all 353 Handshake tests pass (including all RandomLoss and HandshakeSpecificLossPatterns variants), plus 1,328 Basic/Misc/Api tests.

## Documentation

No documentation impact.