### PR TITLE
[Mirror #15203488] Bump ubuntu from `ce4a593` to `5e5b128` in /.docker/ubuntu-22.04

### DIFF
--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM ubuntu:22.04@sha256:ce4a593b4e323dcc3dd728e397e0a866a1bf516a1b7c31d6aa06991baec4f2e0 AS base
+FROM ubuntu:22.04@sha256:5e5b128eb4ff35ee52687c20d081dcc15b8cb55e113247683f435224fc58b956 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/microsoft/msquic
 


### PR DESCRIPTION
Mirrored from internal ADO PR #15203488 by Dependabot

Internal PR: https://dev.azure.com/microsoft/undock/_git/msquic/pullrequest/15203488