### PR TITLE
 Fix Linux XDP Debug BVT runner crash by adding swap space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,11 +189,14 @@ jobs:
     - name: Configure swap space
       if: matrix.vec.plat == 'linux' && matrix.vec.xdp == '-UseXdp'
       run: |
-        sudo fallocate -l 4G /swapfile
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile
-        echo "Swap enabled:"
+        sudo swapoff -a || true
+        sudo rm -f /swapfile /mnt/swapfile || true
+        sudo fallocate -l 6G /mnt/swapfile
+        sudo chmod 600 /mnt/swapfile
+        sudo mkswap /mnt/swapfile
+        sudo swapon /mnt/swapfile
+        echo "Swap configured:"
+        free -h
         swapon --show
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForTest ${{ matrix.vec.xdp }}


### PR DESCRIPTION
## Description

 The BVT (Debug, linux, ubuntu-24.04, x64, quictls, -UseSystemOpenSSLCrypto, -Test, -UseXdp) job consistently 
crashes the GitHub Actions runner at ~72 minutes — test step logs return HTTP 404 and cleanup steps never run. 
The Release variant of the same matrix passes reliably.
 
 Root cause: OOM. GitHub-hosted runners have 7 GB RAM. The Debug + XDP combination exhausts this due to:
 - Unoptimized Debug binaries (larger memory footprint)
 - XDP UMEM allocations (16K frames of pinned kernel memory per AF_XDP socket)
 - Parallel test execution under sudo
 
 When the Linux OOM-killer fires, it can kill the runner agent itself (not just the test process), causing the 
full runner disconnect.
 
 This adds a 6 GB swap file on Linux XDP runners before tests run, giving ~13 GB total virtual memory. The swap 
file is on the runner's ephemeral SSD so performance impact is minimal. Only Linux XDP matrices are affected — 
all other jobs are unchanged.

## Testing

CI 

## Documentation

No
