### PR TITLE
Enable io_uring on aarch64

### DIFF
--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -538,7 +538,7 @@ QuicAddrToString(
 //
 // TODO: build on other 64-bit architectures
 //
-#if CXPLAT_USE_IO_URING && defined(__x86_64__) // liburing
+#if CXPLAT_USE_IO_URING && (defined(__x86_64__) || defined(__aarch64__)) // liburing
 #define LIBURING_INTERNAL
 
 #if defined(__cplusplus)


### PR DESCRIPTION
`io_uring` support is currently gated behind `__x86_64__` in `src/inc/msquic_posix.h`:

```c
//
// TODO: build on other 64-bit architectures
//
#if CXPLAT_USE_IO_URING && defined(__x86_64__) // liburing
```

`io_uring` is a Linux kernel feature (available since 5.1) that is architecture-independent. It works on all 64-bit architectures including `aarch64`. The TODO comment in the code already acknowledges this is a placeholder.

### Change

```diff
-#if CXPLAT_USE_IO_URING && defined(__x86_64__) // liburing
+#if CXPLAT_USE_IO_URING && (defined(__x86_64__) || defined(__aarch64__)) // liburing
```

### Testing

No new tests needed — this removes an architecture guard so existing io_uring code paths now compile and run on aarch64. Validated in production on Azure Cobalt 100 (AKS) with `-DQUIC_LINUX_IOURING_ENABLED=on`.


Fixes #5933 