### PR TITLE
core/binding: fix 'recieve' typo in comment

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -932,7 +932,7 @@ QuicBindingProcessStatelessOperation(
 
         if (PacketLength >= RecvPacket->AvailBufferLength) {
             //
-            // Can't go over the recieve packet's length.
+            // Can't go over the receive packet's length.
             //
             PacketLength = (uint8_t)RecvPacket->AvailBufferLength - 1;
         }


### PR DESCRIPTION
## Description

Comment in `src/core/binding.c` line 935 reads:
```c
// Can't go over the recieve packet's length.
```
Fixed spelling to `receive`. Comment-only change — no code or behavior change.

## Testing
N/A — comment-only fix.