### PR TITLE
fix(retry): ensure Retry Source CID differs from client DCID

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -995,9 +995,18 @@ QuicBindingProcessStatelessOperation(
             goto Exit;
         }
 
+        const uint8_t CidTotalLength = MsQuicLib.CidTotalLength;
         uint8_t NewDestCid[QUIC_CID_MAX_LENGTH];
-        CXPLAT_DBG_ASSERT(sizeof(NewDestCid) >= MsQuicLib.CidTotalLength);
-        CxPlatRandom(sizeof(NewDestCid), NewDestCid);
+        CXPLAT_DBG_ASSERT(sizeof(NewDestCid) >= CidTotalLength);
+        //
+        // RFC 9000 sec. 17.2.5.1: "This value MUST NOT be equal to the
+        // Destination Connection ID field of the packet sent by the client."
+        // Regenerate until the new Source CID differs from the client's DCID.
+        //
+        do {
+            CxPlatRandom(CidTotalLength, NewDestCid);
+        } while (RecvPacket->DestCidLen == CidTotalLength &&
+                 memcmp(NewDestCid, RecvPacket->DestCid, CidTotalLength) == 0);
 
         QUIC_TOKEN_CONTENTS Token = { 0 };
         Token.Authenticated.Timestamp = (uint64_t)CxPlatTimeEpochMs64();
@@ -1008,14 +1017,14 @@ QuicBindingProcessStatelessOperation(
         Token.Encrypted.OrigConnIdLength = RecvPacket->DestCidLen;
 
         uint8_t Iv[CXPLAT_MAX_IV_LENGTH];
-        if (MsQuicLib.CidTotalLength >= CXPLAT_IV_LENGTH) {
+        if (CidTotalLength >= CXPLAT_IV_LENGTH) {
             CxPlatCopyMemory(Iv, NewDestCid, CXPLAT_IV_LENGTH);
-            for (uint8_t i = CXPLAT_IV_LENGTH; i < MsQuicLib.CidTotalLength; ++i) {
+            for (uint8_t i = CXPLAT_IV_LENGTH; i < CidTotalLength; ++i) {
                 Iv[i % CXPLAT_IV_LENGTH] ^= NewDestCid[i];
             }
         } else {
             CxPlatZeroMemory(Iv, CXPLAT_IV_LENGTH);
-            CxPlatCopyMemory(Iv, NewDestCid, MsQuicLib.CidTotalLength);
+            CxPlatCopyMemory(Iv, NewDestCid, CidTotalLength);
         }
 
         CxPlatDispatchLockAcquire(&Partition->StatelessRetryKeysLock);
@@ -1043,7 +1052,7 @@ QuicBindingProcessStatelessOperation(
             QuicPacketEncodeRetryV1(
                 RecvPacket->LH->Version,
                 RecvPacket->SourceCid, RecvPacket->SourceCidLen,
-                NewDestCid, MsQuicLib.CidTotalLength,
+                NewDestCid, CidTotalLength,
                 RecvPacket->DestCid, RecvPacket->DestCidLen,
                 sizeof(Token),
                 (uint8_t*)&Token,
@@ -1059,7 +1068,7 @@ QuicBindingProcessStatelessOperation(
             "[S][TX][-] LH Ver:0x%x DestCid:%s SrcCid:%s Type:R OrigDestCid:%s (Token %hu bytes)",
             RecvPacket->LH->Version,
             QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer,
-            QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer,
+            QuicCidBufToStr(NewDestCid, CidTotalLength).Buffer,
             QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer,
             (uint16_t)sizeof(Token));
 

--- a/src/generated/linux/binding.c.clog.h
+++ b/src/generated/linux/binding.c.clog.h
@@ -96,12 +96,12 @@ tracepoint(CLOG_BINDING_C, PacketTxStatelessReset , arg2);\
             "[S][TX][-] LH Ver:0x%x DestCid:%s SrcCid:%s Type:R OrigDestCid:%s (Token %hu bytes)",
             RecvPacket->LH->Version,
             QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer,
-            QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer,
+            QuicCidBufToStr(NewDestCid, CidTotalLength).Buffer,
             QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer,
             (uint16_t)sizeof(Token));
 // arg2 = arg2 = RecvPacket->LH->Version = arg2
 // arg3 = arg3 = QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer = arg3
-// arg4 = arg4 = QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer = arg4
+// arg4 = arg4 = QuicCidBufToStr(NewDestCid, CidTotalLength).Buffer = arg4
 // arg5 = arg5 = QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer = arg5
 // arg6 = arg6 = (uint16_t)sizeof(Token) = arg6
 ----------------------------------------------------------*/

--- a/src/generated/linux/binding.c.clog.h.lttng.h
+++ b/src/generated/linux/binding.c.clog.h.lttng.h
@@ -72,12 +72,12 @@ TRACEPOINT_EVENT(CLOG_BINDING_C, PacketTxStatelessReset,
             "[S][TX][-] LH Ver:0x%x DestCid:%s SrcCid:%s Type:R OrigDestCid:%s (Token %hu bytes)",
             RecvPacket->LH->Version,
             QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer,
-            QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer,
+            QuicCidBufToStr(NewDestCid, CidTotalLength).Buffer,
             QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer,
             (uint16_t)sizeof(Token));
 // arg2 = arg2 = RecvPacket->LH->Version = arg2
 // arg3 = arg3 = QuicCidBufToStr(RecvPacket->SourceCid, RecvPacket->SourceCidLen).Buffer = arg3
-// arg4 = arg4 = QuicCidBufToStr(NewDestCid, MsQuicLib.CidTotalLength).Buffer = arg4
+// arg4 = arg4 = QuicCidBufToStr(NewDestCid, CidTotalLength).Buffer = arg4
 // arg5 = arg5 = QuicCidBufToStr(RecvPacket->DestCid, RecvPacket->DestCidLen).Buffer = arg5
 // arg6 = arg6 = (uint16_t)sizeof(Token) = arg6
 ----------------------------------------------------------*/


### PR DESCRIPTION
Fixes #5302

## Problem

When generating a Retry packet, `CxPlatRandom` produces a random Source Connection ID but does not check that it differs from the client's Destination CID. RFC 9000 §17.2.5.1 requires that the Source Connection ID in a Retry packet MUST NOT equal the Destination Connection ID sent by the client.

While a collision is astronomically unlikely, the check is required for RFC compliance.

## Fix

Wrapped the `CxPlatRandom` call in a do-while loop that regenerates if the new CID matches the client's DCID:

```c
do {
    CxPlatRandom(MsQuicLib.CidTotalLength, NewDestCid);
} while (RecvPacket->DestCidLen == MsQuicLib.CidTotalLength &&
         memcmp(NewDestCid, RecvPacket->DestCid, MsQuicLib.CidTotalLength) == 0);
```

The length guard is load-bearing — the client DCID length is client-controlled and can legitimately differ from `CidTotalLength`, so skipping it would risk comparing against a shorter buffer.

This also fixes a minor issue in the original: `CxPlatRandom` was called with `sizeof(NewDestCid)` which randomizes the full `QUIC_CID_MAX_LENGTH` buffer, but only `MsQuicLib.CidTotalLength` bytes are ever used downstream. The fix randomizes only the bytes that matter.