### PR TITLE
Fix RebindPortPadded test: port collision with server

### DIFF
--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -719,13 +719,18 @@ QuicTestNatPortRebind(
     TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(OrigLocalAddr));
     ReplaceAddressHelper AddrHelper(OrigLocalAddr.SockAddr);
 
-    AddrHelper.IncrementPort();
+    // Skip the port if it collides with the server's port,
+    // the ReplaceAddressHelper can't simulate a NAT rebind in that case.
+    do {
+        AddrHelper.IncrementPort();
+    } while (QuicAddrGetPort(&AddrHelper.New) == ServerLocalAddr.GetPort());
+
     if (KeepAlivePaddingSize) {
         Connection.SetKeepAlivePadding(KeepAlivePaddingSize);
     }
     Connection.SetSettings(MsQuicSettings{}.SetKeepAlive(25));
 
-    TEST_TRUE(Context.PeerAddrChangedEvent.WaitTimeout(1000))
+    TEST_TRUE(Context.PeerAddrChangedEvent.WaitTimeout(TestWaitTimeout))
     TEST_TRUE(QuicAddrCompare(&AddrHelper.New, &Context.PeerAddr.SockAddr));
 
     Connection.Shutdown(1);
@@ -781,7 +786,7 @@ QuicTestNatAddrRebind(
     }
     Connection.SetSettings(MsQuicSettings{}.SetKeepAlive(1));
 
-    TEST_TRUE(Context.PeerAddrChangedEvent.WaitTimeout(1000))
+    TEST_TRUE(Context.PeerAddrChangedEvent.WaitTimeout(TestWaitTimeout))
     TEST_TRUE(QuicAddrCompare(&AddrHelper.New, &Context.PeerAddr.SockAddr));
 
     Connection.Shutdown(1);


### PR DESCRIPTION
## Description

Fix intermittent `RebindPortPadded` test failure caused by a port collision between the simulated NAT-rebind port and the server's listening port.

**Root cause:** `ReplaceAddressHelper.IncrementPort()` sets `New = ClientPort + 1`. When the OS assigns adjacent ephemeral ports (`ClientPort + 1 == ServerPort`), the send hook's `RemoteAddress == New` check matches clientserver packets and rewrites their destination from the server port back to the client's own port. Every PING gets misrouted, the server receives nothing, and `PEER_ADDRESS_CHANGED` never fires.

Confirmed via QUIC trace logs from 3 independent failures (#5941, #5936, #5866)  all show the identical pattern: 40 `TestHookReplaceAddrSend` rewrites, 0 server `PacketRecv` after hook activation.

**Fix:** Use a `do...while` loop to skip the server port when incrementing. The same guard already exists in `PathTest.cpp` (lines 102-109).

Also widens `PeerAddrChangedEvent` wait from hardcoded 1000ms to `TestWaitTimeout` for consistency with other waits.

Fixes #5813

## Testing

Existing `Basic/WithRebindPaddingArgs.RebindPortPadded` tests cover this. No new tests needed  the fix prevents the port collision that caused the existing tests to fail.

## Documentation

No documentation impact.