### PR TITLE
Fix null deref in QuicCryptoCustomCertValidationComplete after shutdown

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1740,15 +1740,26 @@ QuicCryptoCustomCertValidationComplete(
     _In_ QUIC_TLS_ALERT_CODES TlsAlert
     )
 {
+    QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
+
     if (!Crypto->CertValidationPending) {
         return;
     }
 
     Crypto->CertValidationPending = FALSE;
+
+    //
+    // The connection might have been shutdown during the cert validation.
+    // Nothing to do in that case.
+    //
+    if (Connection->State.ShutdownComplete) {
+        return;
+    }
+
     if (Result) {
         QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
         QuicCryptoProcessDataComplete(Crypto, Crypto->PendingValidationBufferLength);
 
@@ -1762,11 +1773,11 @@ QuicCryptoCustomCertValidationComplete(
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation failed.");
         CXPLAT_DBG_ASSERT(TlsAlert <= QUIC_TLS_ALERT_CODE_MAX);
         QuicConnTransportError(
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             QUIC_ERROR_CRYPTO_ERROR(0xFF & TlsAlert));
     }
     Crypto->PendingValidationBufferLength = 0;

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1753,6 +1753,7 @@ QuicCryptoCustomCertValidationComplete(
     // Nothing to do in that case.
     //
     if (Connection->State.ShutdownComplete) {
+        Crypto->PendingValidationBufferLength = 0;
         return;
     }
 

--- a/src/generated/linux/crypto.c.clog.h
+++ b/src/generated/linux/crypto.c.clog.h
@@ -130,9 +130,9 @@ tracepoint(CLOG_CRYPTO_C, HandshakeConfirmedServer , arg1);\
 // [conn][%p] Custom cert validation succeeded
 // QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
-// arg1 = arg1 = QuicCryptoGetConnection(Crypto) = arg1
+// arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_CustomCertValidationSuccess
 #define _clog_3_ARGS_TRACE_CustomCertValidationSuccess(uniqueId, arg1, encoded_arg_string)\

--- a/src/generated/linux/crypto.c.clog.h.lttng.h
+++ b/src/generated/linux/crypto.c.clog.h.lttng.h
@@ -105,9 +105,9 @@ TRACEPOINT_EVENT(CLOG_CRYPTO_C, HandshakeConfirmedServer,
 // [conn][%p] Custom cert validation succeeded
 // QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
-// arg1 = arg1 = QuicCryptoGetConnection(Crypto) = arg1
+// arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CRYPTO_C, CustomCertValidationSuccess,
     TP_ARGS(

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -351,6 +351,12 @@ QuicTestCustomClientCertificateValidation(
     const CustomCertValidationArgs& Params
     );
 
+void
+QuicTestCustomServerCertValidationAfterShutdown();
+
+void
+QuicTestCustomClientCertValidationAfterShutdown();
+
 struct ClientCertificateArgs {
     int Family;
     bool UseClientCertificate;

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1323,6 +1323,24 @@ TEST_P(WithCustomCertificateValidationArgs, CustomClientCertificateValidation) {
     }
 }
 
+TEST(Handshake, CustomServerCertValidationAfterShutdown) {
+    TestLogger Logger("QuicTestCustomServerCertValidationAfterShutdown");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestCustomServerCertValidationAfterShutdown)));
+    } else {
+        QuicTestCustomServerCertValidationAfterShutdown();
+    }
+}
+
+TEST(Handshake, CustomClientCertValidationAfterShutdown) {
+    TestLogger Logger("QuicTestCustomClientCertValidationAfterShutdown");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestCustomClientCertValidationAfterShutdown)));
+    } else {
+        QuicTestCustomClientCertValidationAfterShutdown();
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Handshake,
     WithCustomCertificateValidationArgs,

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -545,6 +545,8 @@ ExecuteTestRequest(
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
     RegisterTestFunction(QuicTestCustomServerCertificateValidation);
     RegisterTestFunction(QuicTestCustomClientCertificateValidation);
+    RegisterTestFunction(QuicTestCustomServerCertValidationAfterShutdown);
+    RegisterTestFunction(QuicTestCustomClientCertValidationAfterShutdown);
     RegisterTestFunction(QuicTestConnectClientCertificate);
     RegisterTestFunction(QuicTestCibirExtension);
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1281,6 +1281,144 @@ QuicTestCustomClientCertificateValidation(
 }
 
 void
+QuicTestCustomServerCertValidationAfterShutdown()
+{
+    //
+    // Client enables async custom server cert validation, shuts down the
+    // connection while validation is still pending, and then completes the
+    // validation. This used to crash due to a null SourceCids dereference.
+    //
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, MsQuicSettings{}, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicCredentialConfig ClientCredConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION | QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED);
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    UniquePtr<TestConnection> Server;
+    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
+    Listener.Context = &ServerAcceptCtx;
+
+    TestConnection Client(Registration);
+    TEST_TRUE(Client.IsValid());
+
+    Client.SetExpectedCustomValidationResult(true);
+    Client.SetAsyncCustomValidationResult(true);
+    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_USER_CANCELED);
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_UNSPEC,
+            QUIC_TEST_LOOPBACK_FOR_AF(QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+            ServerLocalAddr.GetPort()));
+
+    //
+    // Wait for the cert validation callback to fire.
+    // We configured the callback to defer the validation.
+    //
+    if (!Client.WaitForPeerCertReceived()) {
+        TEST_FAILURE("Timed out waiting for peer certificate.");
+        return;
+    }
+
+    Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+    if (!Client.WaitForShutdownComplete()) {
+        return;
+    }
+
+    //
+    // Complete the validation after shutdown. This must not crash.
+    //
+    TEST_QUIC_SUCCEEDED(Client.SetCustomValidationResult(true));
+}
+
+void
+QuicTestCustomClientCertValidationAfterShutdown()
+{
+    //
+    // Server enables async custom client cert validation, the client
+    // disconnects while validation is still pending, and then the server
+    // completes the validation. This is the exact scenario from the original
+    // kernel crash dump.
+    //
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, MsQuicSettings{}, ServerSelfSignedCredConfigClientAuth);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCertCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    UniquePtr<TestConnection> Server;
+    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
+    ServerAcceptCtx.AsyncCustomCertValidation = true;
+    ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
+    Listener.Context = &ServerAcceptCtx;
+
+    TestConnection Client(Registration);
+    TEST_TRUE(Client.IsValid());
+    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_USER_CANCELED);
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_UNSPEC,
+            QUIC_TEST_LOOPBACK_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+            ServerLocalAddr.GetPort()));
+
+    if (!CxPlatEventWaitWithTimeout(ServerAcceptCtx.NewConnectionReady, TestWaitTimeout)) {
+        TEST_FAILURE("Timed out waiting for server accept.");
+    }
+
+    TEST_NOT_EQUAL(nullptr, Server);
+
+    //
+    // Wait for the server's cert validation callback to fire.
+    // We configured the callback to defer the validation.
+    //
+    if (!Server->WaitForPeerCertReceived()) {
+        TEST_FAILURE("Timed out waiting for peer certificate.");
+        return;
+    }
+
+    Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+    if (!Server->WaitForShutdownComplete()) {
+        return;
+    }
+
+    //
+    // Now complete the certificate validation after shutdown. This must not crash.
+    //
+    TEST_QUIC_SUCCEEDED(Server->SetCustomValidationResult(TRUE));
+}
+
+void
 QuicTestShutdownDuringHandshake(
     const ShutdownDuringHandshakeArgs& Params
     )

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -27,6 +27,7 @@ TestConnection::TestConnection(
     CxPlatEventInitialize(&EventPeerClosed, TRUE, FALSE);
     CxPlatEventInitialize(&EventShutdownComplete, TRUE, FALSE);
     CxPlatEventInitialize(&EventResumptionTicketReceived, TRUE, FALSE);
+    CxPlatEventInitialize(&EventPeerCertReceived, TRUE, FALSE);
 
     if (QuicConnection == nullptr) {
         TEST_FAILURE("Invalid handle passed into TestConnection.");
@@ -49,6 +50,7 @@ TestConnection::TestConnection(
     CxPlatEventInitialize(&EventPeerClosed, TRUE, FALSE);
     CxPlatEventInitialize(&EventShutdownComplete, TRUE, FALSE);
     CxPlatEventInitialize(&EventResumptionTicketReceived, TRUE, FALSE);
+    CxPlatEventInitialize(&EventPeerCertReceived, TRUE, FALSE);
 
     QUIC_STATUS Status =
         MsQuic->ConnectionOpen(
@@ -69,6 +71,7 @@ TestConnection::TestConnection(
 TestConnection::~TestConnection()
 {
     MsQuic->ConnectionClose(QuicConnection);
+    CxPlatEventUninitialize(EventPeerCertReceived);
     CxPlatEventUninitialize(EventResumptionTicketReceived);
     CxPlatEventUninitialize(EventShutdownComplete);
     CxPlatEventUninitialize(EventPeerClosed);
@@ -210,6 +213,16 @@ TestConnection::WaitForPeerClose()
 {
     if (!CxPlatEventWaitWithTimeout(EventPeerClosed, GetWaitTimeout())) {
         TEST_FAILURE("WaitForPeerClose timed out after %u ms.", GetWaitTimeout());
+        return false;
+    }
+    return true;
+}
+
+bool
+TestConnection::WaitForPeerCertReceived()
+{
+    if (!CxPlatEventWaitWithTimeout(EventPeerCertReceived, GetWaitTimeout())) {
+        TEST_FAILURE("WaitForPeerCertReceived timed out after %u ms.", GetWaitTimeout());
         return false;
     }
     return true;
@@ -944,6 +957,7 @@ TestConnection::HandleConnectionEvent(
         break;
 
     case QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED:
+        CxPlatEventSet(EventPeerCertReceived);
         if (AsyncCustomValidation) {
             return QUIC_STATUS_PENDING;
         }

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -91,6 +91,7 @@ class TestConnection
     CXPLAT_EVENT EventPeerClosed{};
     CXPLAT_EVENT EventShutdownComplete{};
     CXPLAT_EVENT EventResumptionTicketReceived{};
+    CXPLAT_EVENT EventPeerCertReceived{};
     CXPLAT_EVENT* EventDeleted{};
 
     NEW_STREAM_CALLBACK_HANDLER NewStreamCallback{};
@@ -195,6 +196,8 @@ public:
     bool WaitForShutdownComplete();
 
     bool WaitForPeerClose();
+
+    bool WaitForPeerCertReceived();
 
     void SetShutdownCompleteCallback(CONN_SHUTDOWN_COMPLETE_CALLBACK_HANDLER Handler) {
         LockGuard LockScope{Lock};


### PR DESCRIPTION
## Description

Fix a null pointer dereference crash in `QuicCryptoCustomCertValidationComplete` when certificate validation completes after the connection has already been shut down.

**Root cause**: When a remote peer closes a QUIC connection while async certificate validation is pending on the server, `QuicConnOnShutdownComplete` frees all SourceCids. When the app later calls `ConnectionCertificateValidationComplete(TRUE)`, `QuicCryptoProcessTlsCompletion` dereferences `Connection->SourceCids.Next` (now NULL), causing an access violation. This was observed as a kernel bugcheck (0x7E) in production.

**Fix**: Add a `ShutdownComplete` guard in `QuicCryptoCustomCertValidationComplete` to bail out early if the connection has already completed shutdown, preventing the code from proceeding into `QuicCryptoProcessTlsCompletion` with freed state.

## Testing

Two new integration tests added:
- `Handshake.CustomServerCertValidationAfterShutdown`  Client-side async cert validation with client shutdown before completion.
- `Handshake.CustomClientCertValidationAfterShutdown`  Server-side async client cert validation with client disconnect before server completes. Mirrors the exact production crash scenario.

Both tests use event-based synchronization (`WaitForPeerCertReceived`) to deterministically ensure cert validation is pending before shutdown.

## Documentation

No documentation impact.