### PR TITLE
Move client Initial key discard before next builder iteration

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -354,6 +354,31 @@ QuicPacketBuilderPrepare(
     if (NewQuicPacket) {
 
         //
+        // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it
+        // first sends a Handshake packet. It must be done on ANY Handshake
+        // packet, to ensure the congestion control state is cleared and
+        // Initial bytes in flight are not limiting Handshake packets.
+        //
+        // Discard here, at the moment we commit to building a new Handshake
+        // packet (after any prior packet has been finalized, before the new
+        // Builder->Key is selected). Doing it earlier than in
+        // QuicPacketBuilderFinalize ensures the Initial encryption level is
+        // fully cleaned up - including resetting RecoveryNextOffset past the
+        // Initial buffer range - before the next send-loop iteration can call
+        // QuicPacketBuilderGetPacketTypeAndKeyForControlFrames again. That
+        // closes a race where the previous location (inside Finalize) could
+        // run between the key check in
+        // QuicPacketBuilderGetPacketTypeAndKeyForControlFrames and the
+        // Builder->Key = WriteKeys[NewPacketKeyType] assignment below,
+        // leaving NewPacketKeyType == QUIC_PACKET_KEY_INITIAL with a NULL
+        // key.
+        //
+        if (QuicConnIsClient(Connection) &&
+            NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
+            QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
+        }
+
+        //
         // Initialize the new QUIC packet state.
         //
 
@@ -996,17 +1021,6 @@ QuicPacketBuilderFinalize(
         &Connection->LossDetection,
         Builder->Path,
         Builder->Metadata);
-
-    //
-    // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it first
-    // sends a Handshake packet. It must be done on ANY Handshake packet, to
-    // ensure the congestion control state is cleared and Initial bytes in flight
-    // are not limiting Handshake packets.
-    //
-    if (QuicConnIsClient(Connection) &&
-        Builder->Key->Type == QUIC_PACKET_KEY_HANDSHAKE) {
-        QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
-    }
 
     Builder->Metadata->FrameCount = 0;
 

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -359,7 +359,6 @@ QuicPacketBuilderPrepare(
         // are not limiting Handshake packets.
         //
         if (QuicConnIsClient(Connection) && NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
-
             QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
             //
             // Ensure we don't keep a dangling pointer to the freed INITIAL keys.

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -352,30 +352,19 @@ QuicPacketBuilderPrepare(
     }
 
     if (NewQuicPacket) {
+        //
+        // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it first
+        // sends a Handshake packet. It must be done on ANY Handshake packet, to
+        // ensure the congestion control state is cleared and Initial bytes in flight
+        // are not limiting Handshake packets.
+        //
+        if (QuicConnIsClient(Connection) && NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
 
-        //
-        // Per RFC 9001 s4.9.1, a client MUST discard Initial keys when it
-        // first sends a Handshake packet. It must be done on ANY Handshake
-        // packet, to ensure the congestion control state is cleared and
-        // Initial bytes in flight are not limiting Handshake packets.
-        //
-        // Discard here, at the moment we commit to building a new Handshake
-        // packet (after any prior packet has been finalized, before the new
-        // Builder->Key is selected). Doing it earlier than in
-        // QuicPacketBuilderFinalize ensures the Initial encryption level is
-        // fully cleaned up - including resetting RecoveryNextOffset past the
-        // Initial buffer range - before the next send-loop iteration can call
-        // QuicPacketBuilderGetPacketTypeAndKeyForControlFrames again. That
-        // closes a race where the previous location (inside Finalize) could
-        // run between the key check in
-        // QuicPacketBuilderGetPacketTypeAndKeyForControlFrames and the
-        // Builder->Key = WriteKeys[NewPacketKeyType] assignment below,
-        // leaving NewPacketKeyType == QUIC_PACKET_KEY_INITIAL with a NULL
-        // key.
-        //
-        if (QuicConnIsClient(Connection) &&
-            NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
             QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
+            //
+            // Ensure we don't keep a dangling pointer to the freed INITIAL keys.
+            //
+            Builder->Key = NULL;
         }
 
         //


### PR DESCRIPTION
## Description

Fixes #5990.

PR #5899 moved the client Initial-keys discard into `QuicPacketBuilderFinalize` so it triggers on any client Handshake packet send (not only those carrying a CRYPTO frame). That fix resolved a CC/keys deadlock (#5664), but introduced a race that fires the `CXPLAT_DBG_ASSERT(Builder->Key != NULL)` at `packet_builder.c:366` under stress (see crash dump in #5990):

1. Send loop has `Builder->PacketType = HANDSHAKE` and Initial keys are still present.
2. Loss recovery for Initial CRYPTO data causes `QuicPacketBuilderGetPacketTypeAndKeyForControlFrames` to return `QUIC_PACKET_KEY_INITIAL` (Initial keys still non-NULL at the check).
3. `QuicPacketBuilderPrepare(Builder, INITIAL, ...)` enters. Because of the packet-type change, it calls QuicPacketBuilderFinalize` on the still-open Handshake packet.
4. Inside `Finalize`, the `client + Builder->Key->Type == HANDSHAKE` branch added by #5899 discards Initial keys.
5. Control returns to `Prepare`, which reads `Builder->Key = WriteKeys[INITIAL]` -- now `NULL` -- and asserts.

### Fix

Move the discard out of `QuicPacketBuilderFinalize` and into the new-packet path of `QuicPacketBuilderPrepare`, inside `if (NewQuicPacket)` and just before `Builder->Key` is re-assigned.

- Still fires on any client Handshake packet send, preserving the #5664 fix: ACK-only Handshake packets release Initial   `BytesInFlight` from congestion control before the next send-loop iteration runs.
- Runs after any prior packet has been finalized (so `Builder->Key` has already been used for its encryption inside `Finalize`) and before `Builder->Key` is re-assigned -- no use-after-free.
- Forces `QuicCryptoDiscardKeys` cleanup (in particular pushing `RecoveryNextOffset` / `NextSendOffset` past   `BufferOffsetHandshake`) to happen before the next call to `QuicPacketBuilderGetPacketTypeAndKeyForControlFrames`, so subsequent iterations cannot select `QUIC_PACKET_KEY_INITIAL` once the client has decided to send a Handshake packet.

## Testing

Covered by `Basic.Handshake*RandomLoss*`, `HandshakeSpecificLossPatterns*` and stress test, no reasonable way to reproduce consistently.

## Documentation

N/A
