### PR TITLE
Fix SNI for IP literal server names

### DIFF
--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -491,6 +491,19 @@ QuicAddrFromString(
 
 typedef int QUIC_XDP_MAP_HANDLE;
 
+QUIC_INLINE
+BOOLEAN
+CxPlatIsIpLiteral(
+    _In_z_ const char* AddrStr
+    )
+{
+    IN_ADDR Ipv4Addr = {0};
+    IN6_ADDR Ipv6Addr = {0};
+    return
+        inet_pton(AF_INET, AddrStr, &Ipv4Addr) == 1 ||
+        inet_pton(AF_INET6, AddrStr, &Ipv6Addr) == 1;
+}
+
 //
 // Represents an IP address and (optionally) port number as a string.
 //

--- a/src/inc/msquic_winkernel.h
+++ b/src/inc/msquic_winkernel.h
@@ -331,6 +331,28 @@ QuicAddrFromString(
     return TRUE;
 }
 
+QUIC_INLINE
+BOOLEAN
+CxPlatIsIpLiteral(
+    _In_z_ const char* AddrStr
+    )
+{
+    const char* Terminator = NULL;
+    IN_ADDR Ipv4Addr = {0};
+    if (RtlIpv4StringToAddressA(AddrStr, TRUE, &Terminator, &Ipv4Addr) == STATUS_SUCCESS &&
+        *Terminator == '\0') {
+        return TRUE;
+    }
+
+    IN6_ADDR Ipv6Addr = {0};
+    if (RtlIpv6StringToAddressA(AddrStr, &Terminator, &Ipv6Addr) == STATUS_SUCCESS &&
+        *Terminator == '\0') {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 //
 // Represents an IP address and (optionally) port number as a string.
 //

--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -341,6 +341,29 @@ QuicAddrFromString(
     return TRUE;
 }
 
+QUIC_INLINE
+_Success_(return != FALSE)
+BOOLEAN
+CxPlatIsIpLiteral(
+    _In_z_ const char* AddrStr
+    )
+{
+    const char* Terminator = NULL;
+    IN_ADDR Ipv4Addr = {0};
+    if (RtlIpv4StringToAddressA(AddrStr, TRUE, &Terminator, &Ipv4Addr) == NO_ERROR &&
+        *Terminator == '\0') {
+        return TRUE;
+    }
+
+    IN6_ADDR Ipv6Addr = {0};
+    if (RtlIpv6StringToAddressA(AddrStr, &Terminator, &Ipv6Addr) == NO_ERROR &&
+        *Terminator == '\0') {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 //
 // Represents an IP address and (optionally) port number as a string.
 //

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -150,6 +150,35 @@ typedef struct CXPLAT_TLS {
 
 } CXPLAT_TLS;
 
+static
+BOOLEAN
+CxPlatTlsServerNameIsIpLiteral(
+    _In_z_ const char* ServerName,
+    _In_ uint16_t ServerNameLength
+    )
+{
+    QUIC_ADDR Addr = {0};
+    if (QuicAddrFromString(ServerName, 0, &Addr)) {
+        return TRUE;
+    }
+
+    if (ServerNameLength >= 2 &&
+        ServerName[0] == '[' &&
+        ServerName[ServerNameLength - 1] == ']') {
+        char UnbracketedName[64];
+        size_t UnbracketedNameLength = ServerNameLength - 2;
+        if (UnbracketedNameLength >= sizeof(UnbracketedName)) {
+            return FALSE;
+        }
+
+        memcpy(UnbracketedName, ServerName + 1, UnbracketedNameLength);
+        UnbracketedName[UnbracketedNameLength] = '\0';
+        return QuicAddrFromString(UnbracketedName, 0, &Addr);
+    }
+
+    return FALSE;
+}
+
 //
 // @struct RECORD_ENTRY
 // @brief Represents a buffered SSL record in a linked list.
@@ -2523,18 +2552,20 @@ CxPlatTlsInitialize(
                 goto Exit;
             }
 
-            TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
-            if (TlsContext->SNI == NULL) {
-                QuicTraceEvent(
-                    AllocFailure,
-                    "Allocation of '%s' failed. (%llu bytes)",
-                    "SNI",
-                    ServerNameLength + 1);
-                Status = QUIC_STATUS_OUT_OF_MEMORY;
-                goto Exit;
-            }
+            if (!CxPlatTlsServerNameIsIpLiteral(Config->ServerName, ServerNameLength)) {
+                TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
+                if (TlsContext->SNI == NULL) {
+                    QuicTraceEvent(
+                        AllocFailure,
+                        "Allocation of '%s' failed. (%llu bytes)",
+                        "SNI",
+                        ServerNameLength + 1);
+                    Status = QUIC_STATUS_OUT_OF_MEMORY;
+                    goto Exit;
+                }
 
-            memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
+                memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
+            }
         }
     }
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -150,35 +150,6 @@ typedef struct CXPLAT_TLS {
 
 } CXPLAT_TLS;
 
-static
-BOOLEAN
-CxPlatTlsServerNameIsIpLiteral(
-    _In_z_ const char* ServerName,
-    _In_ uint16_t ServerNameLength
-    )
-{
-    QUIC_ADDR Addr = {0};
-    if (QuicAddrFromString(ServerName, 0, &Addr)) {
-        return TRUE;
-    }
-
-    if (ServerNameLength >= 2 &&
-        ServerName[0] == '[' &&
-        ServerName[ServerNameLength - 1] == ']') {
-        char UnbracketedName[64];
-        size_t UnbracketedNameLength = ServerNameLength - 2;
-        if (UnbracketedNameLength >= sizeof(UnbracketedName)) {
-            return FALSE;
-        }
-
-        memcpy(UnbracketedName, ServerName + 1, UnbracketedNameLength);
-        UnbracketedName[UnbracketedNameLength] = '\0';
-        return QuicAddrFromString(UnbracketedName, 0, &Addr);
-    }
-
-    return FALSE;
-}
-
 //
 // @struct RECORD_ENTRY
 // @brief Represents a buffered SSL record in a linked list.
@@ -2552,7 +2523,7 @@ CxPlatTlsInitialize(
                 goto Exit;
             }
 
-            if (!CxPlatTlsServerNameIsIpLiteral(Config->ServerName, ServerNameLength)) {
+            if (!CxPlatIsIpLiteral(Config->ServerName)) {
                 TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
                 if (TlsContext->SNI == NULL) {
                     QuicTraceEvent(

--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -153,35 +153,6 @@ typedef struct CXPLAT_TLS {
 
 } CXPLAT_TLS;
 
-static
-BOOLEAN
-CxPlatTlsServerNameIsIpLiteral(
-    _In_z_ const char* ServerName,
-    _In_ uint16_t ServerNameLength
-    )
-{
-    QUIC_ADDR Addr = {0};
-    if (QuicAddrFromString(ServerName, 0, &Addr)) {
-        return TRUE;
-    }
-
-    if (ServerNameLength >= 2 &&
-        ServerName[0] == '[' &&
-        ServerName[ServerNameLength - 1] == ']') {
-        char UnbracketedName[64];
-        size_t UnbracketedNameLength = ServerNameLength - 2;
-        if (UnbracketedNameLength >= sizeof(UnbracketedName)) {
-            return FALSE;
-        }
-
-        memcpy(UnbracketedName, ServerName + 1, UnbracketedNameLength);
-        UnbracketedName[UnbracketedNameLength] = '\0';
-        return QuicAddrFromString(UnbracketedName, 0, &Addr);
-    }
-
-    return FALSE;
-}
-
 //
 // Default list of Cipher used.
 //
@@ -1737,7 +1708,7 @@ CxPlatTlsInitialize(
                 goto Exit;
             }
 
-            if (!CxPlatTlsServerNameIsIpLiteral(Config->ServerName, ServerNameLength)) {
+            if (!CxPlatIsIpLiteral(Config->ServerName)) {
                 TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
                 if (TlsContext->SNI == NULL) {
                     QuicTraceEvent(

--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -153,6 +153,35 @@ typedef struct CXPLAT_TLS {
 
 } CXPLAT_TLS;
 
+static
+BOOLEAN
+CxPlatTlsServerNameIsIpLiteral(
+    _In_z_ const char* ServerName,
+    _In_ uint16_t ServerNameLength
+    )
+{
+    QUIC_ADDR Addr = {0};
+    if (QuicAddrFromString(ServerName, 0, &Addr)) {
+        return TRUE;
+    }
+
+    if (ServerNameLength >= 2 &&
+        ServerName[0] == '[' &&
+        ServerName[ServerNameLength - 1] == ']') {
+        char UnbracketedName[64];
+        size_t UnbracketedNameLength = ServerNameLength - 2;
+        if (UnbracketedNameLength >= sizeof(UnbracketedName)) {
+            return FALSE;
+        }
+
+        memcpy(UnbracketedName, ServerName + 1, UnbracketedNameLength);
+        UnbracketedName[UnbracketedNameLength] = '\0';
+        return QuicAddrFromString(UnbracketedName, 0, &Addr);
+    }
+
+    return FALSE;
+}
+
 //
 // Default list of Cipher used.
 //
@@ -1708,18 +1737,20 @@ CxPlatTlsInitialize(
                 goto Exit;
             }
 
-            TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
-            if (TlsContext->SNI == NULL) {
-                QuicTraceEvent(
-                    AllocFailure,
-                    "Allocation of '%s' failed. (%llu bytes)",
-                    "SNI",
-                    ServerNameLength + 1);
-                Status = QUIC_STATUS_OUT_OF_MEMORY;
-                goto Exit;
-            }
+            if (!CxPlatTlsServerNameIsIpLiteral(Config->ServerName, ServerNameLength)) {
+                TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
+                if (TlsContext->SNI == NULL) {
+                    QuicTraceEvent(
+                        AllocFailure,
+                        "Allocation of '%s' failed. (%llu bytes)",
+                        "SNI",
+                        ServerNameLength + 1);
+                    Status = QUIC_STATUS_OUT_OF_MEMORY;
+                    goto Exit;
+                }
 
-            memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
+                memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
+            }
         }
     }
 

--- a/src/platform/unittest/PlatformTest.cpp
+++ b/src/platform/unittest/PlatformTest.cpp
@@ -64,6 +64,32 @@ TEST(PlatformTest, QuicAddrParsing)
     }
 }
 
+TEST(PlatformTest, CxPlatIsIpLiteral)
+{
+    struct TestEntry {
+        const char* Input;
+        bool IsIpLiteral;
+    };
+
+    TestEntry TestData[] = {
+        { "127.0.0.1", true },
+        { "192.168.1.11", true },
+        { "::1", true },
+        { "fc00::1:11", true },
+        { "::ffff:192.0.2.128", true },
+        { "localhost", false },
+        { "net.host", false },
+        { "128.net.host", false },
+        { "127.0.0.1:443", false },
+        { "[::1]", false },
+        { "[::1]:443", false }
+    };
+
+    for (const auto& Entry : TestData) {
+        ASSERT_EQ(Entry.IsIpLiteral, CxPlatIsIpLiteral(Entry.Input)) << Entry.Input;
+    }
+}
+
 TEST(PlatformTest, EventQueue)
 {
     struct my_sqe : public CXPLAT_SQE {

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -461,6 +461,11 @@ QuicTestConnectBadSni(
     );
 
 void
+QuicTestConnectIpSni(
+    const FamilyArgs& Params
+    );
+
+void
 QuicTestConnectServerRejected(
     const FamilyArgs& Params
     );

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1802,6 +1802,15 @@ TEST_P(WithFamilyArgs, BadSNI) {
     }
 }
 
+TEST_P(WithFamilyArgs, IpSNI) {
+    TestLoggerT<ParamType> Logger("QuicTestConnectIpSni", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestConnectIpSni), GetParam()));
+    } else {
+        QuicTestConnectIpSni(GetParam());
+    }
+}
+
 TEST_P(WithFamilyArgs, ServerRejected) {
     TestLoggerT<ParamType> Logger("QuicTestConnectServerRejected", GetParam());
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -567,6 +567,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestConnectInvalidAddress);
     RegisterTestFunction(QuicTestConnectBadAlpn);
     RegisterTestFunction(QuicTestConnectBadSni);
+    RegisterTestFunction(QuicTestConnectIpSni);
     RegisterTestFunction(QuicTestConnectServerRejected);
     RegisterTestFunction(QuicTestClientBlockedSourcePort);
 #if QUIC_TEST_DATAPATH_HOOKS_ENABLED

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -2707,6 +2707,74 @@ QuicTestConnectBadSni(
     }
 }
 
+void
+QuicTestConnectIpSni(
+    const FamilyArgs& Params
+    )
+{
+    const int Family = Params.Family;
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicSettings Settings;
+    Settings.SetIdleTimeoutMs(3000);
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicCredentialConfig ClientCredConfig;
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+
+    QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
+    QuicAddr ServerLocalAddr(QuicAddrFamily);
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    UniquePtr<TestConnection> Server;
+    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    Listener.Context = &ServerAcceptCtx;
+
+    TestConnection Client(Registration);
+    TEST_TRUE(Client.IsValid());
+    Client.SetSslKeyLogFilePath();
+
+    QuicAddr RemoteAddr(QuicAddrFamily, true);
+    if (UseDuoNic) {
+        QuicAddrSetToDuoNic(&RemoteAddr.SockAddr);
+    }
+    RemoteAddr.SetPort(ServerLocalAddr.GetPort());
+    TEST_QUIC_SUCCEEDED(Client.SetRemoteAddr(RemoteAddr));
+
+    const char* IpServerName =
+        UseDuoNic ?
+            ((Family == 4) ? "192.168.1.11" : "fc00::1:11") :
+            ((Family == 4) ? "127.0.0.1" : "::1");
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QuicAddrFamily,
+            IpServerName,
+            ServerLocalAddr.GetPort()));
+
+    if (!Client.WaitForConnectionComplete()) {
+        return;
+    }
+    TEST_TRUE(Client.GetIsConnected());
+
+    TEST_NOT_EQUAL(nullptr, Server);
+    if (!Server->WaitForConnectionComplete()) {
+        return;
+    }
+    TEST_TRUE(Server->GetIsConnected());
+}
+
 _Function_class_(NEW_CONNECTION_CALLBACK)
 static
 bool


### PR DESCRIPTION
Fixes #3493.

Makes OpenSSL-backed TLS paths avoid sending SNI when the configured server name is an IP literal. Hostname SNI behavior is unchanged.

  Changes:
  - Detect IPv4 and IPv6 literal server names during TLS initialization.
  - Skip copying IP literals into the TLS SNI field for OpenSSL and quicTLS.

## Testing
  -  Added IPv4/IPv6 regression coverage for connecting with an IP literal server name while using an explicit remote address.
  - Confirmed it fixes "Illegal SNI hostname received" when connecting to a Rust quinn/rustls server

## Documentation

-