### PR TITLE
Fix QTIP CIBIR TCP port collision in handshake tests

### DIFF
--- a/src/generated/linux/TestHelpers.h.clog.h
+++ b/src/generated/linux/TestHelpers.h.clog.h
@@ -110,6 +110,26 @@ tracepoint(CLOG_TESTHELPERS_H, TestHookUnregistered );\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for TestPortReservation
+// [test] Port reservation: port=%u, attempts=%d
+// QuicTraceLogVerbose(
+                TestPortReservation,
+                "[test] Port reservation: port=%u, attempts=%d",
+                Port,
+                Attempt + 1);
+// arg2 = arg2 = Port = arg2
+// arg3 = arg3 = Attempt + 1 = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_TestPortReservation
+#define _clog_4_ARGS_TRACE_TestPortReservation(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_TESTHELPERS_H, TestPortReservation , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for TestHookDropPacketRandom
 // [test][hook] Random packet drop
 // QuicTraceLogVerbose(

--- a/src/generated/linux/TestHelpers.h.clog.h.lttng.h
+++ b/src/generated/linux/TestHelpers.h.clog.h.lttng.h
@@ -88,6 +88,29 @@ TRACEPOINT_EVENT(CLOG_TESTHELPERS_H, TestHookUnregistered,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for TestPortReservation
+// [test] Port reservation: port=%u, attempts=%d
+// QuicTraceLogVerbose(
+                TestPortReservation,
+                "[test] Port reservation: port=%u, attempts=%d",
+                Port,
+                Attempt + 1);
+// arg2 = arg2 = Port = arg2
+// arg3 = arg3 = Attempt + 1 = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_TESTHELPERS_H, TestPortReservation,
+    TP_ARGS(
+        unsigned int, arg2,
+        int, arg3), 
+    TP_FIELDS(
+        ctf_integer(unsigned int, arg2, arg2)
+        ctf_integer(int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for TestHookDropPacketRandom
 // [test][hook] Random packet drop
 // QuicTraceLogVerbose(

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -11567,6 +11567,22 @@
       ],
       "macroName": "QuicTraceLogError"
     },
+    "TestPortReservation": {
+      "ModuleProperites": {},
+      "TraceString": "[test] Port reservation: port=%u, attempts=%d",
+      "UniqueId": "TestPortReservation",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "u",
+          "MacroVariableName": "arg2"
+        },
+        {
+          "DefinationEncoding": "d",
+          "MacroVariableName": "arg3"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
     "TestScopeEntry": {
       "ModuleProperites": {},
       "TraceString": "[test]---> %s",
@@ -16591,6 +16607,11 @@
         "UniquenessHash": "3928cc2f-84c2-48ac-845b-40781cf8021b",
         "TraceID": "TestLogFailure",
         "EncodingString": "[test] FAILURE - %s:%d - %s"
+      },
+      {
+        "UniquenessHash": "8420a776-a5e2-5ceb-48bd-37eae8d1107b",
+        "TraceID": "TestPortReservation",
+        "EncodingString": "[test] Port reservation: port=%u, attempts=%d"
       },
       {
         "UniquenessHash": "76b54d32-001b-12e0-4e99-d29d2640eaeb",

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -16,12 +16,6 @@ Abstract:
 
 #include "MsQuicTests.h"
 
-#if defined(_KERNEL_MODE)
-static bool UseQTIP = false;
-#elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
-extern bool UseQTIP;
-#endif
-
 char CurrentWorkingDirectory[MAX_PATH + 1];
 
 QUIC_TEST_DATAPATH_HOOKS DatapathHooks::FuncTable = {
@@ -4238,7 +4232,7 @@ QuicTestCibirExtension(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
     QuicAddr ServerLocalAddr(QuicAddrFamily);
 #if defined(_WIN32) && !defined(_KERNEL_MODE)
-    QuicTestPortReservation PortReservation(QuicAddrFamily, UseQTIP);
+    QuicTestPortReservation PortReservation(QuicAddrFamily);
     if (UseDuoNic && (Mode & 1)) {
         //
         // CIBIR + XDP requires an explicit local port. Reserve an ephemeral port
@@ -4809,7 +4803,7 @@ QuicTestConnectionPoolCreate(
     }
 
 #if defined(_WIN32) && !defined(_KERNEL_MODE)
-    QuicTestPortReservation PortReservation(QuicAddrFamily, UseQTIP);
+    QuicTestPortReservation PortReservation(QuicAddrFamily);
     if (UseDuoNic && TestCibirSupport) {
         //
         // If Cibir+XDP mode is active, we can't pass in a 0 local port

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -4232,7 +4232,7 @@ QuicTestCibirExtension(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
     QuicAddr ServerLocalAddr(QuicAddrFamily);
 #if defined(_WIN32) && !defined(_KERNEL_MODE)
-    QuicTestPortReservation PortReservation(QuicAddrFamily);
+    QuicTestPortReservation PortReservation(QuicAddrFamily, UseQTIP);
     if (UseDuoNic && (Mode & 1)) {
         //
         // CIBIR + XDP requires an explicit local port. Reserve an ephemeral port
@@ -4803,7 +4803,7 @@ QuicTestConnectionPoolCreate(
     }
 
 #if defined(_WIN32) && !defined(_KERNEL_MODE)
-    QuicTestPortReservation PortReservation(QuicAddrFamily);
+    QuicTestPortReservation PortReservation(QuicAddrFamily, UseQTIP);
     if (UseDuoNic && TestCibirSupport) {
         //
         // If Cibir+XDP mode is active, we can't pass in a 0 local port

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -16,6 +16,12 @@ Abstract:
 
 #include "MsQuicTests.h"
 
+#if defined(_KERNEL_MODE)
+static bool UseQTIP = false;
+#elif defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+extern bool UseQTIP;
+#endif
+
 char CurrentWorkingDirectory[MAX_PATH + 1];
 
 QUIC_TEST_DATAPATH_HOOKS DatapathHooks::FuncTable = {

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -98,10 +98,10 @@ QuitTestIsFeatureSupported(uint32_t Feature) {
 
 #if defined(_WIN32) && !defined(_KERNEL_MODE)
 //
-// Reserves an ephemeral UDP port by binding a socket to port 0. The socket
-// stays open to hold the reservation until Release() is called (or the object
-// is destroyed). This minimizes the TOCTOU window between discovering a free
-// port and having the listener bind to it.
+// Reserves an ephemeral port by binding both a UDP and TCP socket to the same
+// port. The sockets stay open to hold the reservation until Release() is called
+// (or the object is destroyed). This minimizes the TOCTOU window between
+// discovering a free port and having the listener bind to it.
 //
 struct QuicTestPortReservation {
     uint16_t Port{0};
@@ -109,8 +109,7 @@ struct QuicTestPortReservation {
     QuicTestPortReservation() = default;
 
     QuicTestPortReservation(
-        _In_ QUIC_ADDRESS_FAMILY Family,
-        _In_ bool ReserveTcp = false
+        _In_ QUIC_ADDRESS_FAMILY Family
         )
     {
         int af = (Family == QUIC_ADDRESS_FAMILY_INET) ? AF_INET : AF_INET6;
@@ -120,6 +119,7 @@ struct QuicTestPortReservation {
                 (int)sizeof(struct sockaddr_in6);
 
         //
+        // Reserve both a UDP and TCP port on the same ephemeral port number.
         // Retry when the UDP ephemeral port collides with an in-use TCP port.
         //
         for (int Attempt = 0; Attempt < 1000; Attempt++) {
@@ -143,21 +143,21 @@ struct QuicTestPortReservation {
             }
 
             Port = QuicAddrGetPort(&Addr);
+            //
+            // Defensive: bind to port 0 should always assign a real port, but
+            // guard against an unexpected OS behavior.
+            //
             if (Port == 0) {
                 Release();
                 return;
             }
 
-            if (!ReserveTcp) {
-                return;
-            }
-
             //
-            // In QTIP mode, also reserve the same port for TCP. CIBIR+XDP
-            // servers skip OS socket creation (for cross-process port sharing),
-            // leaving TCP port N free. Without this, a QTIP client's auxiliary
-            // TCP socket could be assigned port N by the OS, colliding with the
-            // server's entry in the raw socket pool.
+            // Also reserve the same port for TCP. CIBIR+XDP servers skip OS
+            // socket creation (for cross-process port sharing), leaving TCP
+            // port N free. Without this, a client's auxiliary TCP socket could
+            // be assigned port N by the OS, colliding with the server's entry
+            // in the raw socket pool.
             //
             TcpSock = socket(af, SOCK_STREAM, IPPROTO_TCP);
             if (TcpSock == INVALID_SOCKET) {
@@ -165,15 +165,20 @@ struct QuicTestPortReservation {
                 return;
             }
 
-            QuicAddrSetPort(&Addr, Port);
-            if (bind(TcpSock, (struct sockaddr*)&Addr, AddrSize) == 0) {
-                return; // Both UDP and TCP reserved on the same port.
+            if (bind(TcpSock, (struct sockaddr*)&Addr, AddrSize) != 0) {
+                //
+                // TCP port is occupied; close both and retry for a new port.
+                //
+                Release();
+                continue;
             }
 
-            //
-            // TCP port is occupied; close both and retry for a new port.
-            //
-            Release();
+            QuicTraceLogVerbose(
+                TestPortReservation,
+                "[test] Port reservation: port=%u, attempts=%d",
+                Port,
+                Attempt + 1);
+            return;
         }
     }
 

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -151,7 +151,7 @@ struct QuicTestPortReservation {
             //
             // Bind to port 0 should always assign a real port.
             //
-            ASSERT_NE(Port, (uint16_t)0) << "Bind to port 0 failed to assign a real port";
+            CXPLAT_DBG_ASSERT(Port != 0);
 
             //
             // Also reserve the same port for TCP. CIBIR+XDP servers skip OS

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -122,7 +122,7 @@ struct QuicTestPortReservation {
         //
         // Retry when the UDP ephemeral port collides with an in-use TCP port.
         //
-        for (int Attempt = 0; Attempt < 100; Attempt++) {
+        for (int Attempt = 0; Attempt < 1000; Attempt++) {
             UdpSock = socket(af, SOCK_DGRAM, IPPROTO_UDP);
             if (UdpSock == INVALID_SOCKET) {
                 return;

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -109,32 +109,70 @@ struct QuicTestPortReservation {
     QuicTestPortReservation() = default;
 
     QuicTestPortReservation(
-        _In_ QUIC_ADDRESS_FAMILY Family
+        _In_ QUIC_ADDRESS_FAMILY Family,
+        _In_ bool ReserveTcp = false
         )
     {
         int af = (Family == QUIC_ADDRESS_FAMILY_INET) ? AF_INET : AF_INET6;
-
-        Sock = socket(af, SOCK_DGRAM, IPPROTO_UDP);
-        if (Sock == INVALID_SOCKET) {
-            return;
-        }
-
-        QUIC_ADDR Addr{};
-        QuicAddrSetFamily(&Addr, Family);
-
         int AddrSize =
             (af == AF_INET) ?
                 (int)sizeof(struct sockaddr_in) :
                 (int)sizeof(struct sockaddr_in6);
 
-        if (bind(Sock, (struct sockaddr*)&Addr, AddrSize) == 0) {
-            int AddrLen = AddrSize;
-            if (getsockname(Sock, (struct sockaddr*)&Addr, &AddrLen) == 0) {
-                Port = QuicAddrGetPort(&Addr);
+        //
+        // Retry when the UDP ephemeral port collides with an in-use TCP port.
+        //
+        for (int Attempt = 0; Attempt < 100; Attempt++) {
+            UdpSock = socket(af, SOCK_DGRAM, IPPROTO_UDP);
+            if (UdpSock == INVALID_SOCKET) {
+                return;
             }
-        }
 
-        if (Port == 0) {
+            QUIC_ADDR Addr{};
+            QuicAddrSetFamily(&Addr, Family);
+
+            if (bind(UdpSock, (struct sockaddr*)&Addr, AddrSize) != 0) {
+                Release();
+                return;
+            }
+
+            int AddrLen = AddrSize;
+            if (getsockname(UdpSock, (struct sockaddr*)&Addr, &AddrLen) != 0) {
+                Release();
+                return;
+            }
+
+            Port = QuicAddrGetPort(&Addr);
+            if (Port == 0) {
+                Release();
+                return;
+            }
+
+            if (!ReserveTcp) {
+                return;
+            }
+
+            //
+            // In QTIP mode, also reserve the same port for TCP. CIBIR+XDP
+            // servers skip OS socket creation (for cross-process port sharing),
+            // leaving TCP port N free. Without this, a QTIP client's auxiliary
+            // TCP socket could be assigned port N by the OS, colliding with the
+            // server's entry in the raw socket pool.
+            //
+            TcpSock = socket(af, SOCK_STREAM, IPPROTO_TCP);
+            if (TcpSock == INVALID_SOCKET) {
+                Release();
+                return;
+            }
+
+            QuicAddrSetPort(&Addr, Port);
+            if (bind(TcpSock, (struct sockaddr*)&Addr, AddrSize) == 0) {
+                return; // Both UDP and TCP reserved on the same port.
+            }
+
+            //
+            // TCP port is occupied; close both and retry for a new port.
+            //
             Release();
         }
     }
@@ -145,19 +183,25 @@ struct QuicTestPortReservation {
     QuicTestPortReservation& operator=(const QuicTestPortReservation&) = delete;
 
     //
-    // Releases the port reservation by closing the held socket. Call this
+    // Releases the port reservation by closing the held sockets. Call this
     // immediately before the listener binds to the same port.
     //
     void Release()
     {
-        if (Sock != INVALID_SOCKET) {
-            closesocket(Sock);
-            Sock = INVALID_SOCKET;
+        if (UdpSock != INVALID_SOCKET) {
+            closesocket(UdpSock);
+            UdpSock = INVALID_SOCKET;
         }
+        if (TcpSock != INVALID_SOCKET) {
+            closesocket(TcpSock);
+            TcpSock = INVALID_SOCKET;
+        }
+        Port = 0;
     }
 
 private:
-    SOCKET Sock{INVALID_SOCKET};
+    SOCKET UdpSock{INVALID_SOCKET};
+    SOCKET TcpSock{INVALID_SOCKET};
 };
 #endif // _WIN32 && !_KERNEL_MODE
 

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -128,6 +128,11 @@ struct QuicTestPortReservation {
                 return;
             }
 
+            BOOL RandomizePort = TRUE;
+            (void)setsockopt(
+                UdpSock, SOL_SOCKET, SO_RANDOMIZE_PORT,
+                (const char*)&RandomizePort, sizeof(RandomizePort));
+
             QUIC_ADDR Addr{};
             QuicAddrSetFamily(&Addr, Family);
 

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -149,13 +149,9 @@ struct QuicTestPortReservation {
 
             Port = QuicAddrGetPort(&Addr);
             //
-            // Defensive: bind to port 0 should always assign a real port, but
-            // guard against an unexpected OS behavior.
+            // Bind to port 0 should always assign a real port.
             //
-            if (Port == 0) {
-                Release();
-                return;
-            }
+            ASSERT_NE(Port, (uint16_t)0) << "Bind to port 0 failed to assign a real port";
 
             //
             // Also reserve the same port for TCP. CIBIR+XDP servers skip OS


### PR DESCRIPTION
## Description

Fixes #6015 

QuicTestPortReservation is extended to reserve a matching TCP port alongside the UDP port. In QTIP mode, CIBIR+XDP servers skip OS socket creation, leaving the TCP port free. Without the TCP reservation, a QTIP client's auxiliary TCP socket could be assigned the same port by the OS, colliding with the server's raw socket pool entry. The reservation retries up to 1000 times if the chosen ephemeral port's TCP counterpart is already in use.

Changes:
 - Extend QuicTestPortReservation to also reserve a TCP port.

## Testing

Existing CIBIR and ConnectionPool tests cover this change.

## Documentation

N/A
