### PR TITLE
Add opt-in QUIC_OPENSSL_SYMBOL_PREFIX to namespace bundled OpenSSL symbols (Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ endif()
 
 project(msquic)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Set a default build type if none was specified
 set(default_build_type "Release")
 
@@ -113,6 +115,7 @@ option(QUIC_USE_SYSTEM_LIBCRYPTO "Use system libcrypto if quictls TLS" OFF)
 option(QUIC_USE_EXTERNAL_OPENSSL "Use external OpenSSL instead of building from submodules" OFF)
 set(QUIC_OPENSSL_INCLUDE_DIR "" CACHE PATH "Path to OpenSSL include directory")
 set(QUIC_OPENSSL_LIB_DIR "" CACHE PATH "Path to OpenSSL library directory")
+set(QUIC_OPENSSL_SYMBOL_PREFIX "" CACHE STRING "If non-empty, namespace-prefix every symbol in the bundled OpenSSL static archives (Linux only) so the resulting binary can coexist in the same process with another OpenSSL copy. See docs/OpenSSLSymbolPrefix.md")
 set(QUIC_OPENSSL_ROOT_DIR "" CACHE PATH "Path to OpenSSL root directory")
 option(QUIC_HIGH_RES_TIMERS "Configure the system to use high resolution timers" OFF)
 option(QUIC_OFFICIAL_RELEASE "Configured the build for an official release" OFF)
@@ -811,10 +814,37 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
         FetchContent_MakeAvailable(OpenSSLQuic)
     endif()
 
-    target_link_libraries(OpenSSL
-        INTERFACE
-        MsQuic::OpenSSL
-    )
+    # Optional: namespace-prefix the bundled OpenSSL symbols so the resulting
+    # binary can coexist with another OpenSSL copy loaded into the same
+    # process. See docs/OpenSSLSymbolPrefix.md for motivation and caveats.
+    if(NOT "${QUIC_OPENSSL_SYMBOL_PREFIX}" STREQUAL "")
+        if(NOT CX_PLATFORM STREQUAL "linux")
+            message(FATAL_ERROR "QUIC_OPENSSL_SYMBOL_PREFIX is only supported on Linux today (got CX_PLATFORM=${CX_PLATFORM}).")
+        endif()
+        if(QUIC_USE_EXTERNAL_OPENSSL OR QUIC_OPENSSL_INCLUDE_DIR OR QUIC_OPENSSL_LIB_DIR OR QUIC_OPENSSL_ROOT_DIR)
+            message(FATAL_ERROR "QUIC_OPENSSL_SYMBOL_PREFIX requires the bundled OpenSSL build; do not combine with QUIC_USE_EXTERNAL_OPENSSL / QUIC_OPENSSL_INCLUDE_DIR / QUIC_OPENSSL_LIB_DIR / QUIC_OPENSSL_ROOT_DIR.")
+        endif()
+        if(QUIC_USE_SYSTEM_LIBCRYPTO)
+            message(FATAL_ERROR "QUIC_OPENSSL_SYMBOL_PREFIX is incompatible with QUIC_USE_SYSTEM_LIBCRYPTO; the system libcrypto cannot be renamed.")
+        endif()
+
+        include(PrefixOpenSSLArchives)
+        prefix_openssl_archives(
+            PREFIX        "${QUIC_OPENSSL_SYMBOL_PREFIX}"
+            INPUT_TARGET  OpenSSLQuic
+            OUTPUT_TARGET OpenSSLQuicPrefixed
+        )
+
+        target_link_libraries(OpenSSL
+            INTERFACE
+            OpenSSLQuicPrefixed
+        )
+    else()
+        target_link_libraries(OpenSSL
+            INTERFACE
+            MsQuic::OpenSSL
+        )
+    endif()
 endif()
 
 if (QUIC_USE_SYSTEM_LIBCRYPTO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,26 @@ set(QUIC_OPENSSL_INCLUDE_DIR "" CACHE PATH "Path to OpenSSL include directory")
 set(QUIC_OPENSSL_LIB_DIR "" CACHE PATH "Path to OpenSSL library directory")
 set(QUIC_OPENSSL_SYMBOL_PREFIX "" CACHE STRING "If non-empty, namespace-prefix every symbol in the bundled OpenSSL static archives (Linux only) so the resulting binary can coexist in the same process with another OpenSSL copy. See docs/OpenSSLSymbolPrefix.md")
 set(QUIC_OPENSSL_ROOT_DIR "" CACHE PATH "Path to OpenSSL root directory")
+
+# Outer-most validation for QUIC_OPENSSL_SYMBOL_PREFIX so a value combined with
+# a non-quictls/openssl TLS_LIB (e.g. schannel) errors loudly instead of being
+# silently ignored, and so the prefix value is rejected before it is
+# interpolated into objcopy --redefine-syms map lines or build-tree paths.
+if(NOT "${QUIC_OPENSSL_SYMBOL_PREFIX}" STREQUAL "")
+    if(NOT (QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl"))
+        message(FATAL_ERROR
+            "QUIC_OPENSSL_SYMBOL_PREFIX requires QUIC_TLS_LIB=quictls or openssl "
+            "(got QUIC_TLS_LIB='${QUIC_TLS_LIB}'). The prefix only applies to the "
+            "bundled OpenSSL build path.")
+    endif()
+    if(NOT QUIC_OPENSSL_SYMBOL_PREFIX MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+        message(FATAL_ERROR
+            "QUIC_OPENSSL_SYMBOL_PREFIX must match ^[A-Za-z_][A-Za-z0-9_]*$ "
+            "(got '${QUIC_OPENSSL_SYMBOL_PREFIX}'). The prefix is interpolated into "
+            "objcopy --redefine-syms map lines and into the build-tree path; "
+            "whitespace, '#', '/', leading digits, and shell metacharacters are unsafe.")
+    endif()
+endif()
 option(QUIC_HIGH_RES_TIMERS "Configure the system to use high resolution timers" OFF)
 option(QUIC_OFFICIAL_RELEASE "Configured the build for an official release" OFF)
 set(QUIC_FOLDER_PREFIX "" CACHE STRING "Optional prefix for source group folders when using an IDE generator")
@@ -826,6 +846,15 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
         endif()
         if(QUIC_USE_SYSTEM_LIBCRYPTO)
             message(FATAL_ERROR "QUIC_OPENSSL_SYMBOL_PREFIX is incompatible with QUIC_USE_SYSTEM_LIBCRYPTO; the system libcrypto cannot be renamed.")
+        endif()
+        # Block the shared-lib install path until the prefixed archives are
+        # wired into install(EXPORT). The prefixed target is INTERFACE IMPORTED
+        # GLOBAL and cannot be installed via install(TARGETS); a shared-lib
+        # install would either fail or produce a package that references
+        # build-tree-only paths under ${CMAKE_BINARY_DIR}/openssl-prefixed/.
+        # Static-lib consumers (the primary use case) are unaffected.
+        if(BUILD_SHARED_LIBS)
+            message(FATAL_ERROR "QUIC_OPENSSL_SYMBOL_PREFIX is currently only supported with BUILD_SHARED_LIBS=OFF (the shared-lib install path does not yet handle the prefixed imported target).")
         endif()
 
         include(PrefixOpenSSLArchives)

--- a/cmake/PrefixOpenSSLArchives.cmake
+++ b/cmake/PrefixOpenSSLArchives.cmake
@@ -38,15 +38,12 @@
 #   - INTERFACE IMPORTED target `<OUTPUT_TARGET>` exists with include dirs
 #     copied from `<INPUT_TARGET>` and link libs pointing at the renamed
 #     archives.
-#   - Cache variables:
-#       `<OUTPUT_TARGET>_REDEFINE_SYMS`  absolute path to the syms file
-#                                        (so a consumer's POST_BUILD step can
-#                                        apply the same rename to its own
-#                                        archive)
-#       `<OUTPUT_TARGET>_PREFIX_SCRIPT`  absolute path to
-#                                        `cmake/openssl-prefix-rename.sh`
-#                                        (so consumers do not have to
-#                                        re-resolve the script path)
+#   - Two target properties carry the artifacts a consumer needs to apply the
+#     same rename to its own archive (e.g. `libmsquic_platform.a`):
+#       `PREFIX_RENAME_SYMS_FILE`  absolute path to the redefine-syms file
+#       `PREFIX_RENAME_SCRIPT`     absolute path to
+#                                  `cmake/openssl-prefix-rename.sh`
+#     Read them at the consumer site with `get_target_property()`.
 #
 
 # Capture this module's directory at parse time so the script-path lookup is
@@ -153,24 +150,12 @@ function(prefix_openssl_archives)
         INTERFACE "${_renamed_libssl}" "${_renamed_libcrypto}"
     )
 
-    set(${ARG_OUTPUT_TARGET}_REDEFINE_SYMS "${_syms_file}" CACHE INTERNAL
-        "Path to the prefix-rename syms file used by ${ARG_OUTPUT_TARGET}")
-    set(${ARG_OUTPUT_TARGET}_PREFIX_SCRIPT "${_script}" CACHE INTERNAL
-        "Path to cmake/openssl-prefix-rename.sh used by ${ARG_OUTPUT_TARGET}")
-
-    # NOTE: We do NOT pre-create empty placeholder libssl.a / libcrypto.a here.
-    # Earlier revisions did, ostensibly to keep Ninja's dep check happy on a
-    # clean tree, but empty placeholders mask real failures: if gen-syms or
-    # apply silently produced a 0-byte archive, the placeholder would let the
-    # link step blow up with a baffling "no symbols" error instead of the
-    # original tool failure. Ninja is perfectly happy to schedule the custom
-    # commands above for files that don't yet exist.
-    #
-    # NOTE: ${CMAKE_BINARY_DIR}/openssl-prefixed/${ARG_PREFIX} is NOT made
-    # config-specific. The feature is Linux-only today (enforced upstream),
-    # and Linux builds use single-config generators (Make/Ninja) where
-    # CMAKE_BINARY_DIR is per-config. Revisit if/when we ever extend to a
-    # multi-config generator.
+    # Carry the syms file and helper-script paths on the output target itself
+    # (rather than as cache variables) so consumers retrieve them via
+    # get_target_property() at the call site, which keeps the dependency
+    # explicit and avoids polluting the cache.
+    set_property(TARGET ${ARG_OUTPUT_TARGET} PROPERTY PREFIX_RENAME_SYMS_FILE "${_syms_file}")
+    set_property(TARGET ${ARG_OUTPUT_TARGET} PROPERTY PREFIX_RENAME_SCRIPT    "${_script}")
 
     message(STATUS "Configured prefixed OpenSSL archives (${ARG_OUTPUT_TARGET}):")
     message(STATUS "  Prefix:      ${ARG_PREFIX}")

--- a/cmake/PrefixOpenSSLArchives.cmake
+++ b/cmake/PrefixOpenSSLArchives.cmake
@@ -83,7 +83,11 @@ function(prefix_openssl_archives)
     endforeach()
 
     if(NOT _orig_libssl OR NOT _orig_libcrypto)
-        message(FATAL_ERROR "prefix_openssl_archives: ${ARG_INPUT_TARGET} does not expose both libssl.a and libcrypto.a (got: ${_openssl_libs})")
+        message(FATAL_ERROR
+            "prefix_openssl_archives: ${ARG_INPUT_TARGET} does not expose both libssl.a and libcrypto.a as plain archive paths on its INTERFACE_LINK_LIBRARIES. "
+            "Got INTERFACE_LINK_LIBRARIES='${_openssl_libs}', found libssl.a='${_orig_libssl}' libcrypto.a='${_orig_libcrypto}'. "
+            "This helper only handles bundled OpenSSL configurations whose interface points directly at the two static archives; "
+            "generator-expression-wrapped or target-name link items are not supported.")
     endif()
 
     set(_out_dir            "${CMAKE_BINARY_DIR}/openssl-prefixed/${ARG_PREFIX}")
@@ -154,15 +158,19 @@ function(prefix_openssl_archives)
     set(${ARG_OUTPUT_TARGET}_PREFIX_SCRIPT "${_script}" CACHE INTERNAL
         "Path to cmake/openssl-prefix-rename.sh used by ${ARG_OUTPUT_TARGET}")
 
-    # Create placeholder files so Ninja dependency checking passes on clean
-    # builds (the custom commands above will overwrite them with real content
-    # on first build).
-    if(NOT EXISTS "${_renamed_libssl}")
-        file(WRITE "${_renamed_libssl}" "")
-    endif()
-    if(NOT EXISTS "${_renamed_libcrypto}")
-        file(WRITE "${_renamed_libcrypto}" "")
-    endif()
+    # NOTE: We do NOT pre-create empty placeholder libssl.a / libcrypto.a here.
+    # Earlier revisions did, ostensibly to keep Ninja's dep check happy on a
+    # clean tree, but empty placeholders mask real failures: if gen-syms or
+    # apply silently produced a 0-byte archive, the placeholder would let the
+    # link step blow up with a baffling "no symbols" error instead of the
+    # original tool failure. Ninja is perfectly happy to schedule the custom
+    # commands above for files that don't yet exist.
+    #
+    # NOTE: ${CMAKE_BINARY_DIR}/openssl-prefixed/${ARG_PREFIX} is NOT made
+    # config-specific. The feature is Linux-only today (enforced upstream),
+    # and Linux builds use single-config generators (Make/Ninja) where
+    # CMAKE_BINARY_DIR is per-config. Revisit if/when we ever extend to a
+    # multi-config generator.
 
     message(STATUS "Configured prefixed OpenSSL archives (${ARG_OUTPUT_TARGET}):")
     message(STATUS "  Prefix:      ${ARG_PREFIX}")

--- a/cmake/PrefixOpenSSLArchives.cmake
+++ b/cmake/PrefixOpenSSLArchives.cmake
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# PrefixOpenSSLArchives
+#
+# Produce namespace-prefixed copies of the bundled OpenSSL static archives so
+# the resulting MsQuic binary can coexist in the same process with a different
+# copy of OpenSSL (e.g. a system `libcrypto.so.3` pulled in by an unrelated
+# transitive dependency) without colliding on global C symbols.
+#
+# Mechanism: extract every globally-defined external symbol from the input
+# archives and use `objcopy --redefine-syms` to rewrite the symbol table so
+# both definitions and undefined references carry a `${QUIC_OPENSSL_SYMBOL_PREFIX}`
+# prefix. The rename is applied to:
+#   - The bundled `libssl.a` and `libcrypto.a` (their *defined* symbols).
+#   - Any consumer's static archive that references OpenSSL (the *undefined*
+#     references inside, so they resolve against the prefixed archives at the
+#     final link step). For MsQuic this is `libmsquic_platform.a`, handled in
+#     `src/platform/CMakeLists.txt`.
+#
+# This is a Linux-only feature today. Honoring `${CMAKE_NM}` / `${CMAKE_OBJCOPY}`
+# makes the rename step cross-compile-safe. macOS support would require
+# `llvm-objcopy` >= 13 (untested); PE/COFF lacks a flat-namespace symbol table
+# and would need a fundamentally different approach.
+#
+# Function:
+#   prefix_openssl_archives(
+#       PREFIX        <symbol_prefix>          # e.g. "msquic_"
+#       INPUT_TARGET  <bundled-openssl-target> # INTERFACE target whose
+#                                              # INTERFACE_LINK_LIBRARIES
+#                                              # contains the .a paths
+#       OUTPUT_TARGET <new-interface-target>   # name of the renamed target
+#                                              # to create
+#   )
+#
+# After the call:
+#   - INTERFACE IMPORTED target `<OUTPUT_TARGET>` exists with include dirs
+#     copied from `<INPUT_TARGET>` and link libs pointing at the renamed
+#     archives.
+#   - Cache variables:
+#       `<OUTPUT_TARGET>_REDEFINE_SYMS`  absolute path to the syms file
+#                                        (so a consumer's POST_BUILD step can
+#                                        apply the same rename to its own
+#                                        archive)
+#       `<OUTPUT_TARGET>_PREFIX_SCRIPT`  absolute path to
+#                                        `cmake/openssl-prefix-rename.sh`
+#                                        (so consumers do not have to
+#                                        re-resolve the script path)
+#
+
+# Capture this module's directory at parse time so the script-path lookup is
+# independent of the parent build's `CMAKE_SOURCE_DIR` (which may not be
+# msquic's own root when msquic is consumed via `add_subdirectory`).
+set(_PREFIX_OPENSSL_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/openssl-prefix-rename.sh")
+
+function(prefix_openssl_archives)
+    set(options)
+    set(oneValueArgs PREFIX INPUT_TARGET OUTPUT_TARGET)
+    set(multiValueArgs)
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT ARG_PREFIX OR NOT ARG_INPUT_TARGET OR NOT ARG_OUTPUT_TARGET)
+        message(FATAL_ERROR "prefix_openssl_archives requires PREFIX, INPUT_TARGET, and OUTPUT_TARGET")
+    endif()
+
+    if(NOT TARGET ${ARG_INPUT_TARGET})
+        message(FATAL_ERROR "prefix_openssl_archives: INPUT_TARGET '${ARG_INPUT_TARGET}' does not exist")
+    endif()
+
+    # Pull the original archive paths off the INPUT_TARGET INTERFACE properties.
+    get_target_property(_openssl_libs ${ARG_INPUT_TARGET} INTERFACE_LINK_LIBRARIES)
+    get_target_property(_openssl_inc  ${ARG_INPUT_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+
+    set(_orig_libssl)
+    set(_orig_libcrypto)
+    foreach(_lib IN LISTS _openssl_libs)
+        if(_lib MATCHES "libssl\\.a$")
+            set(_orig_libssl "${_lib}")
+        elseif(_lib MATCHES "libcrypto\\.a$")
+            set(_orig_libcrypto "${_lib}")
+        endif()
+    endforeach()
+
+    if(NOT _orig_libssl OR NOT _orig_libcrypto)
+        message(FATAL_ERROR "prefix_openssl_archives: ${ARG_INPUT_TARGET} does not expose both libssl.a and libcrypto.a (got: ${_openssl_libs})")
+    endif()
+
+    set(_out_dir            "${CMAKE_BINARY_DIR}/openssl-prefixed/${ARG_PREFIX}")
+    set(_syms_file          "${_out_dir}/redefine.syms")
+    set(_renamed_libssl     "${_out_dir}/libssl.a")
+    set(_renamed_libcrypto  "${_out_dir}/libcrypto.a")
+    set(_script             "${_PREFIX_OPENSSL_SCRIPT}")
+
+    file(MAKE_DIRECTORY "${_out_dir}")
+
+    # Forward the cross-compile-aware nm/objcopy to the helper script. If
+    # ${CMAKE_NM} / ${CMAKE_OBJCOPY} are unset, the script falls back to its
+    # own defaults (plain `nm` / `objcopy`).
+    set(_env_args)
+    if(CMAKE_NM)
+        list(APPEND _env_args "NM=${CMAKE_NM}")
+    endif()
+    if(CMAKE_OBJCOPY)
+        list(APPEND _env_args "OBJCOPY=${CMAKE_OBJCOPY}")
+    endif()
+
+    add_custom_command(
+        OUTPUT "${_syms_file}"
+        DEPENDS "${_orig_libssl}" "${_orig_libcrypto}" "${_script}"
+        COMMAND ${CMAKE_COMMAND} -E env ${_env_args}
+                "${_script}" gen-syms "${ARG_PREFIX}" "${_syms_file}"
+                "${_orig_libssl}" "${_orig_libcrypto}"
+        COMMENT "Generating OpenSSL symbol prefix-map (prefix=${ARG_PREFIX})"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT "${_renamed_libssl}"
+        DEPENDS "${_orig_libssl}" "${_syms_file}" "${_script}"
+        COMMAND ${CMAKE_COMMAND} -E env ${_env_args}
+                "${_script}" apply "${_syms_file}" "${_orig_libssl}" "${_renamed_libssl}"
+        COMMENT "Prefix-renaming libssl.a (prefix=${ARG_PREFIX})"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT "${_renamed_libcrypto}"
+        DEPENDS "${_orig_libcrypto}" "${_syms_file}" "${_script}"
+        COMMAND ${CMAKE_COMMAND} -E env ${_env_args}
+                "${_script}" apply "${_syms_file}" "${_orig_libcrypto}" "${_renamed_libcrypto}"
+        COMMENT "Prefix-renaming libcrypto.a (prefix=${ARG_PREFIX})"
+        VERBATIM
+    )
+
+    add_custom_target(
+        ${ARG_OUTPUT_TARGET}_Build
+        DEPENDS "${_renamed_libssl}" "${_renamed_libcrypto}" "${_syms_file}"
+    )
+
+    add_library(${ARG_OUTPUT_TARGET} INTERFACE IMPORTED GLOBAL)
+    add_dependencies(${ARG_OUTPUT_TARGET} ${ARG_OUTPUT_TARGET}_Build)
+    set_target_properties(
+        ${ARG_OUTPUT_TARGET}
+        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_openssl_inc}"
+    )
+    target_link_libraries(
+        ${ARG_OUTPUT_TARGET}
+        INTERFACE "${_renamed_libssl}" "${_renamed_libcrypto}"
+    )
+
+    set(${ARG_OUTPUT_TARGET}_REDEFINE_SYMS "${_syms_file}" CACHE INTERNAL
+        "Path to the prefix-rename syms file used by ${ARG_OUTPUT_TARGET}")
+    set(${ARG_OUTPUT_TARGET}_PREFIX_SCRIPT "${_script}" CACHE INTERNAL
+        "Path to cmake/openssl-prefix-rename.sh used by ${ARG_OUTPUT_TARGET}")
+
+    # Create placeholder files so Ninja dependency checking passes on clean
+    # builds (the custom commands above will overwrite them with real content
+    # on first build).
+    if(NOT EXISTS "${_renamed_libssl}")
+        file(WRITE "${_renamed_libssl}" "")
+    endif()
+    if(NOT EXISTS "${_renamed_libcrypto}")
+        file(WRITE "${_renamed_libcrypto}" "")
+    endif()
+
+    message(STATUS "Configured prefixed OpenSSL archives (${ARG_OUTPUT_TARGET}):")
+    message(STATUS "  Prefix:      ${ARG_PREFIX}")
+    message(STATUS "  Syms file:   ${_syms_file}")
+    message(STATUS "  libssl.a:    ${_renamed_libssl}")
+    message(STATUS "  libcrypto.a: ${_renamed_libcrypto}")
+endfunction()

--- a/cmake/openssl-prefix-rename.sh
+++ b/cmake/openssl-prefix-rename.sh
@@ -93,22 +93,17 @@ apply)
     syms=$1
     in_ar=$2
     out_ar=$3
-    if [[ "$(readlink -f -- "$in_ar")" != "$(readlink -f -- "$out_ar")" ]]; then
-        # Tmp-file + atomic rename so an interrupted run does not leave a
-        # fresh-mtime, partially-renamed (or un-renamed) archive at out_ar
-        # that the next build would mistake for up-to-date.
-        tmp="${out_ar}.tmp.$$"
-        trap 'rm -f -- "$tmp"' EXIT
-        cp -- "$in_ar" "$tmp"
-        "$OBJCOPY" --redefine-syms="$syms" "$tmp"
-        mv -- "$tmp" "$out_ar"
-        trap - EXIT
-    else
-        # In-place rename on the same path. No atomic-rename protection is
-        # possible here (callers that need crash-safety should pass a distinct
-        # out_ar). Used by the POST_BUILD step on libmsquic_platform.a.
-        "$OBJCOPY" --redefine-syms="$syms" "$out_ar"
-    fi
+    # Always go through a temp file + atomic rename, even when in_ar and out_ar
+    # resolve to the same path (the POST_BUILD step on libmsquic_platform.a).
+    # POSIX rename(2) over an existing file is atomic, so an interrupted run
+    # cannot leave out_ar in a partially-rewritten (or un-renamed but
+    # fresh-mtime) state that the next build would mistake for up-to-date.
+    tmp="${out_ar}.tmp.$$"
+    trap 'rm -f -- "$tmp"' EXIT
+    cp -- "$in_ar" "$tmp"
+    "$OBJCOPY" --redefine-syms="$syms" "$tmp"
+    mv -- "$tmp" "$out_ar"
+    trap - EXIT
     ;;
 
 *)

--- a/cmake/openssl-prefix-rename.sh
+++ b/cmake/openssl-prefix-rename.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# openssl-prefix-rename.sh
+#
+# Generate a symbol-prefix map from one or more static archives and apply it
+# via `objcopy --redefine-syms` to produce renamed copies.
+#
+# Used by `cmake/PrefixOpenSSLArchives.cmake` to namespace-prefix the bundled
+# OpenSSL static archives (and any consuming archive's undefined references)
+# when `QUIC_OPENSSL_SYMBOL_PREFIX` is set. This lets the resulting binary
+# coexist with another copy of OpenSSL loaded into the same process (e.g. a
+# system `libcrypto.so.3` pulled in by a transitive dependency) without
+# global-symbol collisions.
+#
+# Modes:
+#   gen-syms   PREFIX OUT_SYMS_FILE INPUT_AR [INPUT_AR ...]
+#     Extract all defined external globals (nm types T/D/R/B/W/V/C) from the
+#     input archives, sort+unique, and emit `<sym> <PREFIX><sym>` lines.
+#
+#   apply      SYMS_FILE INPUT_AR OUTPUT_AR
+#     Copy INPUT_AR to OUTPUT_AR (skipped if same path) and run
+#     `objcopy --redefine-syms=SYMS_FILE` on the copy. The rename touches both
+#     definitions and undefined references inside the archive's member objects.
+#
+# Environment overrides (honored for cross-compilation):
+#   NM        path to the binutils `nm` matching the target architecture
+#             (defaults to `nm`; host BFD multi-target usually works but
+#             `${CMAKE_NM}` is the safe choice)
+#   OBJCOPY   path to the binutils `objcopy` matching the target architecture
+#             (defaults to `objcopy`)
+
+set -euo pipefail
+
+NM=${NM:-nm}
+OBJCOPY=${OBJCOPY:-objcopy}
+
+usage() {
+    cat >&2 <<EOF
+usage:
+  $0 gen-syms PREFIX OUT_SYMS_FILE INPUT_AR [INPUT_AR ...]
+  $0 apply    SYMS_FILE INPUT_AR OUTPUT_AR
+
+env (optional, for cross-compile):
+  NM       (default: nm)
+  OBJCOPY  (default: objcopy)
+EOF
+    exit 2
+}
+
+cmd=${1:-}
+shift || usage
+
+case "$cmd" in
+gen-syms)
+    [[ $# -ge 3 ]] || usage
+    prefix=$1
+    out_syms=$2
+    shift 2
+    "$NM" --defined-only --extern-only "$@" 2>/dev/null \
+        | awk 'NF==3 && $2 ~ /^[TDRBWVC]$/ {print $3}' \
+        | LC_ALL=C sort -u \
+        | awk -v p="$prefix" '{print $1 " " p $1}' \
+        > "$out_syms"
+    ;;
+
+apply)
+    [[ $# -eq 3 ]] || usage
+    syms=$1
+    in_ar=$2
+    out_ar=$3
+    if [[ "$(readlink -f -- "$in_ar")" != "$(readlink -f -- "$out_ar")" ]]; then
+        cp -- "$in_ar" "$out_ar"
+    fi
+    "$OBJCOPY" --redefine-syms="$syms" "$out_ar"
+    ;;
+
+*)
+    usage
+    ;;
+esac

--- a/cmake/openssl-prefix-rename.sh
+++ b/cmake/openssl-prefix-rename.sh
@@ -36,6 +36,11 @@ set -euo pipefail
 NM=${NM:-nm}
 OBJCOPY=${OBJCOPY:-objcopy}
 
+# Surface unusable tools as a clear configuration error instead of a generic
+# "no such file or directory" from the underlying exec.
+command -v "$NM" >/dev/null 2>&1 || { echo "$0: NM='$NM' not found" >&2; exit 1; }
+command -v "$OBJCOPY" >/dev/null 2>&1 || { echo "$0: OBJCOPY='$OBJCOPY' not found" >&2; exit 1; }
+
 usage() {
     cat >&2 <<EOF
 usage:
@@ -58,11 +63,29 @@ gen-syms)
     prefix=$1
     out_syms=$2
     shift 2
-    "$NM" --defined-only --extern-only "$@" 2>/dev/null \
-        | awk 'NF==3 && $2 ~ /^[TDRBWVC]$/ {print $3}' \
+    # Defined-extern symbol-type filter:
+    #   T/D/R/B = text / data / read-only / bss globals
+    #   W/V/C   = weak (func / object) and common
+    #   I       = STT_GNU_IFUNC (e.g. AES-NI/SHA-NI dispatch resolvers OpenSSL
+    #             3.x emits on x86_64); these are externally-visible defined
+    #             symbols, so they must end up in the rename map or MsQuic's
+    #             undefs to them won't get prefixed and unprefixed OpenSSL
+    #             symbols will still leak through the consumer archive.
+    # Do NOT pipe nm's stderr to /dev/null: an unreadable archive, a wrong
+    # cross-compile nm, or a corrupt input file should surface its real error
+    # message in the custom-command log.
+    "$NM" --defined-only --extern-only "$@" \
+        | awk 'NF==3 && $2 ~ /^[TDRBWVCI]$/ {print $3}' \
         | LC_ALL=C sort -u \
         | awk -v p="$prefix" '{print $1 " " p $1}' \
         > "$out_syms"
+    # A 0-line syms file would make `objcopy --redefine-syms` a no-op, leaving
+    # the build green with unprefixed symbols. Fail loudly instead.
+    [[ -s "$out_syms" ]] || {
+        echo "$0: gen-syms produced an empty syms file from: $*" >&2
+        echo "$0: (check that nm '$NM' supports the input archives and emits defined-extern globals)" >&2
+        exit 1
+    }
     ;;
 
 apply)
@@ -71,9 +94,21 @@ apply)
     in_ar=$2
     out_ar=$3
     if [[ "$(readlink -f -- "$in_ar")" != "$(readlink -f -- "$out_ar")" ]]; then
-        cp -- "$in_ar" "$out_ar"
+        # Tmp-file + atomic rename so an interrupted run does not leave a
+        # fresh-mtime, partially-renamed (or un-renamed) archive at out_ar
+        # that the next build would mistake for up-to-date.
+        tmp="${out_ar}.tmp.$$"
+        trap 'rm -f -- "$tmp"' EXIT
+        cp -- "$in_ar" "$tmp"
+        "$OBJCOPY" --redefine-syms="$syms" "$tmp"
+        mv -- "$tmp" "$out_ar"
+        trap - EXIT
+    else
+        # In-place rename on the same path. No atomic-rename protection is
+        # possible here (callers that need crash-safety should pass a distinct
+        # out_ar). Used by the POST_BUILD step on libmsquic_platform.a.
+        "$OBJCOPY" --redefine-syms="$syms" "$out_ar"
     fi
-    "$OBJCOPY" --redefine-syms="$syms" "$out_ar"
     ;;
 
 *)

--- a/docs/OpenSSLSymbolPrefix.md
+++ b/docs/OpenSSLSymbolPrefix.md
@@ -48,10 +48,14 @@ the build:
 5. Routes the existing `OpenSSL` interface target at the prefixed archives, so
    the rest of the build is unchanged.
 
-The result is a `libmsquic.so` (or final exe / static archive when
-`BUILD_SHARED_LIBS=OFF`) whose only externally-visible OpenSSL symbols are the
-prefixed ones. The dynamic linker has no reason to resolve them against any
-other OpenSSL copy present in the same process.
+The result is `libmsquic.a` plus the prefixed `libssl.a` / `libcrypto.a` (and
+whatever final executable or shared library the downstream consumer links them
+into) whose only externally-visible OpenSSL symbols are the prefixed ones. The
+dynamic linker has no reason to resolve them against any other OpenSSL copy
+present in the same process. Note that `QUIC_OPENSSL_SYMBOL_PREFIX` itself
+requires `BUILD_SHARED_LIBS=OFF` — see Constraints below — so this mode never
+produces `libmsquic.so` directly; shared-library packaging is the consumer's
+responsibility.
 
 ## Usage
 

--- a/docs/OpenSSLSymbolPrefix.md
+++ b/docs/OpenSSLSymbolPrefix.md
@@ -55,14 +55,38 @@ other OpenSSL copy present in the same process.
 
 ## Usage
 
+Replace `<your_prefix>` with a value unique to your binary, e.g.
+`acme_myapp_msquic_` (so that two independently-renamed MsQuics in the same
+process still do not collide with each other). The prefix must match
+`^[A-Za-z_][A-Za-z0-9_]*$` — the CMake guard rejects anything else, because
+the value is interpolated into `objcopy --redefine-syms` map lines and into
+the build-tree path.
+
 ```bash
-cmake -B build -DQUIC_TLS_LIB=quictls -DQUIC_OPENSSL_SYMBOL_PREFIX=mymsquic_ ...
+cmake -B build -DQUIC_TLS_LIB=quictls -DQUIC_OPENSSL_SYMBOL_PREFIX=<your_prefix> ...
 cmake --build build
 ```
 
-Pick a prefix that is unique to your binary (`<orgname>_<binname>_`) so that
-two independently-renamed MsQuics in the same process still do not collide
-with each other.
+### Changing the prefix value
+
+The POST_BUILD rename step on `libmsquic_platform.a` is keyed on the platform
+archive's mtime, not on the prefix value. If you reconfigure with a different
+`QUIC_OPENSSL_SYMBOL_PREFIX` over the same build tree, the platform archive
+is untouched, the POST_BUILD step does not refire, and the resulting binary
+will still carry the previous prefix on the platform side while the
+`openssl-prefixed/<new_prefix>/` directory holds the new prefix on the OpenSSL
+side — link will fail or, worse, silently produce a mixed-prefix binary.
+
+Workaround until the rename is restructured as a proper `add_custom_command`
+in the dependency graph: when you change the prefix, force a clean rebuild of
+the affected targets:
+
+```bash
+cmake --build build --target clean
+cmake --build build
+```
+
+or blow the build tree away (`rm -rf build && cmake -B build ...`).
 
 ## Constraints
 
@@ -71,6 +95,9 @@ with each other.
 | Linux only (`CX_PLATFORM=linux`) | The implementation uses GNU binutils `objcopy --redefine-syms`. macOS support would need `llvm-objcopy` >= 13 (untested); PE/COFF lacks a flat-namespace symbol table and would need an entirely different approach. |
 | Bundled OpenSSL only | An external/system OpenSSL is owned by the caller and cannot be renamed. The option is rejected with `FATAL_ERROR` if combined with `QUIC_USE_EXTERNAL_OPENSSL`, `QUIC_OPENSSL_INCLUDE_DIR`, `QUIC_OPENSSL_LIB_DIR`, `QUIC_OPENSSL_ROOT_DIR`, or `QUIC_USE_SYSTEM_LIBCRYPTO`. |
 | Cross-compile aware | `${CMAKE_NM}` and `${CMAKE_OBJCOPY}` are honored so cross-compiled builds (e.g. `aarch64-linux-gnu-objcopy`) work correctly. |
+| Prefix charset | Must match `^[A-Za-z_][A-Za-z0-9_]*$`. The CMake guard rejects anything else. The value is interpolated into `objcopy --redefine-syms` map lines and into the build-tree path. |
+| `BUILD_SHARED_LIBS=OFF` only | The prefixed OpenSSL is exposed as an `INTERFACE IMPORTED GLOBAL` target referencing build-tree archive paths under `${CMAKE_BINARY_DIR}/openssl-prefixed/`; it is not installable via `install(TARGETS ... EXPORT msquic)`. Building MsQuic as a shared lib with prefixing enabled is rejected with `FATAL_ERROR` until the install path is restructured. |
+| Prefix changes require clean rebuild | The POST_BUILD rename on `libmsquic_platform.a` is keyed on the archive mtime, not the prefix value. See "Changing the prefix value" above. |
 
 ## Performance
 
@@ -81,11 +108,14 @@ whenever it changes, which is negligible.
 
 ## Verification
 
-After the build, the prefixed archive should contain only renamed symbols:
+Replace `<your_prefix>` and `<arch>_<tls>` (e.g. `x64_quictls`) with the
+values used at configure time. After the build, the prefixed archive should
+contain only renamed symbols:
 
 ```bash
-nm -gC --defined-only build/openssl-prefixed/mymsquic_/libssl.a \
-  | awk 'NF==3 && $2 ~ /^[TDRBWVC]$/ {print $3}' | grep -vc '^mymsquic_'
+nm -g --defined-only build/openssl-prefixed/<your_prefix>/libssl.a \
+  | awk 'NF>=3 && $(NF-1) ~ /^[TDRBWVCI]$/ {print $NF}' \
+  | grep -v '^<your_prefix>' | wc -l
 # Expected: 0
 ```
 
@@ -93,9 +123,22 @@ The shared/static library's external OpenSSL references should all be
 prefixed:
 
 ```bash
-nm -uC build/lib/libmsquic.so | grep -E 'SSL_|EVP_|BN_|ERR_' | grep -v mymsquic_
+nm -u build/linux/<arch>_<tls>/bin/libmsquic.so \
+  | grep -E 'SSL_|EVP_|BN_|ERR_' | grep -v '<your_prefix>'
 # Expected: no output
 ```
+
+Notes on the `nm` invocations above:
+
+- We use plain `-g` (no `-C`) to match the script's symbol filter, which
+  operates on mangled names.
+- The `awk` filter mirrors the script's rule (`NF>=3` and a symbol-type set
+  that includes `I` / GNU IFUNC, used by OpenSSL 3.x dispatch resolvers on
+  x86_64). If you tighten it, you may falsely conclude the rename is
+  incomplete.
+- The pipeline uses `grep -v ... | wc -l` rather than `grep -vc` because
+  `grep -vc` exits non-zero when its count is 0, which under `set -e` would
+  abort a verification script for the success case.
 
 ## Future direction
 

--- a/docs/OpenSSLSymbolPrefix.md
+++ b/docs/OpenSSLSymbolPrefix.md
@@ -63,9 +63,17 @@ the value is interpolated into `objcopy --redefine-syms` map lines and into
 the build-tree path.
 
 ```bash
-cmake -B build -DQUIC_TLS_LIB=quictls -DQUIC_OPENSSL_SYMBOL_PREFIX=<your_prefix> ...
+cmake -B build \
+    -DQUIC_TLS_LIB=quictls \
+    -DQUIC_BUILD_SHARED=OFF \
+    -DQUIC_OPENSSL_SYMBOL_PREFIX=<your_prefix> ...
 cmake --build build
 ```
+
+`-DQUIC_BUILD_SHARED=OFF` is required: this option drives MsQuic's
+`BUILD_SHARED_LIBS`, and the prefixed OpenSSL is currently only supported with
+`BUILD_SHARED_LIBS=OFF` (see Constraints below). Omitting it on a default
+configure (where `QUIC_BUILD_SHARED=ON`) trips the `FATAL_ERROR` guard.
 
 ### Changing the prefix value
 
@@ -119,13 +127,15 @@ nm -g --defined-only build/openssl-prefixed/<your_prefix>/libssl.a \
 # Expected: 0
 ```
 
-The shared/static library's external OpenSSL references should all be
-prefixed:
+`libmsquic_platform.a`'s undefined OpenSSL references should all be
+prefixed (this option requires `QUIC_BUILD_SHARED=OFF`, so the final output is
+the static archive — there is no `libmsquic.so` to check):
 
 ```bash
-nm -u build/linux/<arch>_<tls>/bin/libmsquic.so \
-  | grep -E 'SSL_|EVP_|BN_|ERR_' | grep -v '<your_prefix>'
-# Expected: no output
+nm -u build/linux/<arch>_<tls>/obj/Release/libmsquic_platform.a \
+  | awk '$1=="U"{print $2}' \
+  | grep -E '^(SSL_|EVP_|BN_|ERR_|X509_|OPENSSL_|RAND_|RSA_|EC_|BIO_|ASN1_|PEM_|CRYPTO_)'
+# Expected: no output (every OpenSSL undef is now <your_prefix>-prefixed)
 ```
 
 Notes on the `nm` invocations above:

--- a/docs/OpenSSLSymbolPrefix.md
+++ b/docs/OpenSSLSymbolPrefix.md
@@ -1,0 +1,105 @@
+# OpenSSL Symbol Prefix (`QUIC_OPENSSL_SYMBOL_PREFIX`)
+
+> **Status: Experimental / opt-in.** Linux only. Default off.
+
+## Motivation
+
+When a process links MsQuic statically and also pulls in another copy of
+OpenSSL via an unrelated dependency (e.g. a system `libcrypto.so.3` brought in
+by a logging library, a database driver, or any C++ library that itself uses
+OpenSSL), the two OpenSSL copies share the same global C symbols
+(`SSL_CTX_new`, `EVP_*`, `BN_*`, `ERR_*`, the per-module init constructors,
+etc.). The dynamic linker resolves every reference to the **first definition
+loaded**, so all callers — including MsQuic — silently end up sharing one
+OpenSSL's state machine while their headers and ABI assumptions came from the
+other. Typical symptoms:
+
+- Crashes in `OPENSSL_init_crypto` / `RAND_load_file` when one OpenSSL's
+  per-module init runs against the other's global registries.
+- Spurious SSL handshake failures when callbacks installed against one
+  `SSL_CTX` see the other's vtable layout.
+- ABI mismatches when one OpenSSL is `3.0.x` (system `libcrypto.so.3` on
+  Ubuntu 22.04 / RHEL 9) and MsQuic's bundled OpenSSL is `3.5.x` (required for
+  `SSL_set_quic_tls_cbs`).
+
+Building MsQuic as a `SHARED` library with `--exclude-libs=ALL` hides the
+bundled OpenSSL from the global symbol table, but does not help consumers that
+want a single statically-linked binary, and does not address process-level
+duplicate-singleton issues if the consumer itself produces a `.so`.
+
+## What this option does
+
+When `QUIC_OPENSSL_SYMBOL_PREFIX=<prefix>` is passed at CMake configure time,
+the build:
+
+1. Builds the bundled OpenSSL submodule normally to produce `libssl.a` and
+   `libcrypto.a`.
+2. Extracts every globally-defined external symbol from those two archives
+   using `nm --defined-only --extern-only` and writes a redefine-syms file
+   mapping each `<sym>` to `<prefix><sym>`.
+3. Produces prefixed copies of the archives via
+   `objcopy --redefine-syms=<file> libssl.a libssl_prefixed.a` (and the same
+   for `libcrypto.a`). The rename touches both definitions and undefined
+   references inside each member object.
+4. Applies the same `--redefine-syms` step as a POST_BUILD action on
+   `libmsquic_platform.a` so that MsQuic's own undefined references to
+   OpenSSL (from `tls_openssl.c`, `tls_quictls.c`, `crypt_openssl.c`,
+   `selfsign_openssl.c`) get rewritten to match the prefixed names.
+5. Routes the existing `OpenSSL` interface target at the prefixed archives, so
+   the rest of the build is unchanged.
+
+The result is a `libmsquic.so` (or final exe / static archive when
+`BUILD_SHARED_LIBS=OFF`) whose only externally-visible OpenSSL symbols are the
+prefixed ones. The dynamic linker has no reason to resolve them against any
+other OpenSSL copy present in the same process.
+
+## Usage
+
+```bash
+cmake -B build -DQUIC_TLS_LIB=quictls -DQUIC_OPENSSL_SYMBOL_PREFIX=mymsquic_ ...
+cmake --build build
+```
+
+Pick a prefix that is unique to your binary (`<orgname>_<binname>_`) so that
+two independently-renamed MsQuics in the same process still do not collide
+with each other.
+
+## Constraints
+
+| Constraint | Why |
+| --- | --- |
+| Linux only (`CX_PLATFORM=linux`) | The implementation uses GNU binutils `objcopy --redefine-syms`. macOS support would need `llvm-objcopy` >= 13 (untested); PE/COFF lacks a flat-namespace symbol table and would need an entirely different approach. |
+| Bundled OpenSSL only | An external/system OpenSSL is owned by the caller and cannot be renamed. The option is rejected with `FATAL_ERROR` if combined with `QUIC_USE_EXTERNAL_OPENSSL`, `QUIC_OPENSSL_INCLUDE_DIR`, `QUIC_OPENSSL_LIB_DIR`, `QUIC_OPENSSL_ROOT_DIR`, or `QUIC_USE_SYSTEM_LIBCRYPTO`. |
+| Cross-compile aware | `${CMAKE_NM}` and `${CMAKE_OBJCOPY}` are honored so cross-compiled builds (e.g. `aarch64-linux-gnu-objcopy`) work correctly. |
+
+## Performance
+
+The rename step adds a few seconds to the first build (the syms file is ~95k
+lines; `objcopy --redefine-syms` over each archive runs in 1-2s). Subsequent
+incremental builds re-apply the POST_BUILD step on `libmsquic_platform.a`
+whenever it changes, which is negligible.
+
+## Verification
+
+After the build, the prefixed archive should contain only renamed symbols:
+
+```bash
+nm -gC --defined-only build/openssl-prefixed/mymsquic_/libssl.a \
+  | awk 'NF==3 && $2 ~ /^[TDRBWVC]$/ {print $3}' | grep -vc '^mymsquic_'
+# Expected: 0
+```
+
+The shared/static library's external OpenSSL references should all be
+prefixed:
+
+```bash
+nm -uC build/lib/libmsquic.so | grep -E 'SSL_|EVP_|BN_|ERR_' | grep -v mymsquic_
+# Expected: no output
+```
+
+## Future direction
+
+The cleanest long-term solution is for OpenSSL itself to expose a
+configure-time `--symbol-prefix=` option that compiles every public symbol
+with the prefix baked in. Until that lands upstream, this CMake helper
+provides an equivalent at link time without requiring an OpenSSL fork.

--- a/docs/OpenSSLSymbolPrefix.md
+++ b/docs/OpenSSLSymbolPrefix.md
@@ -2,6 +2,23 @@
 
 > **Status: Experimental / opt-in.** Linux only. Default off.
 
+## Scope
+
+This option only matters in one specific configuration:
+
+- the consuming application links MsQuic statically, **and**
+- MsQuic was built with bundled OpenSSL statically linked
+  (`QUIC_TLS_LIB=quictls|openssl` without `QUIC_USE_SYSTEM_LIBCRYPTO` or any
+  of the external-OpenSSL hooks).
+
+If MsQuic dynamically links to the system OpenSSL, the bundled OpenSSL
+symbols never enter the consumer's binary in the first place and there is
+nothing to namespace. The msquic project is moving toward dynamic linking of
+the system OpenSSL where it is available (e.g. OpenSSL 3.5 on newer distros);
+as that becomes the default for the affected platforms, `QUIC_OPENSSL_SYMBOL_PREFIX`
+becomes irrelevant for those configurations and remains useful only for
+consumers that must continue to bundle OpenSSL statically.
+
 ## Motivation
 
 When a process links MsQuic statically and also pulls in another copy of
@@ -156,7 +173,20 @@ Notes on the `nm` invocations above:
 
 ## Future direction
 
-The cleanest long-term solution is for OpenSSL itself to expose a
-configure-time `--symbol-prefix=` option that compiles every public symbol
-with the prefix baked in. Until that lands upstream, this CMake helper
-provides an equivalent at link time without requiring an OpenSSL fork.
+This CMake helper is a workaround at the link layer. A build-time
+`--symbol-prefix=` configure option in OpenSSL itself — equivalent to
+BoringSSL's [`BORINGSSL_PREFIX`][boringssl-prefix], which bakes the prefix
+into every public symbol at compile time — would make this helper
+unnecessary.
+
+The collision class was raised upstream in
+[openssl/openssl#20766 "OpenSSL symbols conflict while linking with
+application"](https://github.com/openssl/openssl/issues/20766) (Apr 2023) and
+closed Jan 2024 as `resolved: answered` with OpenSSL maintainers explicitly
+declining a prefix mechanism — the upstream position is that statically
+linking two OpenSSL copies into one process is the consumer's problem to
+solve, and that `objcopy`-style renaming (i.e. what this helper does) is
+considered a "dodgy kludge" they do not want in tree. We should treat this
+helper as a permanent workaround unless that upstream position changes.
+
+[boringssl-prefix]: https://github.com/google/boringssl/blob/main/BUILDING.md#building-with-prefixed-symbols

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -101,6 +101,30 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
     if (CX_PLATFORM STREQUAL "darwin")
         target_link_libraries(msquic_platform PUBLIC "-framework CoreFoundation" "-framework Security")
     endif()
+
+    # If QUIC_OPENSSL_SYMBOL_PREFIX is set, rewrite OpenSSL references inside
+    # libmsquic_platform.a to use the prefixed names. Running on the archive
+    # (rather than individual .o files) is sufficient because objcopy
+    # --redefine-syms operates on every member object inside a .a in one pass.
+    # The same rename was already applied to the bundled libssl.a / libcrypto.a
+    # in submodules/CMakeLists.txt, so the final exe / shared-lib link resolves
+    # cleanly.
+    if(NOT "${QUIC_OPENSSL_SYMBOL_PREFIX}" STREQUAL "")
+        add_custom_command(
+            TARGET msquic_platform
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E env
+                "NM=${CMAKE_NM}" "OBJCOPY=${CMAKE_OBJCOPY}"
+                "${OpenSSLQuicPrefixed_PREFIX_SCRIPT}" apply
+                "${OpenSSLQuicPrefixed_REDEFINE_SYMS}"
+                "$<TARGET_FILE:msquic_platform>"
+                "$<TARGET_FILE:msquic_platform>"
+            COMMENT
+                "Prefix-renaming OpenSSL references in $<TARGET_FILE_NAME:msquic_platform> (prefix=${QUIC_OPENSSL_SYMBOL_PREFIX})"
+            VERBATIM
+        )
+        add_dependencies(msquic_platform OpenSSLQuicPrefixed_Build)
+    endif()
 elseif(QUIC_TLS_LIB STREQUAL "schannel")
     target_link_libraries(msquic_platform PUBLIC secur32)
     if (NOT QUIC_GAMECORE_BUILD)

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -107,14 +107,24 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
     # (rather than individual .o files) is sufficient because objcopy
     # --redefine-syms operates on every member object inside a .a in one pass.
     # The same rename was already applied to the bundled libssl.a / libcrypto.a
-    # in submodules/CMakeLists.txt, so the final exe / shared-lib link resolves
-    # cleanly.
+    # in cmake/PrefixOpenSSLArchives.cmake, so the final exe / shared-lib link
+    # resolves cleanly.
     if(NOT "${QUIC_OPENSSL_SYMBOL_PREFIX}" STREQUAL "")
+        # Mirror the conditional NM/OBJCOPY forwarding used in
+        # cmake/PrefixOpenSSLArchives.cmake so an unset CMAKE_NM / CMAKE_OBJCOPY
+        # falls back to the script's defaults instead of forwarding the literal
+        # empty string and breaking the helper's `command -v` check.
+        set(_prefix_env_args)
+        if(CMAKE_NM)
+            list(APPEND _prefix_env_args "NM=${CMAKE_NM}")
+        endif()
+        if(CMAKE_OBJCOPY)
+            list(APPEND _prefix_env_args "OBJCOPY=${CMAKE_OBJCOPY}")
+        endif()
         add_custom_command(
             TARGET msquic_platform
             POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E env
-                "NM=${CMAKE_NM}" "OBJCOPY=${CMAKE_OBJCOPY}"
+            COMMAND ${CMAKE_COMMAND} -E env ${_prefix_env_args}
                 "${OpenSSLQuicPrefixed_PREFIX_SCRIPT}" apply
                 "${OpenSSLQuicPrefixed_REDEFINE_SYMS}"
                 "$<TARGET_FILE:msquic_platform>"

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -103,17 +103,9 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
     endif()
 
     # If QUIC_OPENSSL_SYMBOL_PREFIX is set, rewrite OpenSSL references inside
-    # libmsquic_platform.a to use the prefixed names. Running on the archive
-    # (rather than individual .o files) is sufficient because objcopy
-    # --redefine-syms operates on every member object inside a .a in one pass.
-    # The same rename was already applied to the bundled libssl.a / libcrypto.a
-    # in cmake/PrefixOpenSSLArchives.cmake, so the final exe / shared-lib link
-    # resolves cleanly.
+    # libmsquic_platform.a so they match the prefixed bundled archives. See
+    # cmake/PrefixOpenSSLArchives.cmake and cmake/openssl-prefix-rename.sh.
     if(NOT "${QUIC_OPENSSL_SYMBOL_PREFIX}" STREQUAL "")
-        # Mirror the conditional NM/OBJCOPY forwarding used in
-        # cmake/PrefixOpenSSLArchives.cmake so an unset CMAKE_NM / CMAKE_OBJCOPY
-        # falls back to the script's defaults instead of forwarding the literal
-        # empty string and breaking the helper's `command -v` check.
         set(_prefix_env_args)
         if(CMAKE_NM)
             list(APPEND _prefix_env_args "NM=${CMAKE_NM}")
@@ -121,12 +113,14 @@ if(QUIC_TLS_LIB STREQUAL "quictls" OR QUIC_TLS_LIB STREQUAL "openssl")
         if(CMAKE_OBJCOPY)
             list(APPEND _prefix_env_args "OBJCOPY=${CMAKE_OBJCOPY}")
         endif()
+        get_target_property(_prefix_script  OpenSSLQuicPrefixed PREFIX_RENAME_SCRIPT)
+        get_target_property(_prefix_syms    OpenSSLQuicPrefixed PREFIX_RENAME_SYMS_FILE)
         add_custom_command(
             TARGET msquic_platform
             POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E env ${_prefix_env_args}
-                "${OpenSSLQuicPrefixed_PREFIX_SCRIPT}" apply
-                "${OpenSSLQuicPrefixed_REDEFINE_SYMS}"
+                "${_prefix_script}" apply
+                "${_prefix_syms}"
                 "$<TARGET_FILE:msquic_platform>"
                 "$<TARGET_FILE:msquic_platform>"
             COMMENT


### PR DESCRIPTION
## Description

This PR adds an **opt-in** CMake cache variable, `QUIC_OPENSSL_SYMBOL_PREFIX`, that namespace-prefixes every globally-visible symbol in the bundled OpenSSL static archives (and rewrites MsQuic's own undefined references to match). When `QUIC_OPENSSL_SYMBOL_PREFIX` is left empty (the default), no new code runs and the build is byte-for-byte identical to today.

### Motivation

When MsQuic is statically linked into a process that also pulls in another copy of OpenSSL — for example, a system `libcrypto.so.3` brought in transitively by an unrelated dependency (a logging library, a database client, any C++ library that itself uses OpenSSL) — the two OpenSSL copies share the same global C symbols (`SSL_CTX_new`, `EVP_*`, `BN_*`, `ERR_*`, the per-module init constructors, …). The dynamic linker resolves every reference to the **first definition loaded**, so all callers — including MsQuic — silently end up sharing one OpenSSL's state machine while their headers and ABI assumptions came from the other. Typical symptoms:

- Crashes in `OPENSSL_init_crypto` / `RAND_load_file` when one OpenSSL's per-module init runs against the other's global registries.
- Spurious SSL handshake failures when callbacks installed against one `SSL_CTX` see the other's vtable layout.
- ABI mismatches when one OpenSSL is `3.0.x` (system `libcrypto.so.3` on Ubuntu 22.04 / RHEL 9) and MsQuic's bundled OpenSSL is `3.5.x` (required for `SSL_set_quic_tls_cbs`).

Note that MsQuic's bundled-OpenSSL path always links `libssl.a` / `libcrypto.a` **statically** into MsQuic, regardless of `QUIC_BUILD_SHARED` — `SHARED` just controls whether the result is `libmsquic.so` or `libmsquic.a`. Building `SHARED` with `--exclude-libs=ALL` therefore strips the (statically linked) OpenSSL symbols from `libmsquic.so`'s dynamic export table, which is sufficient when the consumer `dlopen`s/links against `libmsquic.so` itself. It does **not** help:

- Static consumers that link `libmsquic.a` into a final binary — symbols flow straight into the executable's global table.
- Consumers that bundle `libmsquic.a` into their own `.so` — same exposure unless they also `--exclude-libs` it.
- Either case at runtime — even with exports hidden, both `libcrypto`s coexist in one address space and OpenSSL's process-global init/registries (`OPENSSL_init_crypto`, error/atexit tables, `RAND` state) can still collide.

### How it works

When `QUIC_OPENSSL_SYMBOL_PREFIX=<prefix>` is passed at CMake configure time, the build:

1. Builds the bundled OpenSSL submodule normally to produce `libssl.a` and `libcrypto.a`.
2. Extracts every globally-defined external symbol from those archives via `nm --defined-only --extern-only` and writes a redefine-syms file mapping each `<sym>` to `<prefix><sym>`.
3. Produces prefixed copies via `objcopy --redefine-syms=<file>` (touches both definitions and undefined references inside each member object).
4. Applies the same `--redefine-syms` step as a `POST_BUILD` action on `libmsquic_platform.a` so MsQuic's own undefined references to OpenSSL (from `tls_openssl.c`, `tls_quictls.c`, `crypt_openssl.c`, `selfsign_openssl.c`) get rewritten to match.
5. Routes the existing `OpenSSL` interface target at the prefixed archives, so the rest of the build is unchanged.

The result is a `libmsquic.{a,so}` whose only externally-visible OpenSSL symbols are the prefixed ones. The dynamic linker has no reason to resolve them against any other OpenSSL copy present in the same process.

### Constraints

| Constraint | Why |
| --- | --- |
| Linux only (`CX_PLATFORM=linux`) | Uses GNU binutils `objcopy --redefine-syms`. macOS would need `llvm-objcopy` >= 13 (untested); PE/COFF lacks a flat-namespace symbol table. Rejected with `FATAL_ERROR` on other platforms. |
| Bundled OpenSSL only | External/system OpenSSL is owned by the caller and cannot be renamed. Rejected with `FATAL_ERROR` if combined with `QUIC_USE_EXTERNAL_OPENSSL`, `QUIC_OPENSSL_INCLUDE_DIR`, `QUIC_OPENSSL_LIB_DIR`, `QUIC_OPENSSL_ROOT_DIR`, or `QUIC_USE_SYSTEM_LIBCRYPTO`. |
| Cross-compile aware | `${CMAKE_NM}` / `${CMAKE_OBJCOPY}` are forwarded to the helper script, so `aarch64-linux-gnu-objcopy` etc. are used when configured. |

### Files

- `cmake/openssl-prefix-rename.sh` — helper script (`gen-syms` / `apply` modes; honors `NM` / `OBJCOPY` env vars).
- `cmake/PrefixOpenSSLArchives.cmake` — helper function `prefix_openssl_archives(PREFIX … INPUT_TARGET … OUTPUT_TARGET …)`.
- `CMakeLists.txt` — new option + validation + plumbing in the bundled-OpenSSL branch.
- `src/platform/CMakeLists.txt` — `POST_BUILD` rename on `libmsquic_platform.a`.
- `docs/OpenSSLSymbolPrefix.md` — motivation, usage, caveats, verification recipe.

### Future direction

The cleanest long-term solution is for OpenSSL itself to expose a configure-time `--symbol-prefix=` option that compiles every public symbol with the prefix baked in (an analog of BoringSSL's `BSSL_NAMESPACE` or LibreSSL's recurring discussion). I plan to file that issue upstream with this PR linked as concrete prior art demonstrating consumer demand. Until that lands, this CMake helper provides an equivalent at link time without requiring an OpenSSL fork.

## Testing

### Manual verification (local, this PR's branch)

Built on Linux x86_64 with `-G Ninja -DQUIC_TLS_LIB=quictls -DQUIC_BUILD_SHARED=OFF`:

**With `-DQUIC_OPENSSL_SYMBOL_PREFIX=msqtest_`:**

```bash
# 0 unprefixed defined globals in the renamed archives:
nm --defined-only --extern-only build/openssl-prefixed/msqtest_/libssl.a \
  | awk '$2 ~ /^[TDRBWVC]$/ {print $3}' | grep -vc '^msqtest_'    # → 0
nm --defined-only --extern-only build/openssl-prefixed/msqtest_/libcrypto.a \
  | awk '$2 ~ /^[TDRBWVC]$/ {print $3}' | grep -vc '^msqtest_'    # → 0

# 0 unprefixed OpenSSL undefs in msquic_platform.a, 161 prefixed undefs:
nm -u build/obj/Release/libmsquic_platform.a | awk '$1=="U"{print $2}' \
  | grep -E '^(SSL_|EVP_|BN_|ERR_|X509_|OPENSSL_|RAND_|RSA_|EC_|BIO_|ASN1_|PEM_|CRYPTO_)' \
  | wc -l                                                         # → 0
nm -u build/obj/Release/libmsquic_platform.a | awk '$1=="U"{print $2}' \
  | grep -c '^msqtest_'                                           # → 161
```

**Without the option (default build):**

- 138 normal unprefixed OpenSSL undefs in `libmsquic_platform.a`.
- `build/openssl-prefixed/` directory not created.
- Build time identical to baseline (no new compilation; the rename rules simply don't fire).

### Production validation

The same prefix-rename technique has been deployed in Microsoft's [meru](https://github.com/microsoft/meru-common) codebase (a consumer of MsQuic). It is currently validated across this matrix:

- `Release` x86_64
- `Release_ASAN`, `Debug_ASAN`, `Debug_UBSAN`, `Debug_TSAN` x86_64
- `arm_debug_crosscompile` (aarch64)
- `clang_tidy`

See [microsoft/meru-common#4011](https://github.com/microsoft/meru-common/pull/4011) for the consumer-side integration that ports the same helper script + CMake module pattern that this PR upstreams.

### MsQuic CI coverage

The default (option-empty) path is unchanged, so existing CI should be unaffected. The option-set path is Linux-only and opt-in, so it does not need to enter the default matrix. Happy to add a single Linux CI leg that exercises `-DQUIC_OPENSSL_SYMBOL_PREFIX=msquic_` if maintainers think that's worthwhile.

## Documentation

New file: `docs/OpenSSLSymbolPrefix.md` documents motivation, usage, constraints, and a verification recipe.



