### PR TITLE
Temporarily disable fragmented TLS tests

### DIFF
--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -32,7 +32,6 @@ const QUIC_HKDF_LABELS HkdfLabels = { "quic key", "quic iv", "quic hp", "quic ku
 
 bool IsWindows2019() { return OsRunner && strcmp(OsRunner, "windows-2019") == 0; }
 bool IsWindows2022() { return OsRunner && strcmp(OsRunner, "windows-2022") == 0; }
-bool IsWindowsPreRelease() { return OsRunner && strcmp(OsRunner, "WinServerPrerelease") == 0; }
 
 struct TlsTest : public ::testing::TestWithParam<bool>
 {
@@ -1283,7 +1282,7 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
 
 TEST_F(TlsTest, HandshakeFragmented)
 {
-    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove after fixing Schannel, #6035
+    GTEST_SKIP(); // Remove after fixing Schannel, #6035
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
@@ -1295,7 +1294,7 @@ TEST_F(TlsTest, HandshakeFragmented)
 
 TEST_F(TlsTest, HandshakeVeryFragmented)
 {
-    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove after fixing Schannel, #6035
+    GTEST_SKIP(); // Remove after fixing Schannel, #6035
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -32,7 +32,7 @@ const QUIC_HKDF_LABELS HkdfLabels = { "quic key", "quic iv", "quic hp", "quic ku
 
 bool IsWindows2019() { return OsRunner && strcmp(OsRunner, "windows-2019") == 0; }
 bool IsWindows2022() { return OsRunner && strcmp(OsRunner, "windows-2022") == 0; }
-bool IsWindows2025() { return OsRunner && strcmp(OsRunner, "windows-2025") == 0; }
+bool IsWindowsPreRelease() { return OsRunner && strcmp(OsRunner, "WinServerPrerelease") == 0; }
 
 struct TlsTest : public ::testing::TestWithParam<bool>
 {
@@ -1283,7 +1283,7 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
 
 TEST_F(TlsTest, HandshakeFragmented)
 {
-    if (IsWindows2025()) GTEST_SKIP(); // Remove once fixing Schannel
+    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove once fixing Schannel
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
@@ -1295,7 +1295,7 @@ TEST_F(TlsTest, HandshakeFragmented)
 
 TEST_F(TlsTest, HandshakeVeryFragmented)
 {
-    if (IsWindows2025()) GTEST_SKIP(); // Remove once fixing Schannel
+    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove once fixing Schannel
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -1283,7 +1283,7 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
 
 TEST_F(TlsTest, HandshakeFragmented)
 {
-    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove once fixing Schannel
+    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove after fixing Schannel, #6035
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
@@ -1295,7 +1295,7 @@ TEST_F(TlsTest, HandshakeFragmented)
 
 TEST_F(TlsTest, HandshakeVeryFragmented)
 {
-    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove once fixing Schannel
+    if (IsWindowsPreRelease()) GTEST_SKIP(); // Remove after fixing Schannel, #6035
 
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -1280,7 +1280,7 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
     DoHandshake(ServerContext, ClientContext);
 }
 
-TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing Schannel, #6035
+TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing #6035
 {
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
@@ -1290,7 +1290,7 @@ TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing S
     DoHandshake(ServerContext, ClientContext, 200);
 }
 
-TEST_F(TlsTest, DISABLED_HandshakeVeryFragmented) // Remove DISABLED_ after fixing Schannel, #6035
+TEST_F(TlsTest, DISABLED_HandshakeVeryFragmented) // Remove DISABLED_ after fixing #6035
 {
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -32,6 +32,7 @@ const QUIC_HKDF_LABELS HkdfLabels = { "quic key", "quic iv", "quic hp", "quic ku
 
 bool IsWindows2019() { return OsRunner && strcmp(OsRunner, "windows-2019") == 0; }
 bool IsWindows2022() { return OsRunner && strcmp(OsRunner, "windows-2022") == 0; }
+bool IsWindows2025() { return OsRunner && strcmp(OsRunner, "windows-2025") == 0; }
 
 struct TlsTest : public ::testing::TestWithParam<bool>
 {
@@ -1282,6 +1283,8 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
 
 TEST_F(TlsTest, HandshakeFragmented)
 {
+    if (IsWindows2025()) GTEST_SKIP(); // Remove once fixing Schannel
+
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
     TlsContext ServerContext, ClientContext;
@@ -1292,6 +1295,8 @@ TEST_F(TlsTest, HandshakeFragmented)
 
 TEST_F(TlsTest, HandshakeVeryFragmented)
 {
+    if (IsWindows2025()) GTEST_SKIP(); // Remove once fixing Schannel
+
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
     TlsContext ServerContext, ClientContext;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -1280,10 +1280,8 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
     DoHandshake(ServerContext, ClientContext);
 }
 
-TEST_F(TlsTest, HandshakeFragmented)
+TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing Schannel, #6035
 {
-    GTEST_SKIP(); // Remove after fixing Schannel, #6035
-
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
     TlsContext ServerContext, ClientContext;
@@ -1292,10 +1290,8 @@ TEST_F(TlsTest, HandshakeFragmented)
     DoHandshake(ServerContext, ClientContext, 200);
 }
 
-TEST_F(TlsTest, HandshakeVeryFragmented)
+TEST_F(TlsTest, DISABLED_HandshakeVeryFragmented) // Remove DISABLED_ after fixing Schannel, #6035
 {
-    GTEST_SKIP(); // Remove after fixing Schannel, #6035
-
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
     TlsContext ServerContext, ClientContext;


### PR DESCRIPTION
## Description

Temporarily skip the fragmented TLS unit tests to unblock the pipeline until a proper fix can be installed in Schannel. #6035 tracks effort to revert this change.

## Testing

CI

## Documentation

No documentation changes required.