### PR TITLE
Discard client Initial keys when Handshake write keys are installed

### DIFF
--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -359,10 +359,8 @@ QuicPacketBuilderPrepare(
         // are not limiting Handshake packets.
         //
         if (QuicConnIsClient(Connection) && NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
-            QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
-            //
-            // Ensure we don't keep a dangling pointer to the freed INITIAL keys.
-            //
+            Builder->InitialKeysDiscarded =
+                QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
             Builder->Key = NULL;
         }
 

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -359,8 +359,9 @@ QuicPacketBuilderPrepare(
         // are not limiting Handshake packets.
         //
         if (QuicConnIsClient(Connection) && NewPacketKeyType == QUIC_PACKET_KEY_HANDSHAKE) {
-            Builder->InitialKeysDiscarded =
-                QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL);
+            if (QuicCryptoDiscardKeys(&Connection->Crypto, QUIC_PACKET_KEY_INITIAL)) {
+                Builder->InitialKeysDiscarded = TRUE;
+            }
             Builder->Key = NULL;
         }
 

--- a/src/core/packet_builder.h
+++ b/src/core/packet_builder.h
@@ -84,6 +84,11 @@ typedef struct QUIC_PACKET_BUILDER {
     uint8_t WrittenConnectionCloseFrame : 1;
 
     //
+    // Initial keys were discarded during this flush.
+    //
+    uint8_t InitialKeysDiscarded : 1;
+
+    //
     // The total number of datagrams that have been created.
     //
     uint8_t TotalCountDatagrams;

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1493,10 +1493,11 @@ QuicSendFlush(
 
     QuicPacketBuilderCleanup(&Builder);
 
-    if (Builder.InitialKeysDiscarded && Send->SendFlags != 0) {
+    if (Builder.InitialKeysDiscarded &&
+        (Send->SendFlags != 0 || !CxPlatListIsEmpty(&Send->SendStreams))) {
         //
         // Initial keys were discarded mid-flush, which may have freed
-        // send allowance. Schedule a new flush.
+        // send allowance. Schedule a new flush if anything is still queued.
         //
         Result = QUIC_SEND_INCOMPLETE;
     }

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1493,6 +1493,14 @@ QuicSendFlush(
 
     QuicPacketBuilderCleanup(&Builder);
 
+    if (Builder.InitialKeysDiscarded && Send->SendFlags != 0) {
+        //
+        // Initial keys were discarded mid-flush, which may have freed
+        // send allowance. Schedule a new flush.
+        //
+        Result = QUIC_SEND_INCOMPLETE;
+    }
+
     QuicTraceLogConnVerbose(
         SendFlushComplete,
         Connection,


### PR DESCRIPTION
## Description

Fixes #5998.

After a previous fix moving the initial key discard to the packet builder (instead of discarding them only when sending a crypto frame), it was still possible for handshake packets to be blocked by CC because:
- the CC quota freed by discarding the keys is not available by the packet builder during the current send flush
- another send flush was never scheduled because a send flush was already in progress when the CC quota was made available

This is fixed by scheduling a new send flush if there still are things to send after discarding the keys. 

## Testing

Covered by `Handshake/WithHandshakeArgs4.RandomLoss*`. Locally validated:
- All 24 `Handshake/WithHandshakeArgs4.RandomLoss/*` variants pass over 100 iterations on a local device
- `spinquic both -timeout:20000 -repeat_count:1` exits cleanly.

## Documentation

No documentation impact.