### PR TITLE
Fix a repeated sending of RETIRE_CONN_ID

### DIFF
--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1250,8 +1250,9 @@ QuicSendFlush(
         Send->LastFlushTimeValid &&
         CxPlatTimeDiff64(Send->LastFlushTime, TimeNow) >= MS_TO_US(Connection->Settings.DestCidUpdateIdleTimeoutMs) &&
         !Path->InitiatedCidUpdate) {
-        (void)QuicConnRetireCurrentDestCid(Connection, Path);
-        Path->InitiatedCidUpdate = TRUE;
+        if (QuicConnRetireCurrentDestCid(Connection, Path)) {
+            Path->InitiatedCidUpdate = TRUE;
+        }
     }
 
     //

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1248,8 +1248,10 @@ QuicSendFlush(
     //
     if (Connection->Settings.DestCidUpdateIdleTimeoutMs != 0 &&
         Send->LastFlushTimeValid &&
-        CxPlatTimeDiff64(Send->LastFlushTime, TimeNow) >= MS_TO_US(Connection->Settings.DestCidUpdateIdleTimeoutMs)) {
+        CxPlatTimeDiff64(Send->LastFlushTime, TimeNow) >= MS_TO_US(Connection->Settings.DestCidUpdateIdleTimeoutMs) &&
+        !Path->InitiatedCidUpdate) {
         (void)QuicConnRetireCurrentDestCid(Connection, Path);
+        Path->InitiatedCidUpdate = TRUE;
     }
 
     //


### PR DESCRIPTION
## Description

This pull request makes a targeted change to the logic for updating the destination connection ID (CID) in `src/core/send.c`. The update ensures that a CID update is only initiated if one hasn't already been started for the current path.

Connection ID update logic improvement:

* Modified the condition in `QuicSendFlush` to check that `Path->InitiatedCidUpdate` is `FALSE` before initiating a destination CID update, and sets it to `TRUE` after the update is initiated. This prevents repeated or redundant CID updates for the same path.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

No

## Documentation

_Is there any documentation impact for this change?_

No