### PR TITLE
Fix TLS fragment tests

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2445,8 +2445,8 @@ CxPlatTlsWriteDataToSchannel(
             //
             // Not all the input buffer was consumed. There is some 'extra' left over.
             //
-            CXPLAT_DBG_ASSERT(InSecBuffers[1].cbBuffer <= *InBufferLength);
-            *InBufferLength -= InSecBuffers[1].cbBuffer;
+            CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
+            *InBufferLength -= ExtraBuffer->cbBuffer;
         }
 
         QuicTraceLogConnInfo(
@@ -2697,6 +2697,19 @@ CxPlatTlsWriteDataToSchannel(
             CXPLAT_FREE(TlsContext->PeerTransportParams, QUIC_POOL_TLS_TMP_TP);
             TlsContext->PeerTransportParams = NULL;
             TlsContext->PeerTransportParamsLength = 0;
+        }
+
+        //
+        // Some or all of the input data was processed. There may or may not be
+        // corresponding output data to send in response.
+        //
+
+        if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
+            //
+            // Not all the input buffer was consumed. There is some 'extra' left over.
+            //
+            CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
+            *InBufferLength -= ExtraBuffer->cbBuffer;
         }
 
         break;

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2126,6 +2126,18 @@ CxPlatTlsWriteDataToSchannel(
         }
     }
 
+    //
+    // Some or all of the input data was processed. There may or may not be
+    // corresponding output data to send in response.
+    //
+    if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
+        //
+        // Not all the input buffer was consumed. There is some 'extra' left over.
+        //
+        CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
+        *InBufferLength -= ExtraBuffer->cbBuffer;
+    }
+
     switch (SecStatus) {
     case SEC_E_BUFFER_TOO_SMALL: {
         //
@@ -2436,19 +2448,6 @@ CxPlatTlsWriteDataToSchannel(
             break;
         }
 
-        //
-        // Some or all of the input data was processed. There may or may not be
-        // corresponding output data to send in response.
-        //
-
-        if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
-            //
-            // Not all the input buffer was consumed. There is some 'extra' left over.
-            //
-            CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
-            *InBufferLength -= ExtraBuffer->cbBuffer;
-        }
-
         QuicTraceLogConnInfo(
             SchannelConsumedBytes,
             TlsContext->Connection,
@@ -2697,19 +2696,6 @@ CxPlatTlsWriteDataToSchannel(
             CXPLAT_FREE(TlsContext->PeerTransportParams, QUIC_POOL_TLS_TMP_TP);
             TlsContext->PeerTransportParams = NULL;
             TlsContext->PeerTransportParamsLength = 0;
-        }
-
-        //
-        // Some or all of the input data was processed. There may or may not be
-        // corresponding output data to send in response.
-        //
-
-        if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
-            //
-            // Not all the input buffer was consumed. There is some 'extra' left over.
-            //
-            CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
-            *InBufferLength -= ExtraBuffer->cbBuffer;
         }
 
         break;

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -488,6 +488,9 @@ protected:
                 if (ConsumedBuffer > 0) {
                     Buffer += ConsumedBuffer;
                     BufferLength -= ConsumedBuffer;
+                    if (ConsumedBuffer > BufferLength) {
+                        ConsumedBuffer = BufferLength;
+                    }
                 } else {
                     ConsumedBuffer = FragmentSize * ++Count;
                     ConsumedBuffer = CXPLAT_MIN(ConsumedBuffer, BufferLength);
@@ -1280,7 +1283,7 @@ TEST_F(TlsTest, HandshakeMultiAlpnBoth)
     DoHandshake(ServerContext, ClientContext);
 }
 
-TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing #6035
+TEST_F(TlsTest, HandshakeFragmented)
 {
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;
@@ -1290,7 +1293,7 @@ TEST_F(TlsTest, DISABLED_HandshakeFragmented) // Remove DISABLED_ after fixing #
     DoHandshake(ServerContext, ClientContext, 200);
 }
 
-TEST_F(TlsTest, DISABLED_HandshakeVeryFragmented) // Remove DISABLED_ after fixing #6035
+TEST_F(TlsTest, HandshakeVeryFragmented)
 {
     CxPlatClientSecConfig ClientConfig;
     CxPlatServerSecConfig ServerConfig;


### PR DESCRIPTION
## Description

Recent changes exposed a test bug in how tests process TLS fragments, leading to test failures. These tests were disabled to unblock the pipelines.  This change fixes the tests, re-enables them, and also improves fragment handling outside of tests.

## Testing

Tests were re-enabled and pass.

## Documentation

N/A
