### PR TITLE
Fix lldb/gdb backtrace capture in core-dump scripts

### DIFF
--- a/scripts/run-executable.ps1
+++ b/scripts/run-executable.ps1
@@ -318,7 +318,7 @@ function PrintDumpCallStack($DumpFile) {
 
 function PrintLldbCoreCallStack($CoreFile) {
     try {
-        $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
+        $Output = lldb $Path -c $CoreFile -b -o "bt all"
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
         Write-Host "=================================================================================="
@@ -353,7 +353,7 @@ function PrintLldbCoreCallStack($CoreFile) {
 
 function PrintGdbCoreCallStack($CoreFile) {
     try {
-        $Output = gdb $Path $CoreFile -batch -ex "`"bt`"" -ex "`"quit`""
+        $Output = gdb $Path $CoreFile -batch -ex "bt" -ex "quit"
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
         Write-Host "=================================================================================="

--- a/scripts/run-gtest.ps1
+++ b/scripts/run-gtest.ps1
@@ -492,7 +492,7 @@ function PrintDumpCallStack($DumpFile) {
 
 function PrintLldbCoreCallStack($CoreFile) {
     try {
-        $Output = lldb $Path -c $CoreFile -b -o "`"bt all`""
+        $Output = lldb $Path -c $CoreFile -b -o "bt all"
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
         Write-Host "=================================================================================="
@@ -527,7 +527,7 @@ function PrintLldbCoreCallStack($CoreFile) {
 
 function PrintGdbCoreCallStack($CoreFile) {
     try {
-        $Output = gdb $Path $CoreFile -batch -ex "`"bt`"" -ex "`"quit`""
+        $Output = gdb $Path $CoreFile -batch -ex "bt" -ex "quit"
         Write-Host "=================================================================================="
         Write-Host " $(Split-Path $CoreFile -Leaf)"
         Write-Host "=================================================================================="


### PR DESCRIPTION
## Description

The PowerShell scripts that print backtraces from core dumps in CI pass quoted
strings to `lldb -o` and `gdb -ex`, but the inner quotes are escaped, so the
debuggers receive the literal argv elements `"bt all"` / `"bt"` / `"quit"`
(quotes included). lldb emits `error: unknown command shorthand suffix: ' all'`;
gdb silently treats the token as an unknown command in `-batch` mode. The net
effect is that CI captures **no backtrace** for any crashing macOS or Linux
stress run, making them effectively undiagnosable from CI logs alone
(see #6039, #6040, #6045).

This PR drops the inner escaped quotes so each argv element is exactly the
debugger command to run.

## Testing

Validated end-to-end with a temporary `CXPLAT_FRE_ASSERTMSG(FALSE, ...)` at the
start of `spinquic`'s `main()` so every stress matrix entry would abort.

* **Linux (gdb):** captured a fully symbolicated 7-frame backtrace through
  `__pthread_kill` -> `abort` -> `quic_bugcheck` -> `main` at `spinquic.cpp`,
  with files and line numbers. Before the fix only the LWP list and signal
  frame were emitted.
* **macOS (lldb):** lldb now accepts `bt all` and produces real output instead
  of emitting `error: unknown command shorthand suffix: ' all'`. (Note: the
  resulting macOS frames are unsymbolicated because the macOS build uses
  `-gdwarf` with DWARF only in the build `.o` files which are not packaged in
  the artifact -- that is a separate symbolication issue and not addressed
  here.)

## Documentation

No documentation impact.