### PR TITLE
Reducing buffer size for NthPacketDrop test

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3156,7 +3156,7 @@ QuicTestNthPacketDrop(
     const uint32_t BufferLength = 0x800000;
     const uint64_t TimeOutS = 60 * 60; // 1 hour
 #else
-    const uint32_t BufferLength = 0x200000;
+    const uint32_t BufferLength = 0x100000;
     const uint64_t TimeOutS = 50; // All test cases need to complete in less than 60 seconds
 #endif
     uint8_t* RawBuffer = new(std::nothrow) uint8_t[BufferLength];
@@ -3169,7 +3169,7 @@ QuicTestNthPacketDrop(
 
     bool StopRunning = false;
     for (uint32_t i = 0; !StopRunning; ++i) {
-        NthLossHelper LossHelper(i);
+        NthLossHelper LossHelper(2*i);
         MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL);
         CONTINUE_ON_FAIL(Stream.GetInitStatus());
 


### PR DESCRIPTION
## Description
To fix flakiness of NthPacketDrop test, reduced the quic buffer size to 1MB and dropping every other datagram in the buffer keeping the intent of the test.

#5961 

## Testing
CI/CD

## Documentation
No Documentation impact
