### PR TITLE
[release/2.5] backport #6022: fix virtual buffer overflow in stream_recv

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -803,12 +803,9 @@ QuicStreamOnBytesDelivered(
 
         //
         // Limit stream FC window growth by the connection FC window size.
-        // When using app-owned buffers, skip this: the virtual buffer length is entirely based
-        // on the amount of buffer space provided by the app.
         //
         if (Stream->RecvBuffer.VirtualBufferLength != 0 &&
             Stream->RecvBuffer.VirtualBufferLength < Stream->Connection->Settings.ConnFlowControlWindow) {
-
             uint64_t TimeThreshold =
                 ((Stream->RecvWindowBytesDelivered * Stream->Connection->Paths[0].SmoothedRtt) / RecvBufferDrainThreshold);
             if (CxPlatTimeDiff64(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
@@ -832,15 +829,18 @@ QuicStreamOnBytesDelivered(
                 // low.
                 //
 
+                uint64_t NewLength = (uint64_t)Stream->RecvBuffer.VirtualBufferLength * 2;
+                NewLength = CXPLAT_MIN(NewLength, UINT32_MAX);
+
                 QuicRecvBufferIncreaseVirtualBufferLength(
                     &Stream->RecvBuffer,
-                    Stream->RecvBuffer.VirtualBufferLength * 2);
+                    (uint32_t)NewLength);
 
                 QuicTraceLogStreamVerbose(
                     IncreaseRxBuffer,
                     Stream,
                     "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    Stream->RecvBuffer.VirtualBufferLength * 2,
+                    (uint32_t)NewLength,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,
                     Stream->RecvWindowLastUpdate);

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -360,12 +360,12 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
                     IncreaseRxBuffer,
                     Stream,
                     "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    Stream->RecvBuffer.VirtualBufferLength * 2,
+                    (uint32_t)NewLength,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,
                     Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
-// arg3 = arg3 = Stream->RecvBuffer.VirtualBufferLength * 2 = arg3
+// arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -359,12 +359,12 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
                     IncreaseRxBuffer,
                     Stream,
                     "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    Stream->RecvBuffer.VirtualBufferLength * 2,
+                    (uint32_t)NewLength,
                     Stream->Connection->Paths[0].MinRtt,
                     TimeNow,
                     Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
-// arg3 = arg3 = Stream->RecvBuffer.VirtualBufferLength * 2 = arg3
+// arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6


### PR DESCRIPTION
release/2.5 is missing the virtual-buffer overflow fix that's on main (#6022, 36367b6361). In stream_recv.c the virtual buffer length math still uses a uint32 multiply that can wrap, so a crafted receive sequence can drive the buffer accounting past its bound.

checked it on release/2.5: built the stream_recv virtual-buffer length path with -fsanitize=address on ubuntu:22.04 and drove the wrapping multiply — pre-fix the invariant check aborts / the accounting overflows, with the main fix applied the value is clamped and it's clean. (modeled the buffer-math function rather than a full msquic build.)

clean cherry-pick (-x), original author (Gaurav Singh) preserved. the generated clog headers come along with the .c change as upstream had them. happy to rebase.

note: i'll sign the CLA when the bot prompts.

upstream: https://github.com/microsoft/msquic/commit/36367b6361