### PR TITLE
Two phase cleanup for Listener Objects

### DIFF
--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -14,12 +14,6 @@ Abstract:
 #include "listener.c.clog.h"
 #endif
 
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicListenerStopAsync(
-    _In_ QUIC_LISTENER* Listener
-    );
-
 BOOLEAN
 QuicListenerIsOnWorker(
     _In_ QUIC_LISTENER* Listener

--- a/src/core/listener.h
+++ b/src/core/listener.h
@@ -302,3 +302,12 @@ BOOLEAN
 QuicListenerDrainOperations(
     _In_ QUIC_LISTENER* Listener
     );
+
+//
+// Stops the listener asynchronously.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicListenerStopAsync(
+    _In_ QUIC_LISTENER* Listener
+    );

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -396,9 +396,10 @@ MsQuicRegistrationShutdown(
         }
 
         //
-        // Drain listeners under the registration lock into a local list while
-        // taking a non-zero cleanup reference on each one. Then stop them outside
-        // the lock.
+        // Prevent close/shutdown races: once we drop the registration lock we must not
+        // depend on the shared listener list or listener lifetime. We snapshot listeners
+        // under lock and take a non-zero ref so only still-alive listeners are handled
+        // afterward.
         //
         CXPLAT_LIST_ENTRY PendingListeners;
         CxPlatListInitializeHead(&PendingListeners);

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -396,7 +396,7 @@ MsQuicRegistrationShutdown(
         }
 
         //
-        // Drain listeners under the registration lock into a private list while
+        // Drain listeners under the registration lock into a local list while
         // taking a non-zero cleanup reference on each one. Then stop them outside
         // the lock.
         //
@@ -422,7 +422,7 @@ MsQuicRegistrationShutdown(
                     QUIC_LISTENER,
                     RegistrationLink);
 
-            MsQuicListenerStop((HQUIC)Listener);
+            QuicListenerStopAsync(Listener);
             QuicListenerRelease(Listener);
         }
     }

--- a/src/core/registration.c
+++ b/src/core/registration.c
@@ -395,14 +395,35 @@ MsQuicRegistrationShutdown(
             Entry = Entry->Flink;
         }
 
-        CxPlatDispatchLockRelease(&Registration->ConnectionLock);
+        //
+        // Drain listeners under the registration lock into a private list while
+        // taking a non-zero cleanup reference on each one. Then stop them outside
+        // the lock.
+        //
+        CXPLAT_LIST_ENTRY PendingListeners;
+        CxPlatListInitializeHead(&PendingListeners);
 
-        Entry = Registration->Listeners.Flink;
-        while (Entry != &Registration->Listeners) {
+        while (!CxPlatListIsEmpty(&Registration->Listeners)) {
+            Entry = CxPlatListRemoveHead(&Registration->Listeners);
             QUIC_LISTENER* Listener =
                 CXPLAT_CONTAINING_RECORD(Entry, QUIC_LISTENER, RegistrationLink);
-            Entry = Entry->Flink;
+
+            if (CxPlatRefIncrementNonZero(&Listener->RefCount, 1)) {
+                CxPlatListInsertTail(&PendingListeners, &Listener->RegistrationLink);
+            }
+        }
+
+        CxPlatDispatchLockRelease(&Registration->ConnectionLock);
+
+        while (!CxPlatListIsEmpty(&PendingListeners)) {
+            QUIC_LISTENER* Listener =
+                CXPLAT_CONTAINING_RECORD(
+                    CxPlatListRemoveHead(&PendingListeners),
+                    QUIC_LISTENER,
+                    RegistrationLink);
+
             MsQuicListenerStop((HQUIC)Listener);
+            QuicListenerRelease(Listener);
         }
     }
 


### PR DESCRIPTION
## Description
Fixed registration shutdown listener race by safely snapshotting listeners before stopping them.

During registration shutdown, listeners are now drained from the shared registration list under lock, and each listener is conditionally pinned with a non-zero refcount acquire. Only successfully pinned listeners are moved to a private pending list, then stopped outside the lock and released afterward.

This prevents shutdown from touching listeners that concurrently reached refcount zero, avoids stale-list traversal risks, and keeps listener lifetime handling safe under concurrent close/shutdown interleaving's.

Fixes : https://microsoft.visualstudio.com/OS/_workitems/edit/61981303/

## Testing


## Documentation
N/A
