### PR TITLE
[CP] Fix QuicOperationFree using CXPLAT_FREE on pool-allocated QUIC_RECV_CHUNK (#5881)

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1529,7 +1529,7 @@ Error:
     //
     while (!CxPlatListIsEmpty(&ChunkList)) {
         CXPLAT_DBG_ASSERT(Connection != NULL);
-        QuicRecvChunkFree(
+        CxPlatPoolFree(
             CXPLAT_CONTAINING_RECORD(CxPlatListRemoveHead(&ChunkList), QUIC_RECV_CHUNK, Link));
     }
 

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -1529,14 +1529,8 @@ Error:
     //
     while (!CxPlatListIsEmpty(&ChunkList)) {
         CXPLAT_DBG_ASSERT(Connection != NULL);
-        CxPlatPoolFree(
+        QuicRecvChunkFree(
             CXPLAT_CONTAINING_RECORD(CxPlatListRemoveHead(&ChunkList), QUIC_RECV_CHUNK, Link));
-        CXPLAT_FREE(
-            CXPLAT_CONTAINING_RECORD(
-                CxPlatListRemoveHead(&ChunkList),
-                QUIC_RECV_CHUNK,
-                Link),
-            QUIC_POOL_RECVBUF);
     }
 
     QuicTraceEvent(

--- a/src/core/operation.c
+++ b/src/core/operation.c
@@ -121,12 +121,11 @@ QuicOperationFree(
             QuicStreamRelease(ApiCtx->STRM_RECV_SET_ENABLED.Stream, QUIC_STREAM_REF_OPERATION);
         } else if (ApiCtx->Type == QUIC_API_TYPE_STRM_PROVIDE_RECV_BUFFERS) {
             while (!CxPlatListIsEmpty(&ApiCtx->STRM_PROVIDE_RECV_BUFFERS.Chunks)) {
-                CXPLAT_FREE(
+                QuicRecvChunkFree(
                     CXPLAT_CONTAINING_RECORD(
                         CxPlatListRemoveHead(&ApiCtx->STRM_PROVIDE_RECV_BUFFERS.Chunks),
                         QUIC_RECV_CHUNK,
-                        Link),
-                    QUIC_POOL_RECVBUF);
+                        Link));
             }
             QuicStreamRelease(ApiCtx->STRM_PROVIDE_RECV_BUFFERS.Stream, QUIC_STREAM_REF_OPERATION);
         }

--- a/src/core/operation.c
+++ b/src/core/operation.c
@@ -121,7 +121,7 @@ QuicOperationFree(
             QuicStreamRelease(ApiCtx->STRM_RECV_SET_ENABLED.Stream, QUIC_STREAM_REF_OPERATION);
         } else if (ApiCtx->Type == QUIC_API_TYPE_STRM_PROVIDE_RECV_BUFFERS) {
             while (!CxPlatListIsEmpty(&ApiCtx->STRM_PROVIDE_RECV_BUFFERS.Chunks)) {
-                QuicRecvChunkFree(
+                CxPlatPoolFree(
                     CXPLAT_CONTAINING_RECORD(
                         CxPlatListRemoveHead(&ApiCtx->STRM_PROVIDE_RECV_BUFFERS.Chunks),
                         QUIC_RECV_CHUNK,

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -39,12 +39,6 @@ QuicRecvChunkInitialize(
     _In_ BOOLEAN AppOwnedBuffer
     );
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void
-QuicRecvChunkFree(
-    _In_ QUIC_RECV_CHUNK* Chunk
-    );
-
 typedef struct QUIC_RECV_BUFFER {
 
     //

--- a/src/core/recv_buffer.h
+++ b/src/core/recv_buffer.h
@@ -39,6 +39,12 @@ QuicRecvChunkInitialize(
     _In_ BOOLEAN AppOwnedBuffer
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void
+QuicRecvChunkFree(
+    _In_ QUIC_RECV_CHUNK* Chunk
+    );
+
 typedef struct QUIC_RECV_BUFFER {
 
     //


### PR DESCRIPTION
## Description

Fixes #5841

`QuicOperationFree` was calling `CXPLAT_FREE` on `QUIC_RECV_CHUNK` entries left in a `STRM_PROVIDE_RECV_BUFFERS` operation's cleanup path. These chunks are allocated via `CxPlatPoolAlloc`, which returns an interior pointer (`malloc_ptr + sizeof(CXPLAT_POOL_HEADER)`) — passing that to `free()` is invalid and detected by ASAN as a bad free.

## Testing
CI.

## Documentation
No documentation impact.
