### PR TITLE
Add windows-2025 to product build/test matrix; move tool workflows to windows-latest

### DIFF
--- a/.github/workflows/build-reuse-win.yml
+++ b/.github/workflows/build-reuse-win.yml
@@ -31,8 +31,9 @@ on:
       os:
         required: false
         type: string
-        default: 'windows-2022'
+        default: 'windows-latest'
         # options:
+        #   - windows-latest
         #   - windows-2022
         #   - windows-2025
       arch:

--- a/.github/workflows/build-reuse-winkernel.yml
+++ b/.github/workflows/build-reuse-winkernel.yml
@@ -29,9 +29,11 @@ on:
       os:
         required: false
         type: string
-        default: 'windows-2022'
+        default: 'windows-latest'
         # options:
+        #   - windows-latest
         #   - windows-2022
+        #   - windows-2025
       arch:
         required: false
         default: 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [winkernel]
-        os: ['windows-2022', 'windows-2025']
+        os: ['windows-2022'] # windows-2025 disabled: image lacks the WDK bits to build kernel drivers.
         arch: [x64, arm64]
         tls: [schannel]
     uses: ./.github/workflows/build-reuse-winkernel.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     with:
       config: ${{ matrix.config }}
       plat: 'windows'
-      os: 'windows-2022'
+      os: 'windows-latest'
       arch: 'x64'
       tls: 'schannel'
       official: '-ForceOfficialRelease'
@@ -80,7 +80,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [winkernel]
-        os: ['windows-2022']
+        os: ['windows-2022', 'windows-2025']
         arch: [x64, arm64]
         tls: [schannel]
     uses: ./.github/workflows/build-reuse-winkernel.yml
@@ -237,18 +237,18 @@ jobs:
     - name: Download Build Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
-        name: Release-${{ matrix.vec.plat }}-windows-2022-x86-${{ matrix.vec.tls }}
+        name: Release-${{ matrix.vec.plat }}-windows-2025-x86-${{ matrix.vec.tls }}
         path: artifacts
     - name: Download Build Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
-        name: Release-${{ matrix.vec.plat }}-windows-2022-x64-${{ matrix.vec.tls }}
+        name: Release-${{ matrix.vec.plat }}-windows-2025-x64-${{ matrix.vec.tls }}
         path: artifacts
     - name: Download Build Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       if: matrix.vec.tls != 'quictls' # TODO: Remove once quictls is supported
       with:
-        name: Release-${{ matrix.vec.plat }}-windows-2022-arm64-${{ matrix.vec.tls }}
+        name: Release-${{ matrix.vec.plat }}-windows-2025-arm64-${{ matrix.vec.tls }}
         path: artifacts
     - name: Build Package
       shell: pwsh
@@ -256,7 +256,7 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: Nuget-Release-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.tls }}
+        name: Nuget-Release-${{ matrix.vec.plat }}-${{ matrix.vec.tls }}
         path: artifacts/dist/*.nupkg
 
   Complete:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         config: ['Debug', 'Release']
         plat: [windows, uwp] # TODO: Support gamecore_console
-        os: ['windows-2022']
+        os: ['windows-2022', 'windows-2025']
         arch: [x86, x64, arm64]
         tls: [schannel, quictls, openssl]
         static: ['', '-Static']
@@ -230,7 +230,7 @@ jobs:
           { plat: "windows",  tls: "openssl" },
           { plat: "windows",  tls: "schannel" },
         ]
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-latest", arch: "x64", tls: "quictls", build: "-Test" },
         ]
     uses: ./.github/workflows/build-reuse-win.yml
     with:
@@ -46,8 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test", xdp: "-UseXdp" },
+          { config: "Debug", plat: "windows", os: "windows-latest", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-latest", arch: "x64", tls: "quictls", build: "-Test", xdp: "-UseXdp" },
         ]
     runs-on:
      - self-hosted
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-latest", arch: "x64", tls: "quictls", build: "-Test" },
         ]
     runs-on:
     - self-hosted
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-latest", arch: "x64", tls: "quictls", build: "-Test" },
         ]
     runs-on:
     - self-hosted
@@ -185,7 +185,7 @@ jobs:
   merge-coverage:
     name: Merge Coverage
     needs: [bvt-winlatest, stress-winlatest, recvfuzz-winlatest]
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -201,22 +201,22 @@ jobs:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download BVT Coverage Results
       with:
-        name: BVT-Debug-windows-windows-2022-x64-quictls
+        name: BVT-Debug-windows-windows-latest-x64-quictls
         path: artifacts\coverage\windows\x64_Debug_quictls
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download BVT (XDP) Coverage Results
       with:
-        name: BVT-Debug-windows-windows-2022-x64-quictls-UseXdp
+        name: BVT-Debug-windows-windows-latest-x64-quictls-UseXdp
         path: artifacts\coverage\windows\x64_Debug_quictls
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download SpinQuic Coverage Results
       with:
-        name: Spin-Debug-windows-windows-2022-x64-quictls
+        name: Spin-Debug-windows-windows-latest-x64-quictls
         path: artifacts\coverage\windows\x64_Debug_quictls
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download RecvFuzz Coverage Results
       with:
-        name: RecvFuzz-Debug-windows-windows-2022-x64-quictls
+        name: RecvFuzz-Debug-windows-windows-latest-x64-quictls
         path: artifacts\coverage\windows\x64_Debug_quictls
     - name: Dir Folder for Artifacts
       shell: pwsh

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -61,6 +61,8 @@ jobs:
         vec: [
           { plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls" },
           { plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl" },
+          { plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls" },
+          { plat: "windows", os: "windows-2025", arch: "x64", tls: "openssl" },
         ]
     uses: ./.github/workflows/build-reuse-win.yml
     with:
@@ -79,6 +81,7 @@ jobs:
       matrix:
         vec: [
           { plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls" },
+          { plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls" },
           { plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "quictls" },
           { plat: "linux", os: "ubuntu-24.04", arch: "x64", tls: "quictls" },
           { plat: "linux", os: "ubuntu-22.04", arch: "x64", tls: "openssl" },

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   build_dbgext:
     name: Build WinDbg Extension
-    runs-on: windows-2022
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -46,6 +46,10 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", sanitize: "-SanitizeAddress", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", sanitize: "-SanitizeAddress", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "openssl", build: "-Test" },
         ]
     uses: ./.github/workflows/build-reuse-win.yml
     with:
@@ -108,6 +112,10 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", xdp: "-UseXdp", sanitize: "-SanitizeAddress", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", sanitize: "-SanitizeAddress", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", xdp: "-UseXdp", sanitize: "-SanitizeAddress", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
           { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]
     runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson(format('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease-LatestPwsh'', ''JobId=stress-{0}-{1}-{2}-{3}-{4}-{5}'']', matrix.vec.config, matrix.vec.arch, matrix.vec.tls, github.run_id, github.run_number, github.run_attempt)) || matrix.vec.os }}
@@ -124,7 +132,7 @@ jobs:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       if: matrix.vec.plat == 'windows'
       with:
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.build }}
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.sanitize }}${{ matrix.vec.build }}
         path: artifacts
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
@@ -168,6 +176,12 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", xdp: "-UseXdp", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", sanitize: "-SanitizeAddress", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "schannel", xdp: "-UseXdp", sanitize: "-SanitizeAddress", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "openssl", build: "-Test" },
+          { config: "Debug", plat: "windows", os: "windows-2025", arch: "x64", tls: "openssl", xdp: "-UseXdp", build: "-Test" },
           { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]
     runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson(format('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease-LatestPwsh'', ''JobId=recvfuzz-{0}-{1}-{2}-{3}-{4}-{5}'']', matrix.vec.config, matrix.vec.arch, matrix.vec.tls, github.run_id, github.run_number, github.run_attempt)) || matrix.vec.os }}

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -28,6 +28,8 @@ jobs:
           { release: "2.3.11",  os: "ubuntu-22.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },
           { release: "2.3.11",  os: "windows-2022", arch: "x64", tls: "schannel", imgtls: "schannel" },
           { release: "2.3.11",  os: "windows-2022", arch: "x64", tls: "quictls", imgtls: "openssl3" },
+          { release: "2.3.11",  os: "windows-2025", arch: "x64", tls: "schannel", imgtls: "schannel" },
+          { release: "2.3.11",  os: "windows-2025", arch: "x64", tls: "quictls", imgtls: "openssl3" },
           # v2.4
           { release: "2.4.10",  os: "ubuntu-22.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },
           { release: "2.4.10",  os: "ubuntu-24.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vec: [ # Note that GitHub windows-2025 doesn't have the necessary bits to build kernel drivers currently.
+        vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
-          { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+          { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
+          { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" }
         ]
     uses: ./.github/workflows/build-reuse-winkernel.yml
     with:
@@ -218,6 +220,8 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
+          { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Release", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]
@@ -230,8 +234,8 @@ jobs:
         ref: ${{ inputs.ref || '' }}
     - name: Download Kernel Build Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-      with: # note we always use kernel binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+      with: # WinServerPrerelease has no matching kernel build; fall back to the windows-2022 binaries.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os == 'WinServerPrerelease' && 'windows-2022' || matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
         path: artifacts
     - name: Download Usermode Build Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,9 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
-          { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
-          { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" }
+          # windows-2025 disabled: image lacks the WDK bits to build kernel drivers.
+          # { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          # { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" }
         ]
     uses: ./.github/workflows/build-reuse-winkernel.yml
     with:
@@ -220,8 +221,9 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Release", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" },
-          { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
-          { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          # windows-2025 disabled: image lacks the WDK bits to build kernel drivers.
+          # { config: "Debug", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
+          # { config: "Release", plat: "winkernel", os: "windows-2025", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
           { config: "Release", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]

--- a/.github/workflows/wan-perf.yml
+++ b/.github/workflows/wan-perf.yml
@@ -57,7 +57,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
     name: Run Tests
-    runs-on: windows-2022
+    runs-on: windows-latest
     needs: build-perf
     env:
       seed: 41473a2e60b6958500ec0add7dcfb9 # TODO - Randomize?
@@ -112,7 +112,7 @@ jobs:
   merge-data:
     permissions: write-all
     name: Merge Results
-    runs-on: windows-2022
+    runs-on: windows-latest
     needs: wan-perf
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Applies a consistent rule across all CI workflows:

- **If a job exists to validate a specific Windows version** (matrix testing), include both windows-2022 and windows-2025.
- **If a job just needs a Windows runner** and the OS version is incidental, use windows-latest.

## Changes

| File | Change |
|---|---|
| uild.yml | `build-windows` matrix → builds on both 2022 and 2025 (was 2022 only) |
| uild.yml | `build-windows-official` runner → `windows-latest` (was hardcoded 2022; OS-compat already covered by `build-windows`) |
| uild.yml | `build-windows-kernel` matrix → also targets 2025. No WDK install added — letting CI tell us whether the WDK is still discoverable on the 2025 image. If it isn't, we'll revert this single line. |
| uild.yml | `build-nuget` downloads switched to consume windows-2025 artifacts; upload label drops the OS qualifier (a nuget package bundles x86/x64/arm64 binaries — OS in the label was meaningless) |
| uild-reuse-win.yml / uild-reuse-winkernel.yml | Default os input → windows-latest (callers always pass an explicit value; default updated for future callers) |
| dotnet-test.yml | Build and test matrices → 2022 + 2025 |
| code-coverage.yml | Every windows-2022 reference → windows-latest (build matrix, three test matrices, `merge-coverage` runner, four artifact names — all consistent) |
| stress.yml | uild, stress, ecvfuzz matrices → 2022 + 2025 |
| 	est.yml | `build-windows-kernel` and `bvt-kernel` matrices → also target 2025. `bvt-kernel` download is parameterized on `matrix.vec.os` with a `WinServerPrerelease → windows-2022` fallback (mirrors `stress.yml`). |
| 	est-down-level.yml | Release 2.3.11 rows extended to 2025 (matches what 2.4.10 already does) |
| plugins.yml | `build_dbgext` runner → `windows-latest` |
| wan-perf.yml | Tool-only jobs → `windows-latest` |

Also fixes the latent `stress.yml` artifact-name bug where the spinquic test job hardcoded windows-2022 (would have prevented 2025 jobs from picking up the right binaries).

## Intentionally NOT changed

- The `windows-2022 || matrix.vec.os` fallback pattern in `stress.yml` and `test.yml` for self-hosted `WinServerPrerelease` runners — WinServerPrerelease has no matching kernel/usermode build of its own, so it intentionally consumes 2022 artifacts.

Fixes #5242.