### PR TITLE
[CP] Fix TLS fragment tests (#6066)

### DIFF
--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -2126,6 +2126,18 @@ CxPlatTlsWriteDataToSchannel(
         }
     }
 
+    //
+    // Some or all of the input data was processed. There may or may not be
+    // corresponding output data to send in response.
+    //
+    if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
+        //
+        // Not all the input buffer was consumed. There is some 'extra' left over.
+        //
+        CXPLAT_DBG_ASSERT(ExtraBuffer->cbBuffer <= *InBufferLength);
+        *InBufferLength -= ExtraBuffer->cbBuffer;
+    }
+
     switch (SecStatus) {
     case SEC_E_BUFFER_TOO_SMALL: {
         //
@@ -2430,19 +2442,6 @@ CxPlatTlsWriteDataToSchannel(
             }
             Result |= CXPLAT_TLS_RESULT_ERROR;
             break;
-        }
-
-        //
-        // Some or all of the input data was processed. There may or may not be
-        // corresponding output data to send in response.
-        //
-
-        if (ExtraBuffer != NULL && ExtraBuffer->cbBuffer > 0) {
-            //
-            // Not all the input buffer was consumed. There is some 'extra' left over.
-            //
-            CXPLAT_DBG_ASSERT(InSecBuffers[1].cbBuffer <= *InBufferLength);
-            *InBufferLength -= InSecBuffers[1].cbBuffer;
         }
 
         QuicTraceLogConnInfo(

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -466,6 +466,9 @@ protected:
                 if (ConsumedBuffer > 0) {
                     Buffer += ConsumedBuffer;
                     BufferLength -= ConsumedBuffer;
+                    if (ConsumedBuffer > BufferLength) {
+                        ConsumedBuffer = BufferLength;
+                    }
                 } else {
                     ConsumedBuffer = FragmentSize * ++Count;
                     ConsumedBuffer = CXPLAT_MIN(ConsumedBuffer, BufferLength);


### PR DESCRIPTION
## Description

Recent changes exposed a test bug in how tests process TLS fragments, leading to test failures. These tests were disabled to unblock the pipelines.  This change fixes the tests, re-enables them, and also improves fragment handling outside of tests.

## Testing

Tests were re-enabled and pass.

## Documentation

N/A