### PR TITLE
[CP] Enable ProcDump crash dump collection on release/2.5 (diagnostics-only)

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -172,12 +172,12 @@ jobs:
       if: github.event_name == 'pull_request'
       timeout-minutes: 15
       shell: pwsh
-      run: scripts/recvfuzz.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -timeout ${{ env.pr-timeout }} ${{ matrix.vec.xdp }}
+      run: scripts/recvfuzz.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -timeout ${{ env.pr-timeout }} ${{ matrix.vec.xdp }} -UseProcDump
     - name: recvfuzz (Official)
       if: github.event_name != 'pull_request'
       timeout-minutes: 65
       shell: pwsh
-      run: scripts/recvfuzz.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -timeout ${{ env.main-timeout }} ${{ matrix.vec.xdp }}
+      run: scripts/recvfuzz.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -timeout ${{ env.main-timeout }} ${{ matrix.vec.xdp }} -UseProcDump
     - name: Upload on Failure
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: failure()

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -114,12 +114,12 @@ jobs:
       if: github.event_name == 'pull_request'
       timeout-minutes: 15
       shell: pwsh
-      run: scripts/spin.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -Timeout ${{ env.pr-timeout }} -RepeatCount ${{ env.pr-repeat }} -AllocFail ${{ env.pr-allocfail }} ${{ matrix.vec.xdp }}
+      run: scripts/spin.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -Timeout ${{ env.pr-timeout }} -RepeatCount ${{ env.pr-repeat }} -AllocFail ${{ env.pr-allocfail }} ${{ matrix.vec.xdp }} -UseProcDump
     - name: spinquic (Official)
       if: github.event_name != 'pull_request'
       timeout-minutes: 65
       shell: pwsh
-      run: scripts/spin.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -Timeout ${{ env.main-timeout }} -RepeatCount ${{ env.main-repeat }} -AllocFail ${{ env.main-allocfail }} ${{ matrix.vec.xdp }}
+      run: scripts/spin.ps1 -AZP -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -Timeout ${{ env.main-timeout }} -RepeatCount ${{ env.main-repeat }} -AllocFail ${{ env.main-allocfail }} ${{ matrix.vec.xdp }} -UseProcDump
     - name: Fix log permissions for Linux XDP
       if: failure() && matrix.vec.plat == 'linux' # (matrix.vec.plat == 'linux' && matrix.vec.xdp == '-UseXdp') doesn't work for some reason
       run: |

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -488,6 +488,24 @@ function Install-Clog2Text {
     Install-DotnetTool -ToolName "Microsoft.Logging.CLOG2Text.Lttng" -Version "0.0.1" -NuGetPath $NuGetPath
 }
 
+function Install-ProcDump {
+    if (!$IsWindows) { throw "ProcDump is Windows-only." }
+
+    $toolDir = Join-Path $RootDir "artifacts" "tools" "procdump"
+    New-Item -ItemType Directory -Force -Path $toolDir | Out-Null
+
+    $zipPath = Join-Path $toolDir "procdump.zip"
+    $url = "https://download.sysinternals.com/files/Procdump.zip"  # official Sysinternals download
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+
+    Expand-Archive -Path $zipPath -DestinationPath $toolDir -Force
+
+    $pd = Join-Path $toolDir "procdump.exe"
+    if (!(Test-Path $pd)) {
+        throw "ProcDump download/extract succeeded but procdump.exe not found at expected path: $pd"
+    }
+}
+
 # We remove OpenSSL path for kernel builds because it's not needed.
 if ($ForKernel) {
     git rm $RootDir/submodules/quictls
@@ -513,6 +531,11 @@ if ($ForBuild -or $ForContainerBuild) {
     }
 
     git submodule update --jobs=8
+}
+
+if ($IsWindows -and $ForTest) {
+    # Install Procdump for crash dump collection.
+    Install-ProcDump
 }
 
 if ($InstallCoreNetCiDeps) { Download-CoreNet-Deps }

--- a/scripts/recvfuzz.ps1
+++ b/scripts/recvfuzz.ps1
@@ -39,6 +39,9 @@ This script runs recvfuzz locally for a period of time.
 .Parameter AZP
     Runs in Azure Pipelines mode.
 
+.Parameter UseProcDump
+    Use ProcDump to capture crash dumps.
+
 #>
 
 param (
@@ -95,7 +98,10 @@ param (
     [switch]$AZP = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$UseXdp
+    [switch]$UseXdp,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$UseProcDump = $false
 )
 
 $env:ASAN_OPTIONS = "allocator_may_return_null=1"
@@ -175,6 +181,9 @@ if ($CodeCoverage) {
 }
 if ($AZP) {
     $Arguments += " -AZP"
+}
+if ($UseProcDump) {
+    $Arguments += " -UseProcDump"
 }
 
 if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {

--- a/scripts/spin.ps1
+++ b/scripts/spin.ps1
@@ -95,7 +95,10 @@ param (
     [switch]$AZP = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$UseXdp
+    [switch]$UseXdp,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$UseProcDump = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -180,6 +183,10 @@ if ($CodeCoverage) {
 }
 if ($AZP) {
     $Arguments += " -AZP"
+}
+
+if ($UseProcDump) {
+    $Arguments += " -UseProcDump"
 }
 
 if (![string]::IsNullOrWhiteSpace($ExtraArtifactDir)) {


### PR DESCRIPTION
## Description

Cherry-pick diagnostics-collection commits from `main` so the Stress / recvfuzz CI jobs on `release/2.5` capture full memory dumps and the target process exit code (via ProcDump) on failure.

This is to enable root-causing the consistent failure of `recvfuzz (Debug, windows, WinServerPrerelease, x64, schannel, -Test)` on `release/2.5` (exit code `57005` / `0xDEAD`, ~6s after launch, no log/dump currently uploaded).

**This PR is not intended to be merged** — it exists purely to drive a CI run with ProcDump-based crash dump collection enabled. The failing job upload will then contain a `.dmp` from ProcDump (`-ma -e -x <LogDir>`) and `run-executable.ps1` will print the actual target exit code parsed from ProcDump output.

### Cherry-picks
- `2f129967d` — Use ProcDump instead of WER to collect user mode crash dumps (#5665)
- `c62a7e17d` — Enable ProcDump crash dump recording for recvfuzz stress tests (#6046)

Conflict resolution in `.github/workflows/stress.yml`: kept the `release/2.5` form of the `spinquic` step (no `-LogProfile` since `release/2.5` doesn't have the `workflow_dispatch.inputs.logprofile` input) and only appended `-UseProcDump`.

### Testing
CI of this draft PR.

### Documentation
N/A — CI-only change.
