### PR TITLE
ci: drop shogo82148/actions-setup-perl on Windows

### DIFF
--- a/.github/workflows/build-reuse-win.yml
+++ b/.github/workflows/build-reuse-win.yml
@@ -82,18 +82,8 @@ jobs:
       with:
         repository: ${{ inputs.repo}}
         ref: ${{ inputs.ref }}
-    - name: Install Perl
-      uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
-    - name: Use system CMake
-      # Strawberry Perl (added to PATH by actions-setup-perl) ships an
-      # older cmake.exe that shadows the runner image's CMake. Prepend
-      # the image's CMake bin dir so it wins for the rest of the job.
-      shell: pwsh
-      run: Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\CMake\bin'
     - name: Prepare Machine
       shell: pwsh
       run: scripts/prepare-machine.ps1 -ForBuild -Tls ${{ inputs.tls }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -35,21 +35,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-    - name: Install Perl
-      if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
-    - name: Use system CMake
-      # Strawberry Perl (added to PATH by actions-setup-perl) ships an
-      # older cmake.exe that shadows the runner image's CMake. Prepend
-      # the image's CMake bin dir so it wins for the rest of the job.
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\CMake\bin'
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForBuild -InstallTestCertificates
       shell: pwsh

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -41,21 +41,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-    - name: Install Perl
-      if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
-    - name: Use system CMake
-      # Strawberry Perl (added to PATH by actions-setup-perl) ships an
-      # older cmake.exe that shadows the runner image's CMake. Prepend
-      # the image's CMake bin dir so it wins for the rest of the job.
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\CMake\bin'
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -DisableTest
       shell: pwsh


### PR DESCRIPTION
## Description

The `windows-2025-vs2026` runner image ships **Strawberry Perl 5.42.0** preinstalled, with the full Strawberry CPAN distribution including `Text::Template` (the only Perl module beyond core that OpenSSL / QuicTLS `Configure` needs, per `submodules/quictls/INSTALL.md`).

The `shogo82148/actions-setup-perl` step was downloading a second Perl 5.34.3 into `C:\hostedtoolcache\windows\perl\...` and prepending its bundled MinGW directory (`C:\strawberry\c\bin`) to `PATH`. That dir contains an older `cmake.exe` that was shadowing the image's modern CMake 4.3.3 — which is why #6100 had to add a "Use system CMake" step as a workaround.

Dropping the action makes that workaround unnecessary, so this removes both. Net: **−34 lines, one less third-party action, ~20–30 seconds shaved off every Windows CI job**.

Built on top of #6100 — please review/merge #6100 first.

## Testing

CI run on this draft PR. If the openssl / quictls builds succeed, the image's Strawberry Perl has everything they need.

If by chance the build fails with a `Can't locate Foo/Bar.pm` error, we can either revert this PR or install the missing module(s) with `cpan -i Foo::Bar` in `prepare-machine.ps1`.

## Documentation

No public API or doc change.
