### PR TITLE
[CP] Default Windows CI builds to Visual Studio 18 2026 (#6100)

### DIFF
--- a/.github/workflows/build-reuse-win.yml
+++ b/.github/workflows/build-reuse-win.yml
@@ -81,10 +81,6 @@ jobs:
       with:
         repository: ${{ inputs.repo}}
         ref: ${{ inputs.ref }}
-    - name: Install Perl
-      uses: shogo82148/actions-setup-perl@22ab01e83d59dc1abe1796fd8f338da7e7f2d033
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
     - name: Prepare Machine
@@ -93,22 +89,22 @@ jobs:
     - name: Build For Test
       if: inputs.build == '-Test'
       shell: pwsh
-      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} -DisablePerf -DynamicCRT ${{ inputs.sanitize }}
+      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} -DisablePerf -DynamicCRT ${{ inputs.sanitize }} ${{ inputs.os == 'windows-2022' && '-Generator "Visual Studio 17 2022"' || '' }}
     - name: Build External Platform Test
       if: inputs.build == '-Test'
       shell: pwsh
       run: |
         cmake --install build\${{ inputs.plat }}\${{ inputs.arch }}_${{ inputs.tls }} --config ${{ inputs.config }}
-        cmake src/platform/unittest/external -G "Visual Studio 17 2022" -A ${{ inputs.arch }} -B build_external "-DCMAKE_INSTALL_PREFIX:PATH=C:/Program Files/msquic"
+        cmake src/platform/unittest/external -G "${{ inputs.os == 'windows-2022' && 'Visual Studio 17 2022' || 'Visual Studio 18 2026' }}" -A ${{ inputs.arch }} -B build_external "-DCMAKE_INSTALL_PREFIX:PATH=C:/Program Files/msquic"
         cmake --build build_external --config ${{ inputs.config }}
     - name: Build For Perf
       if: inputs.build == '-Perf'
       shell: pwsh
-      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} -DisableTools -DisableTest ${{ inputs.sanitize }}
+      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} -DisableTools -DisableTest ${{ inputs.sanitize }} ${{ inputs.os == 'windows-2022' && '-Generator "Visual Studio 17 2022"' || '' }}
     - name: Build
       if: inputs.build == ''
       shell: pwsh
-      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} ${{ inputs.sanitize }} ${{ inputs.static }} ${{ inputs.official }}
+      run: scripts/build.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.plat }} -Arch ${{ inputs.arch }} -Tls ${{ inputs.tls }} ${{ inputs.sanitize }} ${{ inputs.static }} ${{ inputs.official }} ${{ inputs.os == 'windows-2022' && '-Generator "Visual Studio 17 2022"' || '' }}
     - name: Filter Build Artifacts
       shell: pwsh
       run: |

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,11 +30,6 @@ jobs:
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild -InstallTestCertificates
       shell: pwsh
-    - name: Install Perl
-      if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@22ab01e83d59dc1abe1796fd8f338da7e7f2d033
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -41,11 +41,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: Install Perl
-      if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@22ab01e83d59dc1abe1796fd8f338da7e7f2d033
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
@@ -54,7 +49,7 @@ jobs:
       shell: pwsh
     - name: Build Release
       shell: pwsh
-      run: scripts/build.ps1 -Config Release -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -UseSystemOpenSSLCrypto -DisableTest -DisableTools -DisablePerf
+      run: scripts/build.ps1 -Config Release -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -UseSystemOpenSSLCrypto -DisableTest -DisableTools -DisablePerf ${{ matrix.vec.os == 'windows-2022' && '-Generator "Visual Studio 17 2022"' || '' }}
     - name: Download Tests
       shell: pwsh
       run: |

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -248,7 +248,7 @@ if ($Generator -eq "") {
     if (!$IsWindows) {
         $Generator = "Unix Makefiles"
     } else {
-        $Generator = "Visual Studio 17 2022"
+        $Generator = "Visual Studio 18 2026"
     }
 }
 

--- a/src/platform/unittest/external/CMakeLists.txt
+++ b/src/platform/unittest/external/CMakeLists.txt
@@ -33,4 +33,4 @@ set_target_properties(msquic::inc PROPERTIES  INTERFACE_COMPILE_DEFINITIONS "${d
 add_executable(msquicplatformtest ${SOURCES})
 target_include_directories(msquicplatformtest PRIVATE ${CMAKE_INSTALL_PREFIX}/include)
 target_link_libraries(msquicplatformtest PRIVATE gtest msquic::msquic msquic::platform ws2_32 ntdll ncrypt crypt32 iphlpapi)
-target_compile_definitions(msquicplatformtest PRIVATE QUIC_EVENTS_STUB QUIC_LOGS_STUB _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)
+target_compile_definitions(msquicplatformtest PRIVATE QUIC_EVENTS_STUB QUIC_LOGS_STUB _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION _DISABLE_OPTIONAL_ANNOTATION)


### PR DESCRIPTION
## Description

GitHub's `windows-2025` and `windows-latest` hosted runner images no longer ship Visual Studio 17 2022. Every Windows build job that targets those images currently fails with:

```
CMake Error at CMakeLists.txt:42 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

This change:

- makes **Visual Studio 18 2026** the default CMake generator for Windows builds, and override it back to `Visual Studio 17 2022` for jobs that are still pinned to `windows-2022` (which will soon be out of support).
- remove the action to setup perl
    - the perl present by default in windows-2022 and up is recent enough
    - it was installing a CMake version that was shadowing the CMake from the runner image
- fix some path separator issues in the Rust build, causing failure with the more recent CMake
- fix the sanitize build (more annotations to disable with VS 18)

## Testing

CI now succeeds

## Documentation

`docs/BUILD.md` gains a VS 2026 example block. No other doc impact.
