### PR TITLE
Fix artifact name mismatch in code coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -206,7 +206,7 @@ jobs:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download BVT (XDP) Coverage Results
       with:
-        name: BVT-Debug-windows-windows-2022-x64-quictls-UseXdp
+        name: BVT-Debug-windows-windows-2022-x64-quictlsxdp-v1.1
         path: artifacts\coverage\windows\x64_Debug_quictls
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       name: Download SpinQuic Coverage Results


### PR DESCRIPTION
## Description

Commit d0a9143f2 ("Consume XDP runtime via nuget package installations instead of MSI") changed the `xdp` matrix value in the code coverage BVT job from `-UseXdp` to `xdp-v1.1`, but the hardcoded artifact name in the `merge-coverage` job was not updated to match.

This caused the "Merge Coverage" job to fail because it tried to download an artifact named `BVT-Debug-windows-windows-2022-x64-quictls-UseXdp`, while the BVT XDP job actually uploads `BVT-Debug-windows-windows-2022-x64-quictlsxdp-v1.1`.

This PR updates the download artifact name in the `merge-coverage` job to match the actual uploaded artifact name.

## Testing

No code changes — CI workflow fix only. The code coverage workflow on this PR will validate the fix.

## Documentation

No documentation impact.