### PR TITLE
Add per-connection queue delay statistics

### DIFF
--- a/scripts/generate-dotnet.ps1
+++ b/scripts/generate-dotnet.ps1
@@ -49,6 +49,7 @@ $Arguments = @(
     "-e QUIC_STATISTICS_V2_SIZE_2" # Inconsistent definitions across platforms
     "-e QUIC_STATISTICS_V2_SIZE_3" # Inconsistent definitions across platforms
     "-e QUIC_STATISTICS_V2_SIZE_4" # Inconsistent definitions across platforms
+    "-e QUIC_STATISTICS_V2_SIZE_5" # Inconsistent definitions across platforms
 )
 
 $FullArgs = $Arguments -join " "

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7102,6 +7102,24 @@ QuicConnGetV2Statistics(
     if (STATISTICS_HAS_FIELD(*StatsLength, RttVariance)) {
         Stats->RttVariance = (uint32_t)Path->RttVariance;
     }
+    if (STATISTICS_HAS_FIELD(*StatsLength, ConnectionQueueDelayAvgUs)) {
+        Stats->ConnectionQueueDelayAvgUs = Connection->Stats.Schedule.QueueDelayAvgUs;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, ConnectionQueueDelayMaxUs)) {
+        Stats->ConnectionQueueDelayMaxUs = Connection->Stats.Schedule.QueueDelayMaxUs;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, SendQueueDelayAvgUs)) {
+        Stats->SendQueueDelayAvgUs = Connection->Stats.Schedule.SendQueueDelayAvgUs;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, SendQueueDelayMaxUs)) {
+        Stats->SendQueueDelayMaxUs = Connection->Stats.Schedule.SendQueueDelayMaxUs;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, ReceiveQueueDelayAvgUs)) {
+        Stats->ReceiveQueueDelayAvgUs = Connection->Stats.Schedule.ReceiveQueueDelayAvgUs;
+    }
+    if (STATISTICS_HAS_FIELD(*StatsLength, ReceiveQueueDelayMaxUs)) {
+        Stats->ReceiveQueueDelayMaxUs = Connection->Stats.Schedule.ReceiveQueueDelayMaxUs;
+    }
 
     *StatsLength = CXPLAT_MIN(*StatsLength, sizeof(QUIC_STATISTICS_V2));
 
@@ -7999,6 +8017,11 @@ QuicConnDrainOperations(
 
         BOOLEAN FreeOper = Oper->FreeAfterProcess;
 
+        uint32_t OperQueueDelayUs = CxPlatTimeDiff32(Oper->QueueTimeUs, CxPlatTimeUs32());
+        if (OperQueueDelayUs >= (UINT32_MAX >> 1)) {
+            OperQueueDelayUs = 0;
+        }
+
         switch (Oper->Type) {
 
         case QUIC_OPER_TYPE_API_CALL:
@@ -8011,6 +8034,11 @@ QuicConnDrainOperations(
         case QUIC_OPER_TYPE_FLUSH_RECV:
             if (Connection->State.ShutdownComplete) {
                 break; // Ignore if already shutdown
+            }
+            Connection->Stats.Schedule.ReceiveQueueDelayAvgUs =
+                (7 * Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + OperQueueDelayUs) / 8;
+            if (OperQueueDelayUs > Connection->Stats.Schedule.ReceiveQueueDelayMaxUs) {
+                Connection->Stats.Schedule.ReceiveQueueDelayMaxUs = OperQueueDelayUs;
             }
             if (!QuicConnFlushRecv(Connection)) {
                 //
@@ -8041,6 +8069,11 @@ QuicConnDrainOperations(
         case QUIC_OPER_TYPE_FLUSH_SEND:
             if (Connection->State.ShutdownComplete) {
                 break; // Ignore if already shutdown
+            }
+            Connection->Stats.Schedule.SendQueueDelayAvgUs =
+                (7 * Connection->Stats.Schedule.SendQueueDelayAvgUs + OperQueueDelayUs) / 8;
+            if (OperQueueDelayUs > Connection->Stats.Schedule.SendQueueDelayMaxUs) {
+                Connection->Stats.Schedule.SendQueueDelayMaxUs = OperQueueDelayUs;
             }
             if (QuicSendFlush(&Connection->Send)) {
                 //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -827,11 +827,11 @@ QuicConnUpdateRtt(
 
     } else {
         if (Path->SmoothedRtt > LatestRtt) {
-            Path->RttVariance = (3 * Path->RttVariance + Path->SmoothedRtt - LatestRtt) / 4;
+            Path->RttVariance = CxPlatEwma(Path->RttVariance, Path->SmoothedRtt - LatestRtt, 4);
         } else {
-            Path->RttVariance = (3 * Path->RttVariance + LatestRtt - Path->SmoothedRtt) / 4;
+            Path->RttVariance = CxPlatEwma(Path->RttVariance, LatestRtt - Path->SmoothedRtt, 4);
         }
-        Path->SmoothedRtt = (7 * Path->SmoothedRtt + LatestRtt) / 8;
+        Path->SmoothedRtt = CxPlatEwma(Path->SmoothedRtt, LatestRtt, 8);
     }
 
     if (OurSendTimestamp != UINT64_MAX) {
@@ -847,7 +847,7 @@ QuicConnUpdateRtt(
         } else {
             Path->OneWayDelayLatest =
                 (uint64_t)((int64_t)PeerSendTimestamp - (int64_t)OurSendTimestamp - Connection->Stats.Timing.PhaseShift);
-            Path->OneWayDelay = (7 * Path->OneWayDelay + Path->OneWayDelayLatest) / 8;
+            Path->OneWayDelay = CxPlatEwma(Path->OneWayDelay, Path->OneWayDelayLatest, 8);
         }
     }
 
@@ -7981,17 +7981,15 @@ QuicConnUpdateOperQueueDelay(
 
     case QUIC_OPER_TYPE_FLUSH_RECV:
         Connection->Stats.Schedule.ReceiveQueueDelayAvgUs =
-            (7 * (uint64_t)Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + DelayUs) / 8;
-        if (DelayUs > Connection->Stats.Schedule.ReceiveQueueDelayMaxUs) {
-            Connection->Stats.Schedule.ReceiveQueueDelayMaxUs = DelayUs;
-        }
+            (uint32_t)CxPlatEwma(Connection->Stats.Schedule.ReceiveQueueDelayAvgUs, DelayUs, 8);
+        Connection->Stats.Schedule.ReceiveQueueDelayMaxUs =
+            CXPLAT_MAX(Connection->Stats.Schedule.ReceiveQueueDelayMaxUs, DelayUs);
         break;
     case QUIC_OPER_TYPE_FLUSH_SEND:
         Connection->Stats.Schedule.SendQueueDelayAvgUs =
-            (7 * (uint64_t)Connection->Stats.Schedule.SendQueueDelayAvgUs + DelayUs) / 8;
-        if (DelayUs > Connection->Stats.Schedule.SendQueueDelayMaxUs) {
-            Connection->Stats.Schedule.SendQueueDelayMaxUs = DelayUs;
-        }
+            (uint32_t)CxPlatEwma(Connection->Stats.Schedule.SendQueueDelayAvgUs, DelayUs, 8);
+        Connection->Stats.Schedule.SendQueueDelayMaxUs =
+            CXPLAT_MAX(Connection->Stats.Schedule.SendQueueDelayMaxUs, DelayUs);
         break;
     default:
         break;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7965,6 +7965,42 @@ QuicConnProcessExpiredTimer(
     }
 }
 
+//
+// Update a connection operation delay statistics
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicConnUpdateOperQueueDelay(
+    _Inout_ QUIC_CONNECTION* Connection,
+    _In_ const QUIC_OPERATION* Oper
+    )
+{
+    uint32_t DelayUs = CxPlatTimeDiff32(Oper->QueueTimeUs, CxPlatTimeUs32());
+    if (DelayUs >= (UINT32_MAX >> 1)) {
+        DelayUs = 0;
+    }
+
+    switch (Oper->Type) {
+
+    case QUIC_OPER_TYPE_FLUSH_RECV:
+        Connection->Stats.Schedule.ReceiveQueueDelayAvgUs =
+            (7 * Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + DelayUs) / 8;
+        if (DelayUs > Connection->Stats.Schedule.ReceiveQueueDelayMaxUs) {
+            Connection->Stats.Schedule.ReceiveQueueDelayMaxUs = DelayUs;
+        }
+        break;
+    case QUIC_OPER_TYPE_FLUSH_SEND:
+        Connection->Stats.Schedule.SendQueueDelayAvgUs =
+            (7 * Connection->Stats.Schedule.SendQueueDelayAvgUs + DelayUs) / 8;
+        if (DelayUs > Connection->Stats.Schedule.SendQueueDelayMaxUs) {
+            Connection->Stats.Schedule.SendQueueDelayMaxUs = DelayUs;
+        }
+        break;
+    default:
+        break;
+    }
+}
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicConnDrainOperations(
@@ -8014,13 +8050,9 @@ QuicConnDrainOperations(
         }
 
         QuicOperLog(Connection, Oper);
+        QuicConnUpdateOperQueueDelay(Connection, Oper);
 
         BOOLEAN FreeOper = Oper->FreeAfterProcess;
-
-        uint32_t OperQueueDelayUs = CxPlatTimeDiff32(Oper->QueueTimeUs, CxPlatTimeUs32());
-        if (OperQueueDelayUs >= (UINT32_MAX >> 1)) {
-            OperQueueDelayUs = 0;
-        }
 
         switch (Oper->Type) {
 
@@ -8034,11 +8066,6 @@ QuicConnDrainOperations(
         case QUIC_OPER_TYPE_FLUSH_RECV:
             if (Connection->State.ShutdownComplete) {
                 break; // Ignore if already shutdown
-            }
-            Connection->Stats.Schedule.ReceiveQueueDelayAvgUs =
-                (7 * Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + OperQueueDelayUs) / 8;
-            if (OperQueueDelayUs > Connection->Stats.Schedule.ReceiveQueueDelayMaxUs) {
-                Connection->Stats.Schedule.ReceiveQueueDelayMaxUs = OperQueueDelayUs;
             }
             if (!QuicConnFlushRecv(Connection)) {
                 //
@@ -8069,11 +8096,6 @@ QuicConnDrainOperations(
         case QUIC_OPER_TYPE_FLUSH_SEND:
             if (Connection->State.ShutdownComplete) {
                 break; // Ignore if already shutdown
-            }
-            Connection->Stats.Schedule.SendQueueDelayAvgUs =
-                (7 * Connection->Stats.Schedule.SendQueueDelayAvgUs + OperQueueDelayUs) / 8;
-            if (OperQueueDelayUs > Connection->Stats.Schedule.SendQueueDelayMaxUs) {
-                Connection->Stats.Schedule.SendQueueDelayMaxUs = OperQueueDelayUs;
             }
             if (QuicSendFlush(&Connection->Send)) {
                 //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7976,22 +7976,19 @@ QuicConnUpdateOperQueueDelay(
     )
 {
     uint32_t DelayUs = CxPlatTimeDiff32(Oper->QueueTimeUs, CxPlatTimeUs32());
-    if (DelayUs >= (UINT32_MAX >> 1)) {
-        DelayUs = 0;
-    }
 
     switch (Oper->Type) {
 
     case QUIC_OPER_TYPE_FLUSH_RECV:
         Connection->Stats.Schedule.ReceiveQueueDelayAvgUs =
-            (7 * Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + DelayUs) / 8;
+            (7 * (uint64_t)Connection->Stats.Schedule.ReceiveQueueDelayAvgUs + DelayUs) / 8;
         if (DelayUs > Connection->Stats.Schedule.ReceiveQueueDelayMaxUs) {
             Connection->Stats.Schedule.ReceiveQueueDelayMaxUs = DelayUs;
         }
         break;
     case QUIC_OPER_TYPE_FLUSH_SEND:
         Connection->Stats.Schedule.SendQueueDelayAvgUs =
-            (7 * Connection->Stats.Schedule.SendQueueDelayAvgUs + DelayUs) / 8;
+            (7 * (uint64_t)Connection->Stats.Schedule.SendQueueDelayAvgUs + DelayUs) / 8;
         if (DelayUs > Connection->Stats.Schedule.SendQueueDelayMaxUs) {
             Connection->Stats.Schedule.SendQueueDelayMaxUs = DelayUs;
         }

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -266,6 +266,12 @@ typedef struct QUIC_CONN_STATS {
         uint32_t LastQueueTime;         // Time the connection last entered the work queue.
         uint64_t DrainCount;            // Sum of drain calls
         uint64_t OperationCount;        // Sum of operations processed
+        uint32_t QueueDelayAvgUs;       // EWMA of connection queue delay
+        uint32_t QueueDelayMaxUs;       // Maximum connection queue delay
+        uint32_t SendQueueDelayAvgUs;   // EWMA of send queue delay
+        uint32_t SendQueueDelayMaxUs;   // Maximum send queue delay
+        uint32_t ReceiveQueueDelayAvgUs; // EWMA of receive queue delay
+        uint32_t ReceiveQueueDelayMaxUs; // Maximum receive queue delay
     } Schedule;
 
     struct {
@@ -1455,6 +1461,21 @@ QuicConnGetAckDelay(
         return (uint64_t)Connection->Settings.MaxAckDelayMs + (uint64_t)MsQuicLib.TimerResolutionMs;
     }
     return (uint64_t)Connection->Settings.MaxAckDelayMs;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_INLINE
+void
+QuicConnUpdateQueueDelay(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint32_t TimeInQueueUs
+    )
+{
+    Connection->Stats.Schedule.QueueDelayAvgUs =
+        (7 * Connection->Stats.Schedule.QueueDelayAvgUs + TimeInQueueUs) / 8;
+    if (TimeInQueueUs > Connection->Stats.Schedule.QueueDelayMaxUs) {
+        Connection->Stats.Schedule.QueueDelayMaxUs = TimeInQueueUs;
+    }
 }
 
 //

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1796,7 +1796,8 @@ QuicLibraryGetGlobalParam(
             QUIC_STATISTICS_V2_SIZE_1,
             QUIC_STATISTICS_V2_SIZE_2,
             QUIC_STATISTICS_V2_SIZE_3,
-            QUIC_STATISTICS_V2_SIZE_4
+            QUIC_STATISTICS_V2_SIZE_4,
+            QUIC_STATISTICS_V2_SIZE_5,
         };
         static const uint32_t NumStatSizes = ARRAYSIZE(StatSizes);
         uint32_t MaxSizes = *BufferLength / sizeof(uint32_t);

--- a/src/core/operation.c
+++ b/src/core/operation.c
@@ -149,6 +149,7 @@ QuicOperationEnqueue(
     )
 {
     BOOLEAN StartProcessing;
+    Oper->QueueTimeUs = CxPlatTimeUs32();
     CxPlatDispatchLockAcquire(&OperQ->Lock);
 #if DEBUG
     CXPLAT_DBG_ASSERT(Oper->Link.Flink == NULL);
@@ -170,6 +171,7 @@ QuicOperationEnqueuePriority(
     )
 {
     BOOLEAN StartProcessing;
+    Oper->QueueTimeUs = CxPlatTimeUs32();
     CxPlatDispatchLockAcquire(&OperQ->Lock);
 #if DEBUG
     CXPLAT_DBG_ASSERT(Oper->Link.Flink == NULL);
@@ -192,6 +194,7 @@ QuicOperationEnqueueFront(
     )
 {
     BOOLEAN StartProcessing;
+    Oper->QueueTimeUs = CxPlatTimeUs32();
     CxPlatDispatchLockAcquire(&OperQ->Lock);
 #if DEBUG
     CXPLAT_DBG_ASSERT(Oper->Link.Flink == NULL);

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -219,6 +219,11 @@ typedef struct QUIC_OPERATION {
     //
     BOOLEAN FreeAfterProcess;
 
+    //
+    // Timestamp (us) when the operation was enqueued.
+    //
+    uint32_t QueueTimeUs;
+
     union {
         struct {
             void* Reserved; // Nothing.

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -448,7 +448,8 @@ QuicWorkerUpdateQueueDelay(
     _In_ uint32_t TimeInQueueUs
     )
 {
-    Worker->AverageQueueDelay = (7 * Worker->AverageQueueDelay + TimeInQueueUs) / 8;
+    Worker->AverageQueueDelay =
+        (uint32_t)CxPlatEwma(Worker->AverageQueueDelay, TimeInQueueUs, 8);
     QuicTraceEvent(
         WorkerQueueDelayUpdated,
         "[wrkr][%p] QueueDelay = %u",

--- a/src/core/worker.c
+++ b/src/core/worker.c
@@ -617,6 +617,7 @@ QuicWorkerProcessConnection(
         }
 
         QuicWorkerUpdateQueueDelay(Worker, Delay);
+        QuicConnUpdateQueueDelay(Connection, Delay);
     }
 
     //

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -924,6 +924,24 @@ namespace Microsoft.Quic
 
         [NativeTypeName("uint32_t")]
         internal uint RttVariance;
+
+        [NativeTypeName("uint32_t")]
+        internal uint ConnectionQueueDelayAvgUs;
+
+        [NativeTypeName("uint32_t")]
+        internal uint ConnectionQueueDelayMaxUs;
+
+        [NativeTypeName("uint32_t")]
+        internal uint SendQueueDelayAvgUs;
+
+        [NativeTypeName("uint32_t")]
+        internal uint SendQueueDelayMaxUs;
+
+        [NativeTypeName("uint32_t")]
+        internal uint ReceiveQueueDelayAvgUs;
+
+        [NativeTypeName("uint32_t")]
+        internal uint ReceiveQueueDelayMaxUs;
     }
 
     internal partial struct QUIC_NETWORK_STATISTICS
@@ -3587,6 +3605,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_MAX_TICKET_KEY_COUNT 16")]
         internal const uint QUIC_MAX_TICKET_KEY_COUNT = 16;
+
+        [NativeTypeName("#define QUIC_STATISTICS_V2_SIZE_5 QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, ReceiveQueueDelayMaxUs)")]
+        internal static readonly ulong QUIC_STATISTICS_V2_SIZE_5 = unchecked(((int)(Marshal.OffsetOf<QUIC_STATISTICS_V2>("ReceiveQueueDelayMaxUs"))) + 4);
 
         [NativeTypeName("#define QUIC_TLS_SECRETS_MAX_SECRET_LEN 64")]
         internal const uint QUIC_TLS_SECRETS_MAX_SECRET_LEN = 64;

--- a/src/cs/lib/msquic_generated.cs
+++ b/src/cs/lib/msquic_generated.cs
@@ -3606,9 +3606,6 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_MAX_TICKET_KEY_COUNT 16")]
         internal const uint QUIC_MAX_TICKET_KEY_COUNT = 16;
 
-        [NativeTypeName("#define QUIC_STATISTICS_V2_SIZE_5 QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, ReceiveQueueDelayMaxUs)")]
-        internal static readonly ulong QUIC_STATISTICS_V2_SIZE_5 = unchecked(((int)(Marshal.OffsetOf<QUIC_STATISTICS_V2>("ReceiveQueueDelayMaxUs"))) + 4);
-
         [NativeTypeName("#define QUIC_TLS_SECRETS_MAX_SECRET_LEN 64")]
         internal const uint QUIC_TLS_SECRETS_MAX_SECRET_LEN = 64;
 

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -654,6 +654,15 @@ typedef struct QUIC_STATISTICS_V2 {
 
     uint32_t RttVariance;                   // In microseconds
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+    uint32_t ConnectionQueueDelayAvgUs;     // Sliding average connection queue delay in microseconds
+    uint32_t ConnectionQueueDelayMaxUs;     // Maximum connection queue delay in microseconds
+    uint32_t SendQueueDelayAvgUs;           // Sliding average send queue delay in microseconds
+    uint32_t SendQueueDelayMaxUs;           // Maximum send queue delay in microseconds
+    uint32_t ReceiveQueueDelayAvgUs;        // Sliding average receive queue delay in microseconds
+    uint32_t ReceiveQueueDelayMaxUs;        // Maximum receive queue delay in microseconds
+#endif
+
     // N.B. New fields must be appended to end
 
 } QUIC_STATISTICS_V2;
@@ -676,6 +685,9 @@ typedef struct QUIC_NETWORK_STATISTICS
 #define QUIC_STATISTICS_V2_SIZE_2   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, DestCidUpdateCount)     // MsQuic v2.1 final size
 #define QUIC_STATISTICS_V2_SIZE_3   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, SendEcnCongestionCount) // MsQuic v2.2 final size
 #define QUIC_STATISTICS_V2_SIZE_4   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, RttVariance)            // MsQuic v2.5 final size
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+#define QUIC_STATISTICS_V2_SIZE_5   QUIC_STRUCT_SIZE_THRU_FIELD(QUIC_STATISTICS_V2, ReceiveQueueDelayMaxUs) // MsQuic v2.6 preview size
+#endif
 
 typedef struct QUIC_LISTENER_STATISTICS {
 

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -197,6 +197,25 @@ extern "C" {
 #endif
 
 //
+// Small Computation Helpers
+//
+
+//
+// Exponentially weighted moving average
+//
+QUIC_INLINE
+uint64_t
+CxPlatEwma(
+    _In_ uint64_t Average,
+    _In_ uint64_t Sample,
+    _In_ uint64_t Weight
+    )
+{
+    CXPLAT_DBG_ASSERT(Weight > 0);
+    return ((Weight - 1) * Average + Sample) / Weight;
+}
+
+//
 // Library Initialization
 //
 

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -1212,10 +1212,16 @@ pub struct QUIC_STATISTICS_V2 {
     pub SendEcnCongestionCount: u32,
     pub HandshakeHopLimitTTL: u8,
     pub RttVariance: u32,
+    pub ConnectionQueueDelayAvgUs: u32,
+    pub ConnectionQueueDelayMaxUs: u32,
+    pub SendQueueDelayAvgUs: u32,
+    pub SendQueueDelayMaxUs: u32,
+    pub ReceiveQueueDelayAvgUs: u32,
+    pub ReceiveQueueDelayMaxUs: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_STATISTICS_V2"][::std::mem::size_of::<QUIC_STATISTICS_V2>() - 208usize];
+    ["Size of QUIC_STATISTICS_V2"][::std::mem::size_of::<QUIC_STATISTICS_V2>() - 232usize];
     ["Alignment of QUIC_STATISTICS_V2"][::std::mem::align_of::<QUIC_STATISTICS_V2>() - 8usize];
     ["Offset of field: QUIC_STATISTICS_V2::CorrelationId"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, CorrelationId) - 0usize];
@@ -1283,6 +1289,18 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, HandshakeHopLimitTTL) - 200usize];
     ["Offset of field: QUIC_STATISTICS_V2::RttVariance"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, RttVariance) - 204usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ConnectionQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ConnectionQueueDelayAvgUs) - 208usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ConnectionQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ConnectionQueueDelayMaxUs) - 212usize];
+    ["Offset of field: QUIC_STATISTICS_V2::SendQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendQueueDelayAvgUs) - 216usize];
+    ["Offset of field: QUIC_STATISTICS_V2::SendQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendQueueDelayMaxUs) - 220usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ReceiveQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ReceiveQueueDelayAvgUs) - 224usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ReceiveQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ReceiveQueueDelayMaxUs) - 228usize];
 };
 impl QUIC_STATISTICS_V2 {
     #[inline]

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -1205,10 +1205,16 @@ pub struct QUIC_STATISTICS_V2 {
     pub SendEcnCongestionCount: u32,
     pub HandshakeHopLimitTTL: u8,
     pub RttVariance: u32,
+    pub ConnectionQueueDelayAvgUs: u32,
+    pub ConnectionQueueDelayMaxUs: u32,
+    pub SendQueueDelayAvgUs: u32,
+    pub SendQueueDelayMaxUs: u32,
+    pub ReceiveQueueDelayAvgUs: u32,
+    pub ReceiveQueueDelayMaxUs: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_STATISTICS_V2"][::std::mem::size_of::<QUIC_STATISTICS_V2>() - 208usize];
+    ["Size of QUIC_STATISTICS_V2"][::std::mem::size_of::<QUIC_STATISTICS_V2>() - 232usize];
     ["Alignment of QUIC_STATISTICS_V2"][::std::mem::align_of::<QUIC_STATISTICS_V2>() - 8usize];
     ["Offset of field: QUIC_STATISTICS_V2::CorrelationId"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, CorrelationId) - 0usize];
@@ -1276,6 +1282,18 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, HandshakeHopLimitTTL) - 200usize];
     ["Offset of field: QUIC_STATISTICS_V2::RttVariance"]
         [::std::mem::offset_of!(QUIC_STATISTICS_V2, RttVariance) - 204usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ConnectionQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ConnectionQueueDelayAvgUs) - 208usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ConnectionQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ConnectionQueueDelayMaxUs) - 212usize];
+    ["Offset of field: QUIC_STATISTICS_V2::SendQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendQueueDelayAvgUs) - 216usize];
+    ["Offset of field: QUIC_STATISTICS_V2::SendQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, SendQueueDelayMaxUs) - 220usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ReceiveQueueDelayAvgUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ReceiveQueueDelayAvgUs) - 224usize];
+    ["Offset of field: QUIC_STATISTICS_V2::ReceiveQueueDelayMaxUs"]
+        [::std::mem::offset_of!(QUIC_STATISTICS_V2, ReceiveQueueDelayMaxUs) - 228usize];
 };
 impl QUIC_STATISTICS_V2 {
     #[inline]

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -91,6 +91,7 @@ void QuicTestStreamParam();
 void QuicTestGetPerfCounters();
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 void QuicTestValidateEncryptDecryptPerfCounters();
+void QuicTestConnQueueDelayStatistics();
 #endif
 void QuicTestVersionSettings();
 void QuicTestValidateParamApi();

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -399,6 +399,15 @@ TEST(ParameterValidation, ValidateEncryptDecryptPerfCounters) {
         QuicTestValidateEncryptDecryptPerfCounters();
     }
 }
+
+TEST(ParameterValidation, ConnQueueDelayStatistics) {
+    TestLogger Logger("QuicTestConnQueueDelayStatistics");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestConnQueueDelayStatistics)));
+    } else {
+        QuicTestConnQueueDelayStatistics();
+    }
+}
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 TEST(ParameterValidation, ValidateConfiguration) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -465,6 +465,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestGetPerfCounters);
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     RegisterTestFunction(QuicTestValidateEncryptDecryptPerfCounters);
+    RegisterTestFunction(QuicTestConnQueueDelayStatistics);
 #endif
     RegisterTestFunction(QuicTestValidateConfiguration);
     RegisterTestFunction(QuicTestValidateListener);

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2899,7 +2899,9 @@ void QuicTestGlobalParam()
             QUIC_STATISTICS_V2_SIZE_2,
             QUIC_STATISTICS_V2_SIZE_3,
             QUIC_STATISTICS_V2_SIZE_4,
-            QUIC_STATISTICS_V2_SIZE_5
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+            QUIC_STATISTICS_V2_SIZE_5,
+#endif
         };
 
         //

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2898,7 +2898,8 @@ void QuicTestGlobalParam()
             QUIC_STATISTICS_V2_SIZE_1,
             QUIC_STATISTICS_V2_SIZE_2,
             QUIC_STATISTICS_V2_SIZE_3,
-            QUIC_STATISTICS_V2_SIZE_4
+            QUIC_STATISTICS_V2_SIZE_4,
+            QUIC_STATISTICS_V2_SIZE_5
         };
 
         //
@@ -6080,10 +6081,10 @@ QuicTestValidateEncryptDecryptPerfCounters()
     UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptCallback, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
+    Listener.Context = &Server;
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, Alpn.Length()));
     QuicAddr ServerLocalAddr;
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
-    Listener.Context = &Server;
 
     {
         TestConnection Client(Registration);
@@ -6116,6 +6117,88 @@ QuicTestValidateEncryptDecryptPerfCounters()
 
     TEST_TRUE(CountersAfter[QUIC_PERF_COUNTER_ENCRYPT_DURATION_US] > CountersBefore[QUIC_PERF_COUNTER_ENCRYPT_DURATION_US]);
     TEST_TRUE(CountersAfter[QUIC_PERF_COUNTER_DECRYPT_DURATION_US] > CountersBefore[QUIC_PERF_COUNTER_DECRYPT_DURATION_US]);
+}
+
+void
+QuicTestConnQueueDelayStatistics()
+{
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+    MsQuicSettings Settings;
+    Settings.SetIdleTimeoutMs(10000);
+    Settings.SetPeerBidiStreamCount(1);
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, Settings, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicCredentialConfig ClientCredConfig;
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    UniquePtr<TestConnection> Server;
+    TestListener Listener(Registration, ListenerAcceptCallback, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+    Listener.Context = &Server;
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, Alpn.Length()));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    {
+        TestConnection Client(Registration);
+        TEST_TRUE(Client.IsValid());
+
+        TEST_QUIC_SUCCEEDED(
+            Client.Start(
+                ClientConfiguration,
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr),
+                QUIC_TEST_LOOPBACK_FOR_AF(
+                    QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+                ServerLocalAddr.GetPort()));
+
+        TEST_TRUE(Client.WaitForConnectionComplete());
+        TEST_TRUE(Client.GetIsConnected());
+
+        TEST_NOT_EQUAL(nullptr, Server);
+        TEST_TRUE(Server->WaitForConnectionComplete());
+        TEST_TRUE(Server->GetIsConnected());
+
+        //
+        // Send and receive some data.
+        //
+        UniquePtr<TestStream> Stream(
+            Client.NewStream(
+                nullptr,
+                QUIC_STREAM_OPEN_FLAG_NONE,
+                NEW_STREAM_START_SYNC));
+        TEST_NOT_EQUAL(nullptr, Stream.get());
+        TEST_TRUE(Stream->IsValid());
+        TEST_TRUE(Stream->StartPing(100 * 1024));
+        TEST_TRUE(Stream->WaitForSendShutdownComplete());
+
+        //
+        // Read the full V2 statistics and verify the new per-connection queue
+        // delay fields are reported (i.e. the returned buffer covers them).
+        //
+        QUIC_STATISTICS_V2 Stats = {};
+        uint32_t BufferLength = sizeof(Stats);
+        TEST_QUIC_SUCCEEDED(
+            MsQuic->GetParam(
+                Client.GetConnection(),
+                QUIC_PARAM_CONN_STATISTICS_V2,
+                &BufferLength,
+                &Stats));
+        TEST_TRUE(BufferLength >= QUIC_STATISTICS_V2_SIZE_5);
+
+        //
+        // The sliding average can never exceed the observed maximum for any of
+        // the queue delay metrics. This invariant holds regardless of timing.
+        //
+        TEST_TRUE(Stats.ConnectionQueueDelayAvgUs <= Stats.ConnectionQueueDelayMaxUs);
+        TEST_TRUE(Stats.SendQueueDelayAvgUs <= Stats.SendQueueDelayMaxUs);
+        TEST_TRUE(Stats.ReceiveQueueDelayAvgUs <= Stats.ReceiveQueueDelayMaxUs);
+    }
 }
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 


### PR DESCRIPTION
## Description

Add 6 new fields to `QUIC_STATISTICS_V2` to expose per-connection queue delay metrics:

- `ConnectionQueueDelayAvgUs` / `ConnectionQueueDelayMaxUs` — Sliding average and maximum delay between when the connection is queued for processing and when it is scheduled.
- `SendQueueDelayAvgUs` / `SendQueueDelayMaxUs` — Sliding average and maximum delay for send flush operations.
- `ReceiveQueueDelayAvgUs` / `ReceiveQueueDelayMaxUs` — Sliding average and maximum delay for receive flush operations.

## Testing

Added basic tests exercising the code path - there is no way to validate the data is accurate except for basic invariants.

## Documentation

There is no existing documentation for QUIC_STATISTICS_V2 fields. I'll document them all in a next PR.