### PR TITLE
Fix data race in connection pool by running QuicConnStart on the connection's worker thread

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -450,7 +450,7 @@ MsQuicConnectionStart(
     Oper->API_CALL.Context->CONN_START.ServerName = ServerNameCopy;
     Oper->API_CALL.Context->CONN_START.ServerPort = ServerPort;
     Oper->API_CALL.Context->CONN_START.Family = Family;
-    Oper->API_CALL.Context->CONN_START.FailSilently = FALSE;
+    Oper->API_CALL.Context->CONN_START.Flags = QUIC_CONN_START_FLAG_NONE;
     ServerNameCopy = NULL;
 
     //

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -450,6 +450,7 @@ MsQuicConnectionStart(
     Oper->API_CALL.Context->CONN_START.ServerName = ServerNameCopy;
     Oper->API_CALL.Context->CONN_START.ServerPort = ServerPort;
     Oper->API_CALL.Context->CONN_START.Family = Family;
+    Oper->API_CALL.Context->CONN_START.FailSilently = FALSE;
     ServerNameCopy = NULL;
 
     //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1993,9 +1993,7 @@ Exit:
             // This connection was created internally (e.g. by the connection
             // pool) and was never returned to the application. Mark it
             // internally owned so that closing it locally below drives shutdown
-            // completion (and the final owner deref) to here, on the worker
-            // thread, instead of the creating thread having to flip ownership
-            // and queue a separate close while racing this teardown.
+            // completion.
             //
             Connection->State.ExternalOwner = FALSE;
         }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1988,6 +1988,17 @@ Exit:
     }
 
     if (QUIC_FAILED(Status)) {
+        if (StartFlags & QUIC_CONN_START_FLAG_FAIL_SILENTLY) {
+            //
+            // This connection was created internally (e.g. by the connection
+            // pool) and was never returned to the application. Mark it
+            // internally owned so that closing it locally below drives shutdown
+            // completion (and the final owner deref) to here, on the worker
+            // thread, instead of the creating thread having to flip ownership
+            // and queue a separate close while racing this teardown.
+            //
+            Connection->State.ExternalOwner = FALSE;
+        }
         QuicConnCloseLocally(
             Connection,
             StartFlags & QUIC_CONN_START_FLAG_FAIL_SILENTLY ?

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1991,11 +1991,12 @@ Exit:
         if (StartFlags & QUIC_CONN_START_FLAG_FAIL_SILENTLY) {
             //
             // This connection was created internally (e.g. by the connection
-            // pool) and was never returned to the application. Mark it
-            // internally owned so that closing it locally below drives shutdown
-            // completion.
+            // pool) and was never returned to the application. Suppress the
+            // shutdown-complete notification by clearing the callback handler.
+            // The connection stays externally owned; the creating context is
+            // responsible for closing it and releasing the owner reference.
             //
-            Connection->State.ExternalOwner = FALSE;
+            Connection->ClientCallbackHandler = NULL;
         }
         QuicConnCloseLocally(
             Connection,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7783,7 +7783,8 @@ QuicConnProcessApiOperation(
                 ApiCtx->CONN_START.Family,
                 ApiCtx->CONN_START.ServerName,
                 ApiCtx->CONN_START.ServerPort,
-                QUIC_CONN_START_FLAG_NONE);
+                ApiCtx->CONN_START.FailSilently ?
+                    QUIC_CONN_START_FLAG_FAIL_SILENTLY : QUIC_CONN_START_FLAG_NONE);
         ApiCtx->CONN_START.ServerName = NULL;
         break;
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7792,8 +7792,7 @@ QuicConnProcessApiOperation(
                 ApiCtx->CONN_START.Family,
                 ApiCtx->CONN_START.ServerName,
                 ApiCtx->CONN_START.ServerPort,
-                ApiCtx->CONN_START.FailSilently ?
-                    QUIC_CONN_START_FLAG_FAIL_SILENTLY : QUIC_CONN_START_FLAG_NONE);
+                ApiCtx->CONN_START.Flags);
         ApiCtx->CONN_START.ServerName = NULL;
         break;
 

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1219,11 +1219,6 @@ QuicConnQueueHighestPriorityOper(
     _In_ QUIC_OPERATION* Oper
     );
 
-typedef enum QUIC_CONN_START_FLAGS {
-    QUIC_CONN_START_FLAG_NONE =              0x00000000U,
-    QUIC_CONN_START_FLAG_FAIL_SILENTLY =     0x00000001U // Don't send notification to API client
-} QUIC_CONN_START_FLAGS;
-
 //
 // Starts the connection. Shouldn't be called directly in most instances.
 //

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -269,6 +269,58 @@ QuicConnPoolQueueConnectionClose(
     }
 }
 
+//
+// Start the connection on its worker thread and wait for completion.
+//
+// QuicConnStart must NOT be called inline on the app thread: it adds the
+// connection's source CID to the binding lookup table partway through, after
+// which the receive datapath can deliver packets and the connection's worker
+// can begin processing it concurrently. Running start inline races the worker
+// over the connection's crypto send state (MaxSentLength / NextSendOffset).
+// Queue it as an operation so it is serialized with all other connection work.
+//
+static
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+QuicConnPoolStartConnection(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_CONFIGURATION* Configuration,
+    _In_ QUIC_ADDRESS_FAMILY Family,
+    _In_z_ const char* ServerName,
+    _In_ uint16_t ServerPort
+    )
+{
+    QUIC_STATUS StartStatus = QUIC_STATUS_INTERNAL_ERROR;
+    CXPLAT_EVENT CompletionEvent;
+    QUIC_OPERATION Oper = { 0 };
+    QUIC_API_CONTEXT ApiCtx;
+
+    Oper.Type = QUIC_OPER_TYPE_API_CALL;
+    Oper.FreeAfterProcess = FALSE;          // Stack-allocated; worker must not free it.
+    Oper.API_CALL.Context = &ApiCtx;
+
+    CxPlatEventInitialize(&CompletionEvent, TRUE, FALSE);
+    ApiCtx.Type = QUIC_API_TYPE_CONN_START;
+    ApiCtx.Status = &StartStatus;
+    ApiCtx.Completed = &CompletionEvent;
+    ApiCtx.CONN_START.Configuration = Configuration;
+    ApiCtx.CONN_START.ServerName = ServerName;  // Ownership passes to QuicConnStart.
+    ApiCtx.CONN_START.ServerPort = ServerPort;
+    ApiCtx.CONN_START.Family = Family;
+    ApiCtx.CONN_START.FailSilently = TRUE;
+
+    //
+    // No op-level Configuration ref is needed: we block until the op completes
+    // and the caller keeps the Configuration alive; QuicConnSetConfiguration
+    // takes its own QUIC_CONF_REF_CONNECTION ref.
+    //
+    QuicConnQueueOper(Connection, &Oper);
+    CxPlatEventWaitForever(CompletionEvent);
+    CxPlatEventUninitialize(CompletionEvent);
+
+    return StartStatus;
+}
+
 
 static
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -372,13 +424,12 @@ QuicConnPoolTryCreateConnection(
         }
     }
 
-    Status = QuicConnStart(
+    Status = QuicConnPoolStartConnection(
         *Connection,
         Configuration,
         Family,
         ServerName,
-        ServerPort,
-        QUIC_CONN_START_FLAG_FAIL_SILENTLY);
+        ServerPort);
 
     ServerName = NULL; // The connection now owns the ServerName.
 

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -450,20 +450,19 @@ Error:
         QUIC_CONNECTION* PoolConnection = *Connection;
         if (QUIC_FAILED(Status)) {
             //
-            // This connection has never left MsQuic back to the application.
-            // Mark it as internally owned so no notification is sent to the app,
-            // the closing logic will handle the owner deref.
+            // On failure, QuicConnStart has already marked this (internally
+            // owned) connection for silent teardown and self-cleanup on its
+            // worker thread. We must not touch the connection's state from this
+            // thread (that would race the worker); we only drop our handle to
+            // it here.
             //
-            PoolConnection->State.ExternalOwner = FALSE;
-            QuicConnPoolQueueConnectionClose(PoolConnection, FALSE);
             *Connection = NULL;
         }
         //
         // Release the create-scope reference taken after QuicConnAlloc. This is
-        // the last access to the connection on this thread, so the worker is now
-        // free to run (and, on failure, free) the connection without racing this
-        // function. On success the application retains ownership via the original
-        // owner reference.
+        // the last access to the connection on this thread. On failure the
+        // worker-side teardown performs the final owner deref; on success the
+        // application retains ownership via the original owner reference.
         //
         QuicConnRelease(PoolConnection, QUIC_CONN_REF_HANDLE_OWNER);
     }

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -357,8 +357,7 @@ QuicConnPoolTryCreateConnection(
     // drive the connection to shutdown-complete and release the owner reference
     // (and free the connection) while this thread is still queuing or otherwise
     // operating on it. This extra reference guarantees the connection stays
-    // alive until this function is done with it. It is released, balanced, on
-    // every path below.
+    // alive until this function is done with it.
     //
     QuicConnAddRef(*Connection, QUIC_CONN_REF_HANDLE_OWNER);
 
@@ -449,21 +448,8 @@ Error:
     if (*Connection != NULL) {
         QUIC_CONNECTION* PoolConnection = *Connection;
         if (QUIC_FAILED(Status)) {
-            //
-            // On failure, QuicConnStart has already marked this (internally
-            // owned) connection for silent teardown and self-cleanup on its
-            // worker thread. We must not touch the connection's state from this
-            // thread (that would race the worker); we only drop our handle to
-            // it here.
-            //
             *Connection = NULL;
         }
-        //
-        // Release the create-scope reference taken after QuicConnAlloc. This is
-        // the last access to the connection on this thread. On failure the
-        // worker-side teardown performs the final owner deref; on success the
-        // application retains ownership via the original owner reference.
-        //
         QuicConnRelease(PoolConnection, QUIC_CONN_REF_HANDLE_OWNER);
     }
 

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -302,11 +302,6 @@ QuicConnPoolStartConnection(
     ApiCtx.CONN_START.Family = Family;
     ApiCtx.CONN_START.Flags = QUIC_CONN_START_FLAG_FAIL_SILENTLY;
 
-    //
-    // No op-level Configuration ref is needed: we block until the op completes
-    // and the caller keeps the Configuration alive; QuicConnSetConfiguration
-    // takes its own QUIC_CONF_REF_CONNECTION ref.
-    //
     QuicConnQueueOper(Connection, &Oper);
     CxPlatEventWaitForever(CompletionEvent);
     CxPlatEventUninitialize(CompletionEvent);
@@ -437,11 +432,9 @@ Error:
 
     if (QUIC_FAILED(Status) && *Connection != NULL) {
         //
-        // This connection was never returned to the application. Close it (its
-        // callback handler was already cleared by QuicConnStart, so no shutdown
-        // notification is raised) and release our owner reference so it is
-        // freed. This matches the cleanup path for successfully created pool
-        // connections below.
+        // This connection was never returned to the application. QuicConnStart
+        // cleared the callback handler and closed it on the worker, so we just
+        // need to release our owner reference to free it.
         //
         QuicConnPoolQueueConnectionClose(*Connection, FALSE);
         QuicConnRelease(*Connection, QUIC_CONN_REF_HANDLE_OWNER);

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -353,11 +353,8 @@ QuicConnPoolTryCreateConnection(
 
     //
     // Hold a create-scope reference across the rest of this function. The start
-    // operation is now processed on the connection's worker thread, which can
-    // drive the connection to shutdown-complete and release the owner reference
-    // (and free the connection) while this thread is still queuing or otherwise
-    // operating on it. This extra reference guarantees the connection stays
-    // alive until this function is done with it.
+    // operation is processed on the connection's worker thread. This extra reference
+    // guarantees the connection stays alive until this function is done with it.
     //
     QuicConnAddRef(*Connection, QUIC_CONN_REF_HANDLE_OWNER);
 

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -437,11 +437,14 @@ Error:
 
     if (QUIC_FAILED(Status) && *Connection != NULL) {
         //
-        // On failure, QuicConnStart has marked this internally-owned connection
-        // for silent teardown on its worker thread, which performs the final
-        // owner deref. The connection's initial reference therefore frees it; we
-        // only drop our handle here.
+        // This connection was never returned to the application. Close it (its
+        // callback handler was already cleared by QuicConnStart, so no shutdown
+        // notification is raised) and release our owner reference so it is
+        // freed. This matches the cleanup path for successfully created pool
+        // connections below.
         //
+        QuicConnPoolQueueConnectionClose(*Connection, FALSE);
+        QuicConnRelease(*Connection, QUIC_CONN_REF_HANDLE_OWNER);
         *Connection = NULL;
     }
 

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -300,7 +300,7 @@ QuicConnPoolStartConnection(
     ApiCtx.CONN_START.ServerName = ServerName;  // Ownership passes to QuicConnStart.
     ApiCtx.CONN_START.ServerPort = ServerPort;
     ApiCtx.CONN_START.Family = Family;
-    ApiCtx.CONN_START.FailSilently = TRUE;
+    ApiCtx.CONN_START.Flags = QUIC_CONN_START_FLAG_FAIL_SILENTLY;
 
     //
     // No op-level Configuration ref is needed: we block until the op completes

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -272,13 +272,6 @@ QuicConnPoolQueueConnectionClose(
 //
 // Start the connection on its worker thread and wait for completion.
 //
-// QuicConnStart must NOT be called inline on the app thread: it adds the
-// connection's source CID to the binding lookup table partway through, after
-// which the receive datapath can deliver packets and the connection's worker
-// can begin processing it concurrently. Running start inline races the worker
-// over the connection's crypto send state (MaxSentLength / NextSendOffset).
-// Queue it as an operation so it is serialized with all other connection work.
-//
 static
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
@@ -357,6 +350,17 @@ QuicConnPoolTryCreateConnection(
     }
     (*Connection)->ClientCallbackHandler = Handler;
     (*Connection)->ClientContext = Context;
+
+    //
+    // Hold a create-scope reference across the rest of this function. The start
+    // operation is now processed on the connection's worker thread, which can
+    // drive the connection to shutdown-complete and release the owner reference
+    // (and free the connection) while this thread is still queuing or otherwise
+    // operating on it. This extra reference guarantees the connection stays
+    // alive until this function is done with it. It is released, balanced, on
+    // every path below.
+    //
+    QuicConnAddRef(*Connection, QUIC_CONN_REF_HANDLE_OWNER);
 
     //
     // Set the calculated remote address and local address to get the desired
@@ -442,15 +446,26 @@ Error:
         CXPLAT_FREE(ServerName, QUIC_POOL_SERVERNAME);
     }
 
-    if (QUIC_FAILED(Status) && *Connection != NULL) {
+    if (*Connection != NULL) {
+        QUIC_CONNECTION* PoolConnection = *Connection;
+        if (QUIC_FAILED(Status)) {
+            //
+            // This connection has never left MsQuic back to the application.
+            // Mark it as internally owned so no notification is sent to the app,
+            // the closing logic will handle the owner deref.
+            //
+            PoolConnection->State.ExternalOwner = FALSE;
+            QuicConnPoolQueueConnectionClose(PoolConnection, FALSE);
+            *Connection = NULL;
+        }
         //
-        // This connection has never left MsQuic back to the application.
-        // Mark it as internally owned so no notification is sent to the app,
-        // the closing logic will handle the final deref.
+        // Release the create-scope reference taken after QuicConnAlloc. This is
+        // the last access to the connection on this thread, so the worker is now
+        // free to run (and, on failure, free) the connection without racing this
+        // function. On success the application retains ownership via the original
+        // owner reference.
         //
-        (*Connection)->State.ExternalOwner = FALSE;
-        QuicConnPoolQueueConnectionClose(*Connection, FALSE);
-        *Connection = NULL;
+        QuicConnRelease(PoolConnection, QUIC_CONN_REF_HANDLE_OWNER);
     }
 
     return Status;

--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -352,13 +352,6 @@ QuicConnPoolTryCreateConnection(
     (*Connection)->ClientContext = Context;
 
     //
-    // Hold a create-scope reference across the rest of this function. The start
-    // operation is processed on the connection's worker thread. This extra reference
-    // guarantees the connection stays alive until this function is done with it.
-    //
-    QuicConnAddRef(*Connection, QUIC_CONN_REF_HANDLE_OWNER);
-
-    //
     // Set the calculated remote address and local address to get the desired
     // RSS CPU.
     //
@@ -442,12 +435,14 @@ Error:
         CXPLAT_FREE(ServerName, QUIC_POOL_SERVERNAME);
     }
 
-    if (*Connection != NULL) {
-        QUIC_CONNECTION* PoolConnection = *Connection;
-        if (QUIC_FAILED(Status)) {
-            *Connection = NULL;
-        }
-        QuicConnRelease(PoolConnection, QUIC_CONN_REF_HANDLE_OWNER);
+    if (QUIC_FAILED(Status) && *Connection != NULL) {
+        //
+        // On failure, QuicConnStart has marked this internally-owned connection
+        // for silent teardown on its worker thread, which performs the final
+        // owner deref. The connection's initial reference therefore frees it; we
+        // only drop our handle here.
+        //
+        *Connection = NULL;
     }
 
     return Status;

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -67,6 +67,11 @@ typedef enum QUIC_API_TYPE {
 
 } QUIC_API_TYPE;
 
+typedef enum QUIC_CONN_START_FLAGS {
+    QUIC_CONN_START_FLAG_NONE =              0x00000000U,
+    QUIC_CONN_START_FLAG_FAIL_SILENTLY =     0x00000001U // Don't send notification to API client
+} QUIC_CONN_START_FLAGS;
+
 //
 // Context for an API call. This is allocated separately from QUIC_OPERATION
 // so that non-API-call operations will take less space.
@@ -108,7 +113,7 @@ typedef struct QUIC_API_CONTEXT {
             const char* ServerName;
             uint16_t ServerPort;
             QUIC_ADDRESS_FAMILY Family;
-            BOOLEAN FailSilently;       // Don't notify the app on start failure.
+            QUIC_CONN_START_FLAGS Flags;
         } CONN_START;
         struct {
             QUIC_CONFIGURATION* Configuration;

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -108,6 +108,7 @@ typedef struct QUIC_API_CONTEXT {
             const char* ServerName;
             uint16_t ServerPort;
             QUIC_ADDRESS_FAMILY Family;
+            BOOLEAN FailSilently;       // Don't notify the app on start failure.
         } CONN_START;
         struct {
             QUIC_CONFIGURATION* Configuration;


### PR DESCRIPTION
## Description

QuicConnPoolTryCreateConnection called QuicConnStart directly on the application thread instead of queuing it to the connection's worker.
Partway through, QuicConnStart calls QuicBindingAddSourceConnectionID, which publishes the connection's source CID into the binding lookup table. 
From that point the receive datapath can match inbound packets to the connection and queue work to its worker. Because the start was running outside the per-connection operation queue, the OperQ->ActivelyProcessing gate was never set, so the first inbound packet caused the worker to begin draining the same connection in parallel with the app thread still inside QuicConnStart. 
That breaks msquic's single-threaded-per-connection invariant: two threads then touch Connection->Crypto concurrently.
Fixes #6058 
## Testing

The spinquic stress test exercises this path

## Documentation

NA
