### PR TITLE
Fix ServerAcceptContext smart pointer handling and lifetime

### DIFF
--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -853,11 +853,10 @@ ListenerAcceptConnectionAndStreams(
     )
 {
     ServerAcceptContext* AcceptContext = (ServerAcceptContext*)Listener->Context;
-    *AcceptContext->NewConnection = new(std::nothrow) TestConnection(ConnectionHandle, ConnectionAcceptAndIgnoreStream);
+    AcceptContext->NewConnection->reset(new(std::nothrow) TestConnection(ConnectionHandle, ConnectionAcceptAndIgnoreStream));
     if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
-        delete *AcceptContext->NewConnection;
-        *AcceptContext->NewConnection = nullptr;
+        AcceptContext->NewConnection->reset(nullptr);
         return false;
     }
     CxPlatEventSet(AcceptContext->NewConnectionReady);
@@ -898,6 +897,7 @@ QuicTestClientDisconnect(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnectionAndStreams, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -906,8 +906,7 @@ QuicTestClientDisconnect(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             TestConnection* Client =
@@ -996,6 +995,7 @@ QuicTestStatelessResetKey(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnectionAndStreams, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1004,8 +1004,7 @@ QuicTestStatelessResetKey(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             TestConnection* Client =
@@ -4236,6 +4235,7 @@ QuicTestConnectAndIdleForDestCidChange(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnectionAndStreams, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -4244,8 +4244,7 @@ QuicTestConnectAndIdleForDestCidChange(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -24,11 +24,10 @@ ListenerAcceptConnection(
     )
 {
     ServerAcceptContext* AcceptContext = (ServerAcceptContext*)Listener->Context;
-    *AcceptContext->NewConnection = new(std::nothrow) TestConnection(ConnectionHandle);
+    AcceptContext->NewConnection->reset(new(std::nothrow) TestConnection(ConnectionHandle));
     if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
         TEST_FAILURE("Failed to accept new TestConnection.");
-        delete *AcceptContext->NewConnection;
-        *AcceptContext->NewConnection = nullptr;
+        AcceptContext->NewConnection->reset(nullptr);
         return false;
     }
     (*AcceptContext->NewConnection)->SetHasRandomLoss(Listener->GetHasRandomLoss());
@@ -63,6 +62,7 @@ QuicTestDatagramNegotiation(
     QUIC_BUFFER DatagramBuffer = { sizeof(RawBuffer), RawBuffer };
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -72,8 +72,7 @@ QuicTestDatagramNegotiation(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -164,6 +163,7 @@ QuicTestDatagramSend(
     SelectiveLossHelper LossHelper;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -173,8 +173,7 @@ QuicTestDatagramSend(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -298,6 +297,7 @@ QuicTestDatagramDrop(
     SelectiveLossHelper LossHelper;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -307,8 +307,7 @@ QuicTestDatagramDrop(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -116,17 +116,16 @@ ListenerAcceptConnection(
     )
 {
     ServerAcceptContext* AcceptContext = (ServerAcceptContext*)Listener->Context;
-    *AcceptContext->NewConnection = new(std::nothrow) TestConnection(ConnectionHandle, (NEW_STREAM_CALLBACK_HANDLER)AcceptContext->NewStreamHandler);
+    AcceptContext->NewConnection->reset(new(std::nothrow) TestConnection(ConnectionHandle, (NEW_STREAM_CALLBACK_HANDLER)AcceptContext->NewStreamHandler));
+    if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
+        TEST_FAILURE("Failed to accept new TestConnection.");
+        AcceptContext->NewConnection->reset(nullptr);
+        return false;
+    }
     (*AcceptContext->NewConnection)->SetExpectedCustomTicketValidationResult(AcceptContext->ExpectedCustomTicketValidationResult);
     (*AcceptContext->NewConnection)->SetAsyncCustomValidationResult(AcceptContext->AsyncCustomCertValidation);
     if (AcceptContext->IsCustomCertValidationResultSet) {
         (*AcceptContext->NewConnection)->SetExpectedCustomValidationResult(AcceptContext->CustomCertValidationResult);
-    }
-    if (*AcceptContext->NewConnection == nullptr || !(*AcceptContext->NewConnection)->IsValid()) {
-        TEST_FAILURE("Failed to accept new TestConnection.");
-        delete *AcceptContext->NewConnection;
-        *AcceptContext->NewConnection = nullptr;
-        return false;
     }
     (*AcceptContext->NewConnection)->SetHasRandomLoss(Listener->GetHasRandomLoss());
     if (AcceptContext->ExpectedTransportCloseStatus != QUIC_STATUS_SUCCESS) {
@@ -232,6 +231,7 @@ QuicTestConnect(
     if (SessionResumption == QUIC_TEST_RESUMPTION_REJECTED) {
         TEST_QUIC_SUCCEEDED(ServerConfiguration.SetTicketKey(&BadKey));
     }
+    UniquePtr<TestConnection> Server;
     TestListener Listener(
         Registration,
         ListenerAcceptConnection,
@@ -243,8 +243,7 @@ QuicTestConnect(
     TEST_QUIC_SUCCEEDED(Listener.Start(MultipleALPNs ? Alpn2 : Alpn1, &ServerLocalAddr.SockAddr));
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     if (AsyncTicketValidation) {
         ServerAcceptCtx.ExpectedCustomTicketValidationResult = QUIC_STATUS_PENDING;
     } else {
@@ -846,6 +845,7 @@ QuicTestPathValidationTimeout(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -855,8 +855,7 @@ QuicTestPathValidationTimeout(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -1026,6 +1025,7 @@ QuicTestChangeMaxStreamID(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -1036,8 +1036,7 @@ QuicTestChangeMaxStreamID(
 
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -1112,6 +1111,7 @@ QuicTestConnectAndIdle(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1120,8 +1120,7 @@ QuicTestConnectAndIdle(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -1211,6 +1210,7 @@ QuicTestCustomServerCertificateValidation(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1219,8 +1219,7 @@ QuicTestCustomServerCertificateValidation(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             if (!AcceptCert) {
                 ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_BAD_CERTIFICATE;
             }
@@ -1311,6 +1310,7 @@ QuicTestCustomClientCertificateValidation(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1319,8 +1319,7 @@ QuicTestCustomClientCertificateValidation(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             if (!AcceptCert) {
                 ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_BAD_CERTIFICATE;
                 ServerAcceptCtx.NewStreamHandler = (void*)NewStreamCallbackTestFail;
@@ -1405,6 +1404,7 @@ QuicTestCustomServerCertValidationAfterShutdown()
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1412,8 +1412,7 @@ QuicTestCustomServerCertValidationAfterShutdown()
     QuicAddr ServerLocalAddr;
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
     Listener.Context = &ServerAcceptCtx;
 
@@ -1471,6 +1470,7 @@ QuicTestCustomClientCertValidationAfterShutdown()
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCertCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1478,8 +1478,7 @@ QuicTestCustomClientCertValidationAfterShutdown()
     QuicAddr ServerLocalAddr;
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
     ServerAcceptCtx.AsyncCustomCertValidation = true;
     ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
@@ -1566,6 +1565,7 @@ QuicTestCustomTicketValidationAfterShutdown(
     // Now attempt a resumed connection. The server will return PENDING
     // from the RESUMED callback, deferring ticket validation.
     //
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1573,8 +1573,7 @@ QuicTestCustomTicketValidationAfterShutdown(
     QuicAddr ServerLocalAddr;
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     Listener.Context = &ServerAcceptCtx;
 
     TestConnection Client(Registration);
@@ -1653,6 +1652,7 @@ QuicTestShutdownDuringHandshake(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1661,8 +1661,7 @@ QuicTestShutdownDuringHandshake(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
             Listener.Context = &ServerAcceptCtx;
 
@@ -1868,6 +1867,7 @@ QuicTestVersionNegotiation(
             &Enabled));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1877,8 +1877,7 @@ QuicTestVersionNegotiation(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -1970,6 +1969,7 @@ QuicTestVersionNegotiationRetry(
             &Enabled));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -1979,8 +1979,7 @@ QuicTestVersionNegotiationRetry(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2067,6 +2066,7 @@ QuicTestCompatibleVersionNegotiation(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionNegotiationExtEnabled(!DisableVNEClient));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2075,8 +2075,7 @@ QuicTestCompatibleVersionNegotiation(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2176,6 +2175,7 @@ QuicTestCompatibleVersionNegotiationRetry(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionSettings(ClientVersionSettings));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2184,8 +2184,7 @@ QuicTestCompatibleVersionNegotiationRetry(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2269,6 +2268,7 @@ QuicTestCompatibleVersionNegotiationDefaultServer(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionNegotiationExtEnabled(!DisableVNEClient));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2277,8 +2277,7 @@ QuicTestCompatibleVersionNegotiationDefaultServer(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2369,6 +2368,7 @@ QuicTestCompatibleVersionNegotiationDefaultClient(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionNegotiationExtEnabled(!DisableVNEClient));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2377,8 +2377,7 @@ QuicTestCompatibleVersionNegotiationDefaultClient(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2462,6 +2461,7 @@ QuicTestIncompatibleVersionNegotiation(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionSettings(ClientVersionSettings));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2470,8 +2470,7 @@ QuicTestIncompatibleVersionNegotiation(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2564,6 +2563,7 @@ RunFailedVersionNegotiation(
     TEST_QUIC_SUCCEEDED(ClientConfiguration.SetVersionSettings(ClientVersionSettings));
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -2572,8 +2572,7 @@ RunFailedVersionNegotiation(
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
             if (QUIC_FAILED(ExpectedServerError)) {
                 ServerAcceptCtx.ExpectedTransportCloseStatus = ExpectedServerError;
@@ -2811,6 +2810,7 @@ QuicTestConnectBadAlpn(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -2820,8 +2820,7 @@ QuicTestConnectBadAlpn(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2871,6 +2870,7 @@ QuicTestConnectBadSni(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
@@ -2879,8 +2879,7 @@ QuicTestConnectBadSni(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -2935,6 +2934,7 @@ QuicTestConnectIpSni(
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
 
@@ -2943,8 +2943,7 @@ QuicTestConnectIpSni(
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     Listener.Context = &ServerAcceptCtx;
 
     TestConnection Client(Registration);
@@ -3095,6 +3094,7 @@ QuicTestKeyUpdateRandomLoss(
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
     Listener.SetHasRandomLoss(true);
@@ -3104,8 +3104,7 @@ QuicTestKeyUpdateRandomLoss(
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     Listener.Context = &ServerAcceptCtx;
 
     TestConnection Client(Registration);
@@ -3199,6 +3198,7 @@ QuicTestForceKeyUpdate(
     MsQuicConfiguration ClientConfiguration{Registration, Alpn, Settings, ClientCredConfig};
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
 
@@ -3207,8 +3207,7 @@ QuicTestForceKeyUpdate(
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server{};
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     Listener.Context = &ServerAcceptCtx;
 
     TestConnection Client{Registration};
@@ -3362,6 +3361,7 @@ QuicTestKeyUpdate(
     MsQuicConfiguration ClientConfiguration(Registration, Alpn, Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
+    UniquePtr<TestConnection> Server;
     TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
     TEST_TRUE(Listener.IsValid());
 
@@ -3370,8 +3370,7 @@ QuicTestKeyUpdate(
     TEST_QUIC_SUCCEEDED(Listener.Start(Alpn, &ServerLocalAddr.SockAddr));
     TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
-    UniquePtr<TestConnection> Server;
-    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptContext ServerAcceptCtx(&Server);
     Listener.Context = &ServerAcceptCtx;
 
     TestConnection Client(Registration);
@@ -3449,6 +3448,7 @@ QuicTestCidUpdate(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
 
@@ -3458,8 +3458,7 @@ QuicTestCidUpdate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -3558,6 +3557,7 @@ QuicTestConnectClientCertificate(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3566,8 +3566,7 @@ QuicTestConnectClientCertificate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
             if (!UseClientCertificate) {
                 ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_NO_CERT);
@@ -3666,6 +3665,7 @@ QuicTestValidAlpnLengths(
         QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
         {
+            UniquePtr<TestConnection> Server;
             TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
             TEST_TRUE(Listener.IsValid());
             QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3674,8 +3674,7 @@ QuicTestValidAlpnLengths(
             TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
             {
-                UniquePtr<TestConnection> Server;
-                ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+                ServerAcceptContext ServerAcceptCtx(&Server);
                 Listener.Context = &ServerAcceptCtx;
 
                 {
@@ -3732,6 +3731,7 @@ QuicTestConnectExpiredServerCertificate(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3740,8 +3740,7 @@ QuicTestConnectExpiredServerCertificate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_EXPIRED_CERTIFICATE;
             Listener.Context = &ServerAcceptCtx;
 
@@ -3799,6 +3798,7 @@ QuicTestConnectValidServerCertificate(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3807,8 +3807,7 @@ QuicTestConnectValidServerCertificate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             Listener.Context = &ServerAcceptCtx;
 
             {
@@ -3863,6 +3862,7 @@ QuicTestConnectValidClientCertificate(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3871,8 +3871,7 @@ QuicTestConnectValidClientCertificate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_SUCCESS);
             Listener.Context = &ServerAcceptCtx;
 
@@ -3928,6 +3927,7 @@ QuicTestConnectExpiredClientCertificate(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -3936,8 +3936,7 @@ QuicTestConnectExpiredClientCertificate(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_EXPIRED);
             Listener.Context = &ServerAcceptCtx;
 
@@ -4436,6 +4435,7 @@ QuicTestChangeAlpn(
             QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
             {
+                UniquePtr<TestConnection> Server;
                 TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
                 TEST_TRUE(Listener.IsValid());
                 QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -4444,8 +4444,7 @@ QuicTestChangeAlpn(
                 TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
                 {
-                    UniquePtr<TestConnection> Server;
-                    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+                    ServerAcceptContext ServerAcceptCtx(&Server);
                     Listener.Context = &ServerAcceptCtx;
 
                     {
@@ -4508,6 +4507,7 @@ QuicTestChangeAlpn(
         QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
         {
+            UniquePtr<TestConnection> Server;
             TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
             TEST_TRUE(Listener.IsValid());
             QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -4516,8 +4516,7 @@ QuicTestChangeAlpn(
             TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
             {
-                UniquePtr<TestConnection> Server;
-                ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+                ServerAcceptContext ServerAcceptCtx(&Server);
                 ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_ALPN_NEG_FAILURE;
                 Listener.Context = &ServerAcceptCtx;
 
@@ -4618,6 +4617,7 @@ QuicTestCustomVNTP(
     QUIC_ADDRESS_FAMILY QuicAddrFamily = QUIC_ADDRESS_FAMILY_INET;
 
     {
+        UniquePtr<TestConnection> Server;
         TestListener Listener(Registration, TestServer ? ListenerAcceptConnectionTestTP : ListenerAcceptConnection, ServerConfiguration);
         TEST_TRUE(Listener.IsValid());
         QuicAddr ServerLocalAddr(QuicAddrFamily);
@@ -4626,8 +4626,7 @@ QuicTestCustomVNTP(
         TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
 
         {
-            UniquePtr<TestConnection> Server;
-            ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+            ServerAcceptContext ServerAcceptCtx(&Server);
             ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_INTERNAL_ERROR;
             Listener.Context = &ServerAcceptCtx;
             ServerAcceptCtx.TestTP = TestTP;

--- a/src/test/lib/TestHelpers.h
+++ b/src/test/lib/TestHelpers.h
@@ -240,7 +240,7 @@ class TestConnection;
 
 struct ServerAcceptContext {
     CXPLAT_EVENT NewConnectionReady;
-    TestConnection** NewConnection;
+    UniquePtr<TestConnection>* NewConnection;
     void* NewStreamHandler{nullptr};
     QUIC_TLS_SECRETS* TlsSecrets{nullptr};
     QUIC_STATUS ExpectedTransportCloseStatus{QUIC_STATUS_SUCCESS};
@@ -253,7 +253,7 @@ struct ServerAcceptContext {
     bool AsyncCustomCertValidation{false};
     bool IsCustomCertValidationResultSet{false};
     bool CustomCertValidationResult{false};
-    ServerAcceptContext(TestConnection** _NewConnection) :
+    ServerAcceptContext(UniquePtr<TestConnection>* _NewConnection) :
         NewConnection(_NewConnection) {
         CxPlatEventInitialize(&NewConnectionReady, TRUE, FALSE);
     }


### PR DESCRIPTION
## Description

`ServerAcceptContext` stored its connection as a raw `TestConnection**` and was initialized by casting a `UniquePtr<TestConnection>` to a raw pointer. The smart pointer was also declared after the `TestListener`, giving it a shorter lifetime than the listener that references it through its context.

- Change `ServerAcceptContext::NewConnection` to `UniquePtr<TestConnection>*` and pass the smart pointer directly (no cast).
- Manage the accepted connection through `reset()` in the accept callbacks instead of raw assignment/`delete`.
- Move each `Server` declaration before its `TestListener` so the connection outlives the listener.

## Testing

Test-only change; covered by existing handshake/data/datagram tests. Built `testlib` locally with no errors.

## Documentation

No documentation impact.