### PR TITLE
Handle RELIABLE_RESET_STREAM explicitly in stream frame skip path

### DIFF
--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -958,6 +958,10 @@ QuicStreamFrameSkip(
         QUIC_STOP_SENDING_EX Frame;
         return QuicStopSendingFrameDecode(BufferLength, Buffer, Offset, &Frame);
     }
+    case QUIC_FRAME_RELIABLE_RESET_STREAM: {
+        QUIC_RELIABLE_RESET_STREAM_EX Frame;
+        return QuicReliableResetFrameDecode(BufferLength, Buffer, Offset, &Frame);
+    }
     default: { // QUIC_FRAME_STREAM*
         QUIC_STREAM_EX Frame;
         return QuicStreamFrameDecode(FrameType, BufferLength, Buffer, Offset, &Frame);

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -962,9 +962,20 @@ QuicStreamFrameSkip(
         QUIC_RELIABLE_RESET_STREAM_EX Frame;
         return QuicReliableResetFrameDecode(BufferLength, Buffer, Offset, &Frame);
     }
-    default: { // QUIC_FRAME_STREAM*
+    case QUIC_FRAME_STREAM:
+    case QUIC_FRAME_STREAM_1:
+    case QUIC_FRAME_STREAM_2:
+    case QUIC_FRAME_STREAM_3:
+    case QUIC_FRAME_STREAM_4:
+    case QUIC_FRAME_STREAM_5:
+    case QUIC_FRAME_STREAM_6:
+    case QUIC_FRAME_STREAM_7: {
         QUIC_STREAM_EX Frame;
         return QuicStreamFrameDecode(FrameType, BufferLength, Buffer, Offset, &Frame);
+    }
+    default: {
+        CXPLAT_DBG_ASSERT(FALSE);
+        return FALSE;
     }
     }
 }


### PR DESCRIPTION
## Description
In QuicStreamFrameSkip did not have a dedicated case for RELIABLE_RESET_STREAM and fell through to STREAM frame decoding logic.
That fallback decoder is meant for STREAM frame types and can advance offsets incorrectly for RELIABLE_RESET_STREAM.

Fixes : https://microsoft.visualstudio.com/OS/_workitems/edit/62258694/

## Testing
UnitTests passed

## Documentation
N/A