### PR TITLE
Add weekly scheduled builds for release branches

### DIFF
--- a/.github/workflows/weekly-release-builds.yml
+++ b/.github/workflows/weekly-release-builds.yml
@@ -1,0 +1,39 @@
+name: Weekly Release Branch Builds
+
+# Runs the Build workflow (build.yml) on each supported release branch on a
+# weekly schedule to catch build breakages on branches that no longer receive
+# regular pushes.
+#
+# To update the list of branches that get built, edit the 'branches' matrix
+# below: add a branch when a new release branch is created, and remove it when
+# a release goes out of support.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 13 * * 1' # Weekly on Monday 13:23 UTC; non-round minute to avoid thundering herd
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    name: Trigger builds for release branches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # Needed to trigger the Build workflow via workflow_dispatch.
+    strategy:
+      fail-fast: false
+      matrix:
+        # Update this list when a new release branch is created or goes out of support.
+        branch:
+          - release/2.4
+          - release/2.5
+    steps:
+    - name: Trigger Build workflow for ${{ matrix.branch }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "Triggering Build workflow for ${{ matrix.branch }}"
+        gh workflow run build.yml --ref "${{ matrix.branch }}"


### PR DESCRIPTION
## Description

Adds a scheduled workflow (`.github/workflows/weekly-release-builds.yml`) that triggers the existing **Build** workflow (`build.yml`) on each release branch once a week (Monday 13:23 UTC ≈ 05:23 PST / 06:23 PDT). This catches build breakages on release branches that no longer receive regular pushes (e.g. from runner-image or dependency drift), with runs recently completed by Monday morning Pacific for triage.

The list of branches to build is defined directly in the workflow's `branches` matrix, making it easy to update when a new release branch is created or goes out of support. Each branch runs as a separate matrix job that calls `gh workflow run build.yml --ref <branch>`.

Modeled on the `ci-release-branches.yml` pattern from microsoft/xdp-for-windows.

## Testing

No code changes; CI-only. The workflow can be validated via manual `workflow_dispatch` once merged. Both `release/2.4` and `release/2.5` already have `build.yml` with `workflow_dispatch` enabled, so they can be triggered this way.

## Documentation

No documentation impact.