### PR TITLE
[CP] Fix null deref in QuicCryptoCustomCertValidationComplete after shutdown (#5962)

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1722,15 +1722,27 @@ QuicCryptoCustomCertValidationComplete(
     _In_ QUIC_TLS_ALERT_CODES TlsAlert
     )
 {
+    QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
+
     if (!Crypto->CertValidationPending) {
         return;
     }
 
     Crypto->CertValidationPending = FALSE;
+
+    //
+    // The connection might have been shutdown during the cert validation.
+    // Nothing to do in that case.
+    //
+    if (Connection->State.ShutdownComplete) {
+        Crypto->PendingValidationBufferLength = 0;
+        return;
+    }
+
     if (Result) {
         QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
         QuicCryptoProcessDataComplete(Crypto, Crypto->PendingValidationBufferLength);
 
@@ -1744,11 +1756,11 @@ QuicCryptoCustomCertValidationComplete(
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation failed.");
         CXPLAT_DBG_ASSERT(TlsAlert <= QUIC_TLS_ALERT_CODE_MAX);
         QuicConnTransportError(
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             QUIC_ERROR_CRYPTO_ERROR(0xFF & TlsAlert));
     }
     Crypto->PendingValidationBufferLength = 0;

--- a/src/generated/linux/crypto.c.clog.h
+++ b/src/generated/linux/crypto.c.clog.h
@@ -130,9 +130,9 @@ tracepoint(CLOG_CRYPTO_C, HandshakeConfirmedServer , arg1);\
 // [conn][%p] Custom cert validation succeeded
 // QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
-// arg1 = arg1 = QuicCryptoGetConnection(Crypto) = arg1
+// arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_CustomCertValidationSuccess
 #define _clog_3_ARGS_TRACE_CustomCertValidationSuccess(uniqueId, arg1, encoded_arg_string)\

--- a/src/generated/linux/crypto.c.clog.h.lttng.h
+++ b/src/generated/linux/crypto.c.clog.h.lttng.h
@@ -105,9 +105,9 @@ TRACEPOINT_EVENT(CLOG_CRYPTO_C, HandshakeConfirmedServer,
 // [conn][%p] Custom cert validation succeeded
 // QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
-// arg1 = arg1 = QuicCryptoGetConnection(Crypto) = arg1
+// arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CRYPTO_C, CustomCertValidationSuccess,
     TP_ARGS(

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -232,6 +232,12 @@ QuicTestCustomClientCertificateValidation(
     );
 
 void
+QuicTestCustomServerCertValidationAfterShutdown();
+
+void
+QuicTestCustomClientCertValidationAfterShutdown();
+
+void
 QuicTestConnectClientCertificate(
     _In_ int Family,
     _In_ bool UseClientCertificate
@@ -1407,4 +1413,10 @@ struct QUIC_RUN_CONNECTION_POOL_CREATE_PARAMS {
 #define IOCTL_QUIC_RUN_RETRY_CONFIG_SETTING \
     QUIC_CTL_CODE(134, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-#define QUIC_MAX_IOCTL_FUNC_CODE 134
+#define IOCTL_QUIC_RUN_CUSTOM_SERVER_CERT_VALIDATION_AFTER_SHUTDOWN \
+    QUIC_CTL_CODE(135, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define IOCTL_QUIC_RUN_CUSTOM_CLIENT_CERT_VALIDATION_AFTER_SHUTDOWN \
+    QUIC_CTL_CODE(136, METHOD_BUFFERED, FILE_WRITE_DATA)
+
+#define QUIC_MAX_IOCTL_FUNC_CODE 136

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1163,6 +1163,24 @@ TEST_P(WithHandshakeArgs5, CustomClientCertificateValidation) {
     }
 }
 
+TEST(Handshake, CustomServerCertValidationAfterShutdown) {
+    TestLogger Logger("QuicTestCustomServerCertValidationAfterShutdown");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_CUSTOM_SERVER_CERT_VALIDATION_AFTER_SHUTDOWN));
+    } else {
+        QuicTestCustomServerCertValidationAfterShutdown();
+    }
+}
+
+TEST(Handshake, CustomClientCertValidationAfterShutdown) {
+    TestLogger Logger("QuicTestCustomClientCertValidationAfterShutdown");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(DriverClient.Run(IOCTL_QUIC_RUN_CUSTOM_CLIENT_CERT_VALIDATION_AFTER_SHUTDOWN));
+    } else {
+        QuicTestCustomClientCertValidationAfterShutdown();
+    }
+}
+
 TEST_P(WithHandshakeArgs6, ConnectClientCertificate) {
 #ifdef QUIC_TEST_SCHANNEL_FLAGS
     if (IsWindows2022()) GTEST_SKIP(); // Not supported with Schannel on WS2022

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -533,6 +533,8 @@ size_t QUIC_IOCTL_BUFFER_SIZES[] =
     sizeof(QUIC_RUN_CONNECTION_POOL_CREATE_PARAMS),
     0,
     0,
+    0,
+    0,
 };
 
 CXPLAT_STATIC_ASSERT(
@@ -1030,6 +1032,14 @@ QuicTestCtlEvtIoDeviceControl(
             QuicTestCustomServerCertificateValidation(
                 Params->CustomCertValidationParams.AcceptCert,
                 Params->CustomCertValidationParams.AsyncValidation));
+        break;
+
+    case IOCTL_QUIC_RUN_CUSTOM_SERVER_CERT_VALIDATION_AFTER_SHUTDOWN:
+        QuicTestCtlRun(QuicTestCustomServerCertValidationAfterShutdown());
+        break;
+
+    case IOCTL_QUIC_RUN_CUSTOM_CLIENT_CERT_VALIDATION_AFTER_SHUTDOWN:
+        QuicTestCtlRun(QuicTestCustomClientCertValidationAfterShutdown());
         break;
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/lib/HandshakeTest.cpp
+++ b/src/test/lib/HandshakeTest.cpp
@@ -1028,6 +1028,144 @@ QuicTestCustomClientCertificateValidation(
 }
 
 void
+QuicTestCustomServerCertValidationAfterShutdown()
+{
+    //
+    // Client enables async custom server cert validation, shuts down the
+    // connection while validation is still pending, and then completes the
+    // validation. This used to crash due to a null SourceCids dereference.
+    //
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, MsQuicSettings{}, ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicCredentialConfig ClientCredConfig(QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION | QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED);
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    UniquePtr<TestConnection> Server;
+    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
+    Listener.Context = &ServerAcceptCtx;
+
+    TestConnection Client(Registration);
+    TEST_TRUE(Client.IsValid());
+
+    Client.SetExpectedCustomValidationResult(true);
+    Client.SetAsyncCustomValidationResult(true);
+    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_USER_CANCELED);
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_UNSPEC,
+            QUIC_TEST_LOOPBACK_FOR_AF(QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+            ServerLocalAddr.GetPort()));
+
+    //
+    // Wait for the cert validation callback to fire.
+    // We configured the callback to defer the validation.
+    //
+    if (!Client.WaitForPeerCertReceived()) {
+        TEST_FAILURE("Timed out waiting for peer certificate.");
+        return;
+    }
+
+    Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+    if (!Client.WaitForShutdownComplete()) {
+        return;
+    }
+
+    //
+    // Complete the validation after shutdown. This must not crash.
+    //
+    TEST_QUIC_SUCCEEDED(Client.SetCustomValidationResult(true));
+}
+
+void
+QuicTestCustomClientCertValidationAfterShutdown()
+{
+    //
+    // Server enables async custom client cert validation, the client
+    // disconnects while validation is still pending, and then the server
+    // completes the validation. This is the exact scenario from the original
+    // kernel crash dump.
+    //
+    MsQuicRegistration Registration;
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicAlpn Alpn("MsQuicTest");
+
+    MsQuicConfiguration ServerConfiguration(Registration, Alpn, MsQuicSettings{}, ServerSelfSignedCredConfigClientAuth);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicConfiguration ClientConfiguration(Registration, Alpn, MsQuicSettings{}, ClientCertCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    TestListener Listener(Registration, ListenerAcceptConnection, ServerConfiguration);
+    TEST_TRUE(Listener.IsValid());
+    TEST_QUIC_SUCCEEDED(Listener.Start(Alpn));
+
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    UniquePtr<TestConnection> Server;
+    ServerAcceptContext ServerAcceptCtx((TestConnection**)&Server);
+    ServerAcceptCtx.ExpectedTransportCloseStatus = QUIC_STATUS_USER_CANCELED;
+    ServerAcceptCtx.AsyncCustomCertValidation = true;
+    ServerAcceptCtx.AddExpectedClientCertValidationResult(QUIC_STATUS_CERT_UNTRUSTED_ROOT);
+    Listener.Context = &ServerAcceptCtx;
+
+    TestConnection Client(Registration);
+    TEST_TRUE(Client.IsValid());
+    Client.SetExpectedTransportCloseStatus(QUIC_STATUS_USER_CANCELED);
+
+    TEST_QUIC_SUCCEEDED(
+        Client.Start(
+            ClientConfiguration,
+            QUIC_ADDRESS_FAMILY_UNSPEC,
+            QUIC_TEST_LOOPBACK_FOR_AF(
+                QuicAddrGetFamily(&ServerLocalAddr.SockAddr)),
+            ServerLocalAddr.GetPort()));
+
+    if (!CxPlatEventWaitWithTimeout(ServerAcceptCtx.NewConnectionReady, TestWaitTimeout)) {
+        TEST_FAILURE("Timed out waiting for server accept.");
+    }
+
+    TEST_NOT_EQUAL(nullptr, Server);
+
+    //
+    // Wait for the server's cert validation callback to fire.
+    // We configured the callback to defer the validation.
+    //
+    if (!Server->WaitForPeerCertReceived()) {
+        TEST_FAILURE("Timed out waiting for peer certificate.");
+        return;
+    }
+
+    Client.Shutdown(QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, QUIC_TEST_NO_ERROR);
+    if (!Server->WaitForShutdownComplete()) {
+        return;
+    }
+
+    //
+    // Now complete the certificate validation after shutdown. This must not crash.
+    //
+    TEST_QUIC_SUCCEEDED(Server->SetCustomValidationResult(TRUE));
+}
+
+void
 QuicTestShutdownDuringHandshake(
     _In_ bool ClientShutdown
     )

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -36,6 +36,7 @@ TestConnection::TestConnection(
     CxPlatEventInitialize(&EventPeerClosed, TRUE, FALSE);
     CxPlatEventInitialize(&EventShutdownComplete, TRUE, FALSE);
     CxPlatEventInitialize(&EventResumptionTicketReceived, TRUE, FALSE);
+    CxPlatEventInitialize(&EventPeerCertReceived, TRUE, FALSE);
 
     if (QuicConnection == nullptr) {
         TEST_FAILURE("Invalid handle passed into TestConnection.");
@@ -70,6 +71,7 @@ TestConnection::TestConnection(
     CxPlatEventInitialize(&EventPeerClosed, TRUE, FALSE);
     CxPlatEventInitialize(&EventShutdownComplete, TRUE, FALSE);
     CxPlatEventInitialize(&EventResumptionTicketReceived, TRUE, FALSE);
+    CxPlatEventInitialize(&EventPeerCertReceived, TRUE, FALSE);
 
     QUIC_STATUS Status =
         MsQuic->ConnectionOpen(
@@ -90,6 +92,7 @@ TestConnection::TestConnection(
 TestConnection::~TestConnection()
 {
     MsQuic->ConnectionClose(QuicConnection);
+    CxPlatEventUninitialize(EventPeerCertReceived);
     CxPlatEventUninitialize(EventResumptionTicketReceived);
     CxPlatEventUninitialize(EventShutdownComplete);
     CxPlatEventUninitialize(EventPeerClosed);
@@ -231,6 +234,16 @@ TestConnection::WaitForPeerClose()
 {
     if (!CxPlatEventWaitWithTimeout(EventPeerClosed, GetWaitTimeout())) {
         TEST_FAILURE("WaitForPeerClose timed out after %u ms.", GetWaitTimeout());
+        return false;
+    }
+    return true;
+}
+
+bool
+TestConnection::WaitForPeerCertReceived()
+{
+    if (!CxPlatEventWaitWithTimeout(EventPeerCertReceived, GetWaitTimeout())) {
+        TEST_FAILURE("WaitForPeerCertReceived timed out after %u ms.", GetWaitTimeout());
         return false;
     }
     return true;
@@ -960,6 +973,7 @@ TestConnection::HandleConnectionEvent(
         break;
 
     case QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED:
+        CxPlatEventSet(EventPeerCertReceived);
         if (AsyncCustomValidation) {
             return QUIC_STATUS_PENDING;
         }

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -82,6 +82,7 @@ class TestConnection
     CXPLAT_EVENT EventPeerClosed;
     CXPLAT_EVENT EventShutdownComplete;
     CXPLAT_EVENT EventResumptionTicketReceived;
+    CXPLAT_EVENT EventPeerCertReceived;
     CXPLAT_EVENT* EventDeleted;
 
     NEW_STREAM_CALLBACK_HANDLER NewStreamCallback;
@@ -177,6 +178,8 @@ public:
     bool WaitForShutdownComplete();
 
     bool WaitForPeerClose();
+
+    bool WaitForPeerCertReceived();
 
     void SetShutdownCompleteCallback(CONN_SHUTDOWN_COMPLETE_CALLBACK_HANDLER Handler) {
         ShutdownCompleteCallback = Handler;


### PR DESCRIPTION
## Description

Fix a null pointer dereference crash in `QuicCryptoCustomCertValidationComplete` when certificate validation completes after the connection has already been shut down.

**Root cause**: When a remote peer closes a QUIC connection while async certificate validation is pending on the server, `QuicConnOnShutdownComplete` frees all SourceCids. When the app later calls `ConnectionCertificateValidationComplete(TRUE)`, `QuicCryptoProcessTlsCompletion` dereferences `Connection->SourceCids.Next` (now NULL), causing an access violation. This was observed as a kernel bugcheck (0x7E) in production.

**Fix**: Add a `ShutdownComplete` guard in `QuicCryptoCustomCertValidationComplete` to bail out early if the connection has already completed shutdown, preventing the code from proceeding into `QuicCryptoProcessTlsCompletion` with freed state.

## Testing

Two new integration tests added:
- `Handshake.CustomServerCertValidationAfterShutdown`  Client-side async cert validation with client shutdown before completion.
- `Handshake.CustomClientCertValidationAfterShutdown`  Server-side async client cert validation with client disconnect before server completes. Mirrors the exact production crash scenario.

Both tests use event-based synchronization (`WaitForPeerCertReceived`) to deterministically ensure cert validation is pending before shutdown.

## Documentation

No documentation impact.