### PR TITLE
[Mirror #16091761] Bump ubuntu from `c4a8d55` to `4fbb8e6` in /.docker/ubuntu-24.04

### DIFF
--- a/.docker/ubuntu-24.04/Dockerfile
+++ b/.docker/ubuntu-24.04/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS base
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/microsoft/msquic
 


### PR DESCRIPTION
Mirrored from internal ADO PR #16091761 by Dependabot

Internal PR: https://dev.azure.com/microsoft/undock/_git/msquic/pullrequest/16091761