### PR TITLE
Use ASCII punctuation in settings comment

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -715,7 +715,7 @@ QuicSettingApply(
     //
     // If XDP map mode is active (XdpMapConfigCount > 0), XDP is implicitly
     // enabled for all sockets. Reject an explicit XdpEnabled = FALSE since
-    // it contradicts map mode — there is no OS datapath to fall back to.
+    // it contradicts map mode - there is no OS datapath to fall back to.
     //
     if (Source->IsSet.XdpEnabled && !Source->XdpEnabled && MsQuicLib.XdpMapConfigCount > 0) {
         QuicTraceLogError(


### PR DESCRIPTION
## Description

Replace a Unicode em dash in `src/core/settings.c` with an ASCII hyphen.

This keeps the source comment ASCII-only and avoids source-encoding warnings in builds that do not explicitly select UTF-8 input.

There is no runtime or behavioral change.

## Testing

Not run (comment-only change).

## Documentation

No documentation impact.
