### PR TITLE
Fix: Prevent RELIABLE_RESET offset increase by using correct sentinel

### DIFF
--- a/src/core/sliding_window_extremum.c
+++ b/src/core/sliding_window_extremum.c
@@ -14,9 +14,8 @@ Abstract:
     older elements which value is greater/less than equal to the new element,
     along with the elements which is expired.
     
-    If the queue is full after sweeping expired and dominated entries, the
-    oldest entry (head) is evicted to make room for the new one, preserving
-    the accuracy of the extremum over the window.
+    If there are more elements comparing to the capacity of queue, the
+    algorithm will still work but the accuracy will be compromised.
 
 --*/
 
@@ -120,22 +119,14 @@ QuicSlidingWindowExtremumUpdateMin(
         }
     }
 
-    //
-    // If the queue is full at this point, the new entry still must be
-    // inserted because it is the most recent sample and is not dominated
-    // by any remaining entry. Evict the oldest entry (head) to make room.
-    //
-    if (Window->WindowSize == Window->WindowCapacity) {
-        Window->WindowHead = (Window->WindowHead + 1) % Window->WindowCapacity;
-        Window->WindowSize--;
+    if (Window->WindowSize < Window->WindowCapacity) {
+        uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
+
+        Window->Extremums[NewRear].Value = NewValue;
+        Window->Extremums[NewRear].Time = NewTime;
+
+        Window->WindowSize++;
     }
-
-    uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
-
-    Window->Extremums[NewRear].Value = NewValue;
-    Window->Extremums[NewRear].Time = NewTime;
-
-    Window->WindowSize++;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -168,20 +159,12 @@ QuicSlidingWindowExtremumUpdateMax(
         }
     }
 
-    //
-    // If the queue is full at this point, the new entry still must be
-    // inserted because it is the most recent sample and is not dominated
-    // by any remaining entry. Evict the oldest entry (head) to make room.
-    //
-    if (Window->WindowSize == Window->WindowCapacity) {
-        Window->WindowHead = (Window->WindowHead + 1) % Window->WindowCapacity;
-        Window->WindowSize--;
+    if (Window->WindowSize < Window->WindowCapacity) {
+        uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
+
+        Window->Extremums[NewRear].Value = NewValue;
+        Window->Extremums[NewRear].Time = NewTime;
+
+        Window->WindowSize++;
     }
-
-    uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
-
-    Window->Extremums[NewRear].Value = NewValue;
-    Window->Extremums[NewRear].Time = NewTime;
-
-    Window->WindowSize++;
 }

--- a/src/core/sliding_window_extremum.c
+++ b/src/core/sliding_window_extremum.c
@@ -14,8 +14,9 @@ Abstract:
     older elements which value is greater/less than equal to the new element,
     along with the elements which is expired.
     
-    If there are more elements comparing to the capacity of queue, the
-    algorithm will still work but the accuracy will be compromised.
+    If the queue is full after sweeping expired and dominated entries, the
+    oldest entry (head) is evicted to make room for the new one, preserving
+    the accuracy of the extremum over the window.
 
 --*/
 
@@ -119,14 +120,22 @@ QuicSlidingWindowExtremumUpdateMin(
         }
     }
 
-    if (Window->WindowSize < Window->WindowCapacity) {
-        uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
-
-        Window->Extremums[NewRear].Value = NewValue;
-        Window->Extremums[NewRear].Time = NewTime;
-
-        Window->WindowSize++;
+    //
+    // If the queue is full at this point, the new entry still must be
+    // inserted because it is the most recent sample and is not dominated
+    // by any remaining entry. Evict the oldest entry (head) to make room.
+    //
+    if (Window->WindowSize == Window->WindowCapacity) {
+        Window->WindowHead = (Window->WindowHead + 1) % Window->WindowCapacity;
+        Window->WindowSize--;
     }
+
+    uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
+
+    Window->Extremums[NewRear].Value = NewValue;
+    Window->Extremums[NewRear].Time = NewTime;
+
+    Window->WindowSize++;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -159,12 +168,20 @@ QuicSlidingWindowExtremumUpdateMax(
         }
     }
 
-    if (Window->WindowSize < Window->WindowCapacity) {
-        uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
-
-        Window->Extremums[NewRear].Value = NewValue;
-        Window->Extremums[NewRear].Time = NewTime;
-
-        Window->WindowSize++;
+    //
+    // If the queue is full at this point, the new entry still must be
+    // inserted because it is the most recent sample and is not dominated
+    // by any remaining entry. Evict the oldest entry (head) to make room.
+    //
+    if (Window->WindowSize == Window->WindowCapacity) {
+        Window->WindowHead = (Window->WindowHead + 1) % Window->WindowCapacity;
+        Window->WindowSize--;
     }
+
+    uint32_t NewRear = (Window->WindowHead + Window->WindowSize) % Window->WindowCapacity;
+
+    Window->Extremums[NewRear].Value = NewValue;
+    Window->Extremums[NewRear].Time = NewTime;
+
+    Window->WindowSize++;
 }

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -208,10 +208,8 @@ QuicStreamProcessReliableResetFrame(
 
     if (!Stream->Flags.RemoteCloseResetReliable || ReliableOffset < Stream->RecvMaxLength) {
         //
-        // As outlined in the spec, if we receive multiple RELIABLE_RESET frames, we only accept strictly
-        // decreasing offsets. Use the RemoteCloseResetReliable flag (not RecvMaxLength == 0) as the
-        // "first frame seen" sentinel because ReliableOffset = 0 is a valid value and would otherwise
-        // allow a subsequent frame with a larger offset to bypass this check.
+        // If multiple RELIABLE_RESET frames are received, only accept strictly
+        // decreasing offsets.
         //
         Stream->RecvMaxLength = ReliableOffset;
         Stream->Flags.RemoteCloseResetReliable = TRUE;

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -206,10 +206,12 @@ QuicStreamProcessReliableResetFrame(
         return;
     }
 
-    if (Stream->RecvMaxLength == 0 || ReliableOffset < Stream->RecvMaxLength) {
+    if (!Stream->Flags.RemoteCloseResetReliable || ReliableOffset < Stream->RecvMaxLength) {
         //
-        // As outlined in the spec, if we receive multiple CLOSE_STREAM frames, we only accept strictly
-        // decreasing offsets.
+        // As outlined in the spec, if we receive multiple RELIABLE_RESET frames, we only accept strictly
+        // decreasing offsets. Use the RemoteCloseResetReliable flag (not RecvMaxLength == 0) as the
+        // "first frame seen" sentinel because ReliableOffset = 0 is a valid value and would otherwise
+        // allow a subsequent frame with a larger offset to bypass this check.
         //
         Stream->RecvMaxLength = ReliableOffset;
         Stream->Flags.RemoteCloseResetReliable = TRUE;

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -886,6 +886,12 @@ void
 QuicTestStreamReliableResetMultipleSends(
     );
 
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+void
+QuicTestStreamReliableResetZeroOffset(
+    );
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+
 void
 QuicTestStreamMultiReceive(
     );

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -2855,6 +2855,16 @@ TEST(Misc, StreamReliableResetMultipleSends) {
         QuicTestStreamReliableResetMultipleSends();
     }
 }
+#if defined(QUIC_API_ENABLE_PREVIEW_FEATURES)
+TEST(Misc, StreamReliableResetZeroOffset) {
+    TestLogger Logger("StreamReliableResetZeroOffset");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestStreamReliableResetZeroOffset)));
+    } else {
+        QuicTestStreamReliableResetZeroOffset();
+    }
+}
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 #endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -641,6 +641,9 @@ ExecuteTestRequest(
 #ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
     RegisterTestFunction(QuicTestStreamReliableReset);
     RegisterTestFunction(QuicTestStreamReliableResetMultipleSends);
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+    RegisterTestFunction(QuicTestStreamReliableResetZeroOffset);
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 #endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     RegisterTestFunction(QuicTestStreamMultiReceive);

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -4570,25 +4570,9 @@ QuicTestStreamReliableResetMultipleSends(
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 //
-// Regression test: verifies that ReliableOffset = 0 is treated as a valid
-// "first frame seen" value, not as the "no frame received yet" sentinel.
-//
-// Previously, QuicStreamProcessReliableResetFrame used (RecvMaxLength == 0)
-// as the sentinel to detect the first RELIABLE_RESET frame. This was wrong
-// because 0 is a valid ReliableOffset value. As a result, if a peer sent
-// RELIABLE_RESET(offset=0) followed by RELIABLE_RESET(offset=5000), the
-// second frame would incorrectly pass the check (RecvMaxLength was still 0
-// after the first frame) and bump the offset up to 5000 — violating the
-// spec's strictly-decreasing rule.
-//
-// The fix uses the RemoteCloseResetReliable flag as the sentinel instead.
-// This test confirms that after receiving RELIABLE_RESET(offset=0), the
-// server correctly tracks the received offset as 0 (i.e.
-// QUIC_PARAM_STREAM_RELIABLE_OFFSET_RECV returns 0, not INVALID_STATE).
-// If the old sentinel were still in place, the flag would still be set to
-// TRUE and RecvMaxLength would be 0, so RecvMaxLength == 0 would wrongly
-// look like "no frame received yet" — leaving the door open for a higher-
-// offset frame to pass the check.
+// Validates that a reliable-reset with offset 0 is handled properly: the
+// server correctly records the received offset as 0 and does not treat it
+// as "no frame received yet".
 //
 void
 QuicTestStreamReliableResetZeroOffset(
@@ -4610,10 +4594,11 @@ QuicTestStreamReliableResetZeroOffset(
     StreamReliableResetZeroOffset Context;
 
     //
-    // We need to send at least 1 byte so that QueuedSendOffset > 0 and
-    // SetReliableOffset(0) passes the "offset <= QueuedSendOffset" check.
+    // Send a few bytes so that QueuedSendOffset > 0 (required for
+    // SetReliableOffset(0) to pass the validation check) and so there
+    // is data beyond the reliable reset offset.
     //
-    const uint8_t SendData[1] = { 0 };
+    const uint8_t SendData[16] = { 0 };
     QUIC_BUFFER SendBuffer { sizeof(SendData), (uint8_t*)SendData };
 
     MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, StreamReliableResetZeroOffset::ConnCallback, &Context);
@@ -4630,7 +4615,6 @@ QuicTestStreamReliableResetZeroOffset(
     TEST_TRUE(Connection.HandshakeComplete);
     TEST_TRUE(Listener.LastConnection->HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
     TEST_TRUE(Listener.LastConnection->HandshakeComplete);
-    CxPlatSleep(50); // Wait for things to idle out
 
     {
         MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE, CleanUpManual, StreamReliableResetZeroOffset::ClientStreamCallback, &Context);
@@ -4638,15 +4622,15 @@ QuicTestStreamReliableResetZeroOffset(
         TEST_QUIC_SUCCEEDED(Stream.Start());
 
         //
-        // Send 1 byte so QueuedSendOffset >= 1, making SetReliableOffset(0) valid.
+        // Send data so QueuedSendOffset > 0, which is required for
+        // SetReliableOffset(0) to be valid, and so there is data after
+        // the reliable reset offset.
         //
         TEST_QUIC_SUCCEEDED(Stream.Send(&SendBuffer, 1, QUIC_SEND_FLAG_DELAY_SEND, nullptr));
 
         //
-        // Set ReliableOffset to 0 — this is the corner case. The old code used
-        // RecvMaxLength == 0 as "first frame not yet received", which means
-        // offset=0 looked like "not seen" even after it was processed, allowing
-        // a subsequent RELIABLE_RESET with a larger offset to slip through.
+        // Set ReliableOffset to 0 — this is the corner case where offset=0
+        // must be treated as a valid "frame received" value.
         //
         TEST_QUIC_SUCCEEDED(Stream.SetReliableOffset(0));
 

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -4364,6 +4364,52 @@ struct StreamReliableReset {
     }
 };
 
+
+//
+// Context struct for the ZeroOffset test. Stores the server-side stream so
+// we can query QUIC_PARAM_STREAM_RELIABLE_OFFSET_RECV after shutdown.
+//
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+struct StreamReliableResetZeroOffset {
+    CxPlatEvent ClientStreamShutdownComplete;
+    CxPlatEvent ServerStreamShutdownComplete;
+    MsQuicStream* ServerStream {nullptr};
+    QUIC_UINT62 ShutdownErrorCode {0};
+
+    static QUIC_STATUS ClientStreamCallback(_In_ MsQuicStream*, _In_opt_ void* ClientContext, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (StreamReliableResetZeroOffset*)ClientContext;
+        if (Event->Type == QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE) {
+            TestContext->ClientStreamShutdownComplete.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ServerStreamCallback(_In_ MsQuicStream*, _In_opt_ void* ServerContext, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (StreamReliableResetZeroOffset*)ServerContext;
+        if (Event->Type == QUIC_STREAM_EVENT_PEER_SEND_ABORTED) {
+            TestContext->ShutdownErrorCode = Event->PEER_SEND_ABORTED.ErrorCode;
+        }
+        if (Event->Type == QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE) {
+            TestContext->ServerStreamShutdownComplete.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        auto TestContext = (StreamReliableResetZeroOffset*)Context;
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            TestContext->ServerStream =
+                new(std::nothrow) MsQuicStream(
+                    Event->PEER_STREAM_STARTED.Stream,
+                    CleanUpAutoDelete,
+                    ServerStreamCallback,
+                    Context);
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+
 #ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
 void
 QuicTestStreamReliableReset(
@@ -4521,6 +4567,111 @@ QuicTestStreamReliableResetMultipleSends(
     // Test Error code matches what we sent.
     TEST_TRUE(Context.ShutdownErrorCode == AbortShutdownErrorCode);
 }
+
+#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
+//
+// Regression test: verifies that ReliableOffset = 0 is treated as a valid
+// "first frame seen" value, not as the "no frame received yet" sentinel.
+//
+// Previously, QuicStreamProcessReliableResetFrame used (RecvMaxLength == 0)
+// as the sentinel to detect the first RELIABLE_RESET frame. This was wrong
+// because 0 is a valid ReliableOffset value. As a result, if a peer sent
+// RELIABLE_RESET(offset=0) followed by RELIABLE_RESET(offset=5000), the
+// second frame would incorrectly pass the check (RecvMaxLength was still 0
+// after the first frame) and bump the offset up to 5000 — violating the
+// spec's strictly-decreasing rule.
+//
+// The fix uses the RemoteCloseResetReliable flag as the sentinel instead.
+// This test confirms that after receiving RELIABLE_RESET(offset=0), the
+// server correctly tracks the received offset as 0 (i.e.
+// QUIC_PARAM_STREAM_RELIABLE_OFFSET_RECV returns 0, not INVALID_STATE).
+// If the old sentinel were still in place, the flag would still be set to
+// TRUE and RecvMaxLength would be 0, so RecvMaxLength == 0 would wrongly
+// look like "no frame received yet" — leaving the door open for a higher-
+// offset frame to pass the check.
+//
+void
+QuicTestStreamReliableResetZeroOffset(
+    )
+{
+    MsQuicRegistration Registration(true);
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicSettings TestSettings;
+    TestSettings.SetReliableResetEnabled(true);
+    TestSettings.SetPeerBidiStreamCount(1);
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", TestSettings, ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", TestSettings, MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    StreamReliableResetZeroOffset Context;
+
+    //
+    // We need to send at least 1 byte so that QueuedSendOffset > 0 and
+    // SetReliableOffset(0) passes the "offset <= QueuedSendOffset" check.
+    //
+    const uint8_t SendData[1] = { 0 };
+    QUIC_BUFFER SendBuffer { sizeof(SendData), (uint8_t*)SendData };
+
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, StreamReliableResetZeroOffset::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+    TEST_TRUE(Listener.LastConnection->HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Listener.LastConnection->HandshakeComplete);
+    CxPlatSleep(50); // Wait for things to idle out
+
+    {
+        MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE, CleanUpManual, StreamReliableResetZeroOffset::ClientStreamCallback, &Context);
+        TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+        TEST_QUIC_SUCCEEDED(Stream.Start());
+
+        //
+        // Send 1 byte so QueuedSendOffset >= 1, making SetReliableOffset(0) valid.
+        //
+        TEST_QUIC_SUCCEEDED(Stream.Send(&SendBuffer, 1, QUIC_SEND_FLAG_DELAY_SEND, nullptr));
+
+        //
+        // Set ReliableOffset to 0 — this is the corner case. The old code used
+        // RecvMaxLength == 0 as "first frame not yet received", which means
+        // offset=0 looked like "not seen" even after it was processed, allowing
+        // a subsequent RELIABLE_RESET with a larger offset to slip through.
+        //
+        TEST_QUIC_SUCCEEDED(Stream.SetReliableOffset(0));
+
+        const QUIC_UINT62 AbortErrorCode = 0x1234;
+        TEST_QUIC_SUCCEEDED(Stream.Shutdown(AbortErrorCode, QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND));
+
+        TEST_TRUE(Context.ClientStreamShutdownComplete.WaitTimeout(TestWaitTimeout));
+        TEST_TRUE(Context.ServerStreamShutdownComplete.WaitTimeout(TestWaitTimeout));
+
+        //
+        // Verify the server correctly recorded ReliableOffset = 0.
+        // QUIC_STATUS_SUCCESS (not INVALID_STATE) confirms that
+        // RemoteCloseResetReliable was set to TRUE, i.e. the frame was
+        // recognised and tracked — not treated as "no frame received".
+        //
+        TEST_NOT_EQUAL(Context.ServerStream, nullptr);
+        uint64_t RecvOffset = UINT64_MAX;
+        TEST_QUIC_SUCCEEDED(Context.ServerStream->GetReliableOffsetRecv(&RecvOffset));
+        TEST_EQUAL(RecvOffset, 0ull);
+
+        TEST_TRUE(Context.ShutdownErrorCode == AbortErrorCode);
+    }
+}
+#endif // QUIC_API_ENABLE_PREVIEW_FEATURES
+
 #endif // QUIC_PARAM_STREAM_RELIABLE_OFFSET
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -4401,7 +4401,7 @@ struct StreamReliableResetZeroOffset {
             TestContext->ServerStream =
                 new(std::nothrow) MsQuicStream(
                     Event->PEER_STREAM_STARTED.Stream,
-                    CleanUpAutoDelete,
+                    CleanUpManual,
                     ServerStreamCallback,
                     Context);
         }
@@ -4652,6 +4652,8 @@ QuicTestStreamReliableResetZeroOffset(
         TEST_EQUAL(RecvOffset, 0ull);
 
         TEST_TRUE(Context.ShutdownErrorCode == AbortErrorCode);
+        delete Context.ServerStream;
+        Context.ServerStream = nullptr;
     }
 }
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES


### PR DESCRIPTION
## Description
Fixes a bug where a peer could bypass the strictly-decreasing offset rule for `RELIABLE_RESET` frames.
Right now, `QuicStreamProcessReliableResetFrame` checks `Stream->RecvMaxLength == 0` to see if this is the first `RELIABLE_RESET` we've received. But `0` is actually a valid `ReliableOffset` value! 
If a peer sends a `RELIABLE_RESET` with offset `0`, we update `RecvMaxLength` to `0`. If they then send another one with offset `5000`, the `== 0` check still passes, and we end up increasing the offset to `5000` — which violates the spec.
So instead of checking against `0`, this PR just uses the `RemoteCloseResetReliable` flag to check if we've seen a reliable reset frame yet.
## Testing
Existing reliable reset tests pass fine since standard behavior isn't affected. 
We might want to add a quick test case that sends a `RELIABLE_RESET(offset=0)` followed by a `RELIABLE_RESET(offset=5000)` to verify it gets rejected properly now.
## Documentation
None needed, just an internal state fix.