### PR TITLE
Fix link failure on lib64 distros in build.rs

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -20,7 +20,6 @@ fn cmake_build() {
     use cmake::Config;
     use std::env;
     use std::path::Path;
-    let path_extra = "lib";
     let mut logging_enabled = "off";
     if cfg!(windows) {
         logging_enabled = "on";
@@ -103,8 +102,24 @@ fn cmake_build() {
     };
 
     let dst = config.build();
-    let lib_path = Path::join(Path::new(&dst), Path::new(path_extra));
-    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    // The native MsQuic library is installed via CMake's GNUInstallDirs, which
+    // resolves CMAKE_INSTALL_LIBDIR to "lib" on Debian/Ubuntu-style systems but to
+    // "lib64" on many 64-bit distros (Fedora, RHEL, SUSE, ...). Hardcoding "lib"
+    // makes linking fail on the latter because the .so ends up under "lib64".
+    // Add a link search path for every candidate that actually exists.
+    let mut found_lib_dir = false;
+    for lib_subdir in ["lib", "lib64"] {
+        let lib_path = Path::join(Path::new(&dst), Path::new(lib_subdir));
+        if lib_path.is_dir() {
+            println!("cargo:rustc-link-search=native={}", lib_path.display());
+            found_lib_dir = true;
+        }
+    }
+    if !found_lib_dir {
+        // Fall back to the historical default so any resulting error is meaningful.
+        let lib_path = Path::join(Path::new(&dst), Path::new("lib"));
+        println!("cargo:rustc-link-search=native={}", lib_path.display());
+    }
     if cfg!(feature = "static") {
         if cfg!(target_os = "linux") {
             let numa_lib_path = match target.as_str() {

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -103,10 +103,9 @@ fn cmake_build() {
 
     let dst = config.build();
     // The native MsQuic library is installed via CMake's GNUInstallDirs, which
-    // resolves CMAKE_INSTALL_LIBDIR to "lib" on Debian/Ubuntu-style systems but to
-    // "lib64" on many 64-bit distros (Fedora, RHEL, SUSE, ...). Hardcoding "lib"
-    // makes linking fail on the latter because the .so ends up under "lib64".
-    // Add a link search path for every candidate that actually exists.
+    // resolves CMAKE_INSTALL_LIBDIR to "lib" on Debian/Ubuntu-style systems and to
+    // "lib64" on many 64-bit distros (Fedora, RHEL, SUSE, ...). Add a link search
+    // path for every candidate that exists.
     let mut found_lib_dir = false;
     for lib_subdir in ["lib", "lib64"] {
         let lib_path = Path::join(Path::new(&dst), Path::new(lib_subdir));
@@ -116,9 +115,7 @@ fn cmake_build() {
         }
     }
     if !found_lib_dir {
-        // Fall back to the historical default so any resulting error is meaningful.
-        let lib_path = Path::join(Path::new(&dst), Path::new("lib"));
-        println!("cargo:rustc-link-search=native={}", lib_path.display());
+        panic!("no lib or lib64 directory found under {}", dst.display());
     }
     if cfg!(feature = "static") {
         if cfg!(target_os = "linux") {


### PR DESCRIPTION
## Description

CMake's GNUInstallDirs installs libmsquic into lib64 (not lib) on many 64-bit distros (Fedora, RHEL, SUSE). build.rs hardcoded the "lib" link search path, causing link failures there. Search both lib and lib64.

## Testing

On Fedora, RHEL, SUSE
```sh
cargo test
```

## Documentation

No