### PR TITLE
Fix DisableThreadLibraryCalls CRT guard

### DIFF
--- a/src/bin/winuser/dllmain.c
+++ b/src/bin/winuser/dllmain.c
@@ -37,7 +37,7 @@ DllMain(
     switch (Reason) {
 
     case DLL_PROCESS_ATTACH:
-#ifndef _MT // Don't disable thread library calls with static CRT!
+#ifdef _DLL // Don't disable thread library calls with static CRT!
         DisableThreadLibraryCalls(Instance);
 #else
         UNREFERENCED_PARAMETER(Instance);

--- a/src/bin/winuser_fuzz/dllmain.c
+++ b/src/bin/winuser_fuzz/dllmain.c
@@ -100,7 +100,7 @@ DllMain(
     switch (Reason) {
 
     case DLL_PROCESS_ATTACH:
-#ifndef _MT // Don't disable thread library calls with static CRT!
+#ifdef _DLL // Don't disable thread library calls with static CRT!
         DisableThreadLibraryCalls(Instance);
 #else
         UNREFERENCED_PARAMETER(Instance);


### PR DESCRIPTION
## Description

Use `_DLL` instead of `_MT` to determine whether the Windows DLL entry points call `DisableThreadLibraryCalls`.

`_MT` is defined for both `/MT` and `/MD`, so the previous `#ifndef _MT` condition skipped the call in both static- and dynamic-CRT builds. `_DLL` is defined only for `/MD` and `/MDd`, allowing dynamic-CRT builds to disable thread notifications while preserving the notifications required by the static CRT.

Apply the correction consistently to the regular and fuzz DLL entry points.

## References

- [Predefined macros](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170):

  > "`_MT` ... when `/MD` ... or `/MT` ... is specified."

  > "`_DLL` Defined as 1 when the `/MD` or `/MDd` (Multithreaded DLL) compiler option is specified. Otherwise, undefined."

- [DisableThreadLibraryCalls function](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-disablethreadlibrarycalls):

  > "Do not call this function from a DLL that is linked to the static C run-time library (CRT)."
