### PR TITLE
Add hystart knob for perf client.

### DIFF
--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -730,6 +730,7 @@ public:
     MsQuicSettings& SetDestCidUpdateIdleTimeoutMs(uint32_t Value) { DestCidUpdateIdleTimeoutMs = Value; IsSet.DestCidUpdateIdleTimeoutMs = TRUE; return *this; }
     MsQuicSettings& SetGreaseQuicBitEnabled(bool Value) { GreaseQuicBitEnabled = Value; IsSet.GreaseQuicBitEnabled = TRUE; return *this; }
     MsQuicSettings& SetEcnEnabled(bool Value) { EcnEnabled = Value; IsSet.EcnEnabled = TRUE; return *this; }
+    MsQuicSettings& SetHyStartEnabled(bool Value) { HyStartEnabled = Value; IsSet.HyStartEnabled = TRUE; return *this; }
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
     MsQuicSettings& SetEncryptionOffloadAllowed(bool Value) { EncryptionOffloadAllowed = Value; IsSet.EncryptionOffloadAllowed = TRUE; return *this; }
     MsQuicSettings& SetReliableResetEnabled(bool value) { ReliableResetEnabled = value; IsSet.ReliableResetEnabled = TRUE; return *this; }

--- a/src/perf/lib/PerfClient.h
+++ b/src/perf/lib/PerfClient.h
@@ -170,6 +170,7 @@ struct PerfClient {
             .SetIdleTimeoutMs(PERF_DEFAULT_IDLE_TIMEOUT)
             .SetSendBufferingEnabled(false)
             .SetCongestionControlAlgorithm(PerfDefaultCongestionControl)
+            .SetHyStartEnabled(PerfDefaultHyStartEnabled)
             .SetEcnEnabled(PerfDefaultEcnEnabled)
             .SetEncryptionOffloadAllowed(PerfDefaultQeoAllowed),
         CredentialConfig};

--- a/src/perf/lib/SecNetPerf.h
+++ b/src/perf/lib/SecNetPerf.h
@@ -50,6 +50,7 @@ typedef enum TCP_EXECUTION_PROFILE {
 extern QUIC_EXECUTION_PROFILE PerfDefaultExecutionProfile;
 extern TCP_EXECUTION_PROFILE TcpDefaultExecutionProfile;
 extern QUIC_CONGESTION_CONTROL_ALGORITHM PerfDefaultCongestionControl;
+extern uint8_t PerfDefaultHyStartEnabled;
 extern uint8_t PerfDefaultEcnEnabled;
 extern uint8_t PerfDefaultQeoAllowed;
 extern uint8_t PerfDefaultHighPriority;

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -292,7 +292,6 @@ QuicMainStart(
 
     TryGetValue(argc, argv, "ecn", &PerfDefaultEcnEnabled);
     TryGetValue(argc, argv, "hystart", &PerfDefaultHyStartEnabled);
-    TryGetValue(argc, argv, "histart", &PerfDefaultHyStartEnabled);
     TryGetValue(argc, argv, "qeo", &PerfDefaultQeoAllowed);
     TryGetValue(argc, argv, "dscp", &PerfDefaultDscpValue);
     if (PerfDefaultDscpValue > CXPLAT_MAX_DSCP) {

--- a/src/perf/lib/SecNetPerfMain.cpp
+++ b/src/perf/lib/SecNetPerfMain.cpp
@@ -25,6 +25,7 @@ uint32_t MaxRuntime = 0;
 QUIC_EXECUTION_PROFILE PerfDefaultExecutionProfile = QUIC_EXECUTION_PROFILE_LOW_LATENCY;
 TCP_EXECUTION_PROFILE TcpDefaultExecutionProfile = TCP_EXECUTION_PROFILE_LOW_LATENCY;
 QUIC_CONGESTION_CONTROL_ALGORITHM PerfDefaultCongestionControl = QUIC_CONGESTION_CONTROL_ALGORITHM_CUBIC;
+uint8_t PerfDefaultHyStartEnabled = false;
 uint8_t PerfDefaultEcnEnabled = false;
 uint8_t PerfDefaultQeoAllowed = false;
 uint8_t PerfDefaultHighPriority = false;
@@ -130,6 +131,7 @@ PrintHelp(
         "                            - {lowlat, maxtput, scavenger, realtime}.\n"
         "  -cc:<algo>               Congestion control algorithm to use.\n"
         "                            - {cubic, bbr}.\n"
+        "  -hystart:<0/1>           Disables/enables HyStart++ when using CUBIC. (def:0)\n"
         "  -pollidle:<time_us>      Amount of time to poll while idle before sleeping (default: 0).\n"
         "  -ecn:<0/1>               Enables/disables sender-side ECN support. (def:0)\n"
         "  -qeo:<0/1>               Allows/disallowes QUIC encryption offload. (def:0)\n"
@@ -289,6 +291,8 @@ QuicMainStart(
     }
 
     TryGetValue(argc, argv, "ecn", &PerfDefaultEcnEnabled);
+    TryGetValue(argc, argv, "hystart", &PerfDefaultHyStartEnabled);
+    TryGetValue(argc, argv, "histart", &PerfDefaultHyStartEnabled);
     TryGetValue(argc, argv, "qeo", &PerfDefaultQeoAllowed);
     TryGetValue(argc, argv, "dscp", &PerfDefaultDscpValue);
     if (PerfDefaultDscpValue > CXPLAT_MAX_DSCP) {


### PR DESCRIPTION
This pull request adds support for configuring the HyStart++ congestion control feature in the performance test tools. Users can now enable or disable HyStart++ via a new command-line argument, and the setting is correctly propagated throughout the codebase.

**HyStart++ Configuration Support:**

* Added a new `-hystart:<0/1>` command-line option to enable or disable HyStart++ when using CUBIC congestion control, with help text and argument parsing in `SecNetPerfMain.cpp`. [[1]](diffhunk://#diff-ee5ed74e5a6f2999edbd406df95a2125154105389db8277ebc7e424eb9b8ef79R28) [[2]](diffhunk://#diff-ee5ed74e5a6f2999edbd406df95a2125154105389db8277ebc7e424eb9b8ef79R134) [[3]](diffhunk://#diff-ee5ed74e5a6f2999edbd406df95a2125154105389db8277ebc7e424eb9b8ef79R294)
* Introduced the `PerfDefaultHyStartEnabled` variable and its declaration in `SecNetPerf.h` and initialization in `SecNetPerfMain.cpp`. [[1]](diffhunk://#diff-7c0c13dc1658a9bab99c631b31ea1073f7dff5a1ffbb95b41a592390bd54a18eR53) [[2]](diffhunk://#diff-ee5ed74e5a6f2999edbd406df95a2125154105389db8277ebc7e424eb9b8ef79R28)
* Updated `PerfClient` to set the HyStart++ option in its settings using the new default variable.
* Added the `SetHyStartEnabled` method to `MsQuicSettings` to support programmatic configuration of HyStart++.