### PR TITLE
Indicate the datagram send state to server applications

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -128,7 +128,7 @@ QuicConnAlloc(
     QuicSendInitialize(&Connection->Send, &Connection->Settings);
     QuicCongestionControlInitialize(&Connection->CongestionControl, &Connection->Settings);
     QuicLossDetectionInitialize(&Connection->LossDetection);
-    QuicDatagramInitialize(&Connection->Datagram);
+    QuicDatagramInitialize(&Connection->Datagram, IsServer);
     QuicRangeInitialize(
         QUIC_MAX_RANGE_DECODE_ACKS,
         &Connection->DecodedAckRanges);
@@ -2603,6 +2603,22 @@ QuicConnSetConfiguration(
         ConnHandshakeStart,
         "[conn][%p] Handshake start",
         Connection);
+
+    if (QuicConnIsServer(Connection)) {
+        //
+        // Evaluate the datagram send state for a server. This is the first
+        // point at which both of its inputs are settled and there is an
+        // external owner to indicate the result to: the peer's transport
+        // parameters are processed before the listener hands the connection to
+        // the application, and `Started` selects the MTU that the max send
+        // length is derived from.
+        //
+        // A client's send state is evaluated once its peer's transport
+        // parameters arrive, which is always after it has an owner, so it needs
+        // nothing here.
+        //
+        QuicDatagramOnSendStateChanged(&Connection->Datagram);
+    }
 
     Status =
         QuicCryptoInitializeTls(

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -74,11 +74,21 @@ QuicCalculateDatagramLength(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicDatagramInitialize(
-    _In_ QUIC_DATAGRAM* Datagram
+    _In_ QUIC_DATAGRAM* Datagram,
+    _In_ BOOLEAN IsServer
     )
 {
     Datagram->SendEnabled = TRUE;
     Datagram->MaxSendLength = UINT16_MAX;
+    //
+    // The indicated state starts out as what the application can be assumed to
+    // know already. A client opens the connection itself, so it knows the initial
+    // state set just above; a server is handed a connection whose send state is
+    // settled before it ever sees it, so it knows nothing and assumes the
+    // conservative default of not being able to send.
+    //
+    Datagram->IndicatedSendEnabled = IsServer ? FALSE : TRUE;
+    Datagram->IndicatedMaxSendLength = IsServer ? 0 : UINT16_MAX;
     Datagram->PrioritySendQueueTail = &Datagram->SendQueue;
     Datagram->SendQueueTail = &Datagram->SendQueue;
     CxPlatDispatchLockInitialize(&Datagram->ApiQueueLock);
@@ -283,15 +293,28 @@ QuicDatagramOnSendStateChanged(
         }
     }
 
-    if (SendEnabled == Datagram->SendEnabled) {
-        if (!SendEnabled || NewMaxSendLength == Datagram->MaxSendLength) {
-            return;
-        }
+    //
+    // Whether the live state moved and whether the application's view of it is
+    // stale are separate questions, so they are asked separately. The two answers
+    // differ whenever the state changed with no external owner to indicate to,
+    // which is the normal case for a server: the peer's transport parameters are
+    // processed before the listener hands the connection over.
+    //
+    const BOOLEAN StateChanged =
+        SendEnabled != Datagram->SendEnabled ||
+        (SendEnabled && NewMaxSendLength != Datagram->MaxSendLength);
+    const BOOLEAN IndicationNeeded =
+        Connection->State.ExternalOwner &&
+        (SendEnabled != Datagram->IndicatedSendEnabled ||
+         (SendEnabled && NewMaxSendLength != Datagram->IndicatedMaxSendLength));
+
+    if (!StateChanged && !IndicationNeeded) {
+        return;
     }
 
     Datagram->MaxSendLength = NewMaxSendLength;
 
-    if (Connection->State.ExternalOwner) {
+    if (IndicationNeeded) {
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED;
         Event.DATAGRAM_STATE_CHANGED.SendEnabled = SendEnabled;
@@ -304,15 +327,20 @@ QuicDatagramOnSendStateChanged(
             Event.DATAGRAM_STATE_CHANGED.SendEnabled,
             Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
         (void)QuicConnIndicateEvent(Connection, &Event);
+
+        Datagram->IndicatedSendEnabled = SendEnabled;
+        Datagram->IndicatedMaxSendLength = NewMaxSendLength;
     }
 
-    if (!SendEnabled) {
-        QuicDatagramSendShutdown(Datagram);
-    } else {
-        if (!Datagram->SendEnabled) {
-            Datagram->SendEnabled = TRUE; // This can happen for 0-RTT connections that didn't previously support Datagrams
+    if (StateChanged) {
+        if (!SendEnabled) {
+            QuicDatagramSendShutdown(Datagram);
+        } else {
+            if (!Datagram->SendEnabled) {
+                Datagram->SendEnabled = TRUE; // This can happen for 0-RTT connections that didn't previously support Datagrams
+            }
+            QuicDatagramOnMaxSendLengthChanged(Datagram);
         }
-        QuicDatagramOnMaxSendLengthChanged(Datagram);
     }
 
     QuicDatagramValidate(Datagram);

--- a/src/core/datagram.h
+++ b/src/core/datagram.h
@@ -33,17 +33,32 @@ typedef struct QUIC_DATAGRAM {
     uint16_t MaxSendLength;
 
     //
+    // The send state last indicated to the application, which is not always the
+    // live state above. The two differ while a change made with no external
+    // owner to indicate it to remains unreported, which is the normal case for a
+    // server: the peer's transport parameters are processed before the listener
+    // hands the connection to the application.
+    //
+    uint16_t IndicatedMaxSendLength;
+
+    //
     // Indicates that datagrams are allowed by the peer and can be queued up to
     // send.
     //
     BOOLEAN SendEnabled : 1;
+
+    //
+    // The `SendEnabled` last indicated to the application.
+    //
+    BOOLEAN IndicatedSendEnabled : 1;
 
 } QUIC_DATAGRAM;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicDatagramInitialize(
-    _In_ QUIC_DATAGRAM* Datagram
+    _In_ QUIC_DATAGRAM* Datagram,
+    _In_ BOOLEAN IsServer
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/test/lib/DatagramTest.cpp
+++ b/src/test/lib/DatagramTest.cpp
@@ -111,6 +111,16 @@ QuicTestDatagramNegotiation(
 
                 TEST_TRUE(Server->GetDatagramSendEnabled()); // Client always enabled
 
+                //
+                // Being able to send datagrams is not enough; the app has to be
+                // told. For a server that indication comes once the connection
+                // is started, the first point at which its send state has an
+                // owner to be indicated to.
+                //
+                TEST_TRUE(Server->GetDatagramStateChangedCount() > 0);
+                TEST_TRUE(Server->GetIndicatedDatagramSendEnabled());
+                TEST_NOT_EQUAL(0, Server->GetIndicatedDatagramMaxSendLength());
+
                 CxPlatSleep(100); // Necessary?
 
                 if (DatagramReceiveEnabled) {

--- a/src/test/lib/TestConnection.cpp
+++ b/src/test/lib/TestConnection.cpp
@@ -948,7 +948,9 @@ TestConnection::HandleConnectionEvent(
         break;
 
     case QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED:
-        // Use This
+        DatagramStateChangedCount++;
+        IndicatedDatagramSendEnabled = Event->DATAGRAM_STATE_CHANGED.SendEnabled != FALSE;
+        IndicatedDatagramMaxSendLength = Event->DATAGRAM_STATE_CHANGED.MaxSendLength;
         break;
 
     case QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED:

--- a/src/test/lib/TestConnection.h
+++ b/src/test/lib/TestConnection.h
@@ -106,6 +106,10 @@ class TestConnection
     uint32_t DatagramsLost{};
     uint32_t DatagramsAcknowledged{};
 
+    uint32_t DatagramStateChangedCount{};
+    bool IndicatedDatagramSendEnabled{false};
+    uint16_t IndicatedDatagramMaxSendLength{};
+
     const uint8_t* NegotiatedAlpn{};
     uint8_t NegotiatedAlpnLength{};
 
@@ -336,6 +340,25 @@ public:
         LockGuard LockScope{Lock};
         return DatagramsCanceled;
     }
+    //
+    // The state carried by the last QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED
+    // indicated to this connection, and how many have been indicated. Distinct
+    // from GetDatagramSendEnabled, which queries the live state whether or not
+    // the app was ever told about it.
+    //
+    uint32_t GetDatagramStateChangedCount() const {
+        LockGuard LockScope{Lock};
+        return DatagramStateChangedCount;
+    }
+    bool GetIndicatedDatagramSendEnabled() const {
+        LockGuard LockScope{Lock};
+        return IndicatedDatagramSendEnabled;
+    }
+    uint16_t GetIndicatedDatagramMaxSendLength() const {
+        LockGuard LockScope{Lock};
+        return IndicatedDatagramMaxSendLength;
+    }
+
     uint32_t GetDatagramsSuspectLost() const {
         LockGuard LockScope{Lock};
         return DatagramsSuspectLost;


### PR DESCRIPTION
## Description

A server application never receives `QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED` unless path MTU discovery happens to change the max send length. On a path where it does not, the application waits forever for the event and never sends a datagram, while receiving them perfectly well. `docs/API.md` states that the app receives this event to learn whether the peer supports receiving datagrams, so this is the code not matching the documented behaviour.

### Cause

`QuicDatagramOnSendStateChanged` commits the new state to the `QUIC_DATAGRAM` unconditionally, but indicates it only when `State.ExternalOwner` is set:

```c
    if (SendEnabled == Datagram->SendEnabled) {
        if (!SendEnabled || NewMaxSendLength == Datagram->MaxSendLength) {
            return;                                   // "already reported"
        }
    }

    Datagram->MaxSendLength = NewMaxSendLength;        // recorded regardless

    if (Connection->State.ExternalOwner) {             // reported only if owned
        ... QuicConnIndicateEvent(DATAGRAM_STATE_CHANGED) ...
    }
```

On a server the peer's transport parameters are processed before the listener hands the connection to the application. That evaluation runs unowned: it records a state that nobody can be told about, and from then on every evaluation compares equal to it and returns early. The change has been accounted for as if it were reported.

The only rescue is a later evaluation computing a different length, which in practice means MTU discovery moving `Path->Mtu`. Hence the same build working on one network and hanging on another.

### Fix

`QuicConnSetConfiguration` evaluates the send state for servers, right after `State.Started` is set. That is the first point at which both inputs to the state are settled and there is an owner to indicate the result to — `Started` selects which MTU the max send length is derived from (`QUIC_DPLPMTUD_MIN_MTU` before it, `Path->Mtu` after).

That alone is not enough, because the evaluation is still swallowed whenever the recomputed values happen to equal what was recorded while unowned. They are identical when the peer uses an 8 byte connection ID over an IPv6 path with a 1280 byte MTU, which is exactly the pre-`Started` assumption. So whether the live state moved and whether the application's view of it is stale are now tracked separately: the early return consults the indicated state, the indicated state is updated only where an indication is actually made, and the side effects of a real state change — send shutdown, max length requeue — stay tied to the live state.

The indicated state starts out as what the application can be assumed to know already. A client opens the connection itself, so it knows the initial state; a server is handed a connection whose send state is settled before it ever sees it, so it knows nothing and assumes the conservative default of not being able to send.

### Scope of the behaviour change

- **Clients are unaffected.** Their send state changes always have an owner to indicate to, so the indicated state never goes stale and every existing indication still fires, unchanged.
- **Servers gain exactly one indication**, telling the application once that it may send datagrams.
- **A server whose peer does not support datagrams is still told nothing**, which matches what the application already assumes. No spurious event is introduced.
- `QuicDatagramValidate`'s `!SendEnabled ⇒ MaxSendLength == 0` invariant holds on every path.
- `QUIC_DATAGRAM` is internal to `src/core`, so the two added fields are not an API or ABI change.

## Testing

`QuicTestDatagramNegotiation` covered this path but only asserted that the server *can* send (`GetParam(QUIC_PARAM_CONN_DATAGRAM_SEND_ENABLED)`), which was true even while the application was never told. It now also asserts that the server *was told*: `TestConnection` records the count and contents of the `DATAGRAM_STATE_CHANGED` events indicated to it.

- Without the fix, the extended test fails on all four parameterisations (v4/v6 × datagram receive enabled/disabled).
- With the fix, the full `*Datagram*:*Event*:*Mtu*:*Resumption*:*ValidateConn*:*Basic*:*Handshake*` set passes: 797 tests, no failures. In particular the ordered event validators in `EventTest.cpp` needed no changes, confirming client behaviour is untouched.

## Documentation

No documentation change. `docs/API.md` and `docs/api/QUIC_CONNECTION_EVENT.md` already describe the behaviour this change implements.
