### PR TITLE
Keep buffered data deliverable when no receive is pending

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -1116,8 +1116,18 @@ QuicStreamReceiveComplete(
     //
     // Reclaim any buffer space comsumed by the app.
     //
-    if (Stream->RecvPendingLength == 0 ||
-        QuicRecvBufferDrain(&Stream->RecvBuffer, BufferLength)) {
+    if (Stream->RecvPendingLength == 0) {
+        //
+        // No receive is pending, so there is no space to reclaim: the
+        // indication carried no data, or the completion is one that arrived
+        // with nothing outstanding to complete. Whether anything is still
+        // waiting to be delivered is a question only the receive buffer can
+        // answer.
+        //
+        if (!QuicRecvBufferHasUnreadData(&Stream->RecvBuffer)) {
+            Stream->Flags.ReceiveDataPending = FALSE; // No more pending data to deliver.
+        }
+    } else if (QuicRecvBufferDrain(&Stream->RecvBuffer, BufferLength)) {
         Stream->Flags.ReceiveDataPending = FALSE; // No more pending data to deliver.
     }
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -875,6 +875,10 @@ QuicTestStreamAbortRecvFinRace(
     );
 
 void
+QuicTestStreamReceiveCompleteWithNoPendingReceive(
+    );
+
+void
 QuicTestStreamAbortConnFlowControl(
     );
 

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -2837,6 +2837,15 @@ TEST(Misc, StreamAbortRecvFinRace) {
     }
 }
 
+TEST(Misc, StreamReceiveCompleteWithNoPendingReceive) {
+    TestLogger Logger("StreamReceiveCompleteWithNoPendingReceive");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestStreamReceiveCompleteWithNoPendingReceive)));
+    } else {
+        QuicTestStreamReceiveCompleteWithNoPendingReceive();
+    }
+}
+
 #ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
 TEST(Misc, StreamReliableReset) {
     TestLogger Logger("StreamReliableReset");

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -638,6 +638,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestStreamPriorityInfiniteLoop);
     RegisterTestFunction(QuicTestStreamDifferentAbortErrors);
     RegisterTestFunction(QuicTestStreamAbortRecvFinRace);
+    RegisterTestFunction(QuicTestStreamReceiveCompleteWithNoPendingReceive);
 #ifdef QUIC_PARAM_STREAM_RELIABLE_OFFSET
     RegisterTestFunction(QuicTestStreamReliableReset);
     RegisterTestFunction(QuicTestStreamReliableResetMultipleSends);

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3462,6 +3462,114 @@ QuicTestStreamAbortRecvFinRace(
     TEST_TRUE(Context.ClientStreamShutdownComplete.WaitTimeout(TestWaitTimeout));
 }
 
+struct StreamReceiveCompleteNoPendingReceive {
+    CxPlatEvent ReceiveEvent;
+    MsQuicStream* ServerStream {nullptr};
+    uint32_t ReceiveCount {0};
+    uint64_t FirstReceiveLength {0};
+    uint64_t LastReceiveOffset {0};
+    uint64_t LastReceiveLength {0};
+
+    static QUIC_STATUS ServerStreamCallback(_In_ MsQuicStream*, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (StreamReceiveCompleteNoPendingReceive*)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_RECEIVE) {
+            if (TestContext->ReceiveCount == 0) {
+                TestContext->FirstReceiveLength = Event->RECEIVE.TotalBufferLength;
+            }
+            TestContext->LastReceiveOffset = Event->RECEIVE.AbsoluteOffset;
+            TestContext->LastReceiveLength = Event->RECEIVE.TotalBufferLength;
+            TestContext->ReceiveCount++;
+            TestContext->ReceiveEvent.Set();
+            return QUIC_STATUS_PENDING;
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            auto TestContext = (StreamReceiveCompleteNoPendingReceive*)Context;
+            TestContext->ServerStream =
+                new(std::nothrow) MsQuicStream(
+                    Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete, ServerStreamCallback, Context);
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+
+//
+// Validates that a receive completion processed while no receive is pending
+// leaves the rest of the receive buffer deliverable. Such a completion carries
+// nothing to reclaim, and must not be taken to mean the buffer has been fully
+// drained: doing so silences every later receive indication, and the data
+// already buffered is never delivered.
+//
+void
+QuicTestStreamReceiveCompleteWithNoPendingReceive(
+    )
+{
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", MsQuicSettings().SetPeerUnidiStreamCount(1), ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    StreamReceiveCompleteNoPendingReceive Context;
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, StreamReceiveCompleteNoPendingReceive::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+
+    MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL, CleanUpManual, MsQuicStream::NoOpCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Stream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+
+    const uint32_t SendLength = 100;
+    uint8_t RawBuffer[SendLength] = {0};
+    QUIC_BUFFER SendBuffer { SendLength, RawBuffer };
+    TEST_QUIC_SUCCEEDED(Stream.Send(&SendBuffer, 1, QUIC_SEND_FLAG_NONE));
+
+    TEST_TRUE(Context.ReceiveEvent.WaitTimeout(TestWaitTimeout));
+    TEST_EQUAL(SendLength, Context.FirstReceiveLength);
+
+    //
+    // Accept only half, which pauses receives with the rest still buffered, and
+    // leaves no receive pending.
+    //
+    Context.ServerStream->ReceiveComplete(SendLength / 2);
+
+    //
+    // Give the completion above time to be processed, so the one below is the
+    // case under test: a completion seen with no receive pending. The API
+    // contract is that it is ignored silently.
+    //
+    CxPlatSleep(500);
+    Context.ServerStream->ReceiveComplete(0);
+    CxPlatSleep(500);
+
+    //
+    // The half that was not accepted must still be delivered.
+    //
+    TEST_QUIC_SUCCEEDED(Context.ServerStream->ReceiveSetEnabled(true));
+
+    uint32_t Tries = 0;
+    while (Context.ReceiveCount < 2 && ++Tries < 20) {
+        CxPlatSleep(100);
+    }
+    TEST_TRUE(Context.ReceiveCount >= 2);
+    TEST_EQUAL(SendLength / 2, Context.LastReceiveOffset);
+    TEST_EQUAL(SendLength - SendLength / 2, Context.LastReceiveLength);
+}
+
 struct StreamAbortConnFlowControl {
     CxPlatEvent ClientStreamShutdownComplete;
     uint32_t StreamCount {0};

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3462,6 +3462,121 @@ QuicTestStreamAbortRecvFinRace(
     TEST_TRUE(Context.ClientStreamShutdownComplete.WaitTimeout(TestWaitTimeout));
 }
 
+struct StreamReceiveCompleteNoPendingReceive {
+    CxPlatEvent ReceiveEvent;
+    MsQuicStream* ServerStream {nullptr};
+    uint32_t ReceiveCount {0};
+    uint64_t FirstReceiveLength {0};
+    uint64_t LastReceiveOffset {0};
+    uint64_t LastReceiveLength {0};
+
+    static QUIC_STATUS ServerStreamCallback(_In_ MsQuicStream*, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (StreamReceiveCompleteNoPendingReceive*)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_RECEIVE) {
+            if (TestContext->ReceiveCount == 0) {
+                TestContext->FirstReceiveLength = Event->RECEIVE.TotalBufferLength;
+            }
+            TestContext->LastReceiveOffset = Event->RECEIVE.AbsoluteOffset;
+            TestContext->LastReceiveLength = Event->RECEIVE.TotalBufferLength;
+            TestContext->ReceiveCount++;
+            TestContext->ReceiveEvent.Set();
+            return QUIC_STATUS_PENDING;
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            auto TestContext = (StreamReceiveCompleteNoPendingReceive*)Context;
+            TestContext->ServerStream =
+                new(std::nothrow) MsQuicStream(
+                    Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete, ServerStreamCallback, Context);
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+
+//
+// Validates that a receive completion processed while no receive is pending
+// leaves the rest of the receive buffer deliverable. Such a completion carries
+// nothing to reclaim, and must not be taken to mean the buffer has been fully
+// drained: doing so silences every later receive indication, and the data
+// already buffered is never delivered.
+//
+void
+QuicTestStreamReceiveCompleteWithNoPendingReceive(
+    )
+{
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", MsQuicSettings().SetPeerUnidiStreamCount(1), ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    StreamReceiveCompleteNoPendingReceive Context;
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, StreamReceiveCompleteNoPendingReceive::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+
+    MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL, CleanUpManual, MsQuicStream::NoOpCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Stream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+
+    const uint32_t SendLength = 100;
+    uint8_t RawBuffer[SendLength] = {0};
+    QUIC_BUFFER SendBuffer { SendLength, RawBuffer };
+    TEST_QUIC_SUCCEEDED(Stream.Send(&SendBuffer, 1, QUIC_SEND_FLAG_NONE));
+
+    TEST_TRUE(Context.ReceiveEvent.WaitTimeout(TestWaitTimeout));
+    TEST_EQUAL(SendLength, Context.FirstReceiveLength);
+
+    //
+    // Accept only half, which pauses receives with the rest still buffered, and
+    // leaves no receive pending.
+    //
+    Context.ServerStream->ReceiveComplete(SendLength / 2);
+
+    //
+    // Wait for that completion to be processed, using a normal priority GetParam
+    // as a barrier: it is queued on the connection behind the completion and
+    // blocks until the queue reaches it. The value it returns is not of interest.
+    //
+    // Waiting is what makes the call below the case under test. Both calls share
+    // one pre-allocated operation, so a second completion issued before the first
+    // is dequeued is folded into it and never reaches the stream on its own.
+    //
+    QUIC_UINT62 StreamId;
+    TEST_QUIC_SUCCEEDED(Context.ServerStream->GetID(&StreamId));
+
+    //
+    // A completion seen with no receive pending. The API contract is that it is
+    // ignored silently.
+    //
+    Context.ServerStream->ReceiveComplete(0);
+
+    //
+    // The half that was not accepted must still be delivered. Enabling receives
+    // is queued behind the completion above, so it cannot be processed first.
+    //
+    TEST_QUIC_SUCCEEDED(Context.ServerStream->ReceiveSetEnabled(true));
+
+    TEST_TRUE(Context.ReceiveEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Context.ReceiveCount >= 2);
+    TEST_EQUAL(SendLength / 2, Context.LastReceiveOffset);
+    TEST_EQUAL(SendLength - SendLength / 2, Context.LastReceiveLength);
+}
+
 struct StreamAbortConnFlowControl {
     CxPlatEvent ClientStreamShutdownComplete;
     uint32_t StreamCount {0};


### PR DESCRIPTION
## Description

A stream can stop receiving while data is already sitting in its receive buffer: `QUIC_STREAM_EVENT_RECEIVE` is never indicated for it, and `StreamReceiveSetEnabled` does not bring it back.

### Cause

`QuicStreamReceiveComplete` decides whether anything is left to deliver like this:

```c
    if (Stream->RecvPendingLength == 0 ||
        QuicRecvBufferDrain(&Stream->RecvBuffer, BufferLength)) {
        Stream->Flags.ReceiveDataPending = FALSE; // No more pending data to deliver.
    }
```

`RecvPendingLength == 0` means "no receive is currently pending". It says nothing about whether the receive buffer still holds undelivered data. Only `QuicRecvBufferDrain` answers that, and the `||` short-circuits past it.

`ReceiveDataPending` gates every subsequent indication:

- `QuicStreamRecvQueueFlush` (`stream_recv.c:132`) queues a flush only if `ReceiveEnabled && ReceiveDataPending`
- `QuicStreamRecvFlush` (`stream_recv.c:896`) returns immediately if it is clear
- `QuicStreamReceiveComplete` (`stream_recv.c:1161`) asks for a re-flush only if it is set

So once it is cleared while data remains, that data is never indicated. `StreamReceiveSetEnabled` does not help — it ends up in `QuicStreamRecvQueueFlush`, whose condition is not met. Only newly arriving data sets the flag again (`stream_recv.c:581`), which never happens if the peer has finished sending, or is blocked by flow control precisely because the application never consumed what it was not told about.

A completion processed with no receive pending is not an error case. `docs/api/StreamReceiveComplete.md` says:

> Duplicate `StreamReceiveComplete` calls are ignored silently if no `QUIC_STREAM_EVENT_RECEIVE` is pending when the call is processed, but they could race with a new `QUIC_STREAM_EVENT_RECEIVE` event and complete it

It is documented as harmless, and it also arises without any application mistake: in multi-receive mode an asynchronous completion can be absorbed by a flush that is already in progress (`stream_recv.c:1017`), leaving the queued completion operation to run with nothing outstanding.

### Fix

Ask the two questions separately. When no receive is pending there is no buffer space to reclaim, so the receive buffer is consulted directly for whether anything is still waiting:

```c
    if (Stream->RecvPendingLength == 0) {
        if (!QuicRecvBufferHasUnreadData(&Stream->RecvBuffer)) {
            Stream->Flags.ReceiveDataPending = FALSE;
        }
    } else if (QuicRecvBufferDrain(&Stream->RecvBuffer, BufferLength)) {
        Stream->Flags.ReceiveDataPending = FALSE;
    }
```

Simply dropping the short-circuit and always calling `QuicRecvBufferDrain` does not work: the FIN-only indication path (`QuicStreamRecvFlush` with no data available) reaches the completion with a receive buffer that has no written ranges, and `QuicRecvBufferDrain` asserts on that (`recv_buffer.c:1064`). `QuicRecvBufferHasUnreadData` handles an empty buffer safely (`recv_buffer.c:375-377`), and returns `FALSE` there, so the FIN-only case still clears the flag exactly as before.

The behaviour change is confined to the case where a completion is processed with no receive pending *and* the buffer still holds unread data: previously the remaining data became undeliverable, now it stays deliverable.

## Testing

New test `QuicTestStreamReceiveCompleteWithNoPendingReceive` (`Misc.StreamReceiveCompleteWithNoPendingReceive`), registered for both user and kernel mode. Using the default receive mode:

1. 100 bytes are sent; the server returns `QUIC_STATUS_PENDING` from the receive event.
2. `StreamReceiveComplete(50)` accepts half, which pauses receives and leaves 50 bytes buffered with no receive pending.
3. `StreamReceiveComplete(0)` is the case under test — a completion seen with nothing outstanding.
4. `StreamReceiveSetEnabled` must produce the remaining half, at offset 50 with length 50.

Results:

- Without the fix the new test fails: the second receive event never arrives.
- With the fix it passes.
- `*Receive*:*Recv*:*Stream*:*Abort*:*Data*:*Basic*:*Handshake*:*Shutdown*:*Mtu*` passes in full: 2950 tests, no failures. That includes `Misc.StreamAbortRecvFinRace`, which is the test that catches the `QuicRecvBufferDrain` assert described above.

Step 3 needs the completion in step 2 to have been processed first, and there is no API-visible signal for that, so the test sleeps between the two calls. If the sleep were ever too short the two completions would merge into one and the test would still pass — it loses coverage rather than becoming flaky.

## Documentation

No documentation change. `docs/api/StreamReceiveComplete.md` already states the behaviour this change implements.
