### PR TITLE
[CP] Fix missing failure exit on VersionInfo alloc failure in TP decode (#6008)

### DIFF
--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -1849,7 +1849,7 @@ QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, goo
                         "Allocation of '%s' failed. (%llu bytes)",
                         "Version Negotiation Info",
                         Length);
-                    break;
+                    goto Exit;
                 }
                 CxPlatCopyMemory((uint8_t*)TransportParams->VersionInfo, TPBuf + Offset, Length);
             } else {


### PR DESCRIPTION
## Description
In QuicCryptoTlsDecodeTransportParameters, the QUIC_TP_ID_VERSION_NEGOTIATION_EXT case used break when CXPLAT_ALLOC_NONPAGED failed to allocate VersionInfo. This caused the function to continue past the switch statement and eventually return TRUE.

Changed break to goto Exit so the function correctly returns FALSE on allocation failure.

## Testing


## Documentation
No documentation impact.

<!-- Companion PR for release/2.5: #6182 -->
