### PR TITLE
[CP] Fix null deref in QuicCryptoCustomCertValidationComplete after shutdown (#5962)

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1718,15 +1718,27 @@ QuicCryptoCustomCertValidationComplete(
     _In_ QUIC_TLS_ALERT_CODES TlsAlert
     )
 {
+    QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
+
     if (!Crypto->CertValidationPending) {
         return;
     }
 
     Crypto->CertValidationPending = FALSE;
+
+    //
+    // The connection might have been shutdown during the cert validation.
+    // Nothing to do in that case.
+    //
+    if (Connection->State.ShutdownComplete) {
+        Crypto->PendingValidationBufferLength = 0;
+        return;
+    }
+
     if (Result) {
         QuicTraceLogConnInfo(
             CustomCertValidationSuccess,
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation succeeded");
         QuicCryptoProcessDataComplete(Crypto, Crypto->PendingValidationBufferLength);
 
@@ -1740,11 +1752,11 @@ QuicCryptoCustomCertValidationComplete(
         QuicTraceEvent(
             ConnError,
             "[conn][%p] ERROR, %s.",
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             "Custom cert validation failed.");
         CXPLAT_DBG_ASSERT(TlsAlert <= QUIC_TLS_ALERT_CODE_MAX);
         QuicConnTransportError(
-            QuicCryptoGetConnection(Crypto),
+            Connection,
             QUIC_ERROR_CRYPTO_ERROR(0xFF & TlsAlert));
     }
     Crypto->PendingValidationBufferLength = 0;


### PR DESCRIPTION
## Description

Fix a null pointer dereference crash in `QuicCryptoCustomCertValidationComplete` when certificate validation completes after the connection has already been shut down.

**Root cause**: When a remote peer closes a QUIC connection while async certificate validation is pending on the server, `QuicConnOnShutdownComplete` frees all SourceCids. When the app later calls `ConnectionCertificateValidationComplete(TRUE)`, `QuicCryptoProcessTlsCompletion` dereferences `Connection->SourceCids.Next` (now NULL), causing an access violation. This was observed as a kernel bugcheck (0x7E) in production.

**Fix**: Add a `ShutdownComplete` guard in `QuicCryptoCustomCertValidationComplete` to bail out early if the connection has already completed shutdown, preventing the code from proceeding into `QuicCryptoProcessTlsCompletion` with freed state.

This is a back-port to `release/2.4` of the core fix from #6145 (original #5962), containing only the `src/core/crypto.c` change.

## Testing

Validated locally on `release/2.4`: clean schannel build and all 8 `CustomServerCertificateValidation` / `CustomClientCertificateValidation` (sync + async) handshake tests pass.

## Documentation

No documentation impact.
