### PR TITLE
[CP] Fix null deref in QuicCryptoCustomTicketValidationComplete after shutdown (#5963)

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -1782,6 +1782,18 @@ QuicCryptoCustomTicketValidationComplete(
         return;
     }
 
+    QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
+
+    //
+    // The connection might have been shutdown during the ticket validation.
+    // Nothing to do in that case.
+    //
+    if (Connection->State.ShutdownComplete) {
+        Crypto->TicketValidationPending = FALSE;
+        Crypto->PendingValidationBufferLength = 0;
+        return;
+    }
+
     if (Result) {
         //
         // Just call completion.
@@ -1819,7 +1831,6 @@ QuicCryptoCustomTicketValidationComplete(
             Crypto->TlsState.WriteKeys[i] = NULL;
         }
         QuicRecvBufferResetRead(&Crypto->RecvBuffer);
-        QUIC_CONNECTION* Connection = QuicCryptoGetConnection(Crypto);
         QUIC_STATUS Status = QuicCryptoInitializeTls(Crypto, Connection->Configuration->SecurityConfig, Connection->HandshakeTP);
         if (Status != QUIC_STATUS_SUCCESS) {
             QuicConnFatalError(Connection, Status, "Failed finalizing resumption ticket rejection");


### PR DESCRIPTION
## Description

Partial backport of 50f6b4a63a88b656cceee47930a02fc4e29ffb9b (PR #5963) to `release/2.5` — **ShutdownComplete guard only**.

Adds a `ShutdownComplete` guard to `QuicCryptoCustomTicketValidationComplete` so completing a deferred (async) resumption-ticket validation after the connection has already shut down no longer dereferences freed `SourceCids`. After `ShutdownComplete`, `QuicConnOnShutdownComplete` frees all `SourceCids` (`Connection->SourceCids.Next == NULL`); without the guard, completing the deferred validation calls `QuicCryptoProcessDataComplete` / `QuicCryptoInitializeTls`, both of which dereference freed state (server crash / kernel bugcheck 0x7E).

Only the `crypto.c` ShutdownComplete portion is backported. The unrelated 0-RTT send-loop fix and the tests from the original PR are intentionally excluded per the scope of this backport.

## Testing

Covered on `main` by `Handshake/WithAcceptTicket.CustomTicketValidationAfterShutdown` (from the original PR #5963). No new tests added in this partial backport.

## Documentation

No documentation impact.
