### PR TITLE
Fix weekly release build trigger by specifying repo explicitly

### DIFF
--- a/.github/workflows/weekly-release-builds.yml
+++ b/.github/workflows/weekly-release-builds.yml
@@ -36,4 +36,4 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         echo "Triggering Build workflow for ${{ matrix.branch }}"
-        gh workflow run build.yml --ref "${{ matrix.branch }}"
+        gh workflow run build.yml --repo "${{ github.repository }}" --ref "${{ matrix.branch }}"


### PR DESCRIPTION
## Description

The `Weekly Release Branch Builds` workflow (`.github/workflows/weekly-release-builds.yml`) was failing on every run with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

The `trigger` job has no `actions/checkout` step (it does not need the repo contents), so there is no `.git` directory. When `gh workflow run build.yml --ref "..."` runs without a repository argument, `gh` tries to infer the target repository from local git state and fails.

This change passes the repository explicitly via `--repo "${{ github.repository }}"`, so `gh` no longer depends on a local git clone.

## Testing

Validated end-to-end without merging by dispatching this workflow against the PR branch (`workflow_dispatch` runs the workflow from the specified ref):

```
gh workflow run weekly-release-builds.yml --ref guhetier/fix-weekly-release-builds_copilot -R microsoft/msquic
```

https://github.com/microsoft/msquic/actions/runs/30925121037

## Documentation

No documentation impact.
