### PR TITLE
[CP] Handle zero length datagram in epoll (#6181)

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1939,6 +1939,14 @@ CxPlatSocketContextRecvComplete(
             Datagram = (DATAPATH_RX_PACKET*)
                 ((char*)Datagram + SocketContext->DatapathPartition->Datapath->RecvBlockStride);
         }
+
+        if (IoBlock->RefCount == 0) {
+            //
+            // Nothing referenced the block (e.g. a zero-length datagram)
+            // Return it to the pool here to avoid leaking it.
+            //
+            CxPlatPoolFree(IoBlock);
+        }
     }
 
     if (BytesTransferred == 0 || DatagramHead == NULL) {

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -13,7 +13,7 @@ Environment:
 
 --*/
 
-#include "platform_internal.h" 
+#include "platform_internal.h"
 #include <fcntl.h>
 #include <linux/filter.h>
 #include <linux/in6.h>

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -13,7 +13,7 @@ Environment:
 
 --*/
 
-#include "platform_internal.h"
+#include "platform_internal.h" 
 #include <fcntl.h>
 #include <linux/filter.h>
 #include <linux/in6.h>


### PR DESCRIPTION
## Description
Handle zero length datagram in epoll.

After the chaining loop, when `IoBlock->RefCount == 0`, reclaim the block via `CxPlatPoolFree` instead of dropping it. The check is inside the per-message loop, so a zero-length datagram batched alongside valid ones is also reclaimed, avoiding a leak.

This is the epoll portion of #6181 back-ported to `release/2.5`. The io_uring changes from the original PR are omitted because `src/platform/datapath_iouring.c` does not exist on `release/2.5`.

Fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/62840605/

## Testing

Validated on `release/2.5`: `core` builds on Linux, and `datapath_epoll.c` passes a clean `-Werror` compile with the change.

## Documentation

No documentation impact.
