### PR TITLE
Consume XDP SDK from NuGet

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ MsQuic is Microsoft's cross-platform C implementation of the IETF QUIC protocol.
 | `src/manifest/` | Windows ETW manifest and CLOG config (`clog.sidecar`, `msquic.clog_config`) |
 | `scripts/` | PowerShell build/test/CI scripts (cross-platform via pwsh) |
 | `docs/` | Documentation: `BUILD.md`, `TEST.md`, `API.md`, `Architecture.md`, etc. |
-| `submodules/` | Git submodules: `googletest`, `quictls`, `openssl`, `clog`, `xdp-for-windows` |
+| `submodules/` | Git submodules: `googletest`, `quictls`, `openssl`, `clog` |
 | `cmake/` | CMake helper modules and toolchain files |
 | `.github/workflows/` | CI workflows: `build.yml`, `test.yml`, `cargo.yml`, `check-clog.yml`, `check-dotnet.yml` |
 

--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -8,36 +8,38 @@ on:
     paths:
     - .github/workflows/netperf.yml
     - .gitmodules
+    - packages.config
     - scripts/secnetperf.ps1
     - scripts/secnetperf-helpers.psm1
     - scripts/quic_callback.ps1
     - scripts/prepare-machine.ps1
     - scripts/xdp.json
+    - cmake/FindXdpSdk.cmake
     - src/bin/**
     - src/core/**
     - src/platform/**
     - src/perf/**
     - submodules/quictls/**
     - submodules/openssl/**
-    - submodules/xdp-for-windows/**
   pull_request:
     branches:
     - main
     paths:
     - .github/workflows/netperf.yml
     - .gitmodules
+    - packages.config
     - scripts/secnetperf.ps1
     - scripts/secnetperf-helpers.psm1
     - scripts/quic_callback.ps1
     - scripts/prepare-machine.ps1
     - scripts/xdp.json
+    - cmake/FindXdpSdk.cmake
     - src/bin/**
     - src/core/**
     - src/platform/**
     - src/perf/**
     - submodules/quictls/**
     - submodules/openssl/**
-    - submodules/xdp-for-windows/**
 
 concurrency:
   # Cancel any workflow currently in progress for the same PR.

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -45,7 +45,7 @@ jobs:
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
     - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -DisableTest
+      run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForBuild -DisableTest
       shell: pwsh
     - name: Build Release
       shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+/packages/
 
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,6 @@
 [submodule "submodules/clog"]
 	path = submodules/clog
 	url = https://github.com/microsoft/CLOG.git
-[submodule "submodules/xdp-for-windows"]
-	path = submodules/xdp-for-windows
-	url = https://github.com/microsoft/xdp-for-windows.git
-	branch = release/1.4
 [submodule "submodules/openssl"]
 	path = submodules/openssl
 	url = https://github.com/openssl/openssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -965,6 +965,10 @@ if(QUIC_CODE_CHECK)
     endif()
 endif()
 
+if("${CX_PLATFORM}" STREQUAL "windows")
+    find_package(XdpSdk REQUIRED MODULE)
+endif()
+
 add_subdirectory(src/inc)
 add_subdirectory(src/generated)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ include = [
     "/submodules/openssl/exporters",
     "/submodules/openssl/providers",
     "/submodules/openssl/util",
-    "/submodules/xdp-for-windows/published/external",
     "/scripts/build.rs",
     "/src/**/*.rs",
     "/src/bin",

--- a/cmake/FindXdpSdk.cmake
+++ b/cmake/FindXdpSdk.cmake
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+include(FindPackageHandleStandardArgs)
+
+set(
+    QUIC_NUGET_PACKAGES
+    "${CMAKE_CURRENT_SOURCE_DIR}/packages"
+    CACHE PATH
+    "Directory containing repository-local NuGet packages")
+
+file(
+    READ
+    "${CMAKE_CURRENT_SOURCE_DIR}/packages.config"
+    XDP_SDK_PACKAGES)
+string(
+    REGEX MATCH
+    "<package[^>]*id=\"Microsoft\\.XDP-for-Windows\\.Sdk\"[^>]*version=\"([^\"]+)\""
+    XDP_SDK_PACKAGE_VERSION
+    "${XDP_SDK_PACKAGES}")
+set(XdpSdk_VERSION "${CMAKE_MATCH_1}")
+
+find_path(
+    XdpSdk_INCLUDE_DIR
+    NAMES xdpapi.h
+    PATHS
+        "${QUIC_NUGET_PACKAGES}/Microsoft.XDP-for-Windows.Sdk.${XdpSdk_VERSION}/build/native/include"
+    NO_DEFAULT_PATH)
+
+find_package_handle_standard_args(
+    XdpSdk
+    REQUIRED_VARS XdpSdk_INCLUDE_DIR XdpSdk_VERSION
+    VERSION_VAR XdpSdk_VERSION)
+
+if(XdpSdk_FOUND AND NOT TARGET XdpSdk::Headers)
+    add_library(XdpSdk::Headers INTERFACE IMPORTED)
+    set_target_properties(
+        XdpSdk::Headers
+        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${XdpSdk_INCLUDE_DIR}")
+endif()
+
+set(XDP_INCLUDE_DIR "${XdpSdk_INCLUDE_DIR}")

--- a/docs/XDP.md
+++ b/docs/XDP.md
@@ -5,10 +5,24 @@ MsQuic does not support Linux XDP as a datapath.
 
 ## Installing XDP
 
-MsQuic consumes XDP as a binary dependency for its tests; it does not build XDP
-from source. The available packages — and the exact version pinned for each — are
-defined in [`scripts/xdp.json`](../scripts/xdp.json), which is the single source
-of truth. Each entry is keyed by a version moniker (e.g. `1.1`, `prerelease`).
+MsQuic consumes the XDP SDK headers from the
+[`Microsoft.XDP-for-Windows.Sdk`](https://www.nuget.org/packages/Microsoft.XDP-for-Windows.Sdk)
+NuGet package during Windows builds. Its version is pinned in
+[`packages.config`](../packages.config). Restore the SDK to the conventional
+repository-local `packages` directory before configuring CMake.
+`prepare-machine.ps1 -ForBuild` performs the standard restore on Windows
+user-mode builds. The equivalent command is:
+
+```powershell
+nuget restore packages.config -SolutionDirectory . -NonInteractive
+```
+
+By default, NuGet uses the standard machine-wide configuration. CI environments
+may provide an alternate `NuGet.config` to select authenticated internal feeds.
+
+MsQuic tests install the XDP runtime as a binary dependency. Runtime package
+metadata is defined in [`scripts/xdp.json`](../scripts/xdp.json) and keyed by
+version moniker (e.g. `xdp-v1.4`, `xdp-prerelease`).
 
 To install XDP for testing, use `prepare-machine.ps1`, which downloads the
 runtime NuGet package, extracts it, and installs the driver via the package's
@@ -22,8 +36,8 @@ own `xdp-setup.ps1`:
 ./scripts/prepare-machine.ps1 -ForTest -UseXdp xdp-prerelease
 ```
 
-`-UseXdp` takes the version moniker to install (any key from `xdp.json`); omit it
-to skip XDP entirely.
+`-UseXdp` takes a runtime version moniker from `xdp.json`; omit it to skip XDP
+entirely.
 
 ## What is XDP
 

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.XDP-for-Windows.Sdk" version="1.4.0" targetFramework="native" />
+</packages>

--- a/scripts/prepare-machine.ps1
+++ b/scripts/prepare-machine.ps1
@@ -223,6 +223,25 @@ function Get-XdpArch {
 $XdpPath = Join-Path $ArtifactsPath "xdp"
 $XdpRuntimeNativePath = Join-Path $XdpPath "runtime\native"
 
+function Restore-NuGetPackages {
+    $PackagesConfig = Join-Path $RootDir "packages.config"
+    if (!(Test-Path $PackagesConfig -PathType Leaf)) {
+        throw "NuGet package manifest not found: $PackagesConfig"
+    }
+
+    $NuGet = Get-Command nuget.exe -ErrorAction SilentlyContinue
+    if ($null -eq $NuGet) {
+        throw "nuget.exe is required to restore Windows build dependencies."
+    }
+
+    & $NuGet.Source restore $PackagesConfig `
+        -SolutionDirectory $RootDir `
+        -NonInteractive
+    if ($LASTEXITCODE -ne 0) {
+        throw "NuGet restore failed with exit code $LASTEXITCODE."
+    }
+}
+
 # Installs the XDP driver (for testing).
 # NB: XDP can be uninstalled via Uninstall-Xdp
 function Install-Xdp-Driver {
@@ -238,7 +257,8 @@ function Install-Xdp-Driver {
     $XdpJson = Get-Content (Join-Path $PSScriptRoot "xdp.json") | ConvertFrom-Json
     $XdpEntry = $XdpJson.$XdpVersion
     if ($null -eq $XdpEntry) {
-        Write-Error "Unknown XDP version '$XdpVersion'. Available versions: $($XdpJson.PSObject.Properties.Name -join ', ')"
+        $XdpVersions = $XdpJson.PSObject.Properties.Name
+        Write-Error "Unknown XDP version '$XdpVersion'. Available versions: $($XdpVersions -join ', ')"
     }
     $XdpArch = Get-XdpArch
     $XdpInstaller = $XdpEntry.PSObject.Properties[$XdpArch]
@@ -563,11 +583,6 @@ if ($ForBuild -or $ForContainerBuild) {
     Write-Host "Initializing clog submodule"
     git submodule init $RootDir/submodules/clog
 
-    if (!$IsLinux) {
-        Write-Host "Initializing XDP-for-Windows submodule"
-        git submodule init $RootDir/submodules/xdp-for-windows
-    }
-
     if ($Tls -eq "quictls") {
         Write-Host "Initializing quictls submodule"
         git submodule init $RootDir/submodules/quictls
@@ -584,6 +599,10 @@ if ($ForBuild -or $ForContainerBuild) {
     }
 
     git submodule update --jobs=8
+}
+
+if ($IsWindows -and $ForBuild -and !$ForKernel) {
+    Restore-NuGetPackages
 }
 
 if ($IsWindows -and $ForTest) {

--- a/scripts/templates/APKBUILD.template
+++ b/scripts/templates/APKBUILD.template
@@ -25,7 +25,7 @@ prepare() {
 	default_prepare
 
 	cd "$builddir/submodules"
-	rm -rf clog googletest quictls xdp-for-windows
+	rm -rf clog googletest quictls
 	mv ../../CLOG-*/ clog/
 	mv ../../googletest-*/ googletest/
 	mv ../../openssl-*/ quictls/

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -87,7 +87,7 @@ if ("${CX_PLATFORM}" STREQUAL "windows")
         msquic_platform
         PRIVATE
         ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES}
-        ${PROJECT_SOURCE_DIR}/submodules/xdp-for-windows/published/external)
+        ${XDP_INCLUDE_DIR})
 else()
     target_include_directories(msquic_platform PRIVATE ${EXTRA_PLATFORM_INCLUDE_DIRECTORIES})
 endif()

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(msquictest ${SOURCES})
 target_include_directories(msquictest PRIVATE ${PROJECT_SOURCE_DIR}/src/test)
 
 if (WIN32)
-    target_include_directories(msquictest PRIVATE ${PROJECT_SOURCE_DIR}/submodules/xdp-for-windows/published/external)
+    target_include_directories(msquictest PRIVATE ${XDP_INCLUDE_DIR})
 endif()
 
 set_property(TARGET msquictest PROPERTY FOLDER "${QUIC_FOLDER_PREFIX}tests")

--- a/src/tools/xdpmap/orchestrator/CMakeLists.txt
+++ b/src/tools/xdpmap/orchestrator/CMakeLists.txt
@@ -7,5 +7,4 @@ quic_tool_warnings(orchestrator)
 target_compile_definitions(orchestrator PRIVATE XDP_API_VERSION=3)
 target_include_directories(orchestrator PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_include_directories(orchestrator SYSTEM PRIVATE
-    ${PROJECT_SOURCE_DIR}/submodules/xdp-for-windows/published/external)
+target_include_directories(orchestrator SYSTEM PRIVATE ${XDP_INCLUDE_DIR})


### PR DESCRIPTION
## Description

Remove the XDP-for-Windows git submodule and consume the `Microsoft.XDP-for-Windows.Sdk` v1.4.0 NuGet package during Windows CMake configuration instead. The package URL and SHA-256 are pinned, and the fetched SDK headers are shared by the platform, tests, and XDP map orchestrator targets.

Remove the obsolete submodule setup, packaging, and workflow references.

## Testing

Built the full Debug x64 Schannel configuration, including `msquic_platform`, `msquictest`, and the XDP map orchestrator, without the XDP submodule.

## Documentation

Updated `docs/XDP.md` to distinguish the build-time SDK NuGet dependency from the runtime package used by tests.