### PR TITLE
Update downlevel tests

### DIFF
--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         vec: [
           # v2.5
-          { release: "2.5.9",  os: "ubuntu-24.04", arch: "x64", tls: "quictls" },
-          { release: "2.5.9",  os: "windows-2025", arch: "x64", tls: "schannel" },
-          { release: "2.5.9",  os: "windows-2025", arch: "x64", tls: "quictls"},
+          { release: "2.5.9",  os: "ubuntu-24.04", arch: "x64", config: "Release", tls: "quictls" },
+          { release: "2.5.9",  os: "windows-2025", arch: "x64", config: "Release", tls: "schannel" },
+          { release: "2.5.9",  os: "windows-2025", arch: "x64", config: "Release", tls: "quictls"},
           # v2.6
-          { release: "2.6.0",  os: "ubuntu-24.04", arch: "x64", tls: "quictls" },
-          { release: "2.6.0",  os: "windows-2025", arch: "x64", tls: "schannel" },
-          { release: "2.6.0",  os: "windows-2025", arch: "x64", tls: "quictls" },
+          { release: "2.6.0",  os: "ubuntu-24.04", arch: "x64", config: "Debug", tls: "quictls" },
+          { release: "2.6.0",  os: "windows-2025", arch: "x64", config: "Debug", tls: "schannel" },
+          { release: "2.6.0",  os: "windows-2025", arch: "x64", config: "Debug", tls: "quictls" },
         ]
     runs-on: ${{ matrix.vec.os }}
     name: Test
@@ -44,25 +44,25 @@ jobs:
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -DisableTest
       shell: pwsh
-    - name: Build Release
+    - name: Build
       shell: pwsh
-      run: scripts/build.ps1 -Config Release -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} ${{ runner.os != 'Windows' && '-UseSystemOpenSSLCrypto' || '' }} -DisableTest -DisableTools -DisablePerf ${{ matrix.vec.os == 'windows-2022' && '-Generator "Visual Studio 17 2022"' || '' }}
+      run: scripts/build.ps1 -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} ${{ runner.os != 'Windows' && '-UseSystemOpenSSLCrypto' || '' }} -DisableTest -DisableTools -DisablePerf
     - name: Download Tests
       shell: pwsh
       run: |
         $osName = "${{runner.os}}".ToLower()
-        Invoke-WebRequest -Uri "https://github.com/microsoft/msquic/releases/download/v${{matrix.vec.release}}/msquic_${{runner.os}}_${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}_test.zip" -OutFile "artifacts/test.zip"
-        Expand-Archive -Path artifacts/test.zip -DestinationPath artifacts/bin/$osName/${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}
+        Invoke-WebRequest -Uri "https://github.com/microsoft/msquic/releases/download/v${{matrix.vec.release}}/msquic_${{runner.os}}_${{matrix.vec.arch}}_${{matrix.vec.config}}_${{matrix.vec.tls}}_test.zip" -OutFile "artifacts/test.zip"
+        Expand-Archive -Path artifacts/test.zip -DestinationPath artifacts/bin/$osName/${{matrix.vec.arch}}_${{matrix.vec.config}}_${{matrix.vec.tls}}
     - name: Run Tests (Linux)
       if: runner.os == 'Linux'
       shell: pwsh
       run: |
-        chmod +x artifacts/bin/linux/${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}/msquictest
-        $env:LD_LIBRARY_PATH = Join-Path (Get-Location).Path "artifacts/bin/linux/${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}"
-        scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*CredValidation*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
+        chmod +x artifacts/bin/linux/${{matrix.vec.arch}}_${{matrix.vec.config}}_${{matrix.vec.tls}}/msquictest
+        $env:LD_LIBRARY_PATH = Join-Path (Get-Location).Path "artifacts/bin/linux/${{matrix.vec.arch}}_${{matrix.vec.config}}_${{matrix.vec.tls}}"
+        scripts/test.ps1 -AZP -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*CredValidation*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
     - name: Run Tests (Windows)
       if: runner.os == 'Windows'
-      run: scripts/test.ps1 -AZP -Config Release -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
+      run: scripts/test.ps1 -AZP -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
 
   Complete:
     name: Down Level Complete

--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -24,17 +24,14 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          # v2.3
-          { release: "2.3.11",  os: "ubuntu-22.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },
-          { release: "2.3.11",  os: "windows-2022", arch: "x64", tls: "schannel", imgtls: "schannel" },
-          { release: "2.3.11",  os: "windows-2022", arch: "x64", tls: "quictls", imgtls: "openssl3" },
-          # v2.4
-          { release: "2.4.10",  os: "ubuntu-22.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },
-          { release: "2.4.10",  os: "ubuntu-24.04", arch: "x64", tls: "quictls", imgtls: "openssl3" },
-          { release: "2.4.10",  os: "windows-2022", arch: "x64", tls: "schannel", imgtls: "schannel" },
-          { release: "2.4.10",  os: "windows-2022", arch: "x64", tls: "quictls", imgtls: "openssl3" },
-          { release: "2.4.10",  os: "windows-2025", arch: "x64", tls: "schannel", imgtls: "schannel" },
-          { release: "2.4.10",  os: "windows-2025", arch: "x64", tls: "quictls", imgtls: "openssl3" },
+          # v2.5
+          { release: "2.5.9",  os: "ubuntu-24.04", arch: "x64", tls: "quictls" },
+          { release: "2.5.9",  os: "windows-2025", arch: "x64", tls: "schannel" },
+          { release: "2.5.9",  os: "windows-2025", arch: "x64", tls: "quictls"},
+          # v2.6
+          { release: "2.6.0",  os: "ubuntu-24.04", arch: "x64", tls: "quictls" },
+          { release: "2.6.0",  os: "windows-2025", arch: "x64", tls: "schannel" },
+          { release: "2.6.0",  os: "windows-2025", arch: "x64", tls: "quictls" },
         ]
     runs-on: ${{ matrix.vec.os }}
     name: Test
@@ -54,7 +51,7 @@ jobs:
       shell: pwsh
       run: |
         $osName = "${{runner.os}}".ToLower()
-        Invoke-WebRequest -Uri "https://github.com/microsoft/msquic/releases/download/v${{matrix.vec.release}}/msquic_${{runner.os}}_${{matrix.vec.arch}}_Release_${{matrix.vec.imgtls}}_test.zip" -OutFile "artifacts/test.zip"
+        Invoke-WebRequest -Uri "https://github.com/microsoft/msquic/releases/download/v${{matrix.vec.release}}/msquic_${{runner.os}}_${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}_test.zip" -OutFile "artifacts/test.zip"
         Expand-Archive -Path artifacts/test.zip -DestinationPath artifacts/bin/$osName/${{matrix.vec.arch}}_Release_${{matrix.vec.tls}}
     - name: Run Tests (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
## Description

Update down-level tests:
- remove v2.3 and v2.4 as they are out of support (starting September for v2.4)
- add v2.5 and v2.6
- remove the imgtls flag since new test artifact have been named using "quictls"

## Testing

CI

## Documentation

N/A