### PR TITLE
Enable ML-KEM key shares on the OpenSSL TLS backend

### DIFF
--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -2555,18 +2555,6 @@ CxPlatTlsInitialize(
         goto Exit;
     }
 
-    //
-    // Both the fuzzer and the HandshakeSpecificLossPattern tests have some
-    // issues with larger key shares as introduced by ML-KEM support in openssl
-    // The former doesn't expect Client/Server hellos to span multiple udp datagrams
-    // and hits a buffer space assertion failure, while the latter times out on loss
-    // recovery.  So for now mimic the key shares that schannel offers to work around
-    // that
-    //
-    // TODO: Remove this when the above tests are tolerant of addition of ML-KEM keyshares
-    //
-    SSL_set1_groups_list(TlsContext->Ssl, "secp256r1:x25519");
-
     if (!SSL_set_quic_tls_cbs(TlsContext->Ssl, OpenSslQuicDispatch, NULL)) {
         QuicTraceEvent(
             TlsError,

--- a/src/tools/recvfuzz/recvfuzz.cpp
+++ b/src/tools/recvfuzz/recvfuzz.cpp
@@ -125,6 +125,7 @@ struct PacketParams {
     uint8_t SourceCid[20];
     QUIC_FRAME_TYPE FrameTypes[2];
     uint64_t LargestAcknowledge; // For ACK Frame
+    uint32_t CryptoOffset; // Bytes of the TLS output buffer already framed
 };
 
 class FuzzingData {
@@ -792,6 +793,18 @@ void WriteStreamFrame(
     *Offset += ActualDataLength;
 }
 
+bool FrameSetHasCrypto(
+    _In_ PacketParams* PacketParams
+    )
+{
+    for (int i = 0; i < PacketParams->NumFrames; i++) {
+        if (PacketParams->FrameTypes[i] == QUIC_FRAME_CRYPTO) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void WriteCryptoFrame(
     _Inout_ uint16_t* Offset,
     _In_ uint16_t BufferLength,
@@ -813,23 +826,43 @@ void WriteCryptoFrame(
         }
     }
 
+    //
+    // The TLS output buffer can be larger than a single datagram (an ML-KEM
+    // key share pushes the ClientHello/ServerHello past the UDP payload
+    // limit), so a single CxPlatTlsProcessData pass may need to be carried by
+    // several CRYPTO frames across several datagrams. Emit only the slice that
+    // fits in the room left in this packet, starting at the running crypto
+    // offset, and advance that offset. This mirrors QuicCryptoWriteOneFrame in
+    // the core datapath. BuildAndSend*HeaderPackets keeps allocating datagrams
+    // until the whole buffer has been framed.
+    //
+    uint32_t TotalLength = ClientContext->State.BufferLength;
+    if (PacketParams->CryptoOffset >= TotalLength) {
+        return;
+    }
+
+    uint16_t HeaderLength =
+        sizeof(uint8_t) + QuicVarIntSize(PacketParams->CryptoOffset);
+    if (BufferLength < *Offset + HeaderLength + 4) {
+        // Not enough room for a CRYPTO frame header plus a byte of payload.
+        return;
+    }
+
+    uint16_t Room = BufferLength - *Offset - HeaderLength;
+    Room -= QuicVarIntSize(Room); // Room for the length field itself.
+
+    uint32_t Remaining = TotalLength - PacketParams->CryptoOffset;
+    uint16_t FrameLength = (uint16_t)CXPLAT_MIN(Room, Remaining);
+
     QUIC_CRYPTO_EX Frame = {
-        0, ClientContext->State.BufferLength, ClientContext->State.Buffer
+        PacketParams->CryptoOffset,
+        FrameLength,
+        ClientContext->State.Buffer + PacketParams->CryptoOffset
     };
 
-    //
-    // TODO: The code in the recvfuzzer assumes that all data produced in
-    // a single pass through CxPlatTlsProcessData will fit in a udp datagram
-    // which is not the case with openssl when ML-KEM keyshares are offered.
-    // We should update this code to allow for the splitting of CRYPTO frames
-    // in the same way the core datapath does.  Until then, we disable ML-KEM
-    // for the fuzzer only (see corresponding TODO in tls_openssl.c
-    //
-    QuicCryptoFrameEncode(
-        &Frame,
-        Offset,
-        BufferLength,
-        Buffer);
+    if (QuicCryptoFrameEncode(&Frame, Offset, BufferLength, Buffer)) {
+        PacketParams->CryptoOffset += FrameLength;
+    }
 }
 
 void WriteFrames(
@@ -1057,6 +1090,16 @@ void BuildAndSendLongHeaderPackets(
     CXPLAT_SEND_DATA* SendData = CxPlatSendDataAlloc(Binding, &SendConfig);
     CXPLAT_FRE_ASSERT(SendData != nullptr);
 
+    //
+    // Each call frames the current TLS output buffer from the start: within a
+    // TLS encryption level the CRYPTO stream begins at offset 0, and a fresh
+    // buffer (e.g. the client's handshake-level Finished after the Initial
+    // ClientHello) is a new stream. The offset then accumulates across the
+    // datagrams allocated below so a buffer larger than one datagram is
+    // carried by several CRYPTO frames.
+    //
+    PacketParams->CryptoOffset = 0;
+
     uint8_t numPacketsSent = 0;
     while (!CxPlatSendDataIsFull(SendData) && numPacketsSent <= PacketParams->NumPackets) {
 
@@ -1116,6 +1159,17 @@ void BuildAndSendLongHeaderPackets(
         numPacketsSent++;
 
         if (!FuzzPacket) {
+            //
+            // The non-fuzz path sends exactly the frames it was asked to,
+            // except that a CRYPTO frame whose payload did not fit in one
+            // datagram (an ML-KEM ClientHello) must be continued across
+            // further datagrams until the whole TLS buffer has been framed.
+            //
+            if (FrameSetHasCrypto(PacketParams) &&
+                ClientContext != nullptr &&
+                PacketParams->CryptoOffset < ClientContext->State.BufferLength) {
+                continue;
+            }
             break;
         }
     }


### PR DESCRIPTION
### Description

The OpenSSL backend currently pins the TLS group list to `secp256r1:x25519` in `tls_openssl.c` to keep ML-KEM key shares off the wire. The pin's own `TODO` and #5116 explain why: a hybrid ClientHello/ServerHello grows past the UDP payload limit, and the `recvfuzz` tool assumed each TLS record produced by one `CxPlatTlsProcessData` pass fits in a single datagram, hitting a buffer-space assertion.

This PR fixes that assumption and removes the pin, so the OpenSSL backend offers **X25519MLKEM768 by default** (post-quantum hybrid key exchange), matching the SChannel backend's PQC direction (#5975).

### Changes

- **`src/tools/recvfuzz/recvfuzz.cpp`**: frame the TLS output the way the core datapath does (`QuicCryptoWriteOneFrame`). `WriteCryptoFrame` now emits only the slice that fits in the room left in the current packet, starting from a running crypto offset, and `BuildAndSendLongHeaderPackets` keeps allocating datagrams on the non-fuzz handshake path until the whole buffer is framed. The offset resets per send call, since each TLS encryption level's CRYPTO stream starts at offset 0.
- **`src/platform/tls_openssl.c`**: remove the `SSL_set1_groups_list(..., "secp256r1:x25519")` workaround.

### Testing

Built with the OpenSSL backend on Linux. With the pin removed and this fix in place, `recvfuzz` runs a full 20-second session (~30k datagrams) with the server receiving Initial and 1-RTT packets and **no assertion** — the multi-datagram ML-KEM ClientHello is now framed and accepted end to end.

Note: `recvfuzz` is Windows-only in CMake, so I built and ran it by temporarily enabling it on Linux (not part of this PR). The Windows fuzzer run and the XDP `HandshakeSpecificLossPatterns` tests (#5117) still need validation in CI. Per the discussion on #5117, recent handshake fixes (#5289) are believed to have already addressed the loss-recovery timeout; this PR does not touch that test's timeout.

Closes #5116. Refs #5117, #5975.