### PR TITLE
Clamp MinAckDelay to MaxAckDelay in local transport params

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2333,6 +2333,12 @@ QuicConnGenerateLocalTransportParameters(
         MsQuicLib.ExecutionConfig != NULL &&
         MsQuicLib.ExecutionConfig->PollingIdleTimeoutUs != 0 ?
             0 : MS_TO_US(MsQuicLib.TimerResolutionMs);
+    //
+    // Ensure the advertised MaxAckDelay is not below MinAckDelay.
+    //
+    if (LocalTP->MinAckDelay > MS_TO_US(LocalTP->MaxAckDelay)) {
+        LocalTP->MaxAckDelay = US_TO_MS_CEIL(LocalTP->MinAckDelay);
+    }
     LocalTP->ActiveConnectionIdLimit = QUIC_ACTIVE_CONNECTION_ID_LIMIT;
     LocalTP->Flags =
         QUIC_TP_FLAG_INITIAL_MAX_DATA |

--- a/src/inc/quic_platform.h
+++ b/src/inc/quic_platform.h
@@ -39,6 +39,7 @@ extern "C" {
 #define MS_TO_NS100(x)  ((x)*10000)
 #define NS100_TO_MS(x)  ((x)/10000)
 #define US_TO_MS(x)     ((x) / 1000)
+#define US_TO_MS_CEIL(x) (((x) + 999) / 1000)
 #define MS_TO_US(x)     ((x) * 1000)
 #define US_TO_S(x)      ((x) / (1000 * 1000))
 #define S_TO_US(x)      ((x) * 1000 * 1000)


### PR DESCRIPTION
When MaxAckDelayMs is 0 (delayed ACKs disabled), MaxAckDelay resolves to 0 while MinAckDelay is derived independently from the timer resolution and stays more than 0. This makes MsQuic advertise min_ack_delay > max_ack_delay, which trips a CXPLAT_DBG_ASSERT in QuicCryptoTlsEncodeTransportParameters in Debug builds and produces an invalid transport parameter (rejected by peers, including MsQuic) in Release builds.

Clamp MinAckDelay so it never exceeds MaxAckDelay. Surfaced by SpinQuic settings randomization coverage. 
Fixes: #6212 


