### PR TITLE
[CP] Fix path migration UAF: guard path promotion with InUse check (#6217)

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5458,7 +5458,7 @@ QuicConnRecvPostProcessing(
 
     if (Packet->HasNonProbingFrame &&
         Packet->NewLargestPacketNumber &&
-        !(*Path)->IsActive) {
+        !(*Path)->IsActive && (*Path)->InUse) {
         //
         // The peer has sent a non-probing frame on a path other than the active
         // one. This signals their intent to switch active paths.


### PR DESCRIPTION
## Description

Fixes a use-after-free in QUIC path migration where a stale/removed path could be promoted into Paths[0] during post-processing.

### Root Cause

When QuicConnReplaceRetiredCids is called during NEW_CONNECTION_ID frame processing, it may invoke QuicPathRemove, which frees the path. However, QuicConnRecvPostProcessing later attempts to promote that same path (via the *Path pointer) if it has non-probing frames and a new largest packet number — without verifying the path is still valid.

### Fix

Add a (*Path)->InUse check in QuicConnRecvPostProcessing before promoting a path to active. This ensures we never promote a path that has already been removed by QuicPathRemove.


## Testing

CI and validation on a repro of the issue

## Documentation

N/A
