### PR TITLE
Removed unnecessary Sanitizer

### DIFF
--- a/src/core/range.c
+++ b/src/core/range.c
@@ -248,7 +248,6 @@ QuicRangeGetRange(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _Success_(return != NULL)
 QUIC_SUBRANGE*
-QUIC_NO_SANITIZE("unsigned-integer-overflow")
 QuicRangeAddRange(
     _Inout_ QUIC_RANGE* Range,
     _In_ uint64_t Low,


### PR DESCRIPTION
## Description

Removes the `QUIC_NO_SANITIZE("unsigned-integer-overflow")` attribute from
`QuicRangeAddRange()` in `src/core/range.c`. 

This is no longer needed after this: https://github.com/microsoft/msquic/pull/5942

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
