### PR TITLE
Bump version to 2.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ message(STATUS "Platform version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(QUIC_MAJOR_VERSION 2)
-set(QUIC_FULL_VERSION 2.6.0)
+set(QUIC_FULL_VERSION 2.7.0)
 
 if (WIN32)
     set(CX_PLATFORM "windows")

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.6.0-beta"
+version = "2.7.0-beta"
 edition = "2021"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -24,7 +24,7 @@ $ArtifactsBinDir = Join-Path $BaseArtifactsDir "bin"
 # All direct subfolders are OS's
 $Platforms = Get-ChildItem -Path $ArtifactsBinDir
 
-$Version = "2.6.0"
+$Version = "2.7.0"
 
 $WindowsBuilds = @()
 $AllBuilds = @()

--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -153,7 +153,7 @@ $DistDir = Join-Path $BaseArtifactsDir "dist"
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
 $RepoRemote = Get-GitRemote -RepoDir $RootDir
 
-$Version = "2.6.0"
+$Version = "2.7.0"
 
 $BuildId = $env:BUILD_BUILDID
 if ($null -ne $BuildId) {

--- a/scripts/write-versions.ps1
+++ b/scripts/write-versions.ps1
@@ -26,7 +26,7 @@ $ArtifactsDir = $BuildConfig.ArtifactsDir
 $SourceVersion = $env:BUILD_SOURCEVERSION;
 $SourceBranch = $env:BUILD_SOURCEBRANCH;
 $BuildId = $env:BUILD_BUILDID;
-$VersionNumber = "2.6.0";
+$VersionNumber = "2.7.0";
 
 class BuildData {
     [string]$SourceVersion;

--- a/src/distribution/Info.plist
+++ b/src/distribution/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleVersion</key>
-    <string>2.6.0</string>
+    <string>2.7.0</string>
     <key>NSHumanReadableCopyright</key>
     <string>MIT</string>
     <key>CFBundleGetInfoString</key>

--- a/src/inc/msquic.ver
+++ b/src/inc/msquic.ver
@@ -8,7 +8,7 @@
 #endif
 
 #ifndef VER_MINOR
-#define VER_MINOR 6
+#define VER_MINOR 7
 #endif
 
 #ifndef VER_PATCH

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 2, "minor": 6, "patch": 0 }
+{ "major": 2, "minor": 7, "patch": 0 }


### PR DESCRIPTION
## Description

Bump the version on main from 2.6.0 to 2.7.0 following the creation of the release/2.6 branch and the v2.6.0 release.

## Testing

Ran the repository's update-version.ps1 script and verified all version surfaces were updated consistently.

## Documentation

No documentation impact. The v2.6 release table entry is already present in docs/Release.md.