### PR TITLE
Bump version to 2.4.20

### DIFF
--- a/.azure/OneBranch.Package.yml
+++ b/.azure/OneBranch.Package.yml
@@ -95,7 +95,7 @@ extends:
           ob_createvpack_owneralias: quicdev
           ob_createvpack_description: msquic.$(Build.SourceBranchName)
           ob_createvpack_versionAs: string
-          ob_createvpack_version: 2.4.19-$(Build.BuildId)
+          ob_createvpack_version: 2.4.20-$(Build.BuildId)
         steps:
         - task: DownloadPipelineArtifact@2
           inputs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ message(STATUS "Platform version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(QUIC_MAJOR_VERSION 2)
-set(QUIC_FULL_VERSION 2.4.19)
+set(QUIC_FULL_VERSION 2.4.20)
 
 if (WIN32)
     set(CX_PLATFORM "windows")

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic"
-version = "2.4.19-beta"
+version = "2.4.20-beta"
 edition = "2018"
 authors = ["Microsoft"]
 description = "Microsoft implementation of the IETF QUIC protocol"

--- a/scripts/package-distribution.ps1
+++ b/scripts/package-distribution.ps1
@@ -24,7 +24,7 @@ $ArtifactsBinDir = Join-Path $BaseArtifactsDir "bin"
 # All direct subfolders are OS's
 $Platforms = Get-ChildItem -Path $ArtifactsBinDir
 
-$Version = "2.4.19"
+$Version = "2.4.20"
 
 $WindowsBuilds = @()
 $AllBuilds = @()

--- a/scripts/package-nuget.ps1
+++ b/scripts/package-nuget.ps1
@@ -153,7 +153,7 @@ $DistDir = Join-Path $BaseArtifactsDir "dist"
 $CurrentCommitHash = Get-GitHash -RepoDir $RootDir
 $RepoRemote = Get-GitRemote -RepoDir $RootDir
 
-$Version = "2.4.19"
+$Version = "2.4.20"
 
 $BuildId = $env:BUILD_BUILDID
 if ($null -ne $BuildId) {

--- a/scripts/write-versions.ps1
+++ b/scripts/write-versions.ps1
@@ -26,7 +26,7 @@ $ArtifactsDir = $BuildConfig.ArtifactsDir
 $SourceVersion = $env:BUILD_SOURCEVERSION;
 $SourceBranch = $env:BUILD_SOURCEBRANCH;
 $BuildId = $env:BUILD_BUILDID;
-$VersionNumber = "2.4.19";
+$VersionNumber = "2.4.20";
 
 class BuildData {
     [string]$SourceVersion;

--- a/src/distribution/Info.plist
+++ b/src/distribution/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleVersion</key>
-    <string>2.4.19</string>
+    <string>2.4.20</string>
     <key>NSHumanReadableCopyright</key>
     <string>MIT</string>
     <key>CFBundleGetInfoString</key>

--- a/src/inc/msquic.ver
+++ b/src/inc/msquic.ver
@@ -12,7 +12,7 @@
 #endif
 
 #ifndef VER_PATCH
-#define VER_PATCH 19
+#define VER_PATCH 20
 #endif
 
 #ifndef VER_BUILD_ID

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 2, "minor": 4, "patch": 19 }
+{ "major": 2, "minor": 4, "patch": 20 }


### PR DESCRIPTION
## Description

Bump the patch version on release/2.4 from 2.4.19 to 2.4.20 to prepare for the next servicing release.

## Testing

Ran the repository's update-version.ps1 script with -Part Patch and verified all version surfaces were updated consistently.

## Documentation

No documentation impact.