### PR TITLE
Fix leak on ACK encryption-level mismatch in loss detection

### DIFF
--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1281,7 +1281,7 @@ QuicLossDetectionOnZeroRttRejected(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicLossDetectionProcessAckBlocks(
     _In_ QUIC_LOSS_DETECTION* LossDetection,
     _In_ QUIC_PATH* Path,
@@ -1293,6 +1293,7 @@ QuicLossDetectionProcessAckBlocks(
     _In_opt_ QUIC_ACK_ECN_EX* Ecn
     )
 {
+    BOOLEAN Result = TRUE;
     QUIC_SENT_PACKET_METADATA* AckedPackets = NULL;
     QUIC_SENT_PACKET_METADATA** AckedPacketsTail = &AckedPackets;
 
@@ -1330,10 +1331,11 @@ QuicLossDetectionProcessAckBlocks(
             QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
 
             //
-            // Earlier ACK blocks may have already moved packets into the
-            // AckedPackets list
+            // Earlier ACK blocks may have moved packets into AckedPackets, so
+            // go to cleanup. The connection is already being torn down.
             //
-            goto CleanupAckedPackets;
+            Result = FALSE;
+            goto Exit;
         }
 
         //
@@ -1450,7 +1452,7 @@ CheckSentPackets:
         //
         // Nothing was acknowledged, so we can exit now.
         //
-        return;
+        goto Exit;
     }
 
     uint64_t LargestAckedPacketNum = 0;
@@ -1473,12 +1475,8 @@ CheckSentPackets:
                 Connection,
                 "Incorrect ACK encryption level");
             *InvalidAckBlock = TRUE;
-
-            //
-            // These packets were already unlinked from the SentPackets/
-            // LostPackets lists, so return them to the (partition-owned) pool
-            //
-            goto CleanupAckedPackets;
+            Result = FALSE;
+            goto Exit;
         }
 
         uint64_t PacketRtt = CxPlatTimeDiff64(PacketMeta->SentTime, TimeNow);
@@ -1636,7 +1634,7 @@ CheckSentPackets:
 
     LossDetection->ProbeCount = 0;
 
-CleanupAckedPackets:
+Exit:
 
     AckedPacketsIterator = AckedPackets;
     while (AckedPacketsIterator != NULL) {
@@ -1645,11 +1643,9 @@ CleanupAckedPackets:
         QuicSentPacketPoolReturnPacketMetadata(PacketMeta, Connection);
     }
 
-    //
-    // At least one packet was ACKed. If all packets were ACKed then we'll
-    // cancel the timer; otherwise we'll reset the timer.
-    //
     QuicLossDetectionUpdateTimer(LossDetection, FALSE);
+
+    return Result;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1705,21 +1701,15 @@ QuicLossDetectionProcessAckFrame(
 
             AckDelay <<= Connection->PeerTransportParams.AckDelayExponent;
 
-            QuicLossDetectionProcessAckBlocks(
-                LossDetection,
-                Path,
-                Packet,
-                EncryptLevel,
-                AckDelay,
-                &Connection->DecodedAckRanges,
-                InvalidFrame,
-                FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL);
-
-            if (*InvalidFrame) {
-                //
-                // ProcessAckBlocks flagged the frame as invalid, so fail the
-                // frame here to have the connection torn down by the caller.
-                //
+            if (!QuicLossDetectionProcessAckBlocks(
+                    LossDetection,
+                    Path,
+                    Packet,
+                    EncryptLevel,
+                    AckDelay,
+                    &Connection->DecodedAckRanges,
+                    InvalidFrame,
+                    FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL)) {
                 Result = FALSE;
             }
         }

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1331,8 +1331,7 @@ QuicLossDetectionProcessAckBlocks(
 
             //
             // Earlier ACK blocks may have already moved packets into the
-            // AckedPackets list, so fall through to the shared cleanup to
-            // return them to the pool rather than leaking them.
+            // AckedPackets list
             //
             goto CleanupAckedPackets;
         }

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1328,7 +1328,13 @@ QuicLossDetectionProcessAckBlocks(
                 AckBlock->Low,
                 QuicRangeGetHigh(AckBlock));
             QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
-            return;
+
+            //
+            // Earlier ACK blocks may have already moved packets into the
+            // AckedPackets list, so fall through to the shared cleanup to
+            // return them to the pool rather than leaking them.
+            //
+            goto CleanupAckedPackets;
         }
 
         //
@@ -1473,13 +1479,7 @@ CheckSentPackets:
             // These packets were already unlinked from the SentPackets/
             // LostPackets lists, so return them to the (partition-owned) pool
             //
-            AckedPacketsIterator = AckedPackets;
-            while (AckedPacketsIterator != NULL) {
-                QUIC_SENT_PACKET_METADATA* LeakedPacket = AckedPacketsIterator;
-                AckedPacketsIterator = AckedPacketsIterator->Next;
-                QuicSentPacketPoolReturnPacketMetadata(LeakedPacket, Connection);
-            }
-            return;
+            goto CleanupAckedPackets;
         }
 
         uint64_t PacketRtt = CxPlatTimeDiff64(PacketMeta->SentTime, TimeNow);
@@ -1636,6 +1636,8 @@ CheckSentPackets:
     }
 
     LossDetection->ProbeCount = 0;
+
+CleanupAckedPackets:
 
     AckedPacketsIterator = AckedPackets;
     while (AckedPacketsIterator != NULL) {

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1332,7 +1332,7 @@ QuicLossDetectionProcessAckBlocks(
 
             //
             // Earlier ACK blocks may have moved packets into AckedPackets, so
-            // go to cleanup. The connection is already being torn down.
+            // go to cleanup.
             //
             Result = FALSE;
             goto Exit;

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1628,7 +1628,7 @@ Exit:
 
     if (!Result) {
         //
-        // An invalid ACK block was detected; fail the connection.
+        // A protocol violation was detected; fail the connection.
         //
         QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
     }

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1289,7 +1289,6 @@ QuicLossDetectionProcessAckBlocks(
     _In_ QUIC_ENCRYPT_LEVEL EncryptLevel,
     _In_ uint64_t AckDelay,
     _In_ QUIC_RANGE* AckBlocks,
-    _Out_ BOOLEAN* InvalidAckBlock,
     _In_opt_ QUIC_ACK_ECN_EX* Ecn
     )
 {
@@ -1305,8 +1304,6 @@ QuicLossDetectionProcessAckBlocks(
     BOOLEAN NewLargestAckRetransmittable = FALSE;
     BOOLEAN NewLargestAckDifferentPath = FALSE;
     uint64_t NewLargestAckTimestamp = 0;
-
-    *InvalidAckBlock = FALSE;
 
     QUIC_SENT_PACKET_METADATA** LostPacketsStart = &LossDetection->LostPackets;
     QUIC_SENT_PACKET_METADATA** SentPacketsStart = &LossDetection->SentPackets;
@@ -1328,12 +1325,6 @@ QuicLossDetectionProcessAckBlocks(
                 Connection->Send.SkippedPacketNumber,
                 AckBlock->Low,
                 QuicRangeGetHigh(AckBlock));
-            QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
-
-            //
-            // Earlier ACK blocks may have moved packets into AckedPackets, so
-            // go to cleanup.
-            //
             Result = FALSE;
             goto Exit;
         }
@@ -1474,7 +1465,6 @@ CheckSentPackets:
                 "[conn][%p] ERROR, %s.",
                 Connection,
                 "Incorrect ACK encryption level");
-            *InvalidAckBlock = TRUE;
             Result = FALSE;
             goto Exit;
         }
@@ -1636,13 +1626,23 @@ CheckSentPackets:
 
 Exit:
 
+    if (!Result) {
+        //
+        // An invalid ACK block was detected; fail the connection.
+        //
+        QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+    }
+
     AckedPacketsIterator = AckedPackets;
     while (AckedPacketsIterator != NULL) {
         QUIC_SENT_PACKET_METADATA* PacketMeta = AckedPacketsIterator;
         AckedPacketsIterator = AckedPacketsIterator->Next;
         QuicSentPacketPoolReturnPacketMetadata(PacketMeta, Connection);
     }
-
+    //
+    // At least one packet was ACKed. If all packets were ACKed then we'll
+    // cancel the timer; otherwise we'll reset the timer.
+    //
     QuicLossDetectionUpdateTimer(LossDetection, FALSE);
 
     return Result;
@@ -1708,7 +1708,6 @@ QuicLossDetectionProcessAckFrame(
                     EncryptLevel,
                     AckDelay,
                     &Connection->DecodedAckRanges,
-                    InvalidFrame,
                     FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL)) {
                 Result = FALSE;
             }

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1468,6 +1468,20 @@ CheckSentPackets:
                 Connection,
                 "Incorrect ACK encryption level");
             *InvalidAckBlock = TRUE;
+
+            //
+            // These packets have already been unlinked from the SentPackets and
+            // LostPackets lists, so the whole AckedPackets list must be returned
+            // to the pool here. Otherwise the metadata (and the resources held
+            // by its frames) would leak, since the pool is owned by the
+            // partition and is not reclaimed when the connection is destroyed.
+            //
+            AckedPacketsIterator = AckedPackets;
+            while (AckedPacketsIterator != NULL) {
+                QUIC_SENT_PACKET_METADATA* LeakedPacket = AckedPacketsIterator;
+                AckedPacketsIterator = AckedPacketsIterator->Next;
+                QuicSentPacketPoolReturnPacketMetadata(LeakedPacket, Connection);
+            }
             return;
         }
 
@@ -1702,6 +1716,15 @@ QuicLossDetectionProcessAckFrame(
                 &Connection->DecodedAckRanges,
                 InvalidFrame,
                 FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL);
+
+            if (*InvalidFrame) {
+                //
+                // The ACK acknowledged a packet with a different encryption
+                // level than the frame, which is a protocol violation. Fail the
+                // frame so the connection is torn down by the caller.
+                //
+                Result = FALSE;
+            }
         }
     }
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1470,11 +1470,8 @@ CheckSentPackets:
             *InvalidAckBlock = TRUE;
 
             //
-            // These packets have already been unlinked from the SentPackets and
-            // LostPackets lists, so the whole AckedPackets list must be returned
-            // to the pool here. Otherwise the metadata (and the resources held
-            // by its frames) would leak, since the pool is owned by the
-            // partition and is not reclaimed when the connection is destroyed.
+            // These packets were already unlinked from the SentPackets/
+            // LostPackets lists, so return them to the (partition-owned) pool
             //
             AckedPacketsIterator = AckedPackets;
             while (AckedPacketsIterator != NULL) {
@@ -1719,9 +1716,8 @@ QuicLossDetectionProcessAckFrame(
 
             if (*InvalidFrame) {
                 //
-                // The ACK acknowledged a packet with a different encryption
-                // level than the frame, which is a protocol violation. Fail the
-                // frame so the connection is torn down by the caller.
+                // ProcessAckBlocks flagged the frame as invalid, so fail the
+                // frame here to have the connection torn down by the caller.
                 //
                 Result = FALSE;
             }


### PR DESCRIPTION
## Description
`QuicLossDetectionProcessAckBlocks` moves acknowledged packets out of the
`SentPackets`/`LostPackets` lists into a local `AckedPackets` list *before*
validating that each packet's encryption level matches the ACK frame's level.
On a mismatch it returned early without returning the already-unlinked packets
to the pool, leaking their metadata and the resources held by their frames.

Fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/62826410

## Testing

NA
## Documentation

NA