### PR TITLE
[CP] Avoid receive socket for connection pool tuple lookup (#6235)

### DIFF
--- a/src/core/connection_pool.c
+++ b/src/core/connection_pool.c
@@ -172,31 +172,6 @@ QuicConnPoolAllocServerNameCopy(
 static
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
-QuicConnPoolGetStartingLocalAddress(
-    _In_ QUIC_ADDR* RemoteAddress,
-    _Out_ QUIC_ADDR* LocalAddress,
-    _In_ CXPLAT_SOCKET_FLAGS SocketFlags
-    )
-{
-    CXPLAT_SOCKET* Socket = NULL;
-    CXPLAT_UDP_CONFIG UdpConfig;
-    CxPlatZeroMemory(&UdpConfig, sizeof(UdpConfig));
-    UdpConfig.Flags = SocketFlags;
-    UdpConfig.RemoteAddress = RemoteAddress;
-    QUIC_STATUS Status =
-        CxPlatSocketCreateUdp(MsQuicLib.Datapath, &UdpConfig, &Socket);
-    if (QUIC_SUCCEEDED(Status)) {
-        CXPLAT_DBG_ASSERT(Socket != NULL);
-        CxPlatSocketGetLocalAddress(Socket, LocalAddress);
-        CxPlatSocketDelete(Socket);
-    }
-
-    return Status;
-}
-
-static
-_IRQL_requires_max_(PASSIVE_LEVEL)
-QUIC_STATUS
 QuicConnPoolGetInterfaceIndexForLocalAddress(
     _In_ QUIC_ADDR* LocalAddress,
     _Out_ uint32_t* InterfaceIndex
@@ -547,41 +522,8 @@ MsQuicConnectionPoolCreate(
 
     QuicAddrSetPort(&ResolvedRemoteAddress, Config->ServerPort);
 
-    //
-    // Copying how Connection Settings flow downwards. It will first inherit the global settings,
-    // if a global setting field is not set, but the configuration setting is set, override the global.
-    //
-    QUIC_CONFIGURATION* ConnectionConfig =
-        (QUIC_CONFIGURATION*)Config->Configuration;
-    CXPLAT_SOCKET_FLAGS SocketFlags = CXPLAT_SOCKET_FLAG_NONE;
-
-    if (MsQuicLib.Settings.XdpEnabled) {
-        SocketFlags |= CXPLAT_SOCKET_FLAG_XDP;
-    }
-    if (ConnectionConfig->Settings.IsSet.XdpEnabled) {
-        if (ConnectionConfig->Settings.XdpEnabled) {
-            SocketFlags |= CXPLAT_SOCKET_FLAG_XDP;
-        } else {
-            SocketFlags &= ~CXPLAT_SOCKET_FLAG_XDP;
-        }
-    }
-
-    if (MsQuicLib.Settings.QTIPEnabled) {
-        SocketFlags |= CXPLAT_SOCKET_FLAG_QTIP;
-    }
-    if (ConnectionConfig->Settings.IsSet.QTIPEnabled) {
-        if (ConnectionConfig->Settings.QTIPEnabled) {
-            SocketFlags |= CXPLAT_SOCKET_FLAG_QTIP;
-        } else {
-            SocketFlags &= ~CXPLAT_SOCKET_FLAG_QTIP;
-        }
-    }
-
-    //
-    // Get the local address and a port to start from.
-    //
     QUIC_ADDR LocalAddress;
-    Status = QuicConnPoolGetStartingLocalAddress(&ResolvedRemoteAddress, &LocalAddress, SocketFlags);
+    Status = CxPlatDataPathGetLocalAddressForRemote(&ResolvedRemoteAddress, &LocalAddress);
     if (QUIC_FAILED(Status)) {
         goto Error;
     }

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -596,6 +596,17 @@ CxPlatDataPathGetLocalAddresses(
     );
 
 //
+// Get a local address that would be used to reach a given remote address.
+// Currently only used by the connection pool.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatDataPathGetLocalAddressForRemote(
+    _In_ const QUIC_ADDR* RemoteAddress,
+    _Out_ QUIC_ADDR* LocalAddress
+    );
+
+//
 // Gets the list of Gateway server addresses.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/platform/datapath_unix.c
+++ b/src/platform/datapath_unix.c
@@ -37,6 +37,18 @@ CxPlatDataPathGetLocalAddresses(
     return QUIC_STATUS_NOT_SUPPORTED;
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatDataPathGetLocalAddressForRemote(
+    _In_ const QUIC_ADDR* RemoteAddress,
+    _Out_ QUIC_ADDR* LocalAddress
+    )
+{
+    UNREFERENCED_PARAMETER(RemoteAddress);
+    UNREFERENCED_PARAMETER(LocalAddress);
+    return QUIC_STATUS_NOT_SUPPORTED;
+}
+
 QUIC_STATUS
 CxPlatDataPathGetGatewayAddresses(
     _In_ CXPLAT_DATAPATH* Datapath,

--- a/src/platform/datapath_winkernel.c
+++ b/src/platform/datapath_winkernel.c
@@ -1021,6 +1021,18 @@ Error:
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatDataPathGetLocalAddressForRemote(
+    _In_ const QUIC_ADDR* RemoteAddress,
+    _Out_ QUIC_ADDR* LocalAddress
+    )
+{
+    UNREFERENCED_PARAMETER(RemoteAddress);
+    UNREFERENCED_PARAMETER(LocalAddress);
+    return QUIC_STATUS_NOT_SUPPORTED;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 _Success_(QUIC_SUCCEEDED(return))
 QUIC_STATUS
 CxPlatDataPathGetGatewayAddresses(

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -972,6 +972,40 @@ Exit:
     return Status;
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_STATUS
+CxPlatDataPathGetLocalAddressForRemote(
+    _In_ const QUIC_ADDR* RemoteAddress,
+    _Out_ QUIC_ADDR* LocalAddress
+    )
+{
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+    SOCKET Socket = socket(RemoteAddress->si_family, SOCK_DGRAM, IPPROTO_UDP);
+    if (Socket == INVALID_SOCKET) {
+        return HRESULT_FROM_WIN32(WSAGetLastError());
+    }
+
+    const int RemoteAddressLength =
+        RemoteAddress->si_family == AF_INET ?
+            sizeof(RemoteAddress->Ipv4) :
+            sizeof(RemoteAddress->Ipv6);
+    if (connect(Socket, (PSOCKADDR)RemoteAddress, RemoteAddressLength) == SOCKET_ERROR) {
+        Status = HRESULT_FROM_WIN32(WSAGetLastError());
+        goto Error;
+    }
+
+    CxPlatZeroMemory(LocalAddress, sizeof(*LocalAddress));
+    int LocalAddressLength = sizeof(*LocalAddress);
+    if (getsockname(Socket, (PSOCKADDR)LocalAddress, &LocalAddressLength) == SOCKET_ERROR) {
+        Status = HRESULT_FROM_WIN32(WSAGetLastError());
+        goto Error;
+    }
+
+Error:
+    closesocket(Socket);
+    return Status;
+}
+
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Success_(QUIC_SUCCEEDED(return))


### PR DESCRIPTION
## Description

Connection pools were obtaining the local address by creating a temporary CXPLAT_SOCKET. However, the receive callback for CXPLAT_SOCKET is globally registered and it *requires* a valid binding: if a datagram happens to arrive on the socket/port for this temporary socket, it would cause a null pointer dereference.

This PR replace the temporary MsQuic datapath socket used by connection-pool setup with a native UDP route query. This obtains the route-selected local address and an ephemeral starting port without registering receive callbacks with a null binding context.

Fix #6063.

## Testing

- Clean Windows x64 Debug Schannel build
- `*ConnectionPool*` test filter (13 tests)

## Documentation

No documentation impact.
