### PR TITLE
[CP] Fix uint32 overflow in receive buffer growth (#6226)

### DIFF
--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -830,20 +830,20 @@ QuicStreamOnBytesDelivered(
                 //
 
                 uint64_t NewLength = (uint64_t)Stream->RecvBuffer.VirtualBufferLength * 2;
-                NewLength = CXPLAT_MIN(NewLength, UINT32_MAX);
+                if (NewLength <= UINT32_MAX) {
+                    QuicRecvBufferIncreaseVirtualBufferLength(
+                        &Stream->RecvBuffer,
+                        (uint32_t)NewLength);
 
-                QuicRecvBufferIncreaseVirtualBufferLength(
-                    &Stream->RecvBuffer,
-                    (uint32_t)NewLength);
-
-                QuicTraceLogStreamVerbose(
-                    IncreaseRxBuffer,
-                    Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    (uint32_t)NewLength,
-                    Stream->Connection->Paths[0].MinRtt,
-                    TimeNow,
-                    Stream->RecvWindowLastUpdate);
+                    QuicTraceLogStreamVerbose(
+                        IncreaseRxBuffer,
+                        Stream,
+                        "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
+                        (uint32_t)NewLength,
+                        Stream->Connection->Paths[0].MinRtt,
+                        TimeNow,
+                        Stream->RecvWindowLastUpdate);
+                }
             }
         }
 

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -357,13 +357,13 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
 // Decoder Ring for IncreaseRxBuffer
 // [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
-                    IncreaseRxBuffer,
-                    Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    (uint32_t)NewLength,
-                    Stream->Connection->Paths[0].MinRtt,
-                    TimeNow,
-                    Stream->RecvWindowLastUpdate);
+                        IncreaseRxBuffer,
+                        Stream,
+                        "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
+                        (uint32_t)NewLength,
+                        Stream->Connection->Paths[0].MinRtt,
+                        TimeNow,
+                        Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -356,13 +356,13 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
 // Decoder Ring for IncreaseRxBuffer
 // [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
-                    IncreaseRxBuffer,
-                    Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    (uint32_t)NewLength,
-                    Stream->Connection->Paths[0].MinRtt,
-                    TimeNow,
-                    Stream->RecvWindowLastUpdate);
+                        IncreaseRxBuffer,
+                        Stream,
+                        "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
+                        (uint32_t)NewLength,
+                        Stream->Connection->Paths[0].MinRtt,
+                        TimeNow,
+                        Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4


### PR DESCRIPTION
## Description

Cap internally-managed stream receive buffers at 0x80000000 during
auto-tuning and compute buffer growth in 64-bit, rejecting sizes above
UINT32_MAX. This prevents a uint32 wrap that could spin the growth loop
forever when a very large ConnFlowControlWindow is configured. App-owned
mode behavior is unchanged.

Fixes https://dev.azure.com/microsoft/OS/_workitems/edit/62826267/

## Testing

Added RecvBufferGrowthTest.WriteGrowthOverflow to cover the overflow
boundary. Existing recv buffer tests pass.

## Documentation

NA


<!-- Companion PR for release/2.6: #6247 -->
