### PR TITLE
Don't set DATA send flag for zero-length send requests

### DIFF
--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -652,12 +652,21 @@ QuicStreamSendFlush(
                 0);
         }
 
-        QuicSendSetStreamSendFlag(
-            &Stream->Connection->Send,
-            Stream,
-            QUIC_STREAM_SEND_FLAG_DATA,
-            !!(SendRequest->Flags & QUIC_SEND_FLAG_DELAY_SEND));
+        // A send request with no data and no FIN has nothing to write. Setting
+        // the DATA flag here would leave it set with nothing to clear it, since
+        // the flag is only cleared when stream frames are actually written. That
+        // blocks the flush for every subsequent send on this stream. The FIN case
+        // is handled above by QuicStreamSendShutdown, which sets
+        // QUIC_STREAM_SEND_FLAG_FIN directly.
+        
 
+        if (SendRequest->TotalLength != 0) {
+            QuicSendSetStreamSendFlag(
+                &Stream->Connection->Send,
+                Stream,
+                QUIC_STREAM_SEND_FLAG_DATA,
+                !!(SendRequest->Flags & QUIC_SEND_FLAG_DELAY_SEND));
+        }
         if (Stream->Connection->Settings.SendBufferingEnabled) {
             QuicSendBufferFill(Stream->Connection);
         }

--- a/src/core/stream_send.c
+++ b/src/core/stream_send.c
@@ -1221,7 +1221,18 @@ QuicStreamSendWrite(
         } else {
             RanOutOfRoom = TRUE;
         }
+    } else if ((Stream->SendFlags & QUIC_STREAM_SEND_FLAG_DATA) &&
+               !QuicStreamHasPendingStreamData(Stream)) {
+        //
+        // The DATA flag is set but there is nothing queued to write. Clear it
+        // here so a stale flag doesn't suppress QuicSendQueueFlushForStream for
+        // subsequent sends. QuicStreamHasPendingStreamData compares send
+        // offsets only, so this does not fire when data is pending but blocked
+        // by flow control or by the peer not yet allowing the stream.
+        //
+        Stream->SendFlags &= ~QUIC_STREAM_SEND_FLAG_DATA;
     }
+    
 
     if (Stream->SendFlags & QUIC_STREAM_SEND_FLAG_DATA_BLOCKED) {
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -849,6 +849,10 @@ QuicTestAbortReceive_Incomplete(
 void
 QuicTestSlowReceive(
     );
+        
+void
+QuicTestStreamZeroLengthSend(
+    );
 
 void
 QuicTestNthAllocFail(

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -2778,6 +2778,15 @@ TEST(Misc, SlowReceive) {
     }
 }
 
+TEST(Misc, StreamZeroLengthSend) {
+    TestLogger Logger("StreamZeroLengthSend");
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestStreamZeroLengthSend)));
+    } else {
+        QuicTestStreamZeroLengthSend();
+    }
+}
+
 #ifdef QUIC_TEST_ALLOC_FAILURES_ENABLED
 #ifndef QUIC_TEST_OPENSSL_FLAGS // Not supported on OpenSSL
 TEST(Misc, NthAllocFail) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -618,6 +618,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestAbortReceive_Pending);
     RegisterTestFunction(QuicTestAbortReceive_Incomplete);
     RegisterTestFunction(QuicTestSlowReceive);
+    RegisterTestFunction(QuicTestStreamZeroLengthSend);
 #ifndef QUIC_DISABLE_0RTT_TESTS
     RegisterTestFunction(QuicTestConnectAndPing_Send0Rtt);
     RegisterTestFunction(QuicTestConnectAndPing_Reject0Rtt);

--- a/src/test/lib/DataTest.cpp
+++ b/src/test/lib/DataTest.cpp
@@ -3000,6 +3000,116 @@ QuicTestSlowReceive(
     TEST_TRUE(Context.ServerStreamHasShutdown);
 }
 
+struct ZeroLengthSendTestContext {
+    CxPlatEvent ClientFirstRecvPended;
+    CxPlatEvent ClientReindicated;
+    CxPlatEvent ServerGotSecond;
+    MsQuicStream* ClientStream {nullptr};
+    bool PendNextReceive {true};
+
+    static QUIC_STATUS ServerStreamCallback(_In_ MsQuicStream* Stream, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (ZeroLengthSendTestContext*)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_RECEIVE) {
+            uint64_t Length = Event->RECEIVE.TotalBufferLength;
+            if (Length == 11) {
+                TestContext->ServerGotSecond.Set();
+            } else if (Length == 15) {
+                //
+                // Echo the first payload back so the client can pend it.
+                //
+                static uint8_t EchoBuffer[15];
+                static QUIC_BUFFER Echo { 15, EchoBuffer };
+                Stream->Send(&Echo, 1, QUIC_SEND_FLAG_NONE);
+            }
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ClientStreamCallback(_In_ MsQuicStream*, _In_opt_ void* Context, _Inout_ QUIC_STREAM_EVENT* Event) {
+        auto TestContext = (ZeroLengthSendTestContext*)Context;
+        if (Event->Type == QUIC_STREAM_EVENT_RECEIVE) {
+            if (TestContext->PendNextReceive) {
+                TestContext->PendNextReceive = false;
+                TestContext->ClientFirstRecvPended.Set();
+                return QUIC_STATUS_PENDING;
+            }
+            TestContext->ClientReindicated.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS ConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            new(std::nothrow) MsQuicStream(Event->PEER_STREAM_STARTED.Stream, CleanUpAutoDelete, ServerStreamCallback, Context);
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+
+void
+QuicTestStreamZeroLengthSend(
+    void
+    )
+{
+    //
+    // A zero-length send with no FIN must not prevent subsequent sends on the
+    // stream from being transmitted. Regression test for #6243.
+    //
+    MsQuicRegistration Registration;
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", MsQuicSettings().SetPeerBidiStreamCount(1), ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    ZeroLengthSendTestContext Context;
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, ZeroLengthSendTestContext::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest"));
+    QuicAddr ServerLocalAddr;
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+
+    MsQuicStream Stream(Connection, QUIC_STREAM_OPEN_FLAG_NONE, CleanUpManual, ZeroLengthSendTestContext::ClientStreamCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Stream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+
+    uint8_t RawBuffer[100];
+
+    //
+    // Send data and wait for the echo to be pended by the client.
+    //
+    QUIC_BUFFER FirstBuffer { 15, RawBuffer };
+    TEST_QUIC_SUCCEEDED(Stream.Send(&FirstBuffer, 1, QUIC_SEND_FLAG_NONE));
+    TEST_TRUE(Context.ClientFirstRecvPended.WaitTimeout(TestWaitTimeout));
+
+    //
+    // Complete the pended receive with zero bytes consumed, then issue a
+    // zero-length send and let the connection go quiescent.
+    //
+    TEST_QUIC_SUCCEEDED(Stream.ReceiveSetEnabled(TRUE));
+    Stream.ReceiveComplete(0);
+
+    QUIC_BUFFER EmptyBuffer { 0, RawBuffer };
+    TEST_QUIC_SUCCEEDED(Stream.Send(&EmptyBuffer, 1, QUIC_SEND_FLAG_NONE));
+
+    TEST_TRUE(Context.ClientReindicated.WaitTimeout(TestWaitTimeout));
+    CxPlatSleep(1000);
+
+    //
+    // Subsequent data must still reach the peer.
+    //
+    QUIC_BUFFER SecondBuffer { 11, RawBuffer };
+    TEST_QUIC_SUCCEEDED(Stream.Send(&SecondBuffer, 1, QUIC_SEND_FLAG_NONE));
+    TEST_TRUE(Context.ServerGotSecond.WaitTimeout(TestWaitTimeout));
+}
+
 struct NthAllocFailTestContext {
     CxPlatEvent ServerStreamRecv;
     CxPlatEvent ServerStreamShutdown;


### PR DESCRIPTION
## Fixes #6243.
1. The change:  skip QuicSendSetStreamSendFlag(..., QUIC_STREAM_SEND_FLAG_DATA, ...) in QuicStreamSendFlush when SendRequest->TotalLength == 0.

2. Why this option over the other two in the issue: clearing DATA when a flush finds nothing sendable would also fire when the peer hasn't allowed the stream or when flow control blocks it, QuicStreamSendCanWriteDataFrames treats those as separate branches from "no unsent data" , so that fix would wedge streams a different way. Rejecting zero-length sends outright changes public API behavior.

3. FIN is unaffected: QuicStreamSendShutdown sets QUIC_STREAM_SEND_FLAG_FIN directly on the graceful path, so a zero-length send with FIN still works.

4. Verified: repro from the issue reproduces on 4984c210f (2.7.0), PASS after the fix, SKIP_EMPTY_SEND=1 still PASS, and SEND_COMPLETE still fires for the zero-length request.

**Update:** added a regression test and a second guard.

1. Guard 1 (above) skips setting DATA for zero-length requests in
`QuicStreamSendFlush`.

2. Guard 2 clears a stale DATA flag in the stream write path when the flag is
set but `QuicStreamHasPendingStreamData` returns false. This is the third
option from the issue, but keyed on `QuicStreamHasPendingStreamData` rather
than `QuicStreamSendCanWriteDataFrames` — the former compares send offsets
only, so it doesn't fire when data is pending but blocked by flow control or
by the peer not yet allowing the stream. That's the concern raised in point 2
above.

3. Regression test `Misc.StreamZeroLengthSend` fails on main at 4984c21 and
passes with the fix. Each guard breaks the wedge independently, verified by
disabling one at a time.
