### PR TITLE
Regenerate CLOG sidecar for recv buffer growth fix (#6226)

### DIFF
--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -357,13 +357,13 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
 // Decoder Ring for IncreaseRxBuffer
 // [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
-                    IncreaseRxBuffer,
-                    Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    (uint32_t)NewLength,
-                    Stream->Connection->Paths[0].MinRtt,
-                    TimeNow,
-                    Stream->RecvWindowLastUpdate);
+                        IncreaseRxBuffer,
+                        Stream,
+                        "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
+                        (uint32_t)NewLength,
+                        Stream->Connection->Paths[0].MinRtt,
+                        TimeNow,
+                        Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -356,13 +356,13 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
 // Decoder Ring for IncreaseRxBuffer
 // [strm][%p] Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)
 // QuicTraceLogStreamVerbose(
-                    IncreaseRxBuffer,
-                    Stream,
-                    "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
-                    (uint32_t)NewLength,
-                    Stream->Connection->Paths[0].MinRtt,
-                    TimeNow,
-                    Stream->RecvWindowLastUpdate);
+                        IncreaseRxBuffer,
+                        Stream,
+                        "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
+                        (uint32_t)NewLength,
+                        Stream->Connection->Paths[0].MinRtt,
+                        TimeNow,
+                        Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
 // arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4


### PR DESCRIPTION
## Description

PR #6226 fixed a uint32 overflow in receive buffer growth by wrapping the `IncreaseRxBuffer` trace call in an overflow-guard `if` block in `src/core/stream_recv.c`. That re-indented the trace call, but the CLOG sidecar was not regenerated. CLOG's decoder-ring comments capture each trace call's verbatim source (including indentation), so the generated files were left stale and `check-clog` fails on `main`.

This PR regenerates the sidecar (`update-sidecar.ps1`). No trace name, format string, or arguments changed - only the captured indentation in the generated `stream_recv.c.clog.h` and `.lttng.h` decoder-ring comments.

## Testing

Ran `./scripts/update-sidecar.ps1`; the only resulting diff is the two `stream_recv` generated files. `check-clog` should now pass.

## Documentation

No documentation impact.