### PR TITLE
skip port reuse for dynamic listeners

### DIFF
--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -443,7 +443,9 @@ DEFINE_ENUM_FLAG_OPERATORS(CXPLAT_DATAPATH_FEATURES)
 typedef enum CXPLAT_SOCKET_FLAGS {
     CXPLAT_SOCKET_FLAG_NONE         = 0x00000000,
     CXPLAT_SOCKET_FLAG_PCP          = 0x00000001, // Socket is used for internal PCP support
-    CXPLAT_SOCKET_FLAG_SHARE        = 0x00000002, // Forces sharing of the address and port
+    CXPLAT_SOCKET_FLAG_SHARE        = 0x00000002, // Forces sharing unless the datapath keeps
+                                                  // a dynamically assigned partitioned listener
+                                                  // port exclusive.
     CXPLAT_SOCKET_SERVER_OWNED      = 0x00000004, // Indicates socket is a listener socket
     CXPLAT_SOCKET_FLAG_XDP          = 0x00000008, // Socket will use XDP
     CXPLAT_SOCKET_FLAG_QTIP         = 0x00000010, // Socket will use QTIP

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -723,7 +723,9 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
+        // Non-partitioned listeners need SO_REUSEPORT for their per-processor
+        // sockets. Dynamic partitioned listeners keep their assigned port exclusive,
+        // while connected sockets enable reuse only when explicitly sharing.
         //
         if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -723,6 +723,9 @@ CxPlatSocketContextInitialize(
         }
 
         //
+        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
+        // assigned a server port (unless it's forcing sharing).
+        //
         // Dynamic partitioned listeners use a single socket here, so keep their
         // assigned port exclusive. io_uring retains SO_REUSEPORT because it creates
         // per-processor sockets for partitioned listeners.

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -439,10 +439,6 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
-    const BOOLEAN IsDynamicPartitionedListener =
-        Config->RemoteAddress == NULL &&
-        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
-        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -723,9 +719,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
+        // Only set SO_REUSEPORT when the listening port isn't dynamic.
         //
-        if (!IsDynamicPartitionedListener &&
+        if ((Config->RemoteAddress != NULL ||
+                Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0) &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -439,6 +439,10 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
+    const BOOLEAN IsDynamicPartitionedListener =
+        Config->RemoteAddress == NULL &&
+        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
+        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -719,12 +723,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Multi-socket bindings need SO_REUSEPORT to bind the same port.
+        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
         //
-        if (((Config->RemoteAddress != NULL && (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE)) ||
-                (Config->RemoteAddress == NULL &&
-                    (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0 ||
-                        SocketContext->Binding->NumPerProcessorSockets))) &&
+        if (!IsDynamicPartitionedListener &&
+            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -723,14 +723,15 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // With multiple datapath partitions, server sockets use SO_REUSEPORT except
-        // for dynamic partitioned listeners; clients use it only when sharing.
+        // Dynamic partitioned listeners use a single socket here, so keep their
+        // assigned port exclusive. io_uring retains SO_REUSEPORT because it creates
+        // per-processor sockets for partitioned listeners.
         //
         if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
-            // Enable port sharing.
+            // The port is shared across processors.
             //
             Option = TRUE;
             Result =

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -723,15 +723,14 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Non-partitioned listeners need SO_REUSEPORT for their per-processor
-        // sockets. Dynamic partitioned listeners keep their assigned port exclusive,
-        // while connected sockets enable reuse only when explicitly sharing.
+        // With multiple datapath partitions, server sockets use SO_REUSEPORT except
+        // for dynamic partitioned listeners; clients use it only when sharing.
         //
         if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
-            // The port is shared across processors.
+            // Enable port sharing.
             //
             Option = TRUE;
             Result =

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -439,6 +439,9 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
+    const BOOLEAN IsDynamicListener =
+        Config->RemoteAddress == NULL &&
+        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -719,10 +722,11 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
-        // assigned a server port (unless it's forcing sharing).
+        // Dynamic listeners use a single socket without SO_REUSEPORT so the
+        // assigned port cannot be shared with another endpoint.
         //
-        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if (!IsDynamicListener &&
+            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.
@@ -1086,7 +1090,10 @@ SocketCreateUdp(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const BOOLEAN IsPartitioned =
         Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED || Config->RemoteAddress != NULL;
-    const BOOLEAN NumPerProcessorSockets = !IsPartitioned && Datapath->PartitionCount > 1;
+    const BOOLEAN HasFixedLocalPort =
+        Config->LocalAddress != NULL && QuicAddrGetPort(Config->LocalAddress) != 0;
+    const BOOLEAN NumPerProcessorSockets =
+        HasFixedLocalPort && !IsPartitioned && Datapath->PartitionCount > 1;
     const uint16_t SocketCount = NumPerProcessorSockets ? (uint16_t)CxPlatProcCount() : 1;
 
     CXPLAT_DBG_ASSERT(Datapath->UdpHandlers.Receive != NULL || Config->Flags & CXPLAT_SOCKET_FLAG_PCP);
@@ -1143,14 +1150,16 @@ SocketCreateUdp(
             CxPlatSocketContextInitialize(
                 &Binding->SocketContexts[i],
                 Config,
-                IsPartitioned ? Config->PartitionIndex : (i % Datapath->PartitionCount),
+                IsPartitioned ? Config->PartitionIndex :
+                    (NumPerProcessorSockets ? (i % Datapath->PartitionCount) :
+                        (CxPlatProcCurrentNumber() % Datapath->PartitionCount)),
                 Binding->Type);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }
     }
 
-    if (!IsPartitioned) {
+    if (NumPerProcessorSockets) {
         //
         // The return value is being ignored here, as if a system does not support
         // bpf we still want the server to work. If this happens, the sockets will

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -719,11 +719,12 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Only set SO_REUSEPORT when the listening port isn't dynamic.
+        // Multi-socket bindings need SO_REUSEPORT to bind the same port.
         //
-        if ((Config->RemoteAddress != NULL ||
-                Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0) &&
-            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if (((Config->RemoteAddress != NULL && (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE)) ||
+                (Config->RemoteAddress == NULL &&
+                    (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0 ||
+                        SocketContext->Binding->NumPerProcessorSockets))) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -722,8 +722,8 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Dynamic listeners use a single socket without SO_REUSEPORT so the
-        // assigned port cannot be shared with another endpoint.
+        // Don't set SO_REUSEPORT for dynamic listeners so the assigned port
+        // isn't shared with another endpoint.
         //
         if (!IsDynamicListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&

--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -439,8 +439,9 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
-    const BOOLEAN IsDynamicListener =
+    const BOOLEAN IsDynamicPartitionedListener =
         Config->RemoteAddress == NULL &&
+        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
         (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
@@ -722,10 +723,9 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic listeners so the assigned port
-        // isn't shared with another endpoint.
+        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
         //
-        if (!IsDynamicListener &&
+        if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
@@ -1090,10 +1090,7 @@ SocketCreateUdp(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     const BOOLEAN IsPartitioned =
         Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED || Config->RemoteAddress != NULL;
-    const BOOLEAN HasFixedLocalPort =
-        Config->LocalAddress != NULL && QuicAddrGetPort(Config->LocalAddress) != 0;
-    const BOOLEAN NumPerProcessorSockets =
-        HasFixedLocalPort && !IsPartitioned && Datapath->PartitionCount > 1;
+    const BOOLEAN NumPerProcessorSockets = !IsPartitioned && Datapath->PartitionCount > 1;
     const uint16_t SocketCount = NumPerProcessorSockets ? (uint16_t)CxPlatProcCount() : 1;
 
     CXPLAT_DBG_ASSERT(Datapath->UdpHandlers.Receive != NULL || Config->Flags & CXPLAT_SOCKET_FLAG_PCP);
@@ -1150,16 +1147,14 @@ SocketCreateUdp(
             CxPlatSocketContextInitialize(
                 &Binding->SocketContexts[i],
                 Config,
-                IsPartitioned ? Config->PartitionIndex :
-                    (NumPerProcessorSockets ? (i % Datapath->PartitionCount) :
-                        (CxPlatProcCurrentNumber() % Datapath->PartitionCount)),
+                IsPartitioned ? Config->PartitionIndex : (i % Datapath->PartitionCount),
                 Binding->Type);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }
     }
 
-    if (NumPerProcessorSockets) {
+    if (!IsPartitioned) {
         //
         // The return value is being ignored here, as if a system does not support
         // bpf we still want the server to work. If this happens, the sockets will

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,6 +617,10 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
+    const BOOLEAN IsDynamicPartitionedListener =
+        Config->RemoteAddress == NULL &&
+        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
+        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -897,10 +901,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
-        // assigned a server port (unless it's forcing sharing).
+        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
         //
-        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if (!IsDynamicPartitionedListener &&
+            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,10 +617,6 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
-    const BOOLEAN IsDynamicPartitionedListener =
-        Config->RemoteAddress == NULL &&
-        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
-        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -901,14 +897,13 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // With multiple datapath partitions, server sockets use SO_REUSEPORT except
-        // for dynamic partitioned listeners; clients use it only when sharing.
+        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
+        // assigned a server port (unless it's forcing sharing).
         //
-        if (!IsDynamicPartitionedListener &&
-            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
-            // Enable port sharing.
+            // The port is shared across processors.
             //
             Option = TRUE;
             Result =

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,10 +617,6 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
-    const BOOLEAN IsDynamicPartitionedListener =
-        Config->RemoteAddress == NULL &&
-        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
-        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -901,9 +897,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
+        // Only set SO_REUSEPORT when the listening port isn't dynamic.
         //
-        if (!IsDynamicPartitionedListener &&
+        if ((Config->RemoteAddress != NULL ||
+                Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0) &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,6 +617,9 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
+    const BOOLEAN IsDynamicListener =
+        Config->RemoteAddress == NULL &&
+        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -897,10 +900,11 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
-        // assigned a server port (unless it's forcing sharing).
+        // Dynamic listeners use a single socket without SO_REUSEPORT so the
+        // assigned port cannot be shared with another endpoint.
         //
-        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if (!IsDynamicListener &&
+            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.
@@ -1258,8 +1262,12 @@ SocketCreateUdp(
     )
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
-    const BOOLEAN IsServerSocket = Config->RemoteAddress == NULL;
-    const BOOLEAN NumPerProcessorSockets = IsServerSocket && Datapath->PartitionCount > 1;
+    const BOOLEAN IsPartitioned =
+        Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED || Config->RemoteAddress != NULL;
+    const BOOLEAN HasFixedLocalPort =
+        Config->LocalAddress != NULL && QuicAddrGetPort(Config->LocalAddress) != 0;
+    const BOOLEAN NumPerProcessorSockets =
+        HasFixedLocalPort && !IsPartitioned && Datapath->PartitionCount > 1;
     const uint16_t SocketCount = NumPerProcessorSockets ? (uint16_t)CxPlatProcCount() : 1;
 
     CXPLAT_DBG_ASSERT(Datapath->UdpHandlers.Receive != NULL || Config->Flags & CXPLAT_SOCKET_FLAG_PCP);
@@ -1315,14 +1323,16 @@ SocketCreateUdp(
             CxPlatSocketContextInitialize(
                 &Binding->SocketContexts[i],
                 Config,
-                Config->RemoteAddress ? Config->PartitionIndex : (i % Datapath->PartitionCount),
+                IsPartitioned ? Config->PartitionIndex :
+                    (NumPerProcessorSockets ? (i % Datapath->PartitionCount) :
+                        (CxPlatProcCurrentNumber() % Datapath->PartitionCount)),
                 Binding->Type);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }
     }
 
-    if (IsServerSocket) {
+    if (NumPerProcessorSockets) {
         //
         // The return value is being ignored here, as if a system does not support
         // bpf we still want the server to work. If this happens, the sockets will

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -897,11 +897,12 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Only set SO_REUSEPORT when the listening port isn't dynamic.
+        // Multi-socket bindings need SO_REUSEPORT to bind the same port.
         //
-        if ((Config->RemoteAddress != NULL ||
-                Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0) &&
-            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if (((Config->RemoteAddress != NULL && (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE)) ||
+                (Config->RemoteAddress == NULL &&
+                    (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0 ||
+                        SocketContext->Binding->NumPerProcessorSockets))) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -901,15 +901,14 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Non-partitioned listeners need SO_REUSEPORT for their per-processor
-        // sockets. Dynamic partitioned listeners keep their assigned port exclusive,
-        // while connected sockets enable reuse only when explicitly sharing.
+        // With multiple datapath partitions, server sockets use SO_REUSEPORT except
+        // for dynamic partitioned listeners; clients use it only when sharing.
         //
         if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
-            // The port is shared across processors.
+            // Enable port sharing.
             //
             Option = TRUE;
             Result =

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -900,8 +900,8 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Dynamic listeners use a single socket without SO_REUSEPORT so the
-        // assigned port cannot be shared with another endpoint.
+        // Don't set SO_REUSEPORT for dynamic listeners so the assigned port
+        // isn't shared with another endpoint.
         //
         if (!IsDynamicListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -901,7 +901,9 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
+        // Non-partitioned listeners need SO_REUSEPORT for their per-processor
+        // sockets. Dynamic partitioned listeners keep their assigned port exclusive,
+        // while connected sockets enable reuse only when explicitly sharing.
         //
         if (!IsDynamicPartitionedListener &&
             (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,9 +617,6 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
-    const BOOLEAN IsDynamicListener =
-        Config->RemoteAddress == NULL &&
-        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -900,11 +897,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Don't set SO_REUSEPORT for dynamic listeners so the assigned port
-        // isn't shared with another endpoint.
+        // Only set SO_REUSEPORT on a server socket, otherwise the client could be
+        // assigned a server port (unless it's forcing sharing).
         //
-        if (!IsDynamicListener &&
-            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
+        if ((Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.
@@ -1262,12 +1258,8 @@ SocketCreateUdp(
     )
 {
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
-    const BOOLEAN IsPartitioned =
-        Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED || Config->RemoteAddress != NULL;
-    const BOOLEAN HasFixedLocalPort =
-        Config->LocalAddress != NULL && QuicAddrGetPort(Config->LocalAddress) != 0;
-    const BOOLEAN NumPerProcessorSockets =
-        HasFixedLocalPort && !IsPartitioned && Datapath->PartitionCount > 1;
+    const BOOLEAN IsServerSocket = Config->RemoteAddress == NULL;
+    const BOOLEAN NumPerProcessorSockets = IsServerSocket && Datapath->PartitionCount > 1;
     const uint16_t SocketCount = NumPerProcessorSockets ? (uint16_t)CxPlatProcCount() : 1;
 
     CXPLAT_DBG_ASSERT(Datapath->UdpHandlers.Receive != NULL || Config->Flags & CXPLAT_SOCKET_FLAG_PCP);
@@ -1323,16 +1315,14 @@ SocketCreateUdp(
             CxPlatSocketContextInitialize(
                 &Binding->SocketContexts[i],
                 Config,
-                IsPartitioned ? Config->PartitionIndex :
-                    (NumPerProcessorSockets ? (i % Datapath->PartitionCount) :
-                        (CxPlatProcCurrentNumber() % Datapath->PartitionCount)),
+                Config->RemoteAddress ? Config->PartitionIndex : (i % Datapath->PartitionCount),
                 Binding->Type);
         if (QUIC_FAILED(Status)) {
             goto Exit;
         }
     }
 
-    if (NumPerProcessorSockets) {
+    if (IsServerSocket) {
         //
         // The return value is being ignored here, as if a system does not support
         // bpf we still want the server to work. If this happens, the sockets will

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -617,6 +617,10 @@ CxPlatSocketContextInitialize(
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
     int Result = 0;
     int Option = 0;
+    const BOOLEAN IsDynamicPartitionedListener =
+        Config->RemoteAddress == NULL &&
+        (Config->Flags & CXPLAT_SOCKET_FLAG_PARTITIONED) != 0 &&
+        (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) == 0);
     QUIC_ADDR MappedAddress = {0};
     socklen_t AssignedLocalAddressLength = 0;
 
@@ -897,12 +901,10 @@ CxPlatSocketContextInitialize(
         }
 
         //
-        // Multi-socket bindings need SO_REUSEPORT to bind the same port.
+        // Don't set SO_REUSEPORT for dynamic partitioned listeners.
         //
-        if (((Config->RemoteAddress != NULL && (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE)) ||
-                (Config->RemoteAddress == NULL &&
-                    (Config->LocalAddress == NULL || QuicAddrGetPort(Config->LocalAddress) != 0 ||
-                        SocketContext->Binding->NumPerProcessorSockets))) &&
+        if (!IsDynamicPartitionedListener &&
+            (Config->Flags & CXPLAT_SOCKET_FLAG_SHARE || Config->RemoteAddress == NULL) &&
             SocketContext->Binding->Datapath->PartitionCount > 1) {
             //
             // The port is shared across processors.

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,6 +754,7 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
+// This behavior is specific to the Linux epoll datapath.
 #if defined(CX_PLATFORM_LINUX) && !defined(__FreeBSD__) && !defined(CXPLAT_USE_IO_URING)
 TEST_P(DataPathTest, UdpDynamicPortNoReuse)
 {

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,7 +754,7 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
-#if defined(CX_PLATFORM_LINUX)
+#if defined(CX_PLATFORM_LINUX) && !defined(CXPLAT_USE_IO_URING)
 TEST_P(DataPathTest, UdpDynamicPortNoReuse)
 {
     if (CxPlatProcCount() < 2) {

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,7 +754,7 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
-#if defined(CX_PLATFORM_LINUX)
+#if defined(CX_PLATFORM_LINUX) && !defined(CXPLAT_USE_IO_URING)
 TEST_P(DataPathTest, UdpDynamicPortNoReuse)
 {
     if (CxPlatProcCount() < 2) {
@@ -764,52 +764,16 @@ TEST_P(DataPathTest, UdpDynamicPortNoReuse)
     CxPlatDataPath Datapath(&EmptyUdpCallbacks);
     VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
 
-    for (CXPLAT_SOCKET_FLAGS Flags : {
-            CXPLAT_SOCKET_FLAG_NONE,
-            CXPLAT_SOCKET_FLAG_PARTITIONED}) {
-        QuicAddr LocalAddress = GetNewLocalAddr(false);
-        CxPlatSocket Socket(Datapath, &LocalAddress.SockAddr, nullptr, nullptr, Flags);
-        VERIFY_QUIC_SUCCESS(Socket.GetInitStatus());
-        QUIC_ADDR AssignedAddress = Socket.GetLocalAddress();
-        ASSERT_NE(QuicAddrGetPort(&AssignedAddress), (uint16_t)0);
-
-        int ProbeSocket =
-            socket(
-                GetParam() == 4 ? AF_INET : AF_INET6,
-                SOCK_DGRAM,
-                IPPROTO_UDP);
-        ASSERT_NE(INVALID_SOCKET, ProbeSocket);
-        int ReusePort = TRUE;
-        int SetOptionResult =
-            setsockopt(
-                ProbeSocket,
-                SOL_SOCKET,
-                SO_REUSEPORT,
-                &ReusePort,
-                sizeof(ReusePort));
-        if (SetOptionResult != 0) {
-            close(ProbeSocket);
-            FAIL() << "setsockopt(SO_REUSEPORT) failed";
-        }
-        int BindResult =
-            bind(
-                ProbeSocket,
-                &AssignedAddress.Ip,
-                GetParam() == 4 ? sizeof(AssignedAddress.Ipv4) : sizeof(AssignedAddress.Ipv6));
-        int BindError = errno;
-        close(ProbeSocket);
-        ASSERT_EQ(SOCKET_ERROR, BindResult);
-        ASSERT_EQ(EADDRINUSE, BindError);
-    }
-
-    QuicAddr FixedAddress = GetNewLocalAddr();
-    CxPlatSocket FixedSocket(Datapath, &FixedAddress.SockAddr);
-    while (FixedSocket.GetInitStatus() == QUIC_STATUS_ADDRESS_IN_USE) {
-        FixedAddress.SetPort(GetNextPort());
-        FixedSocket.CreateUdp(Datapath, &FixedAddress.SockAddr);
-    }
-    VERIFY_QUIC_SUCCESS(FixedSocket.GetInitStatus());
-    QUIC_ADDR FixedAssignedAddress = FixedSocket.GetLocalAddress();
+    QuicAddr LocalAddress = GetNewLocalAddr(false);
+    CxPlatSocket Socket(
+        Datapath,
+        &LocalAddress.SockAddr,
+        nullptr,
+        nullptr,
+        CXPLAT_SOCKET_FLAG_PARTITIONED);
+    VERIFY_QUIC_SUCCESS(Socket.GetInitStatus());
+    QUIC_ADDR AssignedAddress = Socket.GetLocalAddress();
+    ASSERT_NE(QuicAddrGetPort(&AssignedAddress), (uint16_t)0);
 
     int ProbeSocket =
         socket(
@@ -832,11 +796,12 @@ TEST_P(DataPathTest, UdpDynamicPortNoReuse)
     int BindResult =
         bind(
             ProbeSocket,
-            &FixedAssignedAddress.Ip,
-            GetParam() == 4 ? sizeof(FixedAssignedAddress.Ipv4) : sizeof(FixedAssignedAddress.Ipv6));
+            &AssignedAddress.Ip,
+            GetParam() == 4 ? sizeof(AssignedAddress.Ipv4) : sizeof(AssignedAddress.Ipv6));
     int BindError = errno;
     close(ProbeSocket);
-    ASSERT_EQ(0, BindResult) << "bind failed with " << BindError;
+    ASSERT_EQ(SOCKET_ERROR, BindResult);
+    ASSERT_EQ(EADDRINUSE, BindError);
 }
 #endif
 

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,6 +754,92 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
+#if defined(CX_PLATFORM_LINUX)
+TEST_P(DataPathTest, UdpDynamicPortNoReuse)
+{
+    if (CxPlatProcCount() < 2) {
+        GTEST_SKIP() << "SO_REUSEPORT requires multiple datapath partitions";
+    }
+
+    CxPlatDataPath Datapath(&EmptyUdpCallbacks);
+    VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
+
+    for (CXPLAT_SOCKET_FLAGS Flags : {
+            CXPLAT_SOCKET_FLAG_NONE,
+            CXPLAT_SOCKET_FLAG_PARTITIONED}) {
+        QuicAddr LocalAddress = GetNewLocalAddr(false);
+        CxPlatSocket Socket(Datapath, &LocalAddress.SockAddr, nullptr, nullptr, Flags);
+        VERIFY_QUIC_SUCCESS(Socket.GetInitStatus());
+        QUIC_ADDR AssignedAddress = Socket.GetLocalAddress();
+        ASSERT_NE(QuicAddrGetPort(&AssignedAddress), (uint16_t)0);
+
+        int ProbeSocket =
+            socket(
+                GetParam() == 4 ? AF_INET : AF_INET6,
+                SOCK_DGRAM,
+                IPPROTO_UDP);
+        ASSERT_NE(INVALID_SOCKET, ProbeSocket);
+        int ReusePort = TRUE;
+        int SetOptionResult =
+            setsockopt(
+                ProbeSocket,
+                SOL_SOCKET,
+                SO_REUSEPORT,
+                &ReusePort,
+                sizeof(ReusePort));
+        if (SetOptionResult != 0) {
+            close(ProbeSocket);
+            FAIL() << "setsockopt(SO_REUSEPORT) failed";
+        }
+        int BindResult =
+            bind(
+                ProbeSocket,
+                &AssignedAddress.Ip,
+                GetParam() == 4 ? sizeof(AssignedAddress.Ipv4) : sizeof(AssignedAddress.Ipv6));
+        int BindError = errno;
+        close(ProbeSocket);
+        ASSERT_EQ(SOCKET_ERROR, BindResult);
+        ASSERT_EQ(EADDRINUSE, BindError);
+    }
+
+    QuicAddr FixedAddress = GetNewLocalAddr();
+    CxPlatSocket FixedSocket(Datapath, &FixedAddress.SockAddr);
+    while (FixedSocket.GetInitStatus() == QUIC_STATUS_ADDRESS_IN_USE) {
+        FixedAddress.SetPort(GetNextPort());
+        FixedSocket.CreateUdp(Datapath, &FixedAddress.SockAddr);
+    }
+    VERIFY_QUIC_SUCCESS(FixedSocket.GetInitStatus());
+    QUIC_ADDR FixedAssignedAddress = FixedSocket.GetLocalAddress();
+
+    int ProbeSocket =
+        socket(
+            GetParam() == 4 ? AF_INET : AF_INET6,
+            SOCK_DGRAM,
+            IPPROTO_UDP);
+    ASSERT_NE(INVALID_SOCKET, ProbeSocket);
+    int ReusePort = TRUE;
+    int SetOptionResult =
+        setsockopt(
+            ProbeSocket,
+            SOL_SOCKET,
+            SO_REUSEPORT,
+            &ReusePort,
+            sizeof(ReusePort));
+    if (SetOptionResult != 0) {
+        close(ProbeSocket);
+        FAIL() << "setsockopt(SO_REUSEPORT) failed";
+    }
+    int BindResult =
+        bind(
+            ProbeSocket,
+            &FixedAssignedAddress.Ip,
+            GetParam() == 4 ? sizeof(FixedAssignedAddress.Ipv4) : sizeof(FixedAssignedAddress.Ipv6));
+    int BindError = errno;
+    close(ProbeSocket);
+    ASSERT_EQ(0, BindResult) << "bind failed with " << BindError;
+}
+#endif
+
 TEST_F(DataPathTest, UdpRebind)
 {
     CxPlatDataPath Datapath(&EmptyUdpCallbacks);

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,7 +754,7 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
-#if defined(CX_PLATFORM_LINUX) && !defined(CXPLAT_USE_IO_URING)
+#if defined(CX_PLATFORM_LINUX)
 TEST_P(DataPathTest, UdpDynamicPortNoReuse)
 {
     if (CxPlatProcCount() < 2) {

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -754,9 +754,10 @@ TEST_F(DataPathTest, UdpBind)
     ASSERT_NE(Socket.GetLocalAddress().Ipv4.sin_port, (uint16_t)0);
 }
 
-#if defined(CX_PLATFORM_LINUX) && !defined(CXPLAT_USE_IO_URING)
+#if defined(CX_PLATFORM_LINUX) && !defined(__FreeBSD__) && !defined(CXPLAT_USE_IO_URING)
 TEST_P(DataPathTest, UdpDynamicPortNoReuse)
 {
+    // The default datapath creates one partition per processor.
     if (CxPlatProcCount() < 2) {
         GTEST_SKIP() << "SO_REUSEPORT requires multiple datapath partitions";
     }
@@ -765,6 +766,7 @@ TEST_P(DataPathTest, UdpDynamicPortNoReuse)
     VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
 
     QuicAddr LocalAddress = GetNewLocalAddr(false);
+    // A non-partitioned multi-context bind still requires SO_REUSEPORT.
     CxPlatSocket NonPartitionedSocket(Datapath, &LocalAddress.SockAddr);
     VERIFY_QUIC_SUCCESS(NonPartitionedSocket.GetInitStatus());
 

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -765,6 +765,9 @@ TEST_P(DataPathTest, UdpDynamicPortNoReuse)
     VERIFY_QUIC_SUCCESS(Datapath.GetInitStatus());
 
     QuicAddr LocalAddress = GetNewLocalAddr(false);
+    CxPlatSocket NonPartitionedSocket(Datapath, &LocalAddress.SockAddr);
+    VERIFY_QUIC_SUCCESS(NonPartitionedSocket.GetInitStatus());
+
     CxPlatSocket Socket(
         Datapath,
         &LocalAddress.SockAddr,


### PR DESCRIPTION
## Description

Prevents dynamically partitioned UDP listeners using the Linux epoll datapath from setting `SO_REUSEPORT` when binding an ephemeral port. Partitioned listeners use a single socket, so port reuse is unnecessary and can allow another process running under the same UID to join the assigned port.

Explicitly bound listeners and the io_uring datapath retain their existing behavior. io_uring support is tracked separately in #6261.

## Testing

Added `DataPathTest.UdpDynamicPortNoReuse` for IPv4 and IPv6 on Linux without io_uring. The test verifies that:

- A dynamic non-partitioned listener still initializes successfully with its existing multi-socket reuse behavior.
- A dynamic partitioned listener receives a non-zero port.
- A second socket using `SO_REUSEPORT` cannot bind that assigned port and fails with `EADDRINUSE`.

## Documentation

No public documentation impact.
