### PR TITLE
Simplify alpn renegotation path

### DIFF
--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -537,39 +537,16 @@ QuicBindingAcceptConnection(
     }
 
     //
-    // Save the negotiated ALPN (starting with the length prefix) to be
-    // used later in building up the TLS response.
+    // Info->ClientAlpnList points into the crypto recv buffer, which can be
+    // freed before ALPN renegotiation, so own a copy here. Check if 
+    // the full list fits and use the preallocated buffer, allocate on the  heap otherwise. 
     //
-    uint16_t NegotiatedAlpnLength = 1 + Info->NegotiatedAlpn[-1];
-    uint8_t* NegotiatedAlpn;
-
-    if (NegotiatedAlpnLength <= TLS_SMALL_ALPN_BUFFER_SIZE) {
-        NegotiatedAlpn = Connection->Crypto.TlsState.SmallAlpnBuffer;
+    
+    uint8_t* ClientAlpnList;
+    if (Info->ClientAlpnListLength < TLS_SMALL_ALPN_BUFFER_SIZE) {
+        ClientAlpnList = Connection->Crypto.TlsState.SmallAlpnBuffer;
     } else {
-        NegotiatedAlpn = CXPLAT_ALLOC_NONPAGED(NegotiatedAlpnLength, QUIC_POOL_ALPN);
-        if (NegotiatedAlpn == NULL) {
-            QuicTraceEvent(
-                AllocFailure,
-                "Allocation of '%s' failed. (%llu bytes)",
-                "NegotiatedAlpn",
-                NegotiatedAlpnLength);
-            QuicConnTransportError(
-                Connection,
-                QUIC_ERROR_INTERNAL_ERROR);
-            goto Error;
-        }
-    }
-    CxPlatCopyMemory(NegotiatedAlpn, Info->NegotiatedAlpn - 1, NegotiatedAlpnLength);
-    Connection->Crypto.TlsState.NegotiatedAlpn = NegotiatedAlpn;
-
-    //
-    // Info->ClientAlpnList points into the crypto recv buffer, which can be freed
-    // before ALPN renegotiation. A single ALPN is redundant with the negotiated
-    // ALPN, so store nothing; otherwise take a heap copy.
-    //
-    if (Info->ClientAlpnListLength != (uint16_t)Info->ClientAlpnList[0] + 1) {
-        uint8_t* ClientAlpnList =
-            CXPLAT_ALLOC_NONPAGED(Info->ClientAlpnListLength, QUIC_POOL_ALPN);
+        ClientAlpnList = CXPLAT_ALLOC_NONPAGED(Info->ClientAlpnListLength, QUIC_POOL_ALPN);
         if (ClientAlpnList == NULL) {
             QuicTraceEvent(
                 AllocFailure,
@@ -581,10 +558,11 @@ QuicBindingAcceptConnection(
                 QUIC_ERROR_INTERNAL_ERROR);
             goto Error;
         }
-        CxPlatCopyMemory(ClientAlpnList, Info->ClientAlpnList, Info->ClientAlpnListLength);
-        Connection->Crypto.TlsState.ClientAlpnList = ClientAlpnList;
-        Connection->Crypto.TlsState.ClientAlpnListLength = Info->ClientAlpnListLength;
     }
+
+    CxPlatCopyMemory(ClientAlpnList, Info->ClientAlpnList, Info->ClientAlpnListLength);
+    Connection->Crypto.TlsState.ClientAlpnList = ClientAlpnList;
+    Connection->Crypto.TlsState.ClientAlpnListLength = Info->ClientAlpnListLength;
 
     //
     // Allow for the listener to decide if it wishes to accept the incoming

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -251,7 +251,9 @@ QuicCryptoUninitialize(
         Crypto->TlsState.NegotiatedAlpn = NULL;
     }
     if (Crypto->TlsState.ClientAlpnList != NULL) {
-        CXPLAT_FREE(Crypto->TlsState.ClientAlpnList, QUIC_POOL_ALPN);
+        if (Crypto->TlsState.ClientAlpnList != Crypto->TlsState.SmallAlpnBuffer) {
+            CXPLAT_FREE(Crypto->TlsState.ClientAlpnList, QUIC_POOL_ALPN);
+        }
         Crypto->TlsState.ClientAlpnList = NULL;
         Crypto->TlsState.ClientAlpnListLength = 0;
     }
@@ -3121,17 +3123,9 @@ QuicCryptoReNegotiateAlpn(
     CXPLAT_DBG_ASSERT(AlpnList != NULL);
     CXPLAT_DBG_ASSERT(AlpnListLength > 0);
 
-    const uint8_t* PrevNegotiatedAlpn = Connection->Crypto.TlsState.NegotiatedAlpn;
     const uint8_t* NewNegotiatedAlpn = NULL;
     const uint8_t* ClientAlpnList = Connection->Crypto.TlsState.ClientAlpnList;
     uint16_t ClientAlpnListLength = Connection->Crypto.TlsState.ClientAlpnListLength;
-    if (ClientAlpnList == NULL) {
-        //
-        // A single ALPN isn't stored separately; it equals the negotiated ALPN.
-        //
-        ClientAlpnList = PrevNegotiatedAlpn;
-        ClientAlpnListLength = (uint16_t)PrevNegotiatedAlpn[0] + 1;
-    }
 
     while (AlpnListLength != 0) {
         const uint8_t* Result =
@@ -3147,9 +3141,14 @@ QuicCryptoReNegotiateAlpn(
         AlpnListLength -= AlpnList[0] + 1;
         AlpnList += AlpnList[0] + 1;
     }
-
+    
+    //
+    // Checks against SmallAlpnBuffer before freeing.
+    //
     if (Connection->Crypto.TlsState.ClientAlpnList != NULL) {
-        CXPLAT_FREE(Connection->Crypto.TlsState.ClientAlpnList, QUIC_POOL_ALPN);
+        if (Connection->Crypto.TlsState.ClientAlpnList != Connection->Crypto.TlsState.SmallAlpnBuffer) {
+            CXPLAT_FREE(Connection->Crypto.TlsState.ClientAlpnList, QUIC_POOL_ALPN);
+        }
         Connection->Crypto.TlsState.ClientAlpnList = NULL;
         Connection->Crypto.TlsState.ClientAlpnListLength = 0;
     }
@@ -3166,13 +3165,7 @@ QuicCryptoReNegotiateAlpn(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    //
-    // Free current ALPN buffer if it's allocated on heap.
-    //
-    if (Connection->Crypto.TlsState.NegotiatedAlpn != Connection->Crypto.TlsState.SmallAlpnBuffer) {
-        CXPLAT_FREE(Connection->Crypto.TlsState.NegotiatedAlpn, QUIC_POOL_ALPN);
-        Connection->Crypto.TlsState.NegotiatedAlpn = NULL;
-    }
+    CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.NegotiatedAlpn == NULL);
 
     uint8_t* NegotiatedAlpn = NULL;
     uint8_t NegotiatedAlpnLength = NewNegotiatedAlpn[0];


### PR DESCRIPTION
## Description

Closes #6239 

In `QuicBindingAcceptConnection`  left  NegotiatedAlpn == NULL and own copied ClientAlpnList instead of just copy.
`SmallAlpnBuffer` size check as well to avoid allocation, otherwise default to standard heap allocation.

`QuicCryptoReNegotiateAlpn`: removed the  PrevNegotiatedAlpn  fast path and single-ALPN fallback. other fixes as specified in issue description and safe cleanup considering the `SmallAlpnBuffer` reuse(`QuicCryptoUninitialize`). 

## Testing

No tests to added, covered by existing tests

## Documentation

NA
