### PR TITLE
Add build.ps1 support for external system OpenSSL 3.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,20 @@ set(QUIC_OPENSSL_LIB_DIR "" CACHE PATH "Path to OpenSSL library directory")
 set(QUIC_OPENSSL_SYMBOL_PREFIX "" CACHE STRING "If non-empty, namespace-prefix every symbol in the bundled OpenSSL static archives (Linux only) so the resulting binary can coexist in the same process with another OpenSSL copy. See docs/OpenSSLSymbolPrefix.md")
 set(QUIC_OPENSSL_ROOT_DIR "" CACHE PATH "Path to OpenSSL root directory")
 
+# QUIC_USE_SYSTEM_LIBCRYPTO only affects the bundled (submodule) OpenSSL build,
+# where it dynamically links the system libcrypto while static-linking the
+# submodule-built libssl. QUIC_USE_EXTERNAL_OPENSSL skips the submodule build
+# entirely and dynamically links both libssl and libcrypto from the system, so
+# QUIC_USE_SYSTEM_LIBCRYPTO would be silently ignored. Reject the combination
+# loudly instead of letting it appear to take effect.
+if(QUIC_USE_EXTERNAL_OPENSSL AND QUIC_USE_SYSTEM_LIBCRYPTO)
+    message(FATAL_ERROR
+        "QUIC_USE_SYSTEM_LIBCRYPTO is incompatible with QUIC_USE_EXTERNAL_OPENSSL. "
+        "External OpenSSL already dynamically links both libssl and libcrypto from "
+        "the system; QUIC_USE_SYSTEM_LIBCRYPTO only applies to the bundled submodule "
+        "build. Set only one of them.")
+endif()
+
 # Outer-most validation for QUIC_OPENSSL_SYMBOL_PREFIX so a value combined with
 # a non-quictls/openssl TLS_LIB (e.g. schannel) errors loudly instead of being
 # silently ignored, and so the prefix value is rejected before it is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,7 @@ set(QUIC_OPENSSL_LIB_DIR "" CACHE PATH "Path to OpenSSL library directory")
 set(QUIC_OPENSSL_SYMBOL_PREFIX "" CACHE STRING "If non-empty, namespace-prefix every symbol in the bundled OpenSSL static archives (Linux only) so the resulting binary can coexist in the same process with another OpenSSL copy. See docs/OpenSSLSymbolPrefix.md")
 set(QUIC_OPENSSL_ROOT_DIR "" CACHE PATH "Path to OpenSSL root directory")
 
-# QUIC_USE_SYSTEM_LIBCRYPTO only affects the bundled (submodule) OpenSSL build,
-# where it dynamically links the system libcrypto while static-linking the
-# submodule-built libssl. QUIC_USE_EXTERNAL_OPENSSL skips the submodule build
+# QUIC_USE_EXTERNAL_OPENSSL skips the submodule build
 # entirely and dynamically links both libssl and libcrypto from the system, so
 # QUIC_USE_SYSTEM_LIBCRYPTO would be silently ignored. Reject the combination
 # loudly instead of letting it appear to take effect.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -147,6 +147,15 @@ Supported only by Windows currently.
 
 `-Tls <schannel/openssl>` Allows for building with different TLS providers. The default is platform dependent (Windows = schannel, Linux = openssl).
 
+`-UseExternalOpenSSL` Links against an external/system OpenSSL (**3.5.0 or newer**) instead of building OpenSSL from the submodules. Only valid together with `-Tls openssl`. Both `libssl` and `libcrypto` are dynamically linked from the system, so neither the `openssl` nor `quictls` submodule is required. If the system OpenSSL is older than 3.5.0 the build fails during CMake configuration with an "unsuitable version" error. When OpenSSL is installed outside the default system locations, add `-OpenSSLRootDir <path>` to point at it. For example, on a distro that ships OpenSSL 3.5+ (e.g. Ubuntu 26.04):
+
+```PowerShell
+./scripts/build.ps1 -Tls openssl -UseExternalOpenSSL
+```
+
+For finer-grained control (for example when the OpenSSL headers and libraries live in separate directories), invoke CMake directly with `-DQUIC_USE_EXTERNAL_OPENSSL=on` plus `-DQUIC_OPENSSL_INCLUDE_DIR=<path>` and `-DQUIC_OPENSSL_LIB_DIR=<path>`. The `build.ps1` helper intentionally exposes only the common `-OpenSSLRootDir` case.
+
+
 `-Clean` Forces a clean build of everything.
 
 For more info, take a look at the [build.ps1](../scripts/build.ps1) script.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -147,7 +147,7 @@ Supported only by Windows currently.
 
 `-Tls <schannel/openssl>` Allows for building with different TLS providers. The default is platform dependent (Windows = schannel, Linux = openssl).
 
-`-UseExternalOpenSSL` Links against an external/system OpenSSL (**3.5.0 or newer**) instead of building OpenSSL from the submodules. Only valid together with `-Tls openssl`. Both `libssl` and `libcrypto` are dynamically linked from the system, so neither the `openssl` nor `quictls` submodule is required. If the system OpenSSL is older than 3.5.0 the build fails during CMake configuration with an "unsuitable version" error. When OpenSSL is installed outside the default system locations, add `-OpenSSLRootDir <path>` to point at it. For example, on a distro that ships OpenSSL 3.5+ (e.g. Ubuntu 26.04):
+`-UseExternalOpenSSL` Links against an external/system OpenSSL (**3.5.0 or newer**) instead of building OpenSSL from the submodules. Only valid together with `-Tls openssl`. By default both `libssl` and `libcrypto` are dynamically linked from the system, so neither the `openssl` nor `quictls` submodule is required. If `-Static` is also specified, the external OpenSSL is linked statically instead (when the corresponding static libraries are available). If the system OpenSSL is older than 3.5.0 the build fails during CMake configuration with an "unsuitable version" error. When OpenSSL is installed outside the default system locations, add `-OpenSSLRootDir <path>` to point at it. For example, on a distro that ships OpenSSL 3.5+ (e.g. Ubuntu 26.04):
 
 ```PowerShell
 ./scripts/build.ps1 -Tls openssl -UseExternalOpenSSL

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -93,6 +93,12 @@ This script provides helpers for building msquic.
 .PARAMETER UseSystemOpenSSLCrypto
     Use system provided OpenSSL crypto libraries. On Linux OpenSSL builds, both libssl and libcrypto are dynamically linked.
 
+.PARAMETER UseExternalOpenSSL
+    Link against an external/system OpenSSL (3.5.0+) instead of building OpenSSL from the submodules. Only valid with '-Tls openssl'. Both libssl and libcrypto are dynamically linked from the system.
+
+.PARAMETER OpenSSLRootDir
+    Path to the root directory of an external OpenSSL installation to use (implies -UseExternalOpenSSL). Passed to CMake as QUIC_OPENSSL_ROOT_DIR. Only needed when OpenSSL is not in a default system location. Only valid with '-Tls openssl'.
+
 .PARAMETER EnableHighResolutionTimers
     Configures the system to use high resolution timers.
 
@@ -217,6 +223,12 @@ param (
     [switch]$UseSystemOpenSSLCrypto = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$UseExternalOpenSSL = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OpenSSLRootDir = "",
+
+    [Parameter(Mandatory = $false)]
     [switch]$EnableHighResolutionTimers = $false,
 
     [Parameter(Mandatory = $false)]
@@ -285,6 +297,17 @@ if ($Arch -eq "arm64ec") {
     }
     if ($Tls -eq "quictls" -Or $Tls -eq "openssl") {
         Write-Error "Arm64EC does not support quictls/openssl"
+    }
+}
+
+# External OpenSSL selection is only supported by the 'openssl' TLS provider.
+$UseExternalOpenSSLRequested = $UseExternalOpenSSL -Or ($OpenSSLRootDir -ne "")
+if ($UseExternalOpenSSLRequested) {
+    if ($Tls -ne "openssl") {
+        Write-Error "External OpenSSL selection (-UseExternalOpenSSL/-OpenSSLRootDir) requires '-Tls openssl'. The 'quictls' provider must be built from submodules."
+    }
+    if ($UseSystemOpenSSLCrypto) {
+        Write-Error "-UseSystemOpenSSLCrypto is incompatible with external OpenSSL selection. External OpenSSL already dynamically links both libssl and libcrypto from the system; -UseSystemOpenSSLCrypto only applies to the bundled submodule build."
     }
 }
 
@@ -439,6 +462,13 @@ function CMake-Generate {
     }
     $Arguments += " -DQUIC_TLS_LIB=" + $Tls
     $Arguments += " -DQUIC_OUTPUT_DIR=""$ArtifactsDir"""
+
+    if ($UseExternalOpenSSLRequested) {
+        $Arguments += " -DQUIC_USE_EXTERNAL_OPENSSL=on"
+        if ($OpenSSLRootDir -ne "") {
+            $Arguments += " -DQUIC_OPENSSL_ROOT_DIR=""$OpenSSLRootDir"""
+        }
+    }
 
     if (!$DisableLogs) {
         $Arguments += " -DQUIC_ENABLE_LOGGING=on"


### PR DESCRIPTION
Expose the existing CMake external-OpenSSL selection through the build.ps1 helper so libmsquic can be built against a system OpenSSL 3.5.0+ without building the openssl/quictls submodules. Both libssl and libcrypto are then dynamically linked from the system.

- build.ps1: add -UseExternalOpenSSL and -OpenSSLRootDir, mapping to QUIC_USE_EXTERNAL_OPENSSL / QUIC_OPENSSL_ROOT_DIR. Validate that they require -Tls openssl and are incompatible with -UseSystemOpenSSLCrypto. Finer-grained include/lib selection remains available via CMake.

- CMakeLists.txt: make QUIC_USE_SYSTEM_LIBCRYPTO and QUIC_USE_EXTERNAL_OPENSSL mutually exclusive with a clear FATAL_ERROR, since the former is silently ignored by the external path.

- docs/BUILD.md: document the new options and point power users to the CMake QUIC_OPENSSL_INCLUDE_DIR/QUIC_OPENSSL_LIB_DIR knobs.

fixes #5210

when build agains external openssl the library becomes much smaller: 
~11× smaller (0.45 MB vs 5.03 MB stripped).

note that we seems to build & ship binaries for Ubuntu 26 using quictls e.g. the old way even if new openssl is available. 



## Testing

- **Ubuntu 26.04 (OpenSSL 3.5.5)** and **Arch (OpenSSL 3.6.3)**: `-UseExternalOpenSSL` builds `libmsquic.so`, dynamically links `libssl.so.3` + `libcrypto.so.3`, and has **no `ossl_time_now`** / no undefined `ossl_*` symbols.
- **With `openssl`/`quictls` submodules masked empty**: build still succeeds — proves no submodule dependency.
- **With submodules present**: `tls_openssl.c` compiles with only `-I.../src/inc`; **no submodule OpenSSL headers leak onto the include path**.
- **Old OpenSSL (host, 3.0.13)**: fails cleanly at configure time — `Could NOT find OpenSSL ... Found unsuitable version "3.0.13" ... minimum required is "3.5.0"`.
- **Conflicting flags**: `QUIC_USE_EXTERNAL_OPENSSL` + `QUIC_USE_SYSTEM_LIBCRYPTO` now fails immediately with the new `FATAL_ERROR`.
- **Size comparison (Arch, RelWithDebInfo, stripped)**: external `~0.45 MB` vs quictls `~5.03 MB` — external is ~11x smaller because OpenSSL is no longer statically embedded.

## Documentation

`docs/BUILD.md` updated with the new `-UseExternalOpenSSL` / `-OpenSSLRootDir` options and a note pointing power users to CMake for include/lib-dir control.

cc: @manickap