### PR TITLE
fix X.509 version for OpenSSL self-signed certificates

### DIFF
--- a/src/platform/selfsign_openssl.c
+++ b/src/platform/selfsign_openssl.c
@@ -162,7 +162,7 @@ GenerateX509Cert(
         goto Exit;
     }
 
-    X509_set_version(Cert, 3);
+    X509_set_version(Cert, X509_VERSION_3);
 
     Ret = ASN1_INTEGER_set(X509_get_serialNumber(Cert), 1);
     if (Ret != 1) {


### PR DESCRIPTION
Use OpenSSL’s X509_VERSION_3 constant when generating self-signed certificates. X.509 version values are zero-indexed, so passing 3 encoded a non-standard v4 certificate that clients such as quic-go reject.