### PR TITLE
Pass Windows 2025 runner to downlevel tests

### DIFF
--- a/.github/workflows/test-down-level.yml
+++ b/.github/workflows/test-down-level.yml
@@ -62,7 +62,7 @@ jobs:
         scripts/test.ps1 -AZP -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*CredValidation*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
     - name: Run Tests (Windows)
       if: runner.os == 'Windows'
-      run: scripts/test.ps1 -AZP -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
+      run: scripts/test.ps1 -AZP -Config ${{matrix.vec.config}} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner windows-2025 -SkipUnitTests -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ConnectClientCertificate*:Basic.StartTwoListenersSameALPN:ParameterValidation.ValidateGlobalParam
 
   Complete:
     name: Down Level Complete


### PR DESCRIPTION
## Description

Pass `-OsRunner windows-2025` to the Windows downlevel test invocation so the v2.5 and v2.6 test binaries apply their Windows Server 2025-specific test handling.

This addresses the currently recurring failure in the `Test (2.6.0, windows-2025, x64, Debug, schannel)` job.

## Testing

Validated the workflow diff with `git diff --check`.

## Documentation

N/A