### PR TITLE
Fix heap buffer overflow in secnetperf TCP frame reassembly

### DIFF
--- a/src/perf/lib/Tcp.cpp
+++ b/src/perf/lib/Tcp.cpp
@@ -859,6 +859,10 @@ bool TcpConnection::ProcessReceiveData(const uint8_t* Buffer, uint32_t BufferLen
 
         auto Frame = (TcpFrame*)BufferedData;
         auto FrameLength = (uint32_t)sizeof(TcpFrame) + Frame->Length + CXPLAT_ENCRYPTION_OVERHEAD;
+        if (FrameLength > sizeof(BufferedData)) {
+            WriteOutput("Invalid frame length\n");
+            return false;
+        }
         auto BytesNeeded = FrameLength - BufferedDataLength;
         if (BufferLength < BytesNeeded) {
             goto BufferData;
@@ -895,6 +899,10 @@ bool TcpConnection::ProcessReceiveData(const uint8_t* Buffer, uint32_t BufferLen
 
 BufferData:
 
+    if (BufferedDataLength + BufferLength > sizeof(BufferedData)) {
+        WriteOutput("Invalid frame length\n");
+        return false;
+    }
     CxPlatCopyMemory(BufferedData+BufferedDataLength, Buffer, BufferLength);
     BufferedDataLength += BufferLength;
 


### PR DESCRIPTION
## Description

`TcpConnection::ProcessReceiveData()` copied frames into the fixed 16 KB
`BufferedData` buffer using `uint16_t` `Frame->Length` (frame up to 65555 bytes)
 with no bounds check. A remote peer could overflow the heap-allocated `TcpConnection`
 object.

fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/63537643/

## Testing

NA
## Documentation

NA