### PR TITLE
[CP] Fix leak on ACK encryption-level mismatch in loss detection (#6232)

### DIFF
--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -1296,7 +1296,7 @@ QuicLossDetectionOnZeroRttRejected(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicLossDetectionProcessAckBlocks(
     _In_ QUIC_LOSS_DETECTION* LossDetection,
     _In_ QUIC_PATH* Path,
@@ -1304,10 +1304,10 @@ QuicLossDetectionProcessAckBlocks(
     _In_ QUIC_ENCRYPT_LEVEL EncryptLevel,
     _In_ uint64_t AckDelay,
     _In_ QUIC_RANGE* AckBlocks,
-    _Out_ BOOLEAN* InvalidAckBlock,
     _In_opt_ QUIC_ACK_ECN_EX* Ecn
     )
 {
+    BOOLEAN Result = TRUE;
     QUIC_SENT_PACKET_METADATA* AckedPackets = NULL;
     QUIC_SENT_PACKET_METADATA** AckedPacketsTail = &AckedPackets;
 
@@ -1319,8 +1319,6 @@ QuicLossDetectionProcessAckBlocks(
     BOOLEAN NewLargestAckRetransmittable = FALSE;
     BOOLEAN NewLargestAckDifferentPath = FALSE;
     uint64_t NewLargestAckTimestamp = 0;
-
-    *InvalidAckBlock = FALSE;
 
     QUIC_SENT_PACKET_METADATA** LostPacketsStart = &LossDetection->LostPackets;
     QUIC_SENT_PACKET_METADATA** SentPacketsStart = &LossDetection->SentPackets;
@@ -1444,7 +1442,7 @@ CheckSentPackets:
         //
         // Nothing was acknowledged, so we can exit now.
         //
-        return;
+        goto Exit;
     }
 
     uint64_t LargestAckedPacketNum = 0;
@@ -1466,8 +1464,8 @@ CheckSentPackets:
                 "[conn][%p] ERROR, %s.",
                 Connection,
                 "Incorrect ACK encryption level");
-            *InvalidAckBlock = TRUE;
-            return;
+            Result = FALSE;
+            goto Exit;
         }
 
         uint64_t PacketRtt = CxPlatTimeDiff64(PacketMeta->SentTime, TimeNow);
@@ -1625,18 +1623,28 @@ CheckSentPackets:
 
     LossDetection->ProbeCount = 0;
 
+Exit:
+
+    if (!Result) {
+        //
+        // A protocol violation was detected; fail the connection.
+        //
+        QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+    }
+
     AckedPacketsIterator = AckedPackets;
     while (AckedPacketsIterator != NULL) {
         QUIC_SENT_PACKET_METADATA* PacketMeta = AckedPacketsIterator;
         AckedPacketsIterator = AckedPacketsIterator->Next;
         QuicSentPacketPoolReturnPacketMetadata(PacketMeta, Connection);
     }
-
     //
     // At least one packet was ACKed. If all packets were ACKed then we'll
     // cancel the timer; otherwise we'll reset the timer.
     //
     QuicLossDetectionUpdateTimer(LossDetection, FALSE);
+
+    return Result;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1692,15 +1700,16 @@ QuicLossDetectionProcessAckFrame(
 
             AckDelay <<= Connection->PeerTransportParams.AckDelayExponent;
 
-            QuicLossDetectionProcessAckBlocks(
-                LossDetection,
-                Path,
-                Packet,
-                EncryptLevel,
-                AckDelay,
-                &Connection->DecodedAckRanges,
-                InvalidFrame,
-                FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL);
+            if (!QuicLossDetectionProcessAckBlocks(
+                    LossDetection,
+                    Path,
+                    Packet,
+                    EncryptLevel,
+                    AckDelay,
+                    &Connection->DecodedAckRanges,
+                    FrameType == QUIC_FRAME_ACK_1 ? &Ecn : NULL)) {
+                Result = FALSE;
+            }
         }
     }
 


### PR DESCRIPTION
## Description
`QuicLossDetectionProcessAckBlocks` moves acknowledged packets out of the
`SentPackets`/`LostPackets` lists into a local `AckedPackets` list *before*
validating that each packet's encryption level matches the ACK frame's level.
On a mismatch it returned early without returning the already-unlinked packets
to the pool, leaking their metadata and the resources held by their frames.

Fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/62826410

## Testing

NA
## Documentation

NA


<!-- Companion PR for release/2.6: #6269 -->
