### PR TITLE
Encapsulate connection paths in QUIC_PATH_SET

### DIFF
--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -221,7 +221,7 @@ BbrCongestionControlGetCongestionWindow(
 
     const uint16_t DatagramPayloadLength =
         // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound): False positive: embedded Cc is valid.
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     uint32_t MinCongestionWindow = kMinCwndInMss * DatagramPayloadLength;
 
@@ -309,7 +309,7 @@ BbrCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
     NetworkStatistics->BytesInFlight = Bbr->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;
@@ -360,7 +360,7 @@ BbrCongestionControlLogOutFlowStatus(
     )
 {
     const QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
 
     QuicTraceEvent(
@@ -488,7 +488,7 @@ BbrCongestionControlUpdateRecoveryWindow(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     CXPLAT_DBG_ASSERT(Bbr->RecoveryState != RECOVERY_STATE_NOT_RECOVERY);
 
@@ -520,7 +520,7 @@ BbrCongestionControlHandleAckInProbeRtt(
     Bbr->BandwidthFilter.AppLimitedExitTarget = LargestSentPacketNumber;
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     if (!Bbr->ProbeRttEndTimeValid &&
         Bbr->BytesInFlight < BbrCongestionControlGetCongestionWindow(Cc) + DatagramPayloadLength) {
@@ -714,7 +714,7 @@ BbrCongestionControlSetSendQuantum(
     uint64_t PacingRate = Bandwidth * Bbr->PacingGain / GAIN_UNIT;
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     if (PacingRate < kLowPacingRateThresholdBytesPerSecond * BW_UNIT) {
         Bbr->SendQuantum = (uint64_t)DatagramPayloadLength;
@@ -741,7 +741,7 @@ BbrCongestionControlUpdateCongestionWindow(
     }
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     BbrCongestionControlSetSendQuantum(Cc);
 
@@ -915,7 +915,7 @@ BbrCongestionControlOnDataLost(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     QuicTraceEvent(
         ConnCongestionV2,
@@ -1007,7 +1007,7 @@ BbrCongestionControlReset(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     Bbr->CongestionWindow = Bbr->InitialCongestionWindowPackets * DatagramPayloadLength;
     Bbr->InitialCongestionWindow = Bbr->InitialCongestionWindowPackets * DatagramPayloadLength;
@@ -1100,7 +1100,7 @@ BbrCongestionControlInitialize(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
     Bbr->InitialCongestionWindowPackets = Settings->InitialWindowPackets;
 

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -221,7 +221,7 @@ BbrCongestionControlGetCongestionWindow(
 
     const uint16_t DatagramPayloadLength =
         // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound): False positive: embedded Cc is valid.
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     uint32_t MinCongestionWindow = kMinCwndInMss * DatagramPayloadLength;
 
@@ -309,7 +309,7 @@ BbrCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
     NetworkStatistics->BytesInFlight = Bbr->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;
@@ -360,7 +360,7 @@ BbrCongestionControlLogOutFlowStatus(
     )
 {
     const QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
 
     QuicTraceEvent(
@@ -488,7 +488,7 @@ BbrCongestionControlUpdateRecoveryWindow(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     CXPLAT_DBG_ASSERT(Bbr->RecoveryState != RECOVERY_STATE_NOT_RECOVERY);
 
@@ -520,7 +520,7 @@ BbrCongestionControlHandleAckInProbeRtt(
     Bbr->BandwidthFilter.AppLimitedExitTarget = LargestSentPacketNumber;
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     if (!Bbr->ProbeRttEndTimeValid &&
         Bbr->BytesInFlight < BbrCongestionControlGetCongestionWindow(Cc) + DatagramPayloadLength) {
@@ -714,7 +714,7 @@ BbrCongestionControlSetSendQuantum(
     uint64_t PacingRate = Bandwidth * Bbr->PacingGain / GAIN_UNIT;
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     if (PacingRate < kLowPacingRateThresholdBytesPerSecond * BW_UNIT) {
         Bbr->SendQuantum = (uint64_t)DatagramPayloadLength;
@@ -741,7 +741,7 @@ BbrCongestionControlUpdateCongestionWindow(
     }
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     BbrCongestionControlSetSendQuantum(Cc);
 
@@ -915,7 +915,7 @@ BbrCongestionControlOnDataLost(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     QuicTraceEvent(
         ConnCongestionV2,
@@ -1007,7 +1007,7 @@ BbrCongestionControlReset(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     Bbr->CongestionWindow = Bbr->InitialCongestionWindowPackets * DatagramPayloadLength;
     Bbr->InitialCongestionWindow = Bbr->InitialCongestionWindowPackets * DatagramPayloadLength;
@@ -1100,7 +1100,7 @@ BbrCongestionControlInitialize(
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
 
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
     Bbr->InitialCongestionWindowPackets = Settings->InitialWindowPackets;
 

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1360,7 +1360,7 @@ QuicBindingCreateConnection(
     }
 
     BindingRefAdded = TRUE;
-    NewConnection->Paths[0].Binding = Binding;
+    QuicPathSetGetActivePath(&NewConnection->Paths)->Binding = Binding;
 
     if (!QuicLookupAddRemoteHash(
             &Binding->Lookup,

--- a/src/core/binding.c
+++ b/src/core/binding.c
@@ -1360,7 +1360,7 @@ QuicBindingCreateConnection(
     }
 
     BindingRefAdded = TRUE;
-    QuicPathSetGetActivePath(&NewConnection->Paths)->Binding = Binding;
+    QuicPathGetActive(&NewConnection->Paths)->Binding = Binding;
 
     if (!QuicLookupAddRemoteHash(
             &Binding->Lookup,

--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -143,9 +143,9 @@ typedef struct QUIC_CID_LIST_ENTRY {
     do {                                                                        \
         CXPLAT_DBG_ASSERT(!Cid->CID.Retired);                                   \
         CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL); Cid->AssignedPath = Path; \
-        for (int PathIdx = Conn->PathsCount - 1; PathIdx > 0; PathIdx--) {      \
-            if (Path != &Conn->Paths[PathIdx])                                  \
-                CXPLAT_DBG_ASSERT(Conn->Paths[PathIdx].DestCid != Cid);         \
+        for (int PathIdx = Conn->Paths.Count - 1; PathIdx > 0; PathIdx--) {     \
+            if (Path != &Conn->Paths.Paths[PathIdx])                            \
+                CXPLAT_DBG_ASSERT(Conn->Paths.Paths[PathIdx].DestCid != Cid);   \
             }                                                                   \
         }                                                                       \
     while (0)
@@ -153,8 +153,8 @@ typedef struct QUIC_CID_LIST_ENTRY {
 #define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                       \
     do {                                                                        \
         CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL);                           \
-        for (int PathIdx = Conn->PathsCount - 1; PathIdx > 0; PathIdx--) {      \
-            CXPLAT_DBG_ASSERT(Conn->Paths[PathIdx].DestCid != Cid);             \
+        for (int PathIdx = Conn->Paths.Count - 1; PathIdx > 0; PathIdx--) {     \
+            CXPLAT_DBG_ASSERT(Conn->Paths.Paths[PathIdx].DestCid != Cid);       \
         }                                                                       \
     } while (0)
 #else

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -126,10 +126,10 @@ QuicConnAlloc(
     QuicSendBufferInitialize(&Connection->SendBuffer);
     QuicOperationQueueInitialize(&Connection->OperQ);
     QuicSendInitialize(&Connection->Send, &Connection->Settings);
+    QuicPathSetInitialize(&Connection->Paths, Connection);
     QuicCongestionControlInitialize(&Connection->CongestionControl, &Connection->Settings);
     QuicLossDetectionInitialize(&Connection->LossDetection);
     QuicDatagramInitialize(&Connection->Datagram);
-    QuicPathSetInitialize(&Connection->Paths, Connection);
 
     QuicRangeInitialize(
         QUIC_MAX_RANGE_DECODE_ACKS,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -129,6 +129,8 @@ QuicConnAlloc(
     QuicCongestionControlInitialize(&Connection->CongestionControl, &Connection->Settings);
     QuicLossDetectionInitialize(&Connection->LossDetection);
     QuicDatagramInitialize(&Connection->Datagram);
+    QuicPathSetInitialize(&Connection->Paths, Connection);
+
     QuicRangeInitialize(
         QUIC_MAX_RANGE_DECODE_ACKS,
         &Connection->DecodedAckRanges);
@@ -143,11 +145,7 @@ QuicConnAlloc(
             goto Error;
         }
     }
-
-    QUIC_PATH* Path = &Connection->Paths[0];
-    QuicPathInitialize(Connection, Path);
-    Path->IsActive = TRUE;
-    Connection->PathsCount = 1;
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
     Connection->EarliestExpirationTime = UINT64_MAX;
     for (QUIC_CONN_TIMER_TYPE Type = 0; Type < QUIC_CONN_TIMER_COUNT; ++Type) {
@@ -364,7 +362,7 @@ QuicConnFree(
         CxPlatRecvDataReturn((CXPLAT_RECV_DATA*)Connection->ReceiveQueue);
         Connection->ReceiveQueue = NULL;
     }
-    QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     if (Path->Binding != NULL) {
         QuicLibraryReleaseBinding(Path->Binding);
         Path->Binding = NULL;
@@ -595,7 +593,8 @@ QuicConnTraceRundownOper(
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        Connection->Paths[0].EcnValidationState == ECN_VALIDATION_CAPABLE);
+        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+            ECN_VALIDATION_CAPABLE);
     CXPLAT_DBG_ASSERT(Connection->Registration);
     QuicTraceEvent(
         ConnRegistered,
@@ -610,20 +609,25 @@ QuicConnTraceRundownOper(
             Connection->Stats.QuicVersion);
     }
     if (Connection->State.Started) {
-        for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+        QUIC_PATH_SET* PathSet = &Connection->Paths;
+        for (uint8_t i = 0; i < PathSet->Count; ++i) {
             if (Connection->State.LocalAddressSet || i != 0) {
                 QuicTraceEvent(
                     ConnLocalAddrAdded,
                      "[conn][%p] New Local IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.LocalAddress), &Connection->Paths[i].Route.LocalAddress));
+                    CASTED_CLOG_BYTEARRAY(
+                        sizeof(PathSet->Paths[i].Route.LocalAddress),
+                        &PathSet->Paths[i].Route.LocalAddress));
             }
             if (Connection->State.RemoteAddressSet || i != 0) {
                 QuicTraceEvent(
                     ConnRemoteAddrAdded,
                     "[conn][%p] New Remote IP: %!ADDR!",
                     Connection,
-                    CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[i].Route.RemoteAddress), &Connection->Paths[i].Route.RemoteAddress));
+                    CASTED_CLOG_BYTEARRAY(
+                        sizeof(PathSet->Paths[i].Route.RemoteAddress),
+                        &PathSet->Paths[i].Route.RemoteAddress));
             }
         }
         for (CXPLAT_SLIST_ENTRY* Entry = Connection->SourceCids.Next;
@@ -901,7 +905,9 @@ QuicConnGenerateNewSourceCid(
             QuicConnFatalError(Connection, QUIC_STATUS_INTERNAL_ERROR, NULL);
             return NULL;
         }
-        if (!QuicBindingAddSourceConnectionID(Connection->Paths[0].Binding, SourceCid)) {
+        if (!QuicBindingAddSourceConnectionID(
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                SourceCid)) {
             CXPLAT_FREE(SourceCid, QUIC_POOL_CIDHASH);
             SourceCid = NULL;
             if (++TryCount > QUIC_CID_MAX_COLLISION_RETRY) {
@@ -1138,9 +1144,10 @@ QuicConnReplaceRetiredCids(
     _In_ QUIC_CONNECTION* Connection
     )
 {
-    CXPLAT_DBG_ASSERT(Connection->PathsCount <= QUIC_MAX_PATH_COUNT);
-    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
-        QUIC_PATH* Path = &Connection->Paths[i];
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    CXPLAT_DBG_ASSERT(PathSet->Count <= QUIC_MAX_PATH_COUNT);
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
+        QUIC_PATH* Path = &PathSet->Paths[i];
         if (Path->DestCid == NULL || !Path->DestCid->CID.Retired) {
             continue;
         }
@@ -1392,7 +1399,7 @@ QuicConnOnShutdownComplete(
     //
     // Clean up any pending state that is irrelevant now.
     //
-    QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     if (Path->Binding != NULL) {
         if (Path->EncryptionOffloading) {
             QuicPathUpdateQeo(Connection, Path, CXPLAT_QEO_OPERATION_REMOVE);
@@ -1402,7 +1409,9 @@ QuicConnOnShutdownComplete(
         // Remove all entries in the binding's lookup tables so we don't get any
         // more packets queued.
         //
-        QuicBindingRemoveConnection(Connection->Paths[0].Binding, Connection);
+        QuicBindingRemoveConnection(
+            QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+            Connection);
     }
 
     //
@@ -1543,7 +1552,9 @@ QuicConnTryClose(
             QuicConnTimerSet(
                 Connection,
                 QUIC_CONN_TIMER_SHUTDOWN,
-                CXPLAT_MAX(MS_TO_US(15), Connection->Paths[0].SmoothedRtt * 2));
+                CXPLAT_MAX(
+                    MS_TO_US(15),
+                    QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt * 2));
 
             QuicSendSetSendFlag(
                 &Connection->Send,
@@ -1565,7 +1576,7 @@ QuicConnTryClose(
             uint64_t Pto =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
-                    &Connection->Paths[0],
+                    QuicPathSetGetActivePath(&Connection->Paths),
                     QUIC_CLOSE_PTO_COUNT);
             QuicConnTimerSet(
                 Connection,
@@ -1607,7 +1618,9 @@ QuicConnTryClose(
             QuicConnTimerSet(
                 Connection,
                 QUIC_CONN_TIMER_SHUTDOWN,
-                CXPLAT_MAX(MS_TO_US(15), Connection->Paths[0].SmoothedRtt * 2));
+                CXPLAT_MAX(
+                    MS_TO_US(15),
+                    QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt * 2));
         }
 
         IsFirstCloseForConnection = FALSE;
@@ -1785,7 +1798,7 @@ QuicConnStart(
     )
 {
     QUIC_STATUS Status;
-    QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     CXPLAT_DBG_ASSERT(QuicConnIsClient(Connection));
 
     if (Connection->State.ClosedLocally || Connection->State.Started) {
@@ -2029,7 +2042,7 @@ QuicConnRestart(
         //
         // Don't reset current RTT measurements unless doing a full reset.
         //
-        QUIC_PATH* Path = &Connection->Paths[0];
+        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
         Path->GotFirstRttSample = FALSE;
         Path->SmoothedRtt = MS_TO_US(Connection->Settings.InitialRttMs);
         Path->RttVariance = Path->SmoothedRtt / 2;
@@ -2326,8 +2339,8 @@ QuicConnGenerateLocalTransportParameters(
     LocalTP->MaxUdpPayloadSize =
         MaxUdpPayloadSizeFromMTU(
             CxPlatSocketGetLocalMtu(
-                Connection->Paths[0].Binding->Socket,
-                &Connection->Paths[0].Route));
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding->Socket,
+                &QuicPathSetGetActivePath(&Connection->Paths)->Route));
     LocalTP->MaxAckDelay = QuicConnGetAckDelay(Connection);
     LocalTP->MinAckDelay =
         MsQuicLib.ExecutionConfig != NULL &&
@@ -3399,7 +3412,8 @@ QuicConnUpdateDestCid(
             Connection->DestCids.Flink,
             QUIC_CID_LIST_ENTRY,
             Link);
-    CXPLAT_DBG_ASSERT(Connection->Paths[0].DestCid == DestCid);
+    CXPLAT_DBG_ASSERT(
+        QuicPathSetGetActivePath(&Connection->Paths)->DestCid == DestCid);
 
     if (Packet->SourceCidLen != DestCid->CID.Length ||
         memcmp(Packet->SourceCid, DestCid->CID.Data, DestCid->CID.Length) != 0) {
@@ -3440,13 +3454,16 @@ QuicConnUpdateDestCid(
                     Packet->SourceCid);
             if (DestCid == NULL) {
                 Connection->DestCidCount--;
-                Connection->Paths[0].DestCid = NULL;
+                QuicPathSetGetActivePath(&Connection->Paths)->DestCid = NULL;
                 QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, "Out of memory");
                 return FALSE;
             }
 
-            Connection->Paths[0].DestCid = DestCid;
-            QUIC_CID_SET_PATH(Connection, DestCid, &Connection->Paths[0]);
+            QuicPathSetGetActivePath(&Connection->Paths)->DestCid = DestCid;
+            QUIC_CID_SET_PATH(
+                Connection,
+                DestCid,
+                QuicPathSetGetActivePath(&Connection->Paths));
             DestCid->CID.UsedLocally = TRUE;
             CxPlatListInsertHead(&Connection->DestCids, &DestCid->Link);
         }
@@ -3488,7 +3505,8 @@ QuicConnRecvVerNeg(
     //
     // Validate that the packet's Source CID matches our current Destination CID
     //
-    const QUIC_CID_LIST_ENTRY* DestCid = Connection->Paths[0].DestCid;
+    const QUIC_CID_LIST_ENTRY* DestCid =
+        QuicPathSetGetActivePath(&Connection->Paths)->DestCid;
     CXPLAT_DBG_ASSERT(DestCid != NULL);
     if (VnSourceCidLen != DestCid->CID.Length ||
         memcmp(VnSourceCid, DestCid->CID.Data, VnSourceCidLen) != 0) {
@@ -3925,7 +3943,7 @@ QuicConnRecvHeader(
             return FALSE;
         }
 
-        QUIC_PATH* Path = &Connection->Paths[0];
+        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
         if (!Path->IsPeerValidated && (Packet->ValidToken || TokenLength != 0)) {
 
             BOOLEAN InvalidRetryToken = FALSE;
@@ -4031,7 +4049,7 @@ QuicConnRecvHeader(
         Packet->KeyType = QUIC_PACKET_KEY_1_RTT;
         Packet->Encrypted =
             !Connection->State.Disable1RttEncrytion &&
-            !Connection->Paths[0].EncryptionOffloading;
+            !QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading;
     }
 
     if (Packet->Encrypted &&
@@ -4685,7 +4703,7 @@ QuicConnRecvFrames(
             } else {
                 if (Status == QUIC_STATUS_VER_NEG_ERROR) {
                     if (QuicBindingQueueStatelessOperation(
-                            Connection->Paths[0].Binding,
+                            QuicPathSetGetActivePath(&Connection->Paths)->Binding,
                             QUIC_OPER_TYPE_VERSION_NEGOTIATION,
                             Packet)) {
                         Packet->ReleaseDeferred = TRUE;
@@ -5197,9 +5215,10 @@ QuicConnRecvFrames(
                 break; // Ignore frame if we are closed.
             }
 
-            CXPLAT_DBG_ASSERT(Connection->PathsCount <= QUIC_MAX_PATH_COUNT);
-            for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
-                QUIC_PATH* TempPath = &Connection->Paths[i];
+            QUIC_PATH_SET* PathSet = &Connection->Paths;
+            CXPLAT_DBG_ASSERT(PathSet->Count <= QUIC_MAX_PATH_COUNT);
+            for (uint8_t i = 0; i < PathSet->Count; ++i) {
+                QUIC_PATH* TempPath = &PathSet->Paths[i];
                 if (!TempPath->IsPeerValidated &&
                     !memcmp(Frame.Data, TempPath->Challenge, sizeof(Frame.Data))) {
                     QuicPerfCounterIncrement(
@@ -5543,12 +5562,13 @@ QuicConnRecvPostProcessing(
             // We need to also send a challenge on the active path to make sure
             // it is still good.
             //
-            CXPLAT_DBG_ASSERT(Connection->Paths[0].IsActive);
-            if (Connection->Paths[0].IsPeerValidated) { // Not already doing peer validation.
-                Connection->Paths[0].IsPeerValidated = FALSE;
-                Connection->Paths[0].SendChallenge = TRUE;
-                Connection->Paths[0].PathValidationStartTime = CxPlatTimeUs64();
-                CxPlatRandom(sizeof(Connection->Paths[0].Challenge), Connection->Paths[0].Challenge);
+            QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+            CXPLAT_DBG_ASSERT(ActivePath->IsActive);
+            if (ActivePath->IsPeerValidated) { // Not already doing peer validation.
+                ActivePath->IsPeerValidated = FALSE;
+                ActivePath->SendChallenge = TRUE;
+                ActivePath->PathValidationStartTime = CxPlatTimeUs64();
+                CxPlatRandom(sizeof(ActivePath->Challenge), ActivePath->Challenge);
             }
 
             QuicSendSetSendFlag(
@@ -5582,13 +5602,15 @@ QuicConnRecvPostProcessing(
         // one. This signals their intent to switch active paths.
         //
         QuicPathSetActive(Connection, *Path);
-        *Path = &Connection->Paths[0];
+        *Path = QuicPathSetGetActivePath(&Connection->Paths);
 
         QuicTraceEvent(
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.RemoteAddress), &Connection->Paths[0].Route.RemoteAddress)); // TODO - Addr removed event?
+            CASTED_CLOG_BYTEARRAY(
+                sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress),
+                &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress)); // TODO - Addr removed event?
 
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED;
@@ -5957,13 +5979,14 @@ QuicConnRecvDatagrams(
     // NB: Traversing the array backwards is simpler and more efficient here due
     // to the array shifting that happens in QuicPathRemove.
     //
-    for (int i = Connection->PathsCount - 1; i > 0; --i) {
-        if (!Connection->Paths[i].GotValidPacket) {
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    for (int i = PathSet->Count - 1; i > 0; --i) {
+        if (!PathSet->Paths[i].GotValidPacket) {
             QuicTraceLogConnInfo(
                 PathDiscarded,
                 Connection,
                 "Removing invalid path[%hhu]",
-                Connection->Paths[i].ID);
+                PathSet->Paths[i].ID);
             QuicPathRemove(Connection, (uint8_t)i);
         }
     }
@@ -6111,7 +6134,9 @@ QuicConnProcessUdpUnreachable(
             Connection,
             "Ignoring received unreachable event");
 
-    } else if (QuicAddrCompare(&Connection->Paths[0].Route.RemoteAddress, RemoteAddress)) {
+    } else if (QuicAddrCompare(
+            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
+            RemoteAddress)) {
         QuicTraceLogConnInfo(
             Unreachable,
             Connection,
@@ -6175,7 +6200,7 @@ QuicConnResetIdleTimeout(
     )
 {
     uint64_t IdleTimeoutMs;
-    QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     if (Connection->State.Connected) {
         //
         // Use the (non-zero) min value between local and peer's configuration.
@@ -6295,8 +6320,9 @@ QuicConnPathValidationTimerUpdate(
     const uint64_t TimeNow = CxPlatTimeUs64();
     uint64_t EarliestDeadline = UINT64_MAX;
 
-    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
-        const QUIC_PATH* Path = &Connection->Paths[i];
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
+        const QUIC_PATH* Path = &PathSet->Paths[i];
         if (Path->IsPeerValidated || Path->PathValidationStartTime == 0) {
             continue;
         }
@@ -6329,9 +6355,10 @@ QuicConnProcessPathValidationTimerOperation(
     // Abandon any path whose validation timed-out.
     //
     const uint64_t TimeNow = CxPlatTimeUs64();
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
     uint8_t i = 0;
-    while (i < Connection->PathsCount) {
-        QUIC_PATH* Path = &Connection->Paths[i];
+    while (i < PathSet->Count) {
+        QUIC_PATH* Path = &PathSet->Paths[i];
         if (Path->IsPeerValidated || Path->PathValidationStartTime == 0) {
             ++i;
             continue;
@@ -6360,7 +6387,7 @@ QuicConnProcessPathValidationTimerOperation(
         // connection is closing. Clear the validation start time so
         // QuicConnPathValidationTimerUpdate won't re-arm the timer.
         //
-        Connection->Paths[i].PathValidationStartTime = 0;
+        PathSet->Paths[i].PathValidationStartTime = 0;
         ++i;
     }
 
@@ -6435,24 +6462,31 @@ QuicConnParamSet(
         }
 
         Connection->State.LocalAddressSet = TRUE;
-        CxPlatCopyMemory(&Connection->Paths[0].Route.LocalAddress, Buffer, sizeof(QUIC_ADDR));
+        CxPlatCopyMemory(
+            &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress,
+            Buffer,
+            sizeof(QUIC_ADDR));
         QuicTraceEvent(
             ConnLocalAddrAdded,
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
-            CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
+            CASTED_CLOG_BYTEARRAY(
+                sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
 
         if (Connection->State.Started) {
 
-            CXPLAT_DBG_ASSERT(Connection->Paths[0].Binding);
+            CXPLAT_DBG_ASSERT(QuicPathSetGetActivePath(&Connection->Paths)->Binding);
             CXPLAT_DBG_ASSERT(Connection->State.RemoteAddressSet);
             CXPLAT_DBG_ASSERT(Connection->Configuration != NULL);
 
-            QUIC_BINDING* OldBinding = Connection->Paths[0].Binding;
+            QUIC_BINDING* OldBinding =
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding;
 
             CXPLAT_UDP_CONFIG UdpConfig = {0};
             UdpConfig.LocalAddress = LocalAddress;
-            UdpConfig.RemoteAddress = &Connection->Paths[0].Route.RemoteAddress;
+            UdpConfig.RemoteAddress =
+                &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress;
             UdpConfig.Flags = CXPLAT_SOCKET_FLAG_NONE;
             UdpConfig.InterfaceIndex = 0;
 #ifdef QUIC_COMPARTMENT_ID
@@ -6473,37 +6507,43 @@ QuicConnParamSet(
             Status =
                 QuicLibraryGetBinding(
                     &UdpConfig,
-                    &Connection->Paths[0].Binding);
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Binding);
             if (QUIC_FAILED(Status)) {
-                Connection->Paths[0].Binding = OldBinding;
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding = OldBinding;
                 break;
             }
-            Connection->Paths[0].Route.State = RouteUnresolved;
-            Connection->Paths[0].Route.Queue = NULL;
+            QuicPathSetGetActivePath(&Connection->Paths)->Route.State = RouteUnresolved;
+            QuicPathSetGetActivePath(&Connection->Paths)->Route.Queue = NULL;
 
             //
             // TODO - Need to free any queued recv packets from old binding.
             //
 
             QuicBindingMoveSourceConnectionIDs(
-                OldBinding, Connection->Paths[0].Binding, Connection);
+                OldBinding,
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                Connection);
             QuicLibraryReleaseBinding(OldBinding);
 
             QuicTraceEvent(
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
+                CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
 
             QuicBindingGetLocalAddress(
-                Connection->Paths[0].Binding,
-                &Connection->Paths[0].Route.LocalAddress);
+                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress);
 
             QuicTraceEvent(
                 ConnLocalAddrAdded,
                 "[conn][%p] New Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
+                CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
 
             QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_PING);
         }
@@ -6527,7 +6567,10 @@ QuicConnParamSet(
         }
 
         Connection->State.RemoteAddressSet = TRUE;
-        CxPlatCopyMemory(&Connection->Paths[0].Route.RemoteAddress, Buffer, sizeof(QUIC_ADDR));
+        CxPlatCopyMemory(
+            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
+            Buffer,
+            sizeof(QUIC_ADDR));
         //
         // Don't log new Remote address added here because it is logged when
         // the connection is started.
@@ -6800,13 +6843,14 @@ QuicConnParamSet(
         }
 
         Connection->State.LocalInterfaceSet = TRUE;
-        Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id = *(uint32_t*)Buffer;
+        QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id =
+            *(uint32_t*)Buffer;
 
         QuicTraceLogConnInfo(
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 
         Status = QUIC_STATUS_SUCCESS;
         break;
@@ -6967,12 +7011,14 @@ QuicConnParamSet(
             Connection,
             "Forcing destination CID update");
 
-        if (!QuicConnRetireCurrentDestCid(Connection, &Connection->Paths[0])) {
+        if (!QuicConnRetireCurrentDestCid(
+                Connection,
+                QuicPathSetGetActivePath(&Connection->Paths))) {
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }
 
-        Connection->Paths[0].InitiatedCidUpdate = TRUE;
+        QuicPathSetGetActivePath(&Connection->Paths)->InitiatedCidUpdate = TRUE;
         Status = QUIC_STATUS_SUCCESS;
         break;
 
@@ -7064,7 +7110,7 @@ QuicConnGetV2Statistics(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
     Stats->CorrelationId = Connection->Stats.CorrelationId;
     Stats->VersionNegotiation = Connection->Stats.VersionNegotiation;
@@ -7241,7 +7287,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &Connection->Paths[0].Route.LocalAddress,
+            &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;
@@ -7268,7 +7314,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &Connection->Paths[0].Route.RemoteAddress,
+            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;
@@ -7318,7 +7364,7 @@ QuicConnParamGet(
         }
 
         QUIC_STATISTICS* Stats = (QUIC_STATISTICS*)Buffer;
-        const QUIC_PATH* Path = &Connection->Paths[0];
+        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
         Stats->CorrelationId = Connection->Stats.CorrelationId;
         Stats->VersionNegotiation = Connection->Stats.VersionNegotiation;
@@ -7658,9 +7704,10 @@ QuicConnApplyNewSettings(
 
     if (!Connection->State.Started) {
 
-        Connection->Paths[0].SmoothedRtt = MS_TO_US(Connection->Settings.InitialRttMs);
-        Connection->Paths[0].RttVariance = Connection->Paths[0].SmoothedRtt / 2;
-        Connection->Paths[0].Mtu = Connection->Settings.MinimumMtu;
+        QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+        ActivePath->SmoothedRtt = MS_TO_US(Connection->Settings.InitialRttMs);
+        ActivePath->RttVariance = ActivePath->SmoothedRtt / 2;
+        ActivePath->Mtu = Connection->Settings.MinimumMtu;
 
         if (Connection->Settings.ServerResumptionLevel > QUIC_SERVER_NO_RESUME &&
             Connection->HandshakeTP == NULL) {
@@ -7752,13 +7799,14 @@ QuicConnApplyNewSettings(
         }
 
         if (Connection->Settings.EcnEnabled) {
-            QUIC_PATH* Path = &Connection->Paths[0];
+            QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
             Path->EcnValidationState = ECN_VALIDATION_TESTING;
         }
     }
 
     if (Connection->State.Started &&
-        (Connection->Settings.EncryptionOffloadAllowed ^ Connection->Paths[0].EncryptionOffloading)) {
+        (Connection->Settings.EncryptionOffloadAllowed ^
+         QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading)) {
         // TODO: enable/disable after start
         CXPLAT_FRE_ASSERT(FALSE);
     }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -145,7 +145,7 @@ QuicConnAlloc(
             goto Error;
         }
     }
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
     Connection->EarliestExpirationTime = UINT64_MAX;
     for (QUIC_CONN_TIMER_TYPE Type = 0; Type < QUIC_CONN_TIMER_COUNT; ++Type) {
@@ -362,7 +362,7 @@ QuicConnFree(
         CxPlatRecvDataReturn((CXPLAT_RECV_DATA*)Connection->ReceiveQueue);
         Connection->ReceiveQueue = NULL;
     }
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     if (Path->Binding != NULL) {
         QuicLibraryReleaseBinding(Path->Binding);
         Path->Binding = NULL;
@@ -593,7 +593,7 @@ QuicConnTraceRundownOper(
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+        QuicPathGetActive(&Connection->Paths)->EcnValidationState ==
             ECN_VALIDATION_CAPABLE);
     CXPLAT_DBG_ASSERT(Connection->Registration);
     QuicTraceEvent(
@@ -906,7 +906,7 @@ QuicConnGenerateNewSourceCid(
             return NULL;
         }
         if (!QuicBindingAddSourceConnectionID(
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                QuicPathGetActive(&Connection->Paths)->Binding,
                 SourceCid)) {
             CXPLAT_FREE(SourceCid, QUIC_POOL_CIDHASH);
             SourceCid = NULL;
@@ -1399,7 +1399,7 @@ QuicConnOnShutdownComplete(
     //
     // Clean up any pending state that is irrelevant now.
     //
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     if (Path->Binding != NULL) {
         if (Path->EncryptionOffloading) {
             QuicPathUpdateQeo(Connection, Path, CXPLAT_QEO_OPERATION_REMOVE);
@@ -1410,7 +1410,7 @@ QuicConnOnShutdownComplete(
         // more packets queued.
         //
         QuicBindingRemoveConnection(
-            QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+            QuicPathGetActive(&Connection->Paths)->Binding,
             Connection);
     }
 
@@ -1554,7 +1554,7 @@ QuicConnTryClose(
                 QUIC_CONN_TIMER_SHUTDOWN,
                 CXPLAT_MAX(
                     MS_TO_US(15),
-                    QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt * 2));
+                    QuicPathGetActive(&Connection->Paths)->SmoothedRtt * 2));
 
             QuicSendSetSendFlag(
                 &Connection->Send,
@@ -1576,7 +1576,7 @@ QuicConnTryClose(
             uint64_t Pto =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
-                    QuicPathSetGetActivePath(&Connection->Paths),
+                    QuicPathGetActive(&Connection->Paths),
                     QUIC_CLOSE_PTO_COUNT);
             QuicConnTimerSet(
                 Connection,
@@ -1620,7 +1620,7 @@ QuicConnTryClose(
                 QUIC_CONN_TIMER_SHUTDOWN,
                 CXPLAT_MAX(
                     MS_TO_US(15),
-                    QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt * 2));
+                    QuicPathGetActive(&Connection->Paths)->SmoothedRtt * 2));
         }
 
         IsFirstCloseForConnection = FALSE;
@@ -1798,7 +1798,7 @@ QuicConnStart(
     )
 {
     QUIC_STATUS Status;
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     CXPLAT_DBG_ASSERT(QuicConnIsClient(Connection));
 
     if (Connection->State.ClosedLocally || Connection->State.Started) {
@@ -2042,7 +2042,7 @@ QuicConnRestart(
         //
         // Don't reset current RTT measurements unless doing a full reset.
         //
-        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
         Path->GotFirstRttSample = FALSE;
         Path->SmoothedRtt = MS_TO_US(Connection->Settings.InitialRttMs);
         Path->RttVariance = Path->SmoothedRtt / 2;
@@ -2339,8 +2339,8 @@ QuicConnGenerateLocalTransportParameters(
     LocalTP->MaxUdpPayloadSize =
         MaxUdpPayloadSizeFromMTU(
             CxPlatSocketGetLocalMtu(
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding->Socket,
-                &QuicPathSetGetActivePath(&Connection->Paths)->Route));
+                QuicPathGetActive(&Connection->Paths)->Binding->Socket,
+                &QuicPathGetActive(&Connection->Paths)->Route));
     LocalTP->MaxAckDelay = QuicConnGetAckDelay(Connection);
     LocalTP->MinAckDelay =
         MsQuicLib.ExecutionConfig != NULL &&
@@ -3413,7 +3413,7 @@ QuicConnUpdateDestCid(
             QUIC_CID_LIST_ENTRY,
             Link);
     CXPLAT_DBG_ASSERT(
-        QuicPathSetGetActivePath(&Connection->Paths)->DestCid == DestCid);
+        QuicPathGetActive(&Connection->Paths)->DestCid == DestCid);
 
     if (Packet->SourceCidLen != DestCid->CID.Length ||
         memcmp(Packet->SourceCid, DestCid->CID.Data, DestCid->CID.Length) != 0) {
@@ -3454,16 +3454,16 @@ QuicConnUpdateDestCid(
                     Packet->SourceCid);
             if (DestCid == NULL) {
                 Connection->DestCidCount--;
-                QuicPathSetGetActivePath(&Connection->Paths)->DestCid = NULL;
+                QuicPathGetActive(&Connection->Paths)->DestCid = NULL;
                 QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, "Out of memory");
                 return FALSE;
             }
 
-            QuicPathSetGetActivePath(&Connection->Paths)->DestCid = DestCid;
+            QuicPathGetActive(&Connection->Paths)->DestCid = DestCid;
             QUIC_CID_SET_PATH(
                 Connection,
                 DestCid,
-                QuicPathSetGetActivePath(&Connection->Paths));
+                QuicPathGetActive(&Connection->Paths));
             DestCid->CID.UsedLocally = TRUE;
             CxPlatListInsertHead(&Connection->DestCids, &DestCid->Link);
         }
@@ -3506,7 +3506,7 @@ QuicConnRecvVerNeg(
     // Validate that the packet's Source CID matches our current Destination CID
     //
     const QUIC_CID_LIST_ENTRY* DestCid =
-        QuicPathSetGetActivePath(&Connection->Paths)->DestCid;
+        QuicPathGetActive(&Connection->Paths)->DestCid;
     CXPLAT_DBG_ASSERT(DestCid != NULL);
     if (VnSourceCidLen != DestCid->CID.Length ||
         memcmp(VnSourceCid, DestCid->CID.Data, VnSourceCidLen) != 0) {
@@ -3943,7 +3943,7 @@ QuicConnRecvHeader(
             return FALSE;
         }
 
-        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
         if (!Path->IsPeerValidated && (Packet->ValidToken || TokenLength != 0)) {
 
             BOOLEAN InvalidRetryToken = FALSE;
@@ -4049,7 +4049,7 @@ QuicConnRecvHeader(
         Packet->KeyType = QUIC_PACKET_KEY_1_RTT;
         Packet->Encrypted =
             !Connection->State.Disable1RttEncrytion &&
-            !QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading;
+            !QuicPathGetActive(&Connection->Paths)->EncryptionOffloading;
     }
 
     if (Packet->Encrypted &&
@@ -4703,7 +4703,7 @@ QuicConnRecvFrames(
             } else {
                 if (Status == QUIC_STATUS_VER_NEG_ERROR) {
                     if (QuicBindingQueueStatelessOperation(
-                            QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                            QuicPathGetActive(&Connection->Paths)->Binding,
                             QUIC_OPER_TYPE_VERSION_NEGOTIATION,
                             Packet)) {
                         Packet->ReleaseDeferred = TRUE;
@@ -5562,7 +5562,7 @@ QuicConnRecvPostProcessing(
             // We need to also send a challenge on the active path to make sure
             // it is still good.
             //
-            QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+            QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
             CXPLAT_DBG_ASSERT(ActivePath->IsActive);
             if (ActivePath->IsPeerValidated) { // Not already doing peer validation.
                 ActivePath->IsPeerValidated = FALSE;
@@ -5602,15 +5602,15 @@ QuicConnRecvPostProcessing(
         // one. This signals their intent to switch active paths.
         //
         QuicPathSetActive(Connection, *Path);
-        *Path = QuicPathSetGetActivePath(&Connection->Paths);
+        *Path = QuicPathGetActive(&Connection->Paths);
 
         QuicTraceEvent(
             ConnRemoteAddrAdded,
             "[conn][%p] New Remote IP: %!ADDR!",
             Connection,
             CASTED_CLOG_BYTEARRAY(
-                sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress),
-                &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress)); // TODO - Addr removed event?
+                sizeof(QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress),
+                &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress)); // TODO - Addr removed event?
 
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED;
@@ -6135,7 +6135,7 @@ QuicConnProcessUdpUnreachable(
             "Ignoring received unreachable event");
 
     } else if (QuicAddrCompare(
-            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
+            &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress,
             RemoteAddress)) {
         QuicTraceLogConnInfo(
             Unreachable,
@@ -6200,7 +6200,7 @@ QuicConnResetIdleTimeout(
     )
 {
     uint64_t IdleTimeoutMs;
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     if (Connection->State.Connected) {
         //
         // Use the (non-zero) min value between local and peer's configuration.
@@ -6463,7 +6463,7 @@ QuicConnParamSet(
 
         Connection->State.LocalAddressSet = TRUE;
         CxPlatCopyMemory(
-            &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress,
+            &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress,
             Buffer,
             sizeof(QUIC_ADDR));
         QuicTraceEvent(
@@ -6471,22 +6471,22 @@ QuicConnParamSet(
             "[conn][%p] New Local IP: %!ADDR!",
             Connection,
             CASTED_CLOG_BYTEARRAY(
-                sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
+                sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress));
 
         if (Connection->State.Started) {
 
-            CXPLAT_DBG_ASSERT(QuicPathSetGetActivePath(&Connection->Paths)->Binding);
+            CXPLAT_DBG_ASSERT(QuicPathGetActive(&Connection->Paths)->Binding);
             CXPLAT_DBG_ASSERT(Connection->State.RemoteAddressSet);
             CXPLAT_DBG_ASSERT(Connection->Configuration != NULL);
 
             QUIC_BINDING* OldBinding =
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding;
+                QuicPathGetActive(&Connection->Paths)->Binding;
 
             CXPLAT_UDP_CONFIG UdpConfig = {0};
             UdpConfig.LocalAddress = LocalAddress;
             UdpConfig.RemoteAddress =
-                &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress;
+                &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress;
             UdpConfig.Flags = CXPLAT_SOCKET_FLAG_NONE;
             UdpConfig.InterfaceIndex = 0;
 #ifdef QUIC_COMPARTMENT_ID
@@ -6507,13 +6507,13 @@ QuicConnParamSet(
             Status =
                 QuicLibraryGetBinding(
                     &UdpConfig,
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Binding);
+                    &QuicPathGetActive(&Connection->Paths)->Binding);
             if (QUIC_FAILED(Status)) {
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding = OldBinding;
+                QuicPathGetActive(&Connection->Paths)->Binding = OldBinding;
                 break;
             }
-            QuicPathSetGetActivePath(&Connection->Paths)->Route.State = RouteUnresolved;
-            QuicPathSetGetActivePath(&Connection->Paths)->Route.Queue = NULL;
+            QuicPathGetActive(&Connection->Paths)->Route.State = RouteUnresolved;
+            QuicPathGetActive(&Connection->Paths)->Route.Queue = NULL;
 
             //
             // TODO - Need to free any queued recv packets from old binding.
@@ -6521,7 +6521,7 @@ QuicConnParamSet(
 
             QuicBindingMoveSourceConnectionIDs(
                 OldBinding,
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                QuicPathGetActive(&Connection->Paths)->Binding,
                 Connection);
             QuicLibraryReleaseBinding(OldBinding);
 
@@ -6530,20 +6530,20 @@ QuicConnParamSet(
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
                 CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress));
 
             QuicBindingGetLocalAddress(
-                QuicPathSetGetActivePath(&Connection->Paths)->Binding,
-                &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress);
+                QuicPathGetActive(&Connection->Paths)->Binding,
+                &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress);
 
             QuicTraceEvent(
                 ConnLocalAddrAdded,
                 "[conn][%p] New Local IP: %!ADDR!",
                 Connection,
                 CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress));
 
             QuicSendSetSendFlag(&Connection->Send, QUIC_CONN_SEND_FLAG_PING);
         }
@@ -6568,7 +6568,7 @@ QuicConnParamSet(
 
         Connection->State.RemoteAddressSet = TRUE;
         CxPlatCopyMemory(
-            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
+            &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress,
             Buffer,
             sizeof(QUIC_ADDR));
         //
@@ -6843,14 +6843,14 @@ QuicConnParamSet(
         }
 
         Connection->State.LocalInterfaceSet = TRUE;
-        QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id =
+        QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id =
             *(uint32_t*)Buffer;
 
         QuicTraceLogConnInfo(
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 
         Status = QUIC_STATUS_SUCCESS;
         break;
@@ -7013,12 +7013,12 @@ QuicConnParamSet(
 
         if (!QuicConnRetireCurrentDestCid(
                 Connection,
-                QuicPathSetGetActivePath(&Connection->Paths))) {
+                QuicPathGetActive(&Connection->Paths))) {
             Status = QUIC_STATUS_INVALID_STATE;
             break;
         }
 
-        QuicPathSetGetActivePath(&Connection->Paths)->InitiatedCidUpdate = TRUE;
+        QuicPathGetActive(&Connection->Paths)->InitiatedCidUpdate = TRUE;
         Status = QUIC_STATUS_SUCCESS;
         break;
 
@@ -7110,7 +7110,7 @@ QuicConnGetV2Statistics(
         return QUIC_STATUS_INVALID_PARAMETER;
     }
 
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
     Stats->CorrelationId = Connection->Stats.CorrelationId;
     Stats->VersionNegotiation = Connection->Stats.VersionNegotiation;
@@ -7287,7 +7287,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress,
+            &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;
@@ -7314,7 +7314,7 @@ QuicConnParamGet(
         *BufferLength = sizeof(QUIC_ADDR);
         CxPlatCopyMemory(
             Buffer,
-            &QuicPathSetGetActivePath(&Connection->Paths)->Route.RemoteAddress,
+            &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress,
             sizeof(QUIC_ADDR));
 
         Status = QUIC_STATUS_SUCCESS;
@@ -7364,7 +7364,7 @@ QuicConnParamGet(
         }
 
         QUIC_STATISTICS* Stats = (QUIC_STATISTICS*)Buffer;
-        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
         Stats->CorrelationId = Connection->Stats.CorrelationId;
         Stats->VersionNegotiation = Connection->Stats.VersionNegotiation;
@@ -7704,7 +7704,7 @@ QuicConnApplyNewSettings(
 
     if (!Connection->State.Started) {
 
-        QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+        QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
         ActivePath->SmoothedRtt = MS_TO_US(Connection->Settings.InitialRttMs);
         ActivePath->RttVariance = ActivePath->SmoothedRtt / 2;
         ActivePath->Mtu = Connection->Settings.MinimumMtu;
@@ -7799,14 +7799,14 @@ QuicConnApplyNewSettings(
         }
 
         if (Connection->Settings.EcnEnabled) {
-            QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+            QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
             Path->EcnValidationState = ECN_VALIDATION_TESTING;
         }
     }
 
     if (Connection->State.Started &&
         (Connection->Settings.EncryptionOffloadAllowed ^
-         QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading)) {
+         QuicPathGetActive(&Connection->Paths)->EncryptionOffloading)) {
         // TODO: enable/disable after start
         CXPLAT_FRE_ASSERT(FALSE);
     }

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -430,12 +430,7 @@ typedef struct QUIC_CONNECTION {
     uint8_t SourceCidLimit;
 
     //
-    // Number of paths the connection is currently tracking.
-    //
-    _Field_range_(0, QUIC_MAX_PATH_COUNT)
-    uint8_t PathsCount;
-
-    //
+    // TODO guhetier: Move to the PATH_SET
     // The next identifier to use for a new path.
     //
     uint8_t NextPathId;
@@ -515,11 +510,9 @@ typedef struct QUIC_CONNECTION {
     QUIC_VAR_INT RetirePriorTo;
 
     //
-    // Per-path state. The first entry in the list is the active path. All the
-    // rest (if any) are other tracked paths, sorted from most to least recently
-    // used.
+    // Network paths known to the connection. There is always an active path in the set.
     //
-    QUIC_PATH Paths[QUIC_MAX_PATH_COUNT];
+    QUIC_PATH_SET Paths;
 
     //
     // The list of connection IDs used for receiving.
@@ -907,7 +900,7 @@ QuicConnLogStatistics(
     _In_ const QUIC_CONNECTION* const Connection
     )
 {
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     UNREFERENCED_PARAMETER(Path);
 
     QuicTraceEvent(
@@ -1308,7 +1301,7 @@ QuicConnGetSourceCidFromSeq(
         if (SourceCid->CID.SequenceNumber == SequenceNumber) {
             if (RemoveFromList) {
                 QuicBindingRemoveSourceConnectionID(
-                    Connection->Paths[0].Binding,
+                    QuicPathSetGetActivePath(&Connection->Paths)->Binding,
                     SourceCid,
                     Entry);
                 QuicTraceEvent(
@@ -1763,13 +1756,14 @@ QuicMtuDiscoveryCheckSearchCompleteTimeout(
     _In_ uint64_t TimeNow
     )
 {
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
     uint64_t TimeoutTime = Connection->Settings.MtuDiscoverySearchCompleteTimeoutUs;
-    for (uint8_t i = 0; i < Connection->PathsCount; i++) {
+    for (uint8_t i = 0; i < PathSet->Count; i++) {
         //
         // Only trigger a new send if we're in Search Complete and enough time has
         // passed.
         //
-        QUIC_PATH* Path = &Connection->Paths[i];
+        QUIC_PATH* Path = &PathSet->Paths[i];
         if (!Path->IsActive || !Path->MtuDiscovery.IsSearchComplete) {
             continue;
         }

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -894,7 +894,7 @@ QuicConnLogStatistics(
     _In_ const QUIC_CONNECTION* const Connection
     )
 {
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     UNREFERENCED_PARAMETER(Path);
 
     QuicTraceEvent(
@@ -1295,7 +1295,7 @@ QuicConnGetSourceCidFromSeq(
         if (SourceCid->CID.SequenceNumber == SequenceNumber) {
             if (RemoveFromList) {
                 QuicBindingRemoveSourceConnectionID(
-                    QuicPathSetGetActivePath(&Connection->Paths)->Binding,
+                    QuicPathGetActive(&Connection->Paths)->Binding,
                     SourceCid,
                     Entry);
                 QuicTraceEvent(

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -430,12 +430,6 @@ typedef struct QUIC_CONNECTION {
     uint8_t SourceCidLimit;
 
     //
-    // TODO guhetier: Move to the PATH_SET
-    // The next identifier to use for a new path.
-    //
-    uint8_t NextPathId;
-
-    //
     // Indicates whether a worker is currently processing a connection.
     // N.B. Multi-threaded access, synchronized by worker's connection lock.
     //

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -495,7 +495,7 @@ QuicCryptoHandshakeConfirmed(
     Connection->State.HandshakeConfirmed = TRUE;
 
     if (SignalBinding) {
-        QUIC_PATH* Path = &Connection->Paths[0];
+        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
         CXPLAT_DBG_ASSERT(Path->Binding != NULL);
         QuicBindingOnConnectionHandshakeConfirmed(Path->Binding, Connection);
     }
@@ -1674,8 +1674,8 @@ QuicCryptoProcessTlsCompletion(
         }
         Connection->Stats.ResumptionSucceeded = Crypto->TlsState.SessionResumed;
 
-        CXPLAT_DBG_ASSERT(Connection->PathsCount == 1);
-        QUIC_PATH* Path = &Connection->Paths[0];
+        CXPLAT_DBG_ASSERT(Connection->Paths.Count == 1);
+        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
         CXPLAT_DBG_ASSERT(Path->IsActive);
 
         if (Connection->Settings.EncryptionOffloadAllowed) {
@@ -1938,13 +1938,14 @@ QuicCryptoProcessData(
             QuicCryptoValidate(Crypto);
 
             Info.QuicVersion = Connection->Stats.QuicVersion;
-            Info.LocalAddress = &Connection->Paths[0].Route.LocalAddress;
-            Info.RemoteAddress = &Connection->Paths[0].Route.RemoteAddress;
+            QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+            Info.LocalAddress = &ActivePath->Route.LocalAddress;
+            Info.RemoteAddress = &ActivePath->Route.RemoteAddress;
             Info.CryptoBufferLength = Buffer.Length;
             Info.CryptoBuffer = Buffer.Buffer;
 
             QuicBindingAcceptConnection(
-                Connection->Paths[0].Binding,
+                ActivePath->Binding,
                 Connection,
                 &Info);
 

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -495,7 +495,7 @@ QuicCryptoHandshakeConfirmed(
     Connection->State.HandshakeConfirmed = TRUE;
 
     if (SignalBinding) {
-        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
         CXPLAT_DBG_ASSERT(Path->Binding != NULL);
         QuicBindingOnConnectionHandshakeConfirmed(Path->Binding, Connection);
     }
@@ -1675,7 +1675,7 @@ QuicCryptoProcessTlsCompletion(
         Connection->Stats.ResumptionSucceeded = Crypto->TlsState.SessionResumed;
 
         CXPLAT_DBG_ASSERT(Connection->Paths.Count == 1);
-        QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
         CXPLAT_DBG_ASSERT(Path->IsActive);
 
         if (Connection->Settings.EncryptionOffloadAllowed) {
@@ -1938,7 +1938,7 @@ QuicCryptoProcessData(
             QuicCryptoValidate(Crypto);
 
             Info.QuicVersion = Connection->Stats.QuicVersion;
-            QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+            QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
             Info.LocalAddress = &ActivePath->Route.LocalAddress;
             Info.RemoteAddress = &ActivePath->Route.RemoteAddress;
             Info.CryptoBufferLength = Buffer.Length;

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -155,7 +155,7 @@ CubicCongestionControlReset(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
     Cubic->SlowStartThreshold = UINT32_MAX;
     Cubic->MinRttInCurrentRound = UINT32_MAX;
     Cubic->HyStartRoundEnd = Connection->Send.NextPacketNumber;
@@ -195,8 +195,8 @@ CubicCongestionControlGetSendAllowance(
     } else if (
         !TimeSinceLastSendValid ||
         !Connection->Settings.PacingEnabled ||
-        !QuicPathSetGetActivePath(&Connection->Paths)->GotFirstRttSample ||
-        QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt < QUIC_MIN_PACING_RTT) {
+        !QuicPathGetActive(&Connection->Paths)->GotFirstRttSample ||
+        QuicPathGetActive(&Connection->Paths)->SmoothedRtt < QUIC_MIN_PACING_RTT) {
         //
         // We're not in the necessary state to pace.
         //
@@ -232,7 +232,7 @@ CubicCongestionControlGetSendAllowance(
             Cubic->LastSendAllowance +
             (uint32_t)(
                 (EstimatedWnd * TimeSinceLastSend) /
-                QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt);
+                QuicPathGetActive(&Connection->Paths)->SmoothedRtt);
         if (SendAllowance < Cubic->LastSendAllowance || // Overflow case
             SendAllowance > (Cubic->CongestionWindow - Cubic->BytesInFlight)) {
             SendAllowance = Cubic->CongestionWindow - Cubic->BytesInFlight;
@@ -281,7 +281,7 @@ CubicCongestionControlOnCongestionEvent(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
     QuicTraceEvent(
         ConnCongestionV2,
         "[conn][%p] Congestion event: IsEcn=%hu",
@@ -315,7 +315,7 @@ CubicCongestionControlOnCongestionEvent(
             Connection);
         Connection->Stats.Send.PersistentCongestionCount++;
 
-        QuicPathSetGetActivePath(&Connection->Paths)->Route.State =
+        QuicPathGetActive(&Connection->Paths)->Route.State =
             RouteSuspected; // used only for RAW datapath
 
         Cubic->IsInPersistentCongestion = TRUE;
@@ -426,7 +426,7 @@ CubicCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
     NetworkStatistics->BytesInFlight = Cubic->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;
@@ -572,7 +572,7 @@ CubicCongestionControlOnDataAcknowledged(
         CXPLAT_DBG_ASSERT(Cubic->CongestionWindow >= Cubic->SlowStartThreshold);
 
         const uint16_t DatagramPayloadLength =
-            QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+            QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
 
         //
         // We require steady ACK feedback to justify window growth. If there is
@@ -584,8 +584,8 @@ CubicCongestionControlOnDataAcknowledged(
             const uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNowUs);
             if (TimeSinceLastAck > MS_TO_US((uint64_t)Cubic->SendIdleTimeoutMs) &&
                 TimeSinceLastAck >
-                    (QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt +
-                     4 * QuicPathSetGetActivePath(&Connection->Paths)->RttVariance)) {
+                    (QuicPathGetActive(&Connection->Paths)->SmoothedRtt +
+                     4 * QuicPathGetActive(&Connection->Paths)->RttVariance)) {
                 Cubic->TimeOfCongAvoidStart += TimeSinceLastAck;
                 if (CxPlatTimeAtOrBefore64(TimeNowUs, Cubic->TimeOfCongAvoidStart)) {
                     Cubic->TimeOfCongAvoidStart = TimeNowUs;
@@ -695,7 +695,7 @@ Exit:
     Cubic->TimeOfLastAckValid = TRUE;
 
     if (Connection->Settings.NetStatsEventEnabled) {
-        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+        const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_NETWORK_STATISTICS;
         Event.NETWORK_STATISTICS.BytesInFlight = Cubic->BytesInFlight;
@@ -833,7 +833,7 @@ CubicCongestionControlLogOutFlowStatus(
     )
 {
     const QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
-    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
 
     QuicTraceEvent(
@@ -928,7 +928,7 @@ CubicCongestionControlInitialize(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
+        QuicPathGetDatagramPayloadSize(QuicPathGetActive(&Connection->Paths));
     Cubic->SlowStartThreshold = UINT32_MAX;
     Cubic->SendIdleTimeoutMs = Settings->SendIdleTimeoutMs;
     Cubic->InitialWindowPackets = Settings->InitialWindowPackets;

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -155,7 +155,7 @@ CubicCongestionControlReset(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
     Cubic->SlowStartThreshold = UINT32_MAX;
     Cubic->MinRttInCurrentRound = UINT32_MAX;
     Cubic->HyStartRoundEnd = Connection->Send.NextPacketNumber;
@@ -195,8 +195,8 @@ CubicCongestionControlGetSendAllowance(
     } else if (
         !TimeSinceLastSendValid ||
         !Connection->Settings.PacingEnabled ||
-        !Connection->Paths[0].GotFirstRttSample ||
-        Connection->Paths[0].SmoothedRtt < QUIC_MIN_PACING_RTT) {
+        !QuicPathSetGetActivePath(&Connection->Paths)->GotFirstRttSample ||
+        QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt < QUIC_MIN_PACING_RTT) {
         //
         // We're not in the necessary state to pace.
         //
@@ -230,7 +230,9 @@ CubicCongestionControlGetSendAllowance(
 
         SendAllowance =
             Cubic->LastSendAllowance +
-            (uint32_t)((EstimatedWnd * TimeSinceLastSend) / Connection->Paths[0].SmoothedRtt);
+            (uint32_t)(
+                (EstimatedWnd * TimeSinceLastSend) /
+                QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt);
         if (SendAllowance < Cubic->LastSendAllowance || // Overflow case
             SendAllowance > (Cubic->CongestionWindow - Cubic->BytesInFlight)) {
             SendAllowance = Cubic->CongestionWindow - Cubic->BytesInFlight;
@@ -279,7 +281,7 @@ CubicCongestionControlOnCongestionEvent(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
     QuicTraceEvent(
         ConnCongestionV2,
         "[conn][%p] Congestion event: IsEcn=%hu",
@@ -313,7 +315,8 @@ CubicCongestionControlOnCongestionEvent(
             Connection);
         Connection->Stats.Send.PersistentCongestionCount++;
 
-        Connection->Paths[0].Route.State = RouteSuspected; // used only for RAW datapath
+        QuicPathSetGetActivePath(&Connection->Paths)->Route.State =
+            RouteSuspected; // used only for RAW datapath
 
         Cubic->IsInPersistentCongestion = TRUE;
         Cubic->WindowPrior =
@@ -423,7 +426,7 @@ CubicCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
     NetworkStatistics->BytesInFlight = Cubic->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;
@@ -569,7 +572,7 @@ CubicCongestionControlOnDataAcknowledged(
         CXPLAT_DBG_ASSERT(Cubic->CongestionWindow >= Cubic->SlowStartThreshold);
 
         const uint16_t DatagramPayloadLength =
-            QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+            QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
 
         //
         // We require steady ACK feedback to justify window growth. If there is
@@ -580,7 +583,9 @@ CubicCongestionControlOnDataAcknowledged(
         if (Cubic->TimeOfLastAckValid) {
             const uint64_t TimeSinceLastAck = CxPlatTimeDiff64(Cubic->TimeOfLastAck, TimeNowUs);
             if (TimeSinceLastAck > MS_TO_US((uint64_t)Cubic->SendIdleTimeoutMs) &&
-                TimeSinceLastAck > (Connection->Paths[0].SmoothedRtt + 4 * Connection->Paths[0].RttVariance)) {
+                TimeSinceLastAck >
+                    (QuicPathSetGetActivePath(&Connection->Paths)->SmoothedRtt +
+                     4 * QuicPathSetGetActivePath(&Connection->Paths)->RttVariance)) {
                 Cubic->TimeOfCongAvoidStart += TimeSinceLastAck;
                 if (CxPlatTimeAtOrBefore64(TimeNowUs, Cubic->TimeOfCongAvoidStart)) {
                     Cubic->TimeOfCongAvoidStart = TimeNowUs;
@@ -690,7 +695,7 @@ Exit:
     Cubic->TimeOfLastAckValid = TRUE;
 
     if (Connection->Settings.NetStatsEventEnabled) {
-        const QUIC_PATH* Path = &Connection->Paths[0];
+        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_NETWORK_STATISTICS;
         Event.NETWORK_STATISTICS.BytesInFlight = Cubic->BytesInFlight;
@@ -828,7 +833,7 @@ CubicCongestionControlLogOutFlowStatus(
     )
 {
     const QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
 
     QuicTraceEvent(
@@ -923,7 +928,7 @@ CubicCongestionControlInitialize(
 
     QUIC_CONNECTION* Connection = QuicCongestionControlGetConnection(Cc);
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection->Paths[0]);
+        QuicPathGetDatagramPayloadSize(QuicPathSetGetActivePath(&Connection->Paths));
     Cubic->SlowStartThreshold = UINT32_MAX;
     Cubic->SendIdleTimeoutMs = Settings->SendIdleTimeoutMs;
     Cubic->InitialWindowPackets = Settings->InitialWindowPackets;

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -271,7 +271,7 @@ QuicDatagramOnSendStateChanged(
                     QUIC_DPLPMTUD_MIN_MTU,
                     QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH);
         } else {
-            const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+            const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
             MtuMaxSendLength =
                 QuicCalculateDatagramLength(
                     QuicAddrGetFamily(&Path->Route.RemoteAddress),

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -271,7 +271,7 @@ QuicDatagramOnSendStateChanged(
                     QUIC_DPLPMTUD_MIN_MTU,
                     QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH);
         } else {
-            const QUIC_PATH* Path = &Connection->Paths[0];
+            const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
             MtuMaxSendLength =
                 QuicCalculateDatagramLength(
                     QuicAddrGetFamily(&Path->Route.RemoteAddress),

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -283,7 +283,7 @@ QuicLossDetectionUpdateTimer(
         return;
     }
 
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Is this right?
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths); // TODO - Is this right?
 
     if (!Path->IsPeerValidated && Path->Allowance < QUIC_MIN_SEND_ALLOWANCE) {
         //
@@ -924,7 +924,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
         uint64_t TwoPto =
             QuicLossDetectionComputeProbeTimeout(
                 LossDetection,
-                QuicPathSetGetActivePath(&Connection->Paths), // TODO - Is this right?
+                QuicPathGetActive(&Connection->Paths), // TODO - Is this right?
                 2);
         while ((Packet = LossDetection->LostPackets) != NULL &&
                 Packet->PacketNumber < LossDetection->LargestAck &&
@@ -953,7 +953,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
         // This implementation excludes kGranularity from the calculation,
         // because it is not needed to keep timers from firing early.
         //
-        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Correct?
+        const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths); // TODO - Correct?
         uint64_t Rtt = CXPLAT_MAX(Path->SmoothedRtt, Path->LatestRttSample);
         uint64_t TimeReorderThreshold = QUIC_TIME_REORDER_THRESHOLD(Rtt);
         uint64_t LargestLostPacketNumber = 0;
@@ -1184,7 +1184,7 @@ QuicLossDetectionDiscardPackets(
     QuicLossValidate(LossDetection);
 
     if (AckedRetransmittableBytes > 0) {
-        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Correct?
+        const QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths); // TODO - Correct?
 
         QUIC_ACK_EVENT AckEvent = {
             .IsImplicit = TRUE,

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -283,7 +283,7 @@ QuicLossDetectionUpdateTimer(
         return;
     }
 
-    QUIC_PATH* Path = &Connection->Paths[0]; // TODO - Is this right?
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Is this right?
 
     if (!Path->IsPeerValidated && Path->Allowance < QUIC_MIN_SEND_ALLOWANCE) {
         //
@@ -924,7 +924,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
         uint64_t TwoPto =
             QuicLossDetectionComputeProbeTimeout(
                 LossDetection,
-                &Connection->Paths[0], // TODO - Is this right?
+                QuicPathSetGetActivePath(&Connection->Paths), // TODO - Is this right?
                 2);
         while ((Packet = LossDetection->LostPackets) != NULL &&
                 Packet->PacketNumber < LossDetection->LargestAck &&
@@ -953,7 +953,7 @@ QuicLossDetectionDetectAndHandleLostPackets(
         // This implementation excludes kGranularity from the calculation,
         // because it is not needed to keep timers from firing early.
         //
-        const QUIC_PATH* Path = &Connection->Paths[0]; // TODO - Correct?
+        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Correct?
         uint64_t Rtt = CXPLAT_MAX(Path->SmoothedRtt, Path->LatestRttSample);
         uint64_t TimeReorderThreshold = QUIC_TIME_REORDER_THRESHOLD(Rtt);
         uint64_t LargestLostPacketNumber = 0;
@@ -1184,7 +1184,7 @@ QuicLossDetectionDiscardPackets(
     QuicLossValidate(LossDetection);
 
     if (AckedRetransmittableBytes > 0) {
-        const QUIC_PATH* Path = &Connection->Paths[0]; // TODO - Correct?
+        const QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths); // TODO - Correct?
 
         QUIC_ACK_EVENT AckEvent = {
             .IsImplicit = TRUE,

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -855,7 +855,8 @@ QuicPacketBuilderFinalize(
     }
 
     if (Builder->EncryptionOverhead != 0 &&
-        !(Builder->Key->Type == QUIC_PACKET_KEY_1_RTT && Connection->Paths[0].EncryptionOffloading)) {
+        !(Builder->Key->Type == QUIC_PACKET_KEY_1_RTT &&
+          QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading)) {
 
         //
         // Encrypt the data.

--- a/src/core/packet_builder.c
+++ b/src/core/packet_builder.c
@@ -856,7 +856,7 @@ QuicPacketBuilderFinalize(
 
     if (Builder->EncryptionOverhead != 0 &&
         !(Builder->Key->Type == QUIC_PACKET_KEY_1_RTT &&
-          QuicPathSetGetActivePath(&Connection->Paths)->EncryptionOffloading)) {
+          QuicPathGetActive(&Connection->Paths)->EncryptionOffloading)) {
 
         //
         // Encrypt the data.

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -7,9 +7,16 @@ Abstract:
 
     Per path functionality for the connection.
 
-TODO:
-
-    Make Path ETW events.
+TODO guhetier:
+    - Improve Path ETW events
+    - Enforce invariants
+        - path[0] is the "active" path and there is always an active path on a started connection
+            - the connection is shutdown rather than having no active path
+        - define an index for a "new" path
+            - does it make sense to have multiple new paths?
+    - change the API so that updating the array is a defered operation that is done only when path are not referenced by an iterator
+    - unit tests
+    - respect of the spec, especially for ID sizes, etc...
 
 --*/
 
@@ -22,7 +29,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathInitialize(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
+    _Out_ QUIC_PATH* Path
     )
 {
     CxPlatZeroMemory(Path, sizeof(QUIC_PATH));
@@ -47,26 +54,51 @@ QuicPathInitialize(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathSetInitialize(
+    _Out_ QUIC_PATH_SET* PathSet,
+    _In_ QUIC_CONNECTION* Connection
+    )
+{
+    CxPlatZeroMemory(PathSet, sizeof(*PathSet));
+    QuicPathInitialize(Connection, &PathSet->Paths[0]);
+    PathSet->Paths[0].IsActive = TRUE;
+    PathSet->Count = 1;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_PATH*
+QuicPathSetGetActivePath(
+    _In_ const QUIC_PATH_SET* PathSet
+    )
+{
+    CXPLAT_DBG_ASSERT(PathSet->Count > 0);
+    CXPLAT_DBG_ASSERT(PathSet->Paths[0].IsActive);
+    return (QUIC_PATH*)&PathSet->Paths[0];
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicPathRemove(
     _In_ QUIC_CONNECTION* Connection,
     _In_ uint8_t Index
     )
 {
-    CXPLAT_DBG_ASSERT(Connection->PathsCount <= QUIC_MAX_PATH_COUNT);
-    if (Connection->PathsCount == 0 ||
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    CXPLAT_DBG_ASSERT(PathSet->Count <= QUIC_MAX_PATH_COUNT);
+    if (PathSet->Count == 0 ||
         Index >= QUIC_MAX_PATH_COUNT ||
-        !Connection->Paths[Index].InUse) {
+        !PathSet->Paths[Index].InUse) {
         CXPLAT_TEL_ASSERTMSG(
-            Connection->PathsCount > 0 &&
+            PathSet->Count > 0 &&
             Index < QUIC_MAX_PATH_COUNT &&
-            Connection->Paths[Index].InUse,
+            PathSet->Paths[Index].InUse,
             "Double or out-of-range path removal!");
         return FALSE;
     }
-    CXPLAT_DBG_ASSERT(Index < Connection->PathsCount);
+    CXPLAT_DBG_ASSERT(Index < PathSet->Count);
 
-    const QUIC_PATH* Path = &Connection->Paths[Index];
+    const QUIC_PATH* Path = &PathSet->Paths[Index];
     CXPLAT_DBG_ASSERT(Path->InUse);
     QuicTraceEvent(
         ConnPathRemoved,
@@ -74,7 +106,7 @@ QuicPathRemove(
         Connection,
         Path->ID);
 
-    if (Connection->PathsCount == 1) {
+    if (PathSet->Count == 1) {
         //
         // Last remaining path. Silently close per RFC 9000 sections 8.2.4 +
         // 10.2, but leave the Paths array intact so in-flight operations see
@@ -91,14 +123,15 @@ QuicPathRemove(
     }
 
     if (Index == 0) {
+        CXPLAT_DBG_ASSERT(PathSet->Count > 1);
         //
         // Removing the active path while other paths exist. Promote the best
         // available fallback: prefer a peer-validated path, otherwise accept
         // any path.
         //
         uint8_t FallbackIndex = 1;
-        for (uint8_t j = 1; j < Connection->PathsCount; ++j) {
-            if (Connection->Paths[j].IsPeerValidated) {
+        for (uint8_t j = 1; j < PathSet->Count; ++j) {
+            if (PathSet->Paths[j].IsPeerValidated) {
                 FallbackIndex = j;
                 break;
             }
@@ -108,8 +141,8 @@ QuicPathRemove(
             Connection,
             "Path[%hhu] removed; falling back to Path[%hhu]",
             Path->ID,
-            Connection->Paths[FallbackIndex].ID);
-        QuicPathSetActive(Connection, &Connection->Paths[FallbackIndex]);
+            PathSet->Paths[FallbackIndex].ID);
+        QuicPathSetActive(Connection, &PathSet->Paths[FallbackIndex]);
         //
         // After the swap the old active path now lives at FallbackIndex.
         // Fall through to remove it there.
@@ -118,21 +151,21 @@ QuicPathRemove(
     }
 
 #if DEBUG
-    if (Connection->Paths[Index].DestCid) {
-        QUIC_CID_CLEAR_PATH(Connection->Paths[Index].DestCid);
+    if (PathSet->Paths[Index].DestCid) {
+        QUIC_CID_CLEAR_PATH(PathSet->Paths[Index].DestCid);
     }
 #endif
 
-    if (Index + 1 < Connection->PathsCount) {
+    if (Index + 1 < PathSet->Count) {
         CxPlatMoveMemory(
-            Connection->Paths + Index,
-            Connection->Paths + Index + 1,
-            (Connection->PathsCount - Index - 1) * sizeof(QUIC_PATH));
+            PathSet->Paths + Index,
+            PathSet->Paths + Index + 1,
+            (PathSet->Count - Index - 1) * sizeof(QUIC_PATH));
     }
 
-    Connection->PathsCount--;
+    PathSet->Count--;
     // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound): False positive: new index is valid.
-    Connection->Paths[Connection->PathsCount].InUse = FALSE;
+    PathSet->Paths[PathSet->Count].InUse = FALSE;
     return TRUE;
 }
 
@@ -223,10 +256,11 @@ QuicConnGetPathByID(
     _Out_ uint8_t* Index
     )
 {
-    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
-        if (Connection->Paths[i].ID == ID) {
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
+        if (PathSet->Paths[i].ID == ID) {
             *Index = i;
-            return &Connection->Paths[i];
+            return &PathSet->Paths[i];
         }
     }
     return NULL;
@@ -240,13 +274,14 @@ QuicConnGetPathForPacket(
     _In_ const QUIC_RX_PACKET* Packet
     )
 {
-    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
         if (!QuicAddrCompare(
                 &Packet->Route->LocalAddress,
-                &Connection->Paths[i].Route.LocalAddress) ||
+                &PathSet->Paths[i].Route.LocalAddress) ||
             !QuicAddrCompare(
                 &Packet->Route->RemoteAddress,
-                &Connection->Paths[i].Route.RemoteAddress)) {
+                &PathSet->Paths[i].Route.RemoteAddress)) {
             if (!Connection->State.HandshakeConfirmed) {
                 //
                 // Ignore packets on any other paths until connected/confirmed.
@@ -255,26 +290,26 @@ QuicConnGetPathForPacket(
             }
             continue;
         }
-        return &Connection->Paths[i];
+        return &PathSet->Paths[i];
     }
 
-    if (Connection->PathsCount == QUIC_MAX_PATH_COUNT) {
+    if (PathSet->Count == QUIC_MAX_PATH_COUNT) {
         //
         // See if any old paths share the same remote address, and is just a rebind.
         // If so, remove the old paths.
         // NB: Traversing the array backwards is simpler and more efficient here due
         // to the array shifting that happens in QuicPathRemove.
         //
-        for (int i = Connection->PathsCount - 1; i > 0; i--) {
-            if (!Connection->Paths[i].IsActive
-                && QuicAddrGetFamily(&Packet->Route->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
-                && QuicAddrCompareIp(&Packet->Route->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
-                && QuicAddrCompare(&Packet->Route->LocalAddress, &Connection->Paths[i].Route.LocalAddress)) {
+        for (int i = PathSet->Count - 1; i > 0; i--) {
+            if (!PathSet->Paths[i].IsActive
+                && QuicAddrGetFamily(&Packet->Route->RemoteAddress) == QuicAddrGetFamily(&PathSet->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompareIp(&Packet->Route->RemoteAddress, &PathSet->Paths[i].Route.RemoteAddress)
+                && QuicAddrCompare(&Packet->Route->LocalAddress, &PathSet->Paths[i].Route.LocalAddress)) {
                 QuicPathRemove(Connection, (uint8_t)i);
             }
         }
 
-        if (Connection->PathsCount == QUIC_MAX_PATH_COUNT) {
+        if (PathSet->Count == QUIC_MAX_PATH_COUNT) {
             //
             // Already tracking the maximum number of paths, and can't free
             // any more.
@@ -283,25 +318,26 @@ QuicConnGetPathForPacket(
         }
     }
 
-    if (Connection->PathsCount > 1) {
+    if (PathSet->Count > 1) {
         //
         // Make room for the new path (at index 1).
         //
         CxPlatMoveMemory(
-            &Connection->Paths[2],
-            &Connection->Paths[1],
-            (Connection->PathsCount - 1) * sizeof(QUIC_PATH));
+            &PathSet->Paths[2],
+            &PathSet->Paths[1],
+            (PathSet->Count - 1) * sizeof(QUIC_PATH));
     }
 
-    CXPLAT_DBG_ASSERT(Connection->PathsCount < QUIC_MAX_PATH_COUNT);
-    QUIC_PATH* Path = &Connection->Paths[1];
+    CXPLAT_DBG_ASSERT(PathSet->Count < QUIC_MAX_PATH_COUNT);
+    QUIC_PATH* Path = &PathSet->Paths[1];
     QuicPathInitialize(Connection, Path);
-    Connection->PathsCount++;
+    PathSet->Count++;
 
-    if (Connection->Paths[0].DestCid->CID.Length == 0) {
-        Path->DestCid = Connection->Paths[0].DestCid; // TODO - Copy instead?
+    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    if (ActivePath->DestCid->CID.Length == 0) {
+        Path->DestCid = ActivePath->DestCid; // TODO - Copy instead?
     }
-    Path->Binding = Connection->Paths[0].Binding;
+    Path->Binding = ActivePath->Binding;
     QuicCopyRouteInfo(&Path->Route, Packet->Route);
     QuicPathValidate(Path);
 
@@ -316,16 +352,17 @@ QuicPathSetActive(
     )
 {
     BOOLEAN UdpPortChangeOnly = FALSE;
-    if (Path == &Connection->Paths[0]) {
+    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+    if (Path == ActivePath) {
         CXPLAT_DBG_ASSERT(!Path->IsActive);
         Path->IsActive = TRUE;
     } else {
         CXPLAT_DBG_ASSERT(Path->DestCid != NULL);
         UdpPortChangeOnly =
-            QuicAddrGetFamily(&Path->Route.RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[0].Route.RemoteAddress) &&
-            QuicAddrCompareIp(&Path->Route.RemoteAddress, &Connection->Paths[0].Route.RemoteAddress);
+            QuicAddrGetFamily(&Path->Route.RemoteAddress) == QuicAddrGetFamily(&ActivePath->Route.RemoteAddress) &&
+            QuicAddrCompareIp(&Path->Route.RemoteAddress, &ActivePath->Route.RemoteAddress);
 
-        QUIC_PATH PrevActivePath = Connection->Paths[0];
+        QUIC_PATH PrevActivePath = *ActivePath;
 
         PrevActivePath.IsActive = FALSE;
         Path->IsActive = TRUE;
@@ -336,7 +373,7 @@ QuicPathSetActive(
             Path->IsMinMtuValidated = PrevActivePath.IsMinMtuValidated;
         }
 
-        Connection->Paths[0] = *Path;
+        *ActivePath = *Path;
         *Path = PrevActivePath;
     }
 
@@ -344,7 +381,7 @@ QuicPathSetActive(
         ConnPathActive,
         "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
         Connection,
-        Connection->Paths[0].ID,
+        ActivePath->ID,
         UdpPortChangeOnly);
 
     if (!UdpPortChangeOnly) {

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -59,7 +59,7 @@ QuicPathSetInitialize(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_PATH*
-QuicPathSetGetActivePath(
+QuicPathGetActive(
     _In_ const QUIC_PATH_SET* PathSet
     )
 {
@@ -324,7 +324,7 @@ QuicConnGetPathForPacket(
     QuicPathInitialize(PathSet->NextPathId++, Connection, Path);
     PathSet->Count++;
 
-    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
     if (ActivePath->DestCid->CID.Length == 0) {
         Path->DestCid = ActivePath->DestCid; // TODO - Copy instead?
     }
@@ -343,7 +343,7 @@ QuicPathSetActive(
     )
 {
     BOOLEAN UdpPortChangeOnly = FALSE;
-    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
     if (Path == ActivePath) {
         CXPLAT_DBG_ASSERT(!Path->IsActive);
         Path->IsActive = TRUE;

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -7,17 +7,6 @@ Abstract:
 
     Per path functionality for the connection.
 
-TODO guhetier:
-    - Improve Path ETW events
-    - Enforce invariants
-        - path[0] is the "active" path and there is always an active path on a started connection
-            - the connection is shutdown rather than having no active path
-        - define an index for a "new" path
-            - does it make sense to have multiple new paths?
-    - change the API so that updating the array is a defered operation that is done only when path are not referenced by an iterator
-    - unit tests
-    - respect of the spec, especially for ID sizes, etc...
-
 --*/
 
 #include "precomp.h"

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -26,14 +26,16 @@ TODO guhetier:
 #endif
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
 void
 QuicPathInitialize(
+    _In_ uint8_t PathId,
     _In_ QUIC_CONNECTION* Connection,
     _Out_ QUIC_PATH* Path
     )
 {
     CxPlatZeroMemory(Path, sizeof(QUIC_PATH));
-    Path->ID = Connection->NextPathId++; // TODO - Check for duplicates after wrap around?
+    Path->ID = PathId; // TODO - Check for duplicates after wrap around?
     Path->InUse = TRUE;
     Path->MinRtt = UINT32_MAX;
     Path->Mtu = Connection->Settings.MinimumMtu;
@@ -61,7 +63,7 @@ QuicPathSetInitialize(
     )
 {
     CxPlatZeroMemory(PathSet, sizeof(*PathSet));
-    QuicPathInitialize(Connection, &PathSet->Paths[0]);
+    QuicPathInitialize(PathSet->NextPathId++, Connection, &PathSet->Paths[0]);
     PathSet->Paths[0].IsActive = TRUE;
     PathSet->Count = 1;
 }
@@ -330,7 +332,7 @@ QuicConnGetPathForPacket(
 
     CXPLAT_DBG_ASSERT(PathSet->Count < QUIC_MAX_PATH_COUNT);
     QUIC_PATH* Path = &PathSet->Paths[1];
-    QuicPathInitialize(Connection, Path);
+    QuicPathInitialize(PathSet->NextPathId++, Connection, Path);
     PathSet->Count++;
 
     QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -202,13 +202,6 @@ CXPLAT_STATIC_ASSERT(
     sizeof(QUIC_PATH) < 256,
     "Ensure path struct stays small since we prealloc them");
 
-_IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicPathInitialize(
-    _In_ QUIC_CONNECTION* Connection,
-    _Out_ QUIC_PATH* Path
-    );
-
 typedef struct QUIC_PATH_SET {
     //
     // Exactly one path is active at all time, the rest (if any) are other tracked paths,
@@ -226,13 +219,17 @@ typedef struct QUIC_PATH_SET {
     _Field_range_(0, QUIC_MAX_PATH_COUNT)
     uint8_t Count;
 
+    //
+    // The next identifier to use for a new path.
+    //
+    uint8_t NextPathId;
+
 } QUIC_PATH_SET;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathSetInitialize(
     _Out_ QUIC_PATH_SET* PathSet,
-    // TODO guhetier: Provide parameters, not the full connection
     _In_ QUIC_CONNECTION* Connection
     );
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -204,11 +204,8 @@ CXPLAT_STATIC_ASSERT(
 
 typedef struct QUIC_PATH_SET {
     //
-    // Exactly one path is active at all time, the rest (if any) are other tracked paths,
-    // sorted from most to least recently used.
-    // Per-path state. The first entry in the list is the active path. All the
-    // rest (if any) are other tracked paths, sorted from most to least recently
-    // used.
+    // Per-path state. The first entry is the active path; the remaining
+    // entries are other tracked paths.
     //
     _Field_size_(Count)
     QUIC_PATH Paths[QUIC_MAX_PATH_COUNT];

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -239,7 +239,7 @@ QuicPathSetInitialize(
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_PATH*
-QuicPathSetGetActivePath(
+QuicPathGetActive(
     _In_ const QUIC_PATH_SET* PathSet
     );
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -206,7 +206,44 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathInitialize(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
+    _Out_ QUIC_PATH* Path
+    );
+
+typedef struct QUIC_PATH_SET {
+    //
+    // Exactly one path is active at all time, the rest (if any) are other tracked paths,
+    // sorted from most to least recently used.
+    // Per-path state. The first entry in the list is the active path. All the
+    // rest (if any) are other tracked paths, sorted from most to least recently
+    // used.
+    //
+    _Field_size_(Count)
+    QUIC_PATH Paths[QUIC_MAX_PATH_COUNT];
+
+    //
+    // Number of paths currently tracked.
+    //
+    _Field_range_(0, QUIC_MAX_PATH_COUNT)
+    uint8_t Count;
+
+} QUIC_PATH_SET;
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathSetInitialize(
+    _Out_ QUIC_PATH_SET* PathSet,
+    // TODO guhetier: Provide parameters, not the full connection
+    _In_ QUIC_CONNECTION* Connection
+    );
+
+//
+// Provide the active path.
+// There is always an active path on a connection.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_PATH*
+QuicPathSetGetActivePath(
+    _In_ const QUIC_PATH_SET* PathSet
     );
 
 //

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -614,8 +614,9 @@ QuicSendWriteFrames(
     if (Send->SendFlags & QUIC_CONN_SEND_FLAG_PATH_RESPONSE) {
 
         uint8_t i;
-        for (i = 0; i < Connection->PathsCount; ++i) {
-            QUIC_PATH* TempPath = &Connection->Paths[i];
+        QUIC_PATH_SET* PathSet = &Connection->Paths;
+        for (i = 0; i < PathSet->Count; ++i) {
+            QUIC_PATH* TempPath = &PathSet->Paths[i];
             if (!TempPath->SendResponse) {
                 continue;
             }
@@ -644,7 +645,7 @@ QuicSendWriteFrames(
             }
         }
 
-        if (i == Connection->PathsCount) {
+        if (i == PathSet->Count) {
             Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_PATH_RESPONSE;
         }
 
@@ -1120,11 +1121,12 @@ QuicSendPathChallenges(
 
     CXPLAT_DBG_ASSERT(Connection->Crypto.TlsState.WriteKeys[QUIC_PACKET_KEY_1_RTT] != NULL);
 
-    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
 
-        QUIC_PATH* Path = &Connection->Paths[i];
-        if (!Connection->Paths[i].SendChallenge ||
-            Connection->Paths[i].Allowance < QUIC_MIN_SEND_ALLOWANCE) {
+        QUIC_PATH* Path = &PathSet->Paths[i];
+        if (!Path->SendChallenge ||
+            Path->Allowance < QUIC_MIN_SEND_ALLOWANCE) {
             continue;
         }
 
@@ -1214,7 +1216,7 @@ QuicSendFlush(
     )
 {
     QUIC_CONNECTION* Connection = QuicSendGetConnection(Send);
-    QUIC_PATH* Path = &Connection->Paths[0];
+    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
 
     CXPLAT_DBG_ASSERT(!Connection->State.HandleClosed);
 
@@ -1291,7 +1293,7 @@ QuicSendFlush(
             uint64_t ThreePtosInUs =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
-                    &Connection->Paths[0],
+                    QuicPathSetGetActivePath(&Connection->Paths),
                     QUIC_CLOSE_PTO_COUNT);
             Builder.Path->EcnTestingEndingTime = TimeNow + ThreePtosInUs;
         }

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1216,7 +1216,7 @@ QuicSendFlush(
     )
 {
     QUIC_CONNECTION* Connection = QuicSendGetConnection(Send);
-    QUIC_PATH* Path = QuicPathSetGetActivePath(&Connection->Paths);
+    QUIC_PATH* Path = QuicPathGetActive(&Connection->Paths);
 
     CXPLAT_DBG_ASSERT(!Connection->State.HandleClosed);
 
@@ -1293,7 +1293,7 @@ QuicSendFlush(
             uint64_t ThreePtosInUs =
                 QuicLossDetectionComputeProbeTimeout(
                     &Connection->LossDetection,
-                    QuicPathSetGetActivePath(&Connection->Paths),
+                    QuicPathGetActive(&Connection->Paths),
                     QUIC_CLOSE_PTO_COUNT);
             Builder.Path->EcnTestingEndingTime = TimeNow + ThreePtosInUs;
         }

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -807,7 +807,9 @@ QuicStreamOnBytesDelivered(
         if (Stream->RecvBuffer.VirtualBufferLength != 0 &&
             Stream->RecvBuffer.VirtualBufferLength < Stream->Connection->Settings.ConnFlowControlWindow) {
             uint64_t TimeThreshold =
-                ((Stream->RecvWindowBytesDelivered * Stream->Connection->Paths[0].SmoothedRtt) / RecvBufferDrainThreshold);
+                ((Stream->RecvWindowBytesDelivered *
+                  QuicPathSetGetActivePath(&Stream->Connection->Paths)->SmoothedRtt) /
+                 RecvBufferDrainThreshold);
             if (CxPlatTimeDiff64(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
 
                 //
@@ -840,7 +842,7 @@ QuicStreamOnBytesDelivered(
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        Stream->Connection->Paths[0].MinRtt,
+                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
                 }

--- a/src/core/stream_recv.c
+++ b/src/core/stream_recv.c
@@ -808,7 +808,7 @@ QuicStreamOnBytesDelivered(
             Stream->RecvBuffer.VirtualBufferLength < Stream->Connection->Settings.ConnFlowControlWindow) {
             uint64_t TimeThreshold =
                 ((Stream->RecvWindowBytesDelivered *
-                  QuicPathSetGetActivePath(&Stream->Connection->Paths)->SmoothedRtt) /
+                  QuicPathGetActive(&Stream->Connection->Paths)->SmoothedRtt) /
                  RecvBufferDrainThreshold);
             if (CxPlatTimeDiff64(Stream->RecvWindowLastUpdate, TimeNow) <= TimeThreshold) {
 
@@ -842,7 +842,7 @@ QuicStreamOnBytesDelivered(
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
+                        QuicPathGetActive(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
                 }

--- a/src/core/unittest/BbrTest.cpp
+++ b/src/core/unittest/BbrTest.cpp
@@ -45,15 +45,15 @@ static void InitBbrMockConnection(
     QUIC_CONNECTION& Connection,
     uint16_t Mtu)
 {
-    Connection.Paths[0].Mtu = Mtu;
-    Connection.Paths[0].IsActive = TRUE;
+    Connection.Paths.Paths[0].Mtu = Mtu;
+    Connection.Paths.Paths[0].IsActive = TRUE;
     Connection.Send.NextPacketNumber = 0;
     Connection.Settings.PacingEnabled = FALSE;
     Connection.Settings.HyStartEnabled = FALSE;
     Connection.Settings.NetStatsEventEnabled = FALSE;
-    Connection.Paths[0].GotFirstRttSample = FALSE;
-    Connection.Paths[0].SmoothedRtt = 0;
-    Connection.Paths[0].OneWayDelay = 0;
+    Connection.Paths.Paths[0].GotFirstRttSample = FALSE;
+    Connection.Paths.Paths[0].SmoothedRtt = 0;
+    Connection.Paths.Paths[0].OneWayDelay = 0;
     Connection.Stats.Send.CongestionCount = 0;
     Connection.Stats.Send.PersistentCongestionCount = 0;
     Connection.Send.PeerMaxData = UINT64_MAX;
@@ -372,7 +372,7 @@ TEST_F(BbrTest_DeepTest, OnDataLost_PersistentCongestion)
 {
     InitializeWithDefaults();
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t MinCW = 4 * DatagramPayloadLength;
 
     CC->QuicCongestionControlOnDataSent(CC, 10000);
@@ -396,7 +396,7 @@ TEST_F(BbrTest_DeepTest, OnDataLost_NonPersistent)
 {
     InitializeWithDefaults();
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t MinCW = 4 * DatagramPayloadLength;
 
     CC->QuicCongestionControlOnDataSent(CC, 10000);
@@ -444,7 +444,7 @@ TEST_F(BbrTest_DeepTest, OnDataLost_AlreadyInRecovery)
     // Second loss: RW_local=7600 (already in recovery, no reset),
     // RW = (7600 > 600+MinCW) ? 7600-600 : MinCW = 7000.
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t MinCW = 4 * DatagramPayloadLength;
     // First loss result
     uint32_t RW1 = (8800u > 1200u + MinCW) ? 8800u - 1200u : MinCW;
@@ -1034,7 +1034,7 @@ TEST_F(BbrTest_DeepTest, GetCongestionWindow_InRecovery)
 {
     InitializeWithDefaults();
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t MinCW = 4 * DatagramPayloadLength;
 
     EnterRecovery();
@@ -1053,7 +1053,7 @@ TEST_F(BbrTest_DeepTest, GetCongestionWindow_ProbeRtt)
 {
     InitializeWithDefaults();
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t MinCW = 4 * DatagramPayloadLength;
 
     DriveToProbeRtt();
@@ -1426,7 +1426,7 @@ TEST_F(BbrTest_DeepTest, Initialize_DefaultState)
 {
     InitializeWithDefaults();
     const uint16_t DatagramPayloadLength =
-        QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+        QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     ASSERT_STREQ(CC->Name, "BBR");
     EXPECT_EQ(Bbr->BbrState, (uint32_t)BBR_STATE_STARTUP);
@@ -1776,7 +1776,7 @@ TEST_F(BbrTest_DeepTest, SetSendQuantum_MediumPacingRate)
     // kLow*8=9,600,000 <= 14,433,593 < kHigh*8=192,000,000
     // → medium pacing rate path → SendQuantum = DatagramPayloadLength * 2
     //
-    const uint16_t DPL = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DPL = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     ASSERT_EQ(Bbr->SendQuantum, (uint64_t)(DPL * 2));
 }
 

--- a/src/core/unittest/BbrTest.cpp
+++ b/src/core/unittest/BbrTest.cpp
@@ -45,6 +45,8 @@ static void InitBbrMockConnection(
     QUIC_CONNECTION& Connection,
     uint16_t Mtu)
 {
+    Connection.Paths.Count = 1;
+    Connection.Paths.NextPathId = 1;
     Connection.Paths.Paths[0].Mtu = Mtu;
     Connection.Paths.Paths[0].IsActive = TRUE;
     Connection.Send.NextPacketNumber = 0;

--- a/src/core/unittest/CubicTest.cpp
+++ b/src/core/unittest/CubicTest.cpp
@@ -70,13 +70,13 @@ static void InitializeMockConnection(
     QUIC_CONNECTION& Connection,
     uint16_t Mtu)
 {
-    Connection.Paths[0].Mtu = Mtu;
-    Connection.Paths[0].IsActive = TRUE;
+    Connection.Paths.Paths[0].Mtu = Mtu;
+    Connection.Paths.Paths[0].IsActive = TRUE;
     Connection.Send.NextPacketNumber = 0;
     Connection.Settings.PacingEnabled = FALSE;
     Connection.Settings.HyStartEnabled = FALSE;
-    Connection.Paths[0].GotFirstRttSample = FALSE;
-    Connection.Paths[0].SmoothedRtt = 0;
+    Connection.Paths.Paths[0].GotFirstRttSample = FALSE;
+    Connection.Paths.Paths[0].SmoothedRtt = 0;
 }
 
 //
@@ -167,12 +167,12 @@ protected:
         InitializeMockConnection(Connection, Mtu);
         Connection.Settings.HyStartEnabled = HyStart ? TRUE : FALSE;
         if (GotRttSample) {
-            Connection.Paths[0].GotFirstRttSample = TRUE;
-            Connection.Paths[0].SmoothedRtt = SmoothedRtt;
+            Connection.Paths.Paths[0].GotFirstRttSample = TRUE;
+            Connection.Paths.Paths[0].SmoothedRtt = SmoothedRtt;
         }
         if (SetMinRtt) {
-            Connection.Paths[0].MinRtt = MinRtt;
-            Connection.Paths[0].RttVariance = RttVariance;
+            Connection.Paths.Paths[0].MinRtt = MinRtt;
+            Connection.Paths.Paths[0].RttVariance = RttVariance;
         }
         CC = &Connection.CongestionControl;
         CubicCongestionControlInitialize(CC, &Settings);
@@ -519,7 +519,7 @@ TEST_F(CubicTest, Recovery_DoubleLossNoDoubleReduction)
 TEST_F(CubicTest, MinimumWindowFloor_AfterLoss)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 2, /*HyStart = */ false);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t InitialWindow = Cubic->CongestionWindow;
     // CW = 2 * 1232 = 2464. CW * 7/10 = 1724.
     // MinimumWindow = 2 * 1232 = 2464. 1724 < 2464 → floor kicks in.
@@ -575,7 +575,7 @@ TEST_F(CubicTest, SlowStart_BytesInFlightMaxClamp)
 TEST_F(CubicTest, CongestionAvoidance_AIMDvsCubicSelection)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 20,  /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     EnterCongestionAvoidance();
 
@@ -635,7 +635,7 @@ TEST_F(CubicTest, CongestionAvoidance_AIMDvsCubicSelection)
 TEST_F(CubicTest, AIMD_SequentialLinearConvergence)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     EnterCongestionAvoidance();
 
@@ -695,7 +695,7 @@ TEST_F(CubicTest, AIMD_SequentialLinearConvergence)
 TEST_F(CubicTest, CongestionAvoidance_RenoFriendlyRegion)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 3, /*HyStart = */ false);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     uint32_t WindowAfterLoss = EnterCongestionAvoidance(/*LostBytes=*/1200);
 
@@ -732,7 +732,7 @@ TEST_F(CubicTest, CongestionAvoidance_RenoFriendlyRegion)
 TEST_F(CubicTest, CongestionAvoidance_BoundedGrowthClamp)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ false);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     // Force into congestion avoidance
     uint32_t CW = 20000;
@@ -778,7 +778,7 @@ TEST_F(CubicTest, CongestionAvoidance_BoundedGrowthClamp)
 TEST_F(CubicTest, SpuriousCongestion_StateRollback)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 20,  /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t InitialWindow = DatagramPayloadLength * Settings.InitialWindowPackets;
 
     // Trigger a congestion event first
@@ -939,7 +939,7 @@ TEST_F(CubicTest, HyStart_ActiveToDone_ViaECN)
 TEST_F(CubicTest, HyStart_AnyToDone_ViaPersistentCongestion)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 30, /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     // Precondition: Can be in any state (we'll test from NOT_STARTED)
     ASSERT_EQ(Cubic->HyStartState, HYSTART_NOT_STARTED);
     // Send data
@@ -1211,8 +1211,8 @@ TEST_F(CubicTest, GetSendAllowanceScenarios)
 
     // Scenario 3: Invalid time - should skip pacing and return full window
     Connection.Settings.PacingEnabled = TRUE;
-    Connection.Paths[0].GotFirstRttSample = TRUE;
-    Connection.Paths[0].SmoothedRtt = 50000;
+    Connection.Paths.Paths[0].GotFirstRttSample = TRUE;
+    Connection.Paths.Paths[0].SmoothedRtt = 50000;
     Allowance = CC->QuicCongestionControlGetSendAllowance(CC, 1000, FALSE); // FALSE = invalid time
     ASSERT_EQ(Allowance, ExpectedAllowance);
 }
@@ -1267,7 +1267,7 @@ TEST_F(CubicTest, GetNetworkStatistics_RetrieveStats)
     ASSERT_EQ(NetworkStats.BytesInFlight, Cubic->BytesInFlight);
     ASSERT_EQ(NetworkStats.SmoothedRTT, 5000u);
     // Bandwidth = CongestionWindow / SmoothedRtt = 12320 / 5000 = 2
-    uint64_t ExpectedBandwidth = Cubic->CongestionWindow / Connection.Paths[0].SmoothedRtt;
+    uint64_t ExpectedBandwidth = Cubic->CongestionWindow / Connection.Paths.Paths[0].SmoothedRtt;
     ASSERT_EQ(NetworkStats.Bandwidth, ExpectedBandwidth);
     // PostedBytes and IdealBytes come from SendBuffer, which is zero-initialized
     ASSERT_EQ(NetworkStats.PostedBytes, 0u);
@@ -1291,7 +1291,7 @@ TEST_F(CubicTest, GetNetworkStatistics_ZeroSmoothedRtt_BandwidthIsZero)
         /*GotRttSample=*/false
     );
 
-    ASSERT_EQ(Connection.Paths[0].SmoothedRtt, 0u);
+    ASSERT_EQ(Connection.Paths.Paths[0].SmoothedRtt, 0u);
 
     CC->QuicCongestionControlOnDataSent(CC, 5000);
 
@@ -1338,7 +1338,7 @@ TEST_F(CubicTest, OnDataAcknowledged_NetStats_ZeroSmoothedRtt_BandwidthIsZero)
     Connection.Settings.NetStatsEventEnabled = TRUE;
     Connection.ClientCallbackHandler = NetStatsDummyCallback;
 
-    ASSERT_EQ(Connection.Paths[0].SmoothedRtt, 0u);
+    ASSERT_EQ(Connection.Paths.Paths[0].SmoothedRtt, 0u);
 
     Cubic->BytesInFlight = 5000;
 
@@ -1435,7 +1435,7 @@ TEST_F(CubicTest, AppLimited_APICoverage)
 TEST_F(CubicTest, ResetScenarios)
 {
     InitializeWithDefaults();
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t ExpectedWindow = DatagramPayloadLength * Settings.InitialWindowPackets;
 
     // Scenario 1: Partial reset (FullReset=FALSE) - preserves BytesInFlight
@@ -1581,7 +1581,7 @@ TEST_F(CubicTest, Pacing_SlowStartWindowEstimation)
     // In slow start: EstimatedWnd = min(2 * CongestionWindow, SlowStartThreshold) = 24640
     // CongestionWindow = (1280 - 48) * 10 = 12320
     uint32_t CongestionWindow = Cubic->CongestionWindow;
-    uint64_t SmoothedRtt = Connection.Paths[0].SmoothedRtt;
+    uint64_t SmoothedRtt = Connection.Paths.Paths[0].SmoothedRtt;
     uint32_t TimeSinceLastSend = 10000;
     uint32_t EstimatedWnd = 2 * CongestionWindow; // SSThresh == UINT32_MAX, so min(2*CW, SST) = 2*CW
     uint32_t ExpectedAllowance = (uint32_t)(((uint64_t)EstimatedWnd * TimeSinceLastSend) / SmoothedRtt);
@@ -1752,7 +1752,7 @@ TEST_F(CubicTest, AIMD_AccumulatorAboveWindowPrior)
 TEST_F(CubicTest, AIMD_AccumulatorTriggersWindowGrowth)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     EnterCongestionAvoidance();
 
@@ -1789,7 +1789,7 @@ TEST_F(CubicTest, AIMD_AccumulatorTriggersWindowGrowth)
 TEST_F(CubicTest, CubicWindow_OverflowToBytesInFlightMax)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 20,  /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
 
     uint32_t WindowAfterLoss = EnterCongestionAvoidance();
 
@@ -1833,7 +1833,7 @@ TEST_F(CubicTest, CubicWindow_OverflowToBytesInFlightMax)
 TEST_F(CubicTest, TimeGap_IdlePeriodHandling)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 20,  /*HyStart = */ true);
-    Connection.Paths[0].RttVariance = 5000;
+    Connection.Paths.Paths[0].RttVariance = 5000;
 
     // Trigger loss → recovery
     CC->QuicCongestionControlOnDataSent(CC, Cubic->CongestionWindow);
@@ -1900,7 +1900,7 @@ TEST_F(CubicTest, TimeGap_IdlePeriodHandling)
 TEST_F(CubicTest, CongestionAvoidance_TimeGapOverflowProtection)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ false);
-    Connection.Paths[0].RttVariance = 10000;
+    Connection.Paths.Paths[0].RttVariance = 10000;
 
     // Force into congestion avoidance by setting window >= threshold
     Cubic->SlowStartThreshold = 10000;
@@ -2003,7 +2003,7 @@ TEST_F(CubicTest, SlowStart_WindowOverflowAfterPersistentCongestion)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ false);
 
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t InitialWindow = DatagramPayloadLength * Settings.InitialWindowPackets;
     ASSERT_EQ(Cubic->CongestionWindow, InitialWindow);
 
@@ -2080,7 +2080,7 @@ TEST_F(CubicTest, SlowStart_WindowOverflowAfterPersistentCongestion)
 TEST_F(CubicTest, HyStart_InitialStateVerification)
 {
     InitializeDefaultWithRtt(/*WindowPackets = */ 10, /*HyStart = */ true);
-    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths[0]);
+    const uint16_t DatagramPayloadLength = QuicPathGetDatagramPayloadSize(&Connection.Paths.Paths[0]);
     uint32_t InitialWindow = DatagramPayloadLength * Settings.InitialWindowPackets;
 
     // Verify initial state

--- a/src/core/unittest/CubicTest.cpp
+++ b/src/core/unittest/CubicTest.cpp
@@ -70,6 +70,8 @@ static void InitializeMockConnection(
     QUIC_CONNECTION& Connection,
     uint16_t Mtu)
 {
+    Connection.Paths.Count = 1;
+    Connection.Paths.NextPathId = 1;
     Connection.Paths.Paths[0].Mtu = Mtu;
     Connection.Paths.Paths[0].IsActive = TRUE;
     Connection.Send.NextPacketNumber = 0;

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -745,9 +745,9 @@ tracepoint(CLOG_CONNECTION_C, FirstCidUsage , arg1, arg3);\
                 PathDiscarded,
                 Connection,
                 "Removing invalid path[%hhu]",
-                Connection->Paths[i].ID);
+                PathSet->Paths[i].ID);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Connection->Paths[i].ID = arg3
+// arg3 = arg3 = PathSet->Paths[i].ID = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_PathDiscarded
 #define _clog_4_ARGS_TRACE_PathDiscarded(uniqueId, arg1, encoded_arg_string, arg3)\
@@ -863,9 +863,9 @@ tracepoint(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme , arg1, arg3);\
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id = arg3
+// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_LocalInterfaceSet
 #define _clog_4_ARGS_TRACE_LocalInterfaceSet(uniqueId, arg1, encoded_arg_string, arg3)\
@@ -1851,9 +1851,11 @@ tracepoint(CLOG_CONNECTION_C, ConnAssignWorker , arg2, arg3);\
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        Connection->Paths[0].EcnValidationState == ECN_VALIDATION_CAPABLE);
+        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+            ECN_VALIDATION_CAPABLE);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Connection->Paths[0].EcnValidationState == ECN_VALIDATION_CAPABLE = arg3
+// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+            ECN_VALIDATION_CAPABLE = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_ConnEcnCapable
 #define _clog_4_ARGS_TRACE_ConnEcnCapable(uniqueId, encoded_arg_string, arg2, arg3)\
@@ -2238,9 +2240,13 @@ tracepoint(CLOG_CONNECTION_C, ConnPathValidationTimeout , arg2, arg3);\
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
+                CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress) = arg3
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress) = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_ConnLocalAddrRemoved
 #define _clog_5_ARGS_TRACE_ConnLocalAddrRemoved(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -863,9 +863,9 @@ tracepoint(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme , arg1, arg3);\
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
+// arg3 = arg3 = QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_LocalInterfaceSet
 #define _clog_4_ARGS_TRACE_LocalInterfaceSet(uniqueId, arg1, encoded_arg_string, arg3)\
@@ -1851,10 +1851,10 @@ tracepoint(CLOG_CONNECTION_C, ConnAssignWorker , arg2, arg3);\
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+        QuicPathGetActive(&Connection->Paths)->EcnValidationState ==
             ECN_VALIDATION_CAPABLE);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+// arg3 = arg3 = QuicPathGetActive(&Connection->Paths)->EcnValidationState ==
             ECN_VALIDATION_CAPABLE = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_4_ARGS_TRACE_ConnEcnCapable
@@ -2241,12 +2241,12 @@ tracepoint(CLOG_CONNECTION_C, ConnPathValidationTimeout , arg2, arg3);\
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
                 CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress));
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress) = arg3
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress) = arg3
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_ConnLocalAddrRemoved
 #define _clog_5_ARGS_TRACE_ConnLocalAddrRemoved(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -926,9 +926,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme,
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
+// arg3 = arg3 = QuicPathGetActive(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, LocalInterfaceSet,
     TP_ARGS(
@@ -2075,10 +2075,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnAssignWorker,
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+        QuicPathGetActive(&Connection->Paths)->EcnValidationState ==
             ECN_VALIDATION_CAPABLE);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+// arg3 = arg3 = QuicPathGetActive(&Connection->Paths)->EcnValidationState ==
             ECN_VALIDATION_CAPABLE = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnEcnCapable,
@@ -2532,12 +2532,12 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnPathValidationTimeout,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
                 CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress));
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
-                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
-                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress) = arg3
+                    sizeof(QuicPathGetActive(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathGetActive(&Connection->Paths)->Route.LocalAddress) = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnLocalAddrRemoved,
     TP_ARGS(

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -792,9 +792,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, FirstCidUsage,
                 PathDiscarded,
                 Connection,
                 "Removing invalid path[%hhu]",
-                Connection->Paths[i].ID);
+                PathSet->Paths[i].ID);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Connection->Paths[i].ID = arg3
+// arg3 = arg3 = PathSet->Paths[i].ID = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, PathDiscarded,
     TP_ARGS(
@@ -926,9 +926,9 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, UpdateStreamSchedulingScheme,
             LocalInterfaceSet,
             Connection,
             "Local interface set to %u",
-            Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id);
+            QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id);
 // arg1 = arg1 = Connection = arg1
-// arg3 = arg3 = Connection->Paths[0].Route.LocalAddress.Ipv6.sin6_scope_id = arg3
+// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress.Ipv6.sin6_scope_id = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, LocalInterfaceSet,
     TP_ARGS(
@@ -2075,9 +2075,11 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnAssignWorker,
         ConnEcnCapable,
         "[conn][%p] Ecn: IsCapable=%hu",
         Connection,
-        Connection->Paths[0].EcnValidationState == ECN_VALIDATION_CAPABLE);
+        QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+            ECN_VALIDATION_CAPABLE);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Connection->Paths[0].EcnValidationState == ECN_VALIDATION_CAPABLE = arg3
+// arg3 = arg3 = QuicPathSetGetActivePath(&Connection->Paths)->EcnValidationState ==
+            ECN_VALIDATION_CAPABLE = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnEcnCapable,
     TP_ARGS(
@@ -2529,9 +2531,13 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnPathValidationTimeout,
                 ConnLocalAddrRemoved,
                 "[conn][%p] Removed Local IP: %!ADDR!",
                 Connection,
-                CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress));
+                CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress));
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(sizeof(Connection->Paths[0].Route.LocalAddress), &Connection->Paths[0].Route.LocalAddress) = arg3
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
+                    sizeof(QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress),
+                    &QuicPathSetGetActivePath(&Connection->Paths)->Route.LocalAddress) = arg3
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnLocalAddrRemoved,
     TP_ARGS(

--- a/src/generated/linux/path.c.clog.h
+++ b/src/generated/linux/path.c.clog.h
@@ -33,10 +33,10 @@ extern "C" {
             Connection,
             "Path[%hhu] removed; falling back to Path[%hhu]",
             Path->ID,
-            Connection->Paths[FallbackIndex].ID);
+            PathSet->Paths[FallbackIndex].ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
-// arg4 = arg4 = Connection->Paths[FallbackIndex].ID = arg4
+// arg4 = arg4 = PathSet->Paths[FallbackIndex].ID = arg4
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_PathActiveFallback
 #define _clog_5_ARGS_TRACE_PathActiveFallback(uniqueId, arg1, encoded_arg_string, arg3, arg4)\
@@ -156,10 +156,10 @@ tracepoint(CLOG_PATH_C, ConnPathValidated , arg2, arg3, arg4);\
         ConnPathActive,
         "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
         Connection,
-        Connection->Paths[0].ID,
+        ActivePath->ID,
         UdpPortChangeOnly);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Connection->Paths[0].ID = arg3
+// arg3 = arg3 = ActivePath->ID = arg3
 // arg4 = arg4 = UdpPortChangeOnly = arg4
 ----------------------------------------------------------*/
 #ifndef _clog_5_ARGS_TRACE_ConnPathActive

--- a/src/generated/linux/path.c.clog.h.lttng.h
+++ b/src/generated/linux/path.c.clog.h.lttng.h
@@ -9,10 +9,10 @@
             Connection,
             "Path[%hhu] removed; falling back to Path[%hhu]",
             Path->ID,
-            Connection->Paths[FallbackIndex].ID);
+            PathSet->Paths[FallbackIndex].ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
-// arg4 = arg4 = Connection->Paths[FallbackIndex].ID = arg4
+// arg4 = arg4 = PathSet->Paths[FallbackIndex].ID = arg4
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PATH_C, PathActiveFallback,
     TP_ARGS(
@@ -154,10 +154,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathValidated,
         ConnPathActive,
         "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
         Connection,
-        Connection->Paths[0].ID,
+        ActivePath->ID,
         UdpPortChangeOnly);
 // arg2 = arg2 = Connection = arg2
-// arg3 = arg3 = Connection->Paths[0].ID = arg3
+// arg3 = arg3 = ActivePath->ID = arg3
 // arg4 = arg4 = UdpPortChangeOnly = arg4
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathActive,

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -361,12 +361,12 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        Stream->Connection->Paths[0].MinRtt,
+                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
-// arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4
+// arg4 = arg4 = QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6
 ----------------------------------------------------------*/

--- a/src/generated/linux/stream_recv.c.clog.h
+++ b/src/generated/linux/stream_recv.c.clog.h
@@ -361,12 +361,12 @@ tracepoint(CLOG_STREAM_RECV_C, RemoteBlocked , arg1, arg3);\
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
+                        QuicPathGetActive(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
-// arg4 = arg4 = QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt = arg4
+// arg4 = arg4 = QuicPathGetActive(&Stream->Connection->Paths)->MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6
 ----------------------------------------------------------*/

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -360,12 +360,12 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        Stream->Connection->Paths[0].MinRtt,
+                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
-// arg4 = arg4 = Stream->Connection->Paths[0].MinRtt = arg4
+// arg4 = arg4 = QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6
 ----------------------------------------------------------*/

--- a/src/generated/linux/stream_recv.c.clog.h.lttng.h
+++ b/src/generated/linux/stream_recv.c.clog.h.lttng.h
@@ -360,12 +360,12 @@ TRACEPOINT_EVENT(CLOG_STREAM_RECV_C, RemoteBlocked,
                         Stream,
                         "Increasing max RX buffer size to %u (MinRtt=%llu; TimeNow=%llu; LastUpdate=%llu)",
                         (uint32_t)NewLength,
-                        QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt,
+                        QuicPathGetActive(&Stream->Connection->Paths)->MinRtt,
                         TimeNow,
                         Stream->RecvWindowLastUpdate);
 // arg1 = arg1 = Stream = arg1
 // arg3 = arg3 = (uint32_t)NewLength = arg3
-// arg4 = arg4 = QuicPathSetGetActivePath(&Stream->Connection->Paths)->MinRtt = arg4
+// arg4 = arg4 = QuicPathGetActive(&Stream->Connection->Paths)->MinRtt = arg4
 // arg5 = arg5 = TimeNow = arg5
 // arg6 = arg6 = Stream->RecvWindowLastUpdate = arg6
 ----------------------------------------------------------*/


### PR DESCRIPTION
## Description

Encapsulates the connection path array and its bookkeeping in `QUIC_PATH_SET`.
There is no behavior change, this is preparatory work for further refactoring.

- Adds path-set initialization and active-path access helpers.
- Moves `NextPathId` into the path set.
- Initializes the path set before congestion control and updates congestion-control tests.
    - Congestion control was accessing `path[0]` before it was initialized
- Replaces direct active-path array access with the path-set helper.

## Testing

CI

## Documentation

No documentation impact.