### PR TITLE
Flush receive batch before path lookup

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5769,15 +5769,9 @@ QuicConnRecvDatagrams(
         CXPLAT_DBG_ASSERT(Packet->ReleaseDeferred == IsDeferred);
         Packet->ReleaseDeferred = FALSE;
 
-        QUIC_PATH* DatagramPath = QuicConnGetPathForPacket(Connection, Packet);
-        if (DatagramPath == NULL) {
-            QuicPacketLogDrop(Connection, Packet, "Max paths already tracked");
-            goto Drop;
-        }
-
-        CxPlatUpdateRoute(&DatagramPath->Route, Packet->Route);
-
-        if (DatagramPath != CurrentPath) {
+        if (CurrentPath == NULL) {
+            CurrentPath = QuicConnGetPathForPacket(Connection, Packet);
+        } else if (!QuicPathMatchPacket(CurrentPath, Packet)) {
             if (BatchCount != 0) {
                 //
                 // This datagram is from a different path than the current
@@ -5793,8 +5787,19 @@ QuicConnRecvDatagrams(
                     &RecvState);
                 BatchCount = 0;
             }
-            CurrentPath = DatagramPath;
+            //
+            // Path lookup can modify the path array, so only do it after the
+            // current batch no longer holds a path pointer.
+            //
+            CurrentPath = QuicConnGetPathForPacket(Connection, Packet);
         }
+
+        if (CurrentPath == NULL) {
+            QuicPacketLogDrop(Connection, Packet, "Max paths already tracked");
+            goto Drop;
+        }
+
+        CxPlatUpdateRoute(&CurrentPath->Route, Packet->Route);
 
         if (!IsDeferred) {
             Connection->Stats.Recv.TotalBytes += Packet->BufferLength;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5777,7 +5777,6 @@ QuicConnRecvDatagrams(
                 // This datagram is from a different path than the current
                 // batch. Flush the current batch before continuing.
                 //
-                CXPLAT_DBG_ASSERT(CurrentPath != NULL);
                 QuicConnRecvDatagramBatch(
                     Connection,
                     CurrentPath,

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -283,12 +283,7 @@ QuicConnGetPathForPacket(
 {
     QUIC_PATH_SET* PathSet = &Connection->Paths;
     for (uint8_t i = 0; i < PathSet->Count; ++i) {
-        if (!QuicAddrCompare(
-                &Packet->Route->LocalAddress,
-                &PathSet->Paths[i].Route.LocalAddress) ||
-            !QuicAddrCompare(
-                &Packet->Route->RemoteAddress,
-                &PathSet->Paths[i].Route.RemoteAddress)) {
+        if (!QuicPathMatchPacket(&PathSet->Paths[i], Packet)) {
             if (!Connection->State.HandshakeConfirmed) {
                 //
                 // Ignore packets on any other paths until connected/confirmed.

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -258,6 +258,22 @@ QuicConnGetPathByID(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicPathMatchPacket(
+    _In_ const QUIC_PATH* Path,
+    _In_ const QUIC_RX_PACKET* Packet
+    )
+{
+    return
+        QuicAddrCompare(
+            &Packet->Route->LocalAddress,
+            &Path->Route.LocalAddress) &&
+        QuicAddrCompare(
+            &Packet->Route->RemoteAddress,
+            &Path->Route.RemoteAddress);
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 _Ret_maybenull_
 QUIC_PATH*
 QuicConnGetPathForPacket(

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -334,6 +334,13 @@ QuicConnGetPathByID(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicPathMatchPacket(
+    _In_ const QUIC_PATH* Path,
+    _In_ const QUIC_RX_PACKET* Packet
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 _Ret_maybenull_
 QUIC_PATH*
 QuicConnGetPathForPacket(


### PR DESCRIPTION
## Description

`QuicConnGetPathForPacket` mutate the `Path` array, potentially invalidating any pointer to a path.
This rearranges the receive batching loop to ensure a pointer to a path is never carried accros a call to `QuicConnGetPathForPacket`.

- Flushes the current receive batch before looking up a packet from a different path.
- Path matching is done without mutating the path array using `QuicPathMatchPacket`.

## Testing

CI and local test run

## Documentation

No documentation impact.