### PR TITLE
Defer active path activation

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1168,6 +1168,10 @@ QuicConnReplaceRetiredCids(
                 NonActivePathCidRetired,
                 Connection,
                 "Non-active path has no replacement for retired CID.");
+            //
+            // A path pending deferred activation is still considered non-active here and
+            // may be removed. CID replacement will be deferred in the next stack layer.
+            //
             CXPLAT_DBG_ASSERT(i != 0);
             QuicPathRemove(Connection, i--);
             continue;
@@ -5488,7 +5492,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicConnRecvPostProcessing(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH** Path,
+    _Inout_ QUIC_PATH* CurrentPath,
     _In_ QUIC_RX_PACKET* Packet
     )
 {
@@ -5512,10 +5516,10 @@ QuicConnRecvPostProcessing(
         }
     }
 
-    if (!(*Path)->GotValidPacket) {
-        (*Path)->GotValidPacket = TRUE;
+    if (!CurrentPath->GotValidPacket) {
+        CurrentPath->GotValidPacket = TRUE;
 
-        if (!(*Path)->IsActive) {
+        if (!CurrentPath->IsActive) {
 
             //
             // This is the first valid packet received on this non-active path.
@@ -5523,8 +5527,8 @@ QuicConnRecvPostProcessing(
             // sent back out.
             //
 
-            if ((*Path)->DestCid == NULL ||
-                (PeerUpdatedCid && (*Path)->DestCid->CID.Length != 0)) {
+            if (CurrentPath->DestCid == NULL ||
+                (PeerUpdatedCid && CurrentPath->DestCid->CID.Length != 0)) {
                 //
                 // TODO - What if the peer (client) only sends a single CID and
                 // rebinding happens? Should we support using the same CID over?
@@ -5536,27 +5540,27 @@ QuicConnRecvPostProcessing(
                         "[conn][%p] ERROR, %s.",
                         Connection,
                         "No unused CID for new path");
-                    (*Path)->GotValidPacket = FALSE; // Don't have a new CID to use!!!
-                    (*Path)->DestCid = NULL;
+                    CurrentPath->GotValidPacket = FALSE; // Don't have a new CID to use!!!
+                    CurrentPath->DestCid = NULL;
                     return;
                 }
-                CXPLAT_DBG_ASSERT(NewDestCid != (*Path)->DestCid);
-                (*Path)->DestCid = NewDestCid;
-                QUIC_CID_SET_PATH(Connection, (*Path)->DestCid, (*Path));
-                (*Path)->DestCid->CID.UsedLocally = TRUE;
+                CXPLAT_DBG_ASSERT(NewDestCid != CurrentPath->DestCid);
+                CurrentPath->DestCid = NewDestCid;
+                QUIC_CID_SET_PATH(Connection, CurrentPath->DestCid, CurrentPath);
+                CurrentPath->DestCid->CID.UsedLocally = TRUE;
             }
 
-            CXPLAT_DBG_ASSERT((*Path)->DestCid != NULL);
-            QuicPathValidate((*Path));
-            (*Path)->SendChallenge = TRUE;
-            (*Path)->PathValidationStartTime = CxPlatTimeUs64();
+            CXPLAT_DBG_ASSERT(CurrentPath->DestCid != NULL);
+            QuicPathValidate(CurrentPath);
+            CurrentPath->SendChallenge = TRUE;
+            CurrentPath->PathValidationStartTime = CxPlatTimeUs64();
 
             //
             // NB: The path challenge payload is initialized here and reused
             // for any retransmits, but the spec requires a new payload in each
             // path challenge.
             //
-            CxPlatRandom(sizeof((*Path)->Challenge), (*Path)->Challenge);
+            CxPlatRandom(sizeof(CurrentPath->Challenge), CurrentPath->Challenge);
 
             //
             // We need to also send a challenge on the active path to make sure
@@ -5587,39 +5591,23 @@ QuicConnRecvPostProcessing(
         // If we didn't initiate the CID change locally, we need to
         // respond to this change with a change of our own.
         //
-        if (!(*Path)->InitiatedCidUpdate) {
-            QuicConnRetireCurrentDestCid(Connection, *Path);
+        if (!CurrentPath->InitiatedCidUpdate) {
+            QuicConnRetireCurrentDestCid(Connection, CurrentPath);
         } else {
-            (*Path)->InitiatedCidUpdate = FALSE;
+            CurrentPath->InitiatedCidUpdate = FALSE;
         }
     }
 
     if (Packet->HasNonProbingFrame &&
         Packet->NewLargestPacketNumber &&
-        !(*Path)->IsActive && (*Path)->InUse) {
+        CurrentPath->ID != Connection->Paths.NextActivePathId &&
+        CurrentPath->InUse) {
         //
-        // The peer has sent a non-probing frame on a path other than the active
-        // one. This signals their intent to switch active paths.
+        // Non-probing frames on a new path indicate the peer migrated to a new address.
+        // Mark this path for activation (activating it invalidates pointers to path, so this
+        // is deferred after the receive loop).
         //
-        QuicPathSetActive(Connection, *Path);
-        *Path = QuicPathGetActive(&Connection->Paths);
-
-        QuicTraceEvent(
-            ConnRemoteAddrAdded,
-            "[conn][%p] New Remote IP: %!ADDR!",
-            Connection,
-            CASTED_CLOG_BYTEARRAY(
-                sizeof(QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress),
-                &QuicPathGetActive(&Connection->Paths)->Route.RemoteAddress)); // TODO - Addr removed event?
-
-        QUIC_CONNECTION_EVENT Event;
-        Event.Type = QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED;
-        Event.PEER_ADDRESS_CHANGED.Address = &(*Path)->Route.RemoteAddress;
-        QuicTraceLogConnVerbose(
-            IndicatePeerAddrChanged,
-            Connection,
-            "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
-        (void)QuicConnIndicateEvent(Connection, &Event);
+        Connection->Paths.NextActivePathId = CurrentPath->ID;
     }
 }
 
@@ -5685,11 +5673,12 @@ QuicConnRecvDatagramBatch(
             }
         } else if (QuicConnRecvFrames(Connection, Path, Packet, ECN)) {
 
-            QuicConnRecvPostProcessing(Connection, &Path, Packet);
+            QuicConnRecvPostProcessing(Connection, Path, Packet);
             RecvState->ResetIdleTimeout |= Packet->CompletelyValid;
 
             if (Connection->Registration != NULL && !Connection->Registration->NoPartitioning &&
-                !Path->Binding->Partitioned && !Connection->State.Partitioned && Path->IsActive &&
+                !Path->Binding->Partitioned && !Connection->State.Partitioned &&
+                Path->ID == Connection->Paths.NextActivePathId &&
                 !Path->PartitionUpdated && Packet->CompletelyValid &&
                 (Packets[i]->PartitionIndex % MsQuicLib.PartitionCount) != RecvState->PartitionIndex) {
                 RecvState->PartitionIndex = Packets[i]->PartitionIndex % MsQuicLib.PartitionCount;
@@ -5994,6 +5983,13 @@ QuicConnRecvDatagrams(
             QuicPathRemove(Connection, (uint8_t)i);
         }
     }
+
+    //
+    // The active path might have changed, update it.
+    // This invalidates pointers to paths.
+    //
+    QuicPathUpdateActive(Connection);
+
     if (!Connection->State.UpdateWorker && Connection->State.Connected &&
         !Connection->State.ShutdownComplete && RecvState.UpdatePartitionId) {
         //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -3362,7 +3362,7 @@ QuicConnQueueRouteCompletion(
     _When_(Succeeded == FALSE, _Reserved_)
     _When_(Succeeded == TRUE, _In_reads_bytes_(6))
         const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     )
 {
@@ -5978,7 +5978,7 @@ QuicConnRecvDatagrams(
             QuicTraceLogConnInfo(
                 PathDiscarded,
                 Connection,
-                "Removing invalid path[%hhu]",
+                "Removing invalid path[%u]",
                 PathSet->Paths[i].ID);
             QuicPathRemove(Connection, (uint8_t)i);
         }
@@ -6163,7 +6163,7 @@ void
 QuicConnProcessRouteCompletion(
     _In_ QUIC_CONNECTION* Connection,
     _In_ const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     )
 {
@@ -6182,7 +6182,7 @@ QuicConnProcessRouteCompletion(
         QuicTraceLogConnInfo(
             FailedRouteResolution,
             Connection,
-            "Route resolution failed on Path[%hhu]. Switching paths...",
+            "Route resolution failed on Path[%u]. Switching paths...",
             PathId);
 
         QuicPathRemove(Connection, PathIndex);
@@ -6371,7 +6371,7 @@ QuicConnProcessPathValidationTimerOperation(
 
         QuicTraceEvent(
             ConnPathValidationTimeout,
-            "[conn][%p] Path[%hhu] validation timed out",
+            "[conn][%p] Path[%u] validation timed out",
             Connection,
             Path->ID);
         QuicPerfCounterIncrement(Connection->Partition, QUIC_PERF_COUNTER_PATH_FAILURE);

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1666,7 +1666,7 @@ QuicConnQueueRouteCompletion(
     _When_(Succeeded == FALSE, _Reserved_)
     _When_(Succeeded == TRUE, _In_reads_bytes_(6))
         const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     );
 

--- a/src/core/loss_detection.c
+++ b/src/core/loss_detection.c
@@ -646,7 +646,7 @@ QuicLossDetectionOnPacketAcknowledged(
             QuicTraceLogConnInfo(
                 PathMinMtuValidated,
                 Connection,
-                "Path[%hhu] Minimum MTU validated",
+                "Path[%u] Minimum MTU validated",
                 Path->ID);
         }
 

--- a/src/core/mtu_discovery.c
+++ b/src/core/mtu_discovery.c
@@ -62,7 +62,7 @@ QuicMtuDiscoveryMoveToSearchComplete(
     QuicTraceLogConnInfo(
         MtuSearchComplete,
         Connection,
-        "Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu",
+        "Path[%u] Mtu Discovery Entering Search Complete at MTU %hu",
         Path->ID,
         Path->Mtu);
 }
@@ -136,7 +136,7 @@ QuicMtuDiscoveryMoveToSearching(
     QuicTraceLogConnInfo(
         MtuSearching,
         Connection,
-        "Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu",
+        "Path[%u] Mtu Discovery Search Packet Sending with MTU %hu",
         Path->ID,
         MtuDiscovery->ProbeSize);
 
@@ -167,7 +167,7 @@ QuicMtuDiscoveryPeerValidated(
     QuicTraceLogConnInfo(
         MtuPathInitialized,
         Connection,
-        "Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
+        "Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
         Path->ID,
         MtuDiscovery->MaxMtu,
         Path->Mtu);
@@ -192,7 +192,7 @@ QuicMtuDiscoveryOnAckedPacket(
         QuicTraceLogConnVerbose(
             MtuIncorrectSize,
             Connection,
-            "Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u",
+            "Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u",
             Path->ID,
             MtuDiscovery->ProbeSize,
             PacketMtu);
@@ -207,7 +207,7 @@ QuicMtuDiscoveryOnAckedPacket(
     QuicTraceLogConnInfo(
         PathMtuUpdated,
         Connection,
-        "Path[%hhu] MTU updated to %hu bytes",
+        "Path[%u] MTU updated to %hu bytes",
         Path->ID,
         Path->Mtu);
 
@@ -237,7 +237,7 @@ QuicMtuDiscoveryProbePacketDiscarded(
         QuicTraceLogConnVerbose(
             MtuIncorrectSize,
             Connection,
-            "Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u",
+            "Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u",
             Path->ID,
             MtuDiscovery->ProbeSize,
             PacketMtu);
@@ -247,7 +247,7 @@ QuicMtuDiscoveryProbePacketDiscarded(
     QuicTraceLogConnInfo(
         MtuDiscarded,
         Connection,
-        "Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
+        "Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
         Path->ID,
         MtuDiscovery->ProbeSize,
         MtuDiscovery->ProbeCount);

--- a/src/core/operation.h
+++ b/src/core/operation.h
@@ -263,7 +263,7 @@ typedef struct QUIC_OPERATION {
         } STATELESS; // Stateless reset, retry and VN
         struct {
             uint8_t PhysicalAddress[6];
-            uint8_t PathId;
+            uint32_t PathId;
             BOOLEAN Succeeded;
         } ROUTE;
     };

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -69,6 +69,14 @@ QuicPathGetActive(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
+void
+QuicPathSetActive(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ uint8_t PathId
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathUpdateActive(
     _In_ QUIC_CONNECTION* Connection
@@ -387,6 +395,7 @@ QuicConnGetPathForPacket(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
 void
 QuicPathSetActive(
     _In_ QUIC_CONNECTION* Connection,

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -18,13 +18,13 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 static
 void
 QuicPathInitialize(
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ QUIC_CONNECTION* Connection,
     _Out_ QUIC_PATH* Path
     )
 {
     CxPlatZeroMemory(Path, sizeof(QUIC_PATH));
-    Path->ID = PathId; // TODO - Check for duplicates after wrap around?
+    Path->ID = PathId;
     Path->InUse = TRUE;
     Path->MinRtt = UINT32_MAX;
     Path->Mtu = Connection->Settings.MinimumMtu;
@@ -39,7 +39,7 @@ QuicPathInitialize(
 
     QuicTraceEvent(
         ConnPathInitialized,
-        "[conn][%p] Path[%hhu] Initialized",
+        "[conn][%p] Path[%u] Initialized",
         Connection,
         Path->ID);
 }
@@ -73,7 +73,7 @@ static
 void
 QuicPathSetActive(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -139,7 +139,7 @@ QuicPathRemove(
         Path->ID != PathSet->NextActivePathId);
     QuicTraceEvent(
         ConnPathRemoved,
-        "[conn][%p] Path[%hhu] Removed",
+        "[conn][%p] Path[%u] Removed",
         Connection,
         Path->ID);
 
@@ -176,7 +176,7 @@ QuicPathRemove(
         QuicTraceLogConnInfo(
             PathActiveFallback,
             Connection,
-            "Path[%hhu] removed; falling back to Path[%hhu]",
+            "Path[%u] removed; falling back to Path[%u]",
             Path->ID,
             PathSet->Paths[FallbackIndex].ID);
         QuicPathSetActive(Connection, PathSet->Paths[FallbackIndex].ID);
@@ -260,7 +260,7 @@ QuicPathSetValid(
 
     QuicTraceEvent(
         ConnPathValidated,
-        "[conn][%p] Path[%hhu] Validated (%hhu)",
+        "[conn][%p] Path[%u] Validated (%hhu)",
         Connection,
         Path->ID,
         Reason);
@@ -289,7 +289,7 @@ _Success_(return != NULL)
 QUIC_PATH*
 QuicConnGetPathByID(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ uint8_t ID,
+    _In_ uint32_t ID,
     _Out_ uint8_t* Index
     )
 {
@@ -367,6 +367,10 @@ QuicConnGetPathForPacket(
         }
     }
 
+    if (PathSet->NextPathId == UINT32_MAX) {
+        return NULL;
+    }
+
     if (PathSet->Count > 1) {
         //
         // Make room for the new path (at index 1).
@@ -398,7 +402,7 @@ static
 void
 QuicPathSetActive(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     )
 {
     BOOLEAN UdpPortChangeOnly = FALSE;
@@ -433,7 +437,7 @@ QuicPathSetActive(
 
     QuicTraceEvent(
         ConnPathActive,
-        "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
+        "[conn][%p] Path[%u] Set active (rebind=%hhu)",
         Connection,
         ActivePath->ID,
         UdpPortChangeOnly);
@@ -495,7 +499,7 @@ QuicPathUpdateQeo(
             QuicTraceLogConnInfo(
                 PathQeoEnabled,
                 Connection,
-                "Path[%hhu] QEO enabled",
+                "Path[%u] QEO enabled",
                 Path->ID);
         }
         CxPlatSecureZeroMemory(Offloads, sizeof(Offloads));
@@ -506,7 +510,7 @@ QuicPathUpdateQeo(
         QuicTraceLogConnInfo(
             PathQeoDisabled,
             Connection,
-            "Path[%hhu] QEO disabled",
+            "Path[%u] QEO disabled",
             Path->ID);
     }
 }

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -69,6 +69,50 @@ QuicPathGetActive(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathUpdateActive(
+    _In_ QUIC_CONNECTION* Connection
+    )
+{
+    QUIC_PATH_SET* PathSet = &Connection->Paths;
+    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    if (PathSet->NextActivePathId == ActivePath->ID) {
+        //
+        // The active path hasn't changed, nothing to do.
+        //
+        return;
+    }
+
+    uint8_t ActivePathIndex = 0;
+    QUIC_PATH* NewActivePath =
+        QuicConnGetPathByID(
+            Connection,
+            PathSet->NextActivePathId,
+            &ActivePathIndex);
+    CXPLAT_DBG_ASSERT(NewActivePath != NULL);
+
+    QuicPathSetActive(Connection, NewActivePath);
+
+    ActivePath = QuicPathSetGetActivePath(PathSet);
+    QuicTraceEvent(
+        ConnRemoteAddrAdded,
+        "[conn][%p] New Remote IP: %!ADDR!",
+        Connection,
+        CASTED_CLOG_BYTEARRAY(
+            sizeof(ActivePath->Route.RemoteAddress),
+            &ActivePath->Route.RemoteAddress)); // TODO - Addr removed event?
+
+    QUIC_CONNECTION_EVENT Event;
+    Event.Type = QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED;
+    Event.PEER_ADDRESS_CHANGED.Address = &ActivePath->Route.RemoteAddress;
+    QuicTraceLogConnVerbose(
+        IndicatePeerAddrChanged,
+        Connection,
+        "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
+    (void)QuicConnIndicateEvent(Connection, &Event);
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
 QuicPathRemove(
     _In_ QUIC_CONNECTION* Connection,
@@ -91,6 +135,9 @@ QuicPathRemove(
 
     const QUIC_PATH* Path = &PathSet->Paths[Index];
     CXPLAT_DBG_ASSERT(Path->InUse);
+    CXPLAT_DBG_ASSERT(
+        PathSet->NextActivePathId == QuicPathSetGetActivePath(PathSet)->ID ||
+        Path->ID != PathSet->NextActivePathId);
     QuicTraceEvent(
         ConnPathRemoved,
         "[conn][%p] Path[%hhu] Removed",
@@ -304,6 +351,7 @@ QuicConnGetPathForPacket(
         //
         for (int i = PathSet->Count - 1; i > 0; i--) {
             if (!PathSet->Paths[i].IsActive
+                && PathSet->Paths[i].ID != PathSet->NextActivePathId
                 && QuicAddrGetFamily(&Packet->Route->RemoteAddress) == QuicAddrGetFamily(&PathSet->Paths[i].Route.RemoteAddress)
                 && QuicAddrCompareIp(&Packet->Route->RemoteAddress, &PathSet->Paths[i].Route.RemoteAddress)
                 && QuicAddrCompare(&Packet->Route->LocalAddress, &PathSet->Paths[i].Route.LocalAddress)) {
@@ -389,6 +437,7 @@ QuicPathSetActive(
     if (!UdpPortChangeOnly) {
         QuicCongestionControlReset(&Connection->CongestionControl, FALSE);
     }
+    Connection->Paths.NextActivePathId = ActivePath->ID;
     CXPLAT_DBG_ASSERT(Path->DestCid != NULL);
     CXPLAT_DBG_ASSERT(!Path->DestCid->CID.Retired);
 }

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -396,7 +396,7 @@ QuicPathSetActive(
     BOOLEAN UdpPortChangeOnly = FALSE;
     uint8_t PathIndex;
     QUIC_PATH* Path = QuicConnGetPathByID(Connection, PathId, &PathIndex);
-    CXPLAT_FRE_ASSERT(Path != NULL);
+    CXPLAT_DBG_ASSERT(Path != NULL);
 
     QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
     if (Path == ActivePath) {

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -83,15 +83,7 @@ QuicPathUpdateActive(
         return;
     }
 
-    uint8_t ActivePathIndex = 0;
-    QUIC_PATH* NewActivePath =
-        QuicConnGetPathByID(
-            Connection,
-            PathSet->NextActivePathId,
-            &ActivePathIndex);
-    CXPLAT_DBG_ASSERT(NewActivePath != NULL);
-
-    QuicPathSetActive(Connection, NewActivePath);
+    QuicPathSetActive(Connection, PathSet->NextActivePathId);
 
     ActivePath = QuicPathSetGetActivePath(PathSet);
     QuicTraceEvent(
@@ -180,7 +172,7 @@ QuicPathRemove(
             "Path[%hhu] removed; falling back to Path[%hhu]",
             Path->ID,
             PathSet->Paths[FallbackIndex].ID);
-        QuicPathSetActive(Connection, &PathSet->Paths[FallbackIndex]);
+        QuicPathSetActive(Connection, PathSet->Paths[FallbackIndex].ID);
         //
         // After the swap the old active path now lives at FallbackIndex.
         // Fall through to remove it there.
@@ -398,10 +390,14 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathSetActive(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
+    _In_ uint8_t PathId
     )
 {
     BOOLEAN UdpPortChangeOnly = FALSE;
+    uint8_t PathIndex;
+    QUIC_PATH* Path = QuicConnGetPathByID(Connection, PathId, &PathIndex);
+    CXPLAT_FRE_ASSERT(Path != NULL);
+
     QUIC_PATH* ActivePath = QuicPathGetActive(&Connection->Paths);
     if (Path == ActivePath) {
         CXPLAT_DBG_ASSERT(!Path->IsActive);

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -75,7 +75,7 @@ QuicPathUpdateActive(
     )
 {
     QUIC_PATH_SET* PathSet = &Connection->Paths;
-    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
     if (PathSet->NextActivePathId == ActivePath->ID) {
         //
         // The active path hasn't changed, nothing to do.
@@ -85,7 +85,7 @@ QuicPathUpdateActive(
 
     QuicPathSetActive(Connection, PathSet->NextActivePathId);
 
-    ActivePath = QuicPathSetGetActivePath(PathSet);
+    ActivePath = QuicPathGetActive(PathSet);
     QuicTraceEvent(
         ConnRemoteAddrAdded,
         "[conn][%p] New Remote IP: %!ADDR!",
@@ -128,7 +128,7 @@ QuicPathRemove(
     const QUIC_PATH* Path = &PathSet->Paths[Index];
     CXPLAT_DBG_ASSERT(Path->InUse);
     CXPLAT_DBG_ASSERT(
-        PathSet->NextActivePathId == QuicPathSetGetActivePath(PathSet)->ID ||
+        PathSet->NextActivePathId == QuicPathGetActive(PathSet)->ID ||
         Path->ID != PathSet->NextActivePathId);
     QuicTraceEvent(
         ConnPathRemoved,

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -83,8 +83,7 @@ QuicPathUpdateActive(
     )
 {
     QUIC_PATH_SET* PathSet = &Connection->Paths;
-    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
-    if (PathSet->NextActivePathId == ActivePath->ID) {
+    if (PathSet->NextActivePathId == QuicPathGetActive(PathSet)->ID) {
         //
         // The active path hasn't changed, nothing to do.
         //
@@ -93,7 +92,7 @@ QuicPathUpdateActive(
 
     QuicPathSetActive(Connection, PathSet->NextActivePathId);
 
-    ActivePath = QuicPathGetActive(PathSet);
+    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
     QuicTraceEvent(
         ConnRemoteAddrAdded,
         "[conn][%p] New Remote IP: %!ADDR!",

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -221,6 +221,11 @@ typedef struct QUIC_PATH_SET {
     //
     uint8_t NextPathId;
 
+    //
+    // ID of the path that will be set active at the end of the next packet receive loop.
+    //
+    uint8_t NextActivePathId;
+
 } QUIC_PATH_SET;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -238,6 +243,16 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_PATH*
 QuicPathGetActive(
     _In_ const QUIC_PATH_SET* PathSet
+    );
+
+//
+// Update the active path to PathSet->NextActivePathId
+// Invalidates pointers to paths.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathUpdateActive(
+    _In_ QUIC_CONNECTION* Connection
     );
 
 //

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -47,7 +47,7 @@ typedef struct QUIC_PATH {
     //
     // Unique identifier;
     //
-    uint8_t ID;
+    uint32_t ID;
 
     //
     // Indicates the path object is actively in use.
@@ -219,12 +219,12 @@ typedef struct QUIC_PATH_SET {
     //
     // The next identifier to use for a new path.
     //
-    uint8_t NextPathId;
+    uint32_t NextPathId;
 
     //
     // ID of the active path, or the path pending activation.
     //
-    uint8_t NextActivePathId;
+    uint32_t NextActivePathId;
 
 } QUIC_PATH_SET;
 
@@ -337,7 +337,7 @@ _Success_(return != NULL)
 QUIC_PATH*
 QuicConnGetPathByID(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ uint8_t ID,
+    _In_ uint32_t ID,
     _Out_ uint8_t* Index
     );
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -335,7 +335,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathSetActive(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
+    _In_ uint8_t PathId
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -222,7 +222,7 @@ typedef struct QUIC_PATH_SET {
     uint8_t NextPathId;
 
     //
-    // ID of the path that will be set active at the end of the next packet receive loop.
+    // ID of the active path, or the path pending activation.
     //
     uint8_t NextActivePathId;
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -332,13 +332,6 @@ QuicPathSetValid(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
-QuicPathSetActive(
-    _In_ QUIC_CONNECTION* Connection,
-    _In_ uint8_t PathId
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
 _Ret_maybenull_
 _Success_(return != NULL)
 QUIC_PATH*

--- a/src/core/sent_packet_metadata.h
+++ b/src/core/sent_packet_metadata.h
@@ -149,7 +149,7 @@ typedef struct QUIC_SENT_PACKET_METADATA {
     uint64_t TotalBytesSent;
     uint64_t SentTime; // In microseconds
     uint16_t PacketLength;
-    uint8_t PathId;
+    uint32_t PathId;
 
     LAST_ACKED_PACKET_INFO LastAckedPacketInfo;
 

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -1407,24 +1407,6 @@ tracepoint(CLOG_CONNECTION_C, IndicatePeerNeedStreamsV2 , arg1, arg3);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for IndicatePeerAddrChanged
-// [conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED
-// QuicTraceLogConnVerbose(
-            IndicatePeerAddrChanged,
-            Connection,
-            "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_IndicatePeerAddrChanged
-#define _clog_3_ARGS_TRACE_IndicatePeerAddrChanged(uniqueId, arg1, encoded_arg_string)\
-tracepoint(CLOG_CONNECTION_C, IndicatePeerAddrChanged , arg1);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for UdpRecvBatch
 // [conn][%p] Batch Recv %u UDP datagrams
 // QuicTraceLogConnVerbose(

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -740,11 +740,11 @@ tracepoint(CLOG_CONNECTION_C, FirstCidUsage , arg1, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PathDiscarded
-// [conn][%p] Removing invalid path[%hhu]
+// [conn][%p] Removing invalid path[%u]
 // QuicTraceLogConnInfo(
                 PathDiscarded,
                 Connection,
-                "Removing invalid path[%hhu]",
+                "Removing invalid path[%u]",
                 PathSet->Paths[i].ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = PathSet->Paths[i].ID = arg3
@@ -778,11 +778,11 @@ tracepoint(CLOG_CONNECTION_C, Unreachable , arg1);\
 
 /*----------------------------------------------------------
 // Decoder Ring for FailedRouteResolution
-// [conn][%p] Route resolution failed on Path[%hhu]. Switching paths...
+// [conn][%p] Route resolution failed on Path[%u]. Switching paths...
 // QuicTraceLogConnInfo(
             FailedRouteResolution,
             Connection,
-            "Route resolution failed on Path[%hhu]. Switching paths...",
+            "Route resolution failed on Path[%u]. Switching paths...",
             PathId);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = PathId = arg3
@@ -2197,10 +2197,10 @@ tracepoint(CLOG_CONNECTION_C, ConnRecvUdpDatagrams , arg2, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathValidationTimeout
-// [conn][%p] Path[%hhu] validation timed out
+// [conn][%p] Path[%u] validation timed out
 // QuicTraceEvent(
             ConnPathValidationTimeout,
-            "[conn][%p] Path[%hhu] validation timed out",
+            "[conn][%p] Path[%u] validation timed out",
             Connection,
             Path->ID);
 // arg2 = arg2 = Connection = arg2

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -787,11 +787,11 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, FirstCidUsage,
 
 /*----------------------------------------------------------
 // Decoder Ring for PathDiscarded
-// [conn][%p] Removing invalid path[%hhu]
+// [conn][%p] Removing invalid path[%u]
 // QuicTraceLogConnInfo(
                 PathDiscarded,
                 Connection,
-                "Removing invalid path[%hhu]",
+                "Removing invalid path[%u]",
                 PathSet->Paths[i].ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = PathSet->Paths[i].ID = arg3
@@ -799,10 +799,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, FirstCidUsage,
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, PathDiscarded,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -829,11 +829,11 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, Unreachable,
 
 /*----------------------------------------------------------
 // Decoder Ring for FailedRouteResolution
-// [conn][%p] Route resolution failed on Path[%hhu]. Switching paths...
+// [conn][%p] Route resolution failed on Path[%u]. Switching paths...
 // QuicTraceLogConnInfo(
             FailedRouteResolution,
             Connection,
-            "Route resolution failed on Path[%hhu]. Switching paths...",
+            "Route resolution failed on Path[%u]. Switching paths...",
             PathId);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = PathId = arg3
@@ -841,10 +841,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, Unreachable,
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, FailedRouteResolution,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -2484,10 +2484,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnRecvUdpDatagrams,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathValidationTimeout
-// [conn][%p] Path[%hhu] validation timed out
+// [conn][%p] Path[%u] validation timed out
 // QuicTraceEvent(
             ConnPathValidationTimeout,
-            "[conn][%p] Path[%hhu] validation timed out",
+            "[conn][%p] Path[%u] validation timed out",
             Connection,
             Path->ID);
 // arg2 = arg2 = Connection = arg2
@@ -2496,10 +2496,10 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnRecvUdpDatagrams,
 TRACEPOINT_EVENT(CLOG_CONNECTION_C, ConnPathValidationTimeout,
     TP_ARGS(
         const void *, arg2,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -1559,25 +1559,6 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, IndicatePeerNeedStreamsV2,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for IndicatePeerAddrChanged
-// [conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED
-// QuicTraceLogConnVerbose(
-            IndicatePeerAddrChanged,
-            Connection,
-            "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CONNECTION_C, IndicatePeerAddrChanged,
-    TP_ARGS(
-        const void *, arg1), 
-    TP_FIELDS(
-        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-    )
-)
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for UdpRecvBatch
 // [conn][%p] Batch Recv %u UDP datagrams
 // QuicTraceLogConnVerbose(

--- a/src/generated/linux/datapath_raw_socket.c.clog.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h
@@ -51,11 +51,11 @@ tracepoint(CLOG_DATAPATH_RAW_SOCKET_C, DatapathTcpAuxBinding , arg2, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for RouteResolutionEnd
-// [conn][%p] Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx
+// [conn][%p] Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx
 // QuicTraceLogConnInfo(
         RouteResolutionEnd,
         Connection,
-        "Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+        "Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
         PathId,
         Route->NextHopLinkLayerAddress[0],
         Route->NextHopLinkLayerAddress[1],

--- a/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_socket.c.clog.h.lttng.h
@@ -26,11 +26,11 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathTcpAuxBinding,
 
 /*----------------------------------------------------------
 // Decoder Ring for RouteResolutionEnd
-// [conn][%p] Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx
+// [conn][%p] Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx
 // QuicTraceLogConnInfo(
         RouteResolutionEnd,
         Connection,
-        "Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+        "Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
         PathId,
         Route->NextHopLinkLayerAddress[0],
         Route->NextHopLinkLayerAddress[1],
@@ -50,7 +50,7 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, DatapathTcpAuxBinding,
 TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, RouteResolutionEnd,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned char, arg4,
         unsigned char, arg5,
         unsigned char, arg6,
@@ -59,7 +59,7 @@ TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_C, RouteResolutionEnd,
         unsigned char, arg9), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned char, arg4, arg4)
         ctf_integer(unsigned char, arg5, arg5)
         ctf_integer(unsigned char, arg6, arg6)

--- a/src/generated/linux/datapath_raw_socket_win.c.clog.h
+++ b/src/generated/linux/datapath_raw_socket_win.c.clog.h
@@ -27,11 +27,11 @@ extern "C" {
 #endif
 /*----------------------------------------------------------
 // Decoder Ring for RouteResolutionStart
-// [conn][%p] Starting to look up neighbor on Path[%hhu] with status %u
+// [conn][%p] Starting to look up neighbor on Path[%u] with status %u
 // QuicTraceLogConnInfo(
         RouteResolutionStart,
         Context,
-        "Starting to look up neighbor on Path[%hhu] with status %u",
+        "Starting to look up neighbor on Path[%u] with status %u",
         PathId,
         Status);
 // arg1 = arg1 = Context = arg1

--- a/src/generated/linux/datapath_raw_socket_win.c.clog.h.lttng.h
+++ b/src/generated/linux/datapath_raw_socket_win.c.clog.h.lttng.h
@@ -3,11 +3,11 @@
 
 /*----------------------------------------------------------
 // Decoder Ring for RouteResolutionStart
-// [conn][%p] Starting to look up neighbor on Path[%hhu] with status %u
+// [conn][%p] Starting to look up neighbor on Path[%u] with status %u
 // QuicTraceLogConnInfo(
         RouteResolutionStart,
         Context,
-        "Starting to look up neighbor on Path[%hhu] with status %u",
+        "Starting to look up neighbor on Path[%u] with status %u",
         PathId,
         Status);
 // arg1 = arg1 = Context = arg1
@@ -17,11 +17,11 @@
 TRACEPOINT_EVENT(CLOG_DATAPATH_RAW_SOCKET_WIN_C, RouteResolutionStart,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned int, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
     )
 )

--- a/src/generated/linux/loss_detection.c.clog.h
+++ b/src/generated/linux/loss_detection.c.clog.h
@@ -289,11 +289,11 @@ tracepoint(CLOG_LOSS_DETECTION_C, HandshakeConfirmedAck , arg1);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PathMinMtuValidated
-// [conn][%p] Path[%hhu] Minimum MTU validated
+// [conn][%p] Path[%u] Minimum MTU validated
 // QuicTraceLogConnInfo(
                 PathMinMtuValidated,
                 Connection,
-                "Path[%hhu] Minimum MTU validated",
+                "Path[%u] Minimum MTU validated",
                 Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3

--- a/src/generated/linux/loss_detection.c.clog.h.lttng.h
+++ b/src/generated/linux/loss_detection.c.clog.h.lttng.h
@@ -299,11 +299,11 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, HandshakeConfirmedAck,
 
 /*----------------------------------------------------------
 // Decoder Ring for PathMinMtuValidated
-// [conn][%p] Path[%hhu] Minimum MTU validated
+// [conn][%p] Path[%u] Minimum MTU validated
 // QuicTraceLogConnInfo(
                 PathMinMtuValidated,
                 Connection,
-                "Path[%hhu] Minimum MTU validated",
+                "Path[%u] Minimum MTU validated",
                 Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
@@ -311,10 +311,10 @@ TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, HandshakeConfirmedAck,
 TRACEPOINT_EVENT(CLOG_LOSS_DETECTION_C, PathMinMtuValidated,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 

--- a/src/generated/linux/mtu_discovery.c.clog.h
+++ b/src/generated/linux/mtu_discovery.c.clog.h
@@ -27,11 +27,11 @@ extern "C" {
 #endif
 /*----------------------------------------------------------
 // Decoder Ring for MtuSearchComplete
-// [conn][%p] Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu
+// [conn][%p] Path[%u] Mtu Discovery Entering Search Complete at MTU %hu
 // QuicTraceLogConnInfo(
         MtuSearchComplete,
         Connection,
-        "Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu",
+        "Path[%u] Mtu Discovery Entering Search Complete at MTU %hu",
         Path->ID,
         Path->Mtu);
 // arg1 = arg1 = Connection = arg1
@@ -49,11 +49,11 @@ tracepoint(CLOG_MTU_DISCOVERY_C, MtuSearchComplete , arg1, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuSearching
-// [conn][%p] Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu
+// [conn][%p] Path[%u] Mtu Discovery Search Packet Sending with MTU %hu
 // QuicTraceLogConnInfo(
         MtuSearching,
         Connection,
-        "Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu",
+        "Path[%u] Mtu Discovery Search Packet Sending with MTU %hu",
         Path->ID,
         MtuDiscovery->ProbeSize);
 // arg1 = arg1 = Connection = arg1
@@ -71,11 +71,11 @@ tracepoint(CLOG_MTU_DISCOVERY_C, MtuSearching , arg1, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuPathInitialized
-// [conn][%p] Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u
+// [conn][%p] Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u
 // QuicTraceLogConnInfo(
         MtuPathInitialized,
         Connection,
-        "Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
+        "Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
         Path->ID,
         MtuDiscovery->MaxMtu,
         Path->Mtu);
@@ -95,11 +95,11 @@ tracepoint(CLOG_MTU_DISCOVERY_C, MtuPathInitialized , arg1, arg3, arg4, arg5);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PathMtuUpdated
-// [conn][%p] Path[%hhu] MTU updated to %hu bytes
+// [conn][%p] Path[%u] MTU updated to %hu bytes
 // QuicTraceLogConnInfo(
         PathMtuUpdated,
         Connection,
-        "Path[%hhu] MTU updated to %hu bytes",
+        "Path[%u] MTU updated to %hu bytes",
         Path->ID,
         Path->Mtu);
 // arg1 = arg1 = Connection = arg1
@@ -117,11 +117,11 @@ tracepoint(CLOG_MTU_DISCOVERY_C, PathMtuUpdated , arg1, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuDiscarded
-// [conn][%p] Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u
+// [conn][%p] Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u
 // QuicTraceLogConnInfo(
         MtuDiscarded,
         Connection,
-        "Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
+        "Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
         Path->ID,
         MtuDiscovery->ProbeSize,
         MtuDiscovery->ProbeCount);
@@ -141,11 +141,11 @@ tracepoint(CLOG_MTU_DISCOVERY_C, MtuDiscarded , arg1, arg3, arg4, arg5);\
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuIncorrectSize
-// [conn][%p] Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u
+// [conn][%p] Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u
 // QuicTraceLogConnVerbose(
             MtuIncorrectSize,
             Connection,
-            "Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u",
+            "Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u",
             Path->ID,
             MtuDiscovery->ProbeSize,
             PacketMtu);

--- a/src/generated/linux/mtu_discovery.c.clog.h.lttng.h
+++ b/src/generated/linux/mtu_discovery.c.clog.h.lttng.h
@@ -3,11 +3,11 @@
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuSearchComplete
-// [conn][%p] Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu
+// [conn][%p] Path[%u] Mtu Discovery Entering Search Complete at MTU %hu
 // QuicTraceLogConnInfo(
         MtuSearchComplete,
         Connection,
-        "Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu",
+        "Path[%u] Mtu Discovery Entering Search Complete at MTU %hu",
         Path->ID,
         Path->Mtu);
 // arg1 = arg1 = Connection = arg1
@@ -17,11 +17,11 @@
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearchComplete,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned short, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned short, arg4, arg4)
     )
 )
@@ -30,11 +30,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearchComplete,
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuSearching
-// [conn][%p] Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu
+// [conn][%p] Path[%u] Mtu Discovery Search Packet Sending with MTU %hu
 // QuicTraceLogConnInfo(
         MtuSearching,
         Connection,
-        "Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu",
+        "Path[%u] Mtu Discovery Search Packet Sending with MTU %hu",
         Path->ID,
         MtuDiscovery->ProbeSize);
 // arg1 = arg1 = Connection = arg1
@@ -44,11 +44,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearchComplete,
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearching,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned short, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned short, arg4, arg4)
     )
 )
@@ -57,11 +57,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearching,
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuPathInitialized
-// [conn][%p] Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u
+// [conn][%p] Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u
 // QuicTraceLogConnInfo(
         MtuPathInitialized,
         Connection,
-        "Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
+        "Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
         Path->ID,
         MtuDiscovery->MaxMtu,
         Path->Mtu);
@@ -73,12 +73,12 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuSearching,
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuPathInitialized,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned int, arg4,
         unsigned int, arg5), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
         ctf_integer(unsigned int, arg5, arg5)
     )
@@ -88,11 +88,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuPathInitialized,
 
 /*----------------------------------------------------------
 // Decoder Ring for PathMtuUpdated
-// [conn][%p] Path[%hhu] MTU updated to %hu bytes
+// [conn][%p] Path[%u] MTU updated to %hu bytes
 // QuicTraceLogConnInfo(
         PathMtuUpdated,
         Connection,
-        "Path[%hhu] MTU updated to %hu bytes",
+        "Path[%u] MTU updated to %hu bytes",
         Path->ID,
         Path->Mtu);
 // arg1 = arg1 = Connection = arg1
@@ -102,11 +102,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuPathInitialized,
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, PathMtuUpdated,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned short, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned short, arg4, arg4)
     )
 )
@@ -115,11 +115,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, PathMtuUpdated,
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuDiscarded
-// [conn][%p] Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u
+// [conn][%p] Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u
 // QuicTraceLogConnInfo(
         MtuDiscarded,
         Connection,
-        "Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
+        "Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
         Path->ID,
         MtuDiscovery->ProbeSize,
         MtuDiscovery->ProbeCount);
@@ -131,12 +131,12 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, PathMtuUpdated,
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuDiscarded,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned int, arg4,
         unsigned int, arg5), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
         ctf_integer(unsigned int, arg5, arg5)
     )
@@ -146,11 +146,11 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuDiscarded,
 
 /*----------------------------------------------------------
 // Decoder Ring for MtuIncorrectSize
-// [conn][%p] Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u
+// [conn][%p] Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u
 // QuicTraceLogConnVerbose(
             MtuIncorrectSize,
             Connection,
-            "Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u",
+            "Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u",
             Path->ID,
             MtuDiscovery->ProbeSize,
             PacketMtu);
@@ -162,12 +162,12 @@ TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuDiscarded,
 TRACEPOINT_EVENT(CLOG_MTU_DISCOVERY_C, MtuIncorrectSize,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned int, arg4,
         unsigned int, arg5), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned int, arg4, arg4)
         ctf_integer(unsigned int, arg5, arg5)
     )

--- a/src/generated/linux/path.c.clog.h
+++ b/src/generated/linux/path.c.clog.h
@@ -31,11 +31,11 @@ extern "C" {
 #endif
 /*----------------------------------------------------------
 // Decoder Ring for PathActiveFallback
-// [conn][%p] Path[%hhu] removed; falling back to Path[%hhu]
+// [conn][%p] Path[%u] removed; falling back to Path[%u]
 // QuicTraceLogConnInfo(
             PathActiveFallback,
             Connection,
-            "Path[%hhu] removed; falling back to Path[%hhu]",
+            "Path[%u] removed; falling back to Path[%u]",
             Path->ID,
             PathSet->Paths[FallbackIndex].ID);
 // arg1 = arg1 = Connection = arg1
@@ -53,11 +53,11 @@ tracepoint(CLOG_PATH_C, PathActiveFallback , arg1, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PathQeoEnabled
-// [conn][%p] Path[%hhu] QEO enabled
+// [conn][%p] Path[%u] QEO enabled
 // QuicTraceLogConnInfo(
                 PathQeoEnabled,
                 Connection,
-                "Path[%hhu] QEO enabled",
+                "Path[%u] QEO enabled",
                 Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
@@ -73,11 +73,11 @@ tracepoint(CLOG_PATH_C, PathQeoEnabled , arg1, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for PathQeoDisabled
-// [conn][%p] Path[%hhu] QEO disabled
+// [conn][%p] Path[%u] QEO disabled
 // QuicTraceLogConnInfo(
             PathQeoDisabled,
             Connection,
-            "Path[%hhu] QEO disabled",
+            "Path[%u] QEO disabled",
             Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
@@ -111,10 +111,10 @@ tracepoint(CLOG_PATH_C, IndicatePeerAddrChanged , arg1);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathInitialized
-// [conn][%p] Path[%hhu] Initialized
+// [conn][%p] Path[%u] Initialized
 // QuicTraceEvent(
         ConnPathInitialized,
-        "[conn][%p] Path[%hhu] Initialized",
+        "[conn][%p] Path[%u] Initialized",
         Connection,
         Path->ID);
 // arg2 = arg2 = Connection = arg2
@@ -155,10 +155,10 @@ tracepoint(CLOG_PATH_C, ConnRemoteAddrAdded , arg2, arg3_len, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathRemoved
-// [conn][%p] Path[%hhu] Removed
+// [conn][%p] Path[%u] Removed
 // QuicTraceEvent(
         ConnPathRemoved,
-        "[conn][%p] Path[%hhu] Removed",
+        "[conn][%p] Path[%u] Removed",
         Connection,
         Path->ID);
 // arg2 = arg2 = Connection = arg2
@@ -175,10 +175,10 @@ tracepoint(CLOG_PATH_C, ConnPathRemoved , arg2, arg3);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathValidated
-// [conn][%p] Path[%hhu] Validated (%hhu)
+// [conn][%p] Path[%u] Validated (%hhu)
 // QuicTraceEvent(
         ConnPathValidated,
-        "[conn][%p] Path[%hhu] Validated (%hhu)",
+        "[conn][%p] Path[%u] Validated (%hhu)",
         Connection,
         Path->ID,
         Reason);
@@ -197,10 +197,10 @@ tracepoint(CLOG_PATH_C, ConnPathValidated , arg2, arg3, arg4);\
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathActive
-// [conn][%p] Path[%hhu] Set active (rebind=%hhu)
+// [conn][%p] Path[%u] Set active (rebind=%hhu)
 // QuicTraceEvent(
         ConnPathActive,
-        "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
+        "[conn][%p] Path[%u] Set active (rebind=%hhu)",
         Connection,
         ActivePath->ID,
         UdpPortChangeOnly);

--- a/src/generated/linux/path.c.clog.h
+++ b/src/generated/linux/path.c.clog.h
@@ -18,6 +18,10 @@
 #define _clog_MACRO_QuicTraceLogConnInfo  1
 #define QuicTraceLogConnInfo(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
 #endif
+#ifndef _clog_MACRO_QuicTraceLogConnVerbose
+#define _clog_MACRO_QuicTraceLogConnVerbose  1
+#define QuicTraceLogConnVerbose(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
+#endif
 #ifndef _clog_MACRO_QuicTraceEvent
 #define _clog_MACRO_QuicTraceEvent  1
 #define QuicTraceEvent(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
@@ -88,6 +92,24 @@ tracepoint(CLOG_PATH_C, PathQeoDisabled , arg1, arg3);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for IndicatePeerAddrChanged
+// [conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED
+// QuicTraceLogConnVerbose(
+        IndicatePeerAddrChanged,
+        Connection,
+        "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_IndicatePeerAddrChanged
+#define _clog_3_ARGS_TRACE_IndicatePeerAddrChanged(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_PATH_C, IndicatePeerAddrChanged , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for ConnPathInitialized
 // [conn][%p] Path[%hhu] Initialized
 // QuicTraceEvent(
@@ -101,6 +123,30 @@ tracepoint(CLOG_PATH_C, PathQeoDisabled , arg1, arg3);\
 #ifndef _clog_4_ARGS_TRACE_ConnPathInitialized
 #define _clog_4_ARGS_TRACE_ConnPathInitialized(uniqueId, encoded_arg_string, arg2, arg3)\
 tracepoint(CLOG_PATH_C, ConnPathInitialized , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for ConnRemoteAddrAdded
+// [conn][%p] New Remote IP: %!ADDR!
+// QuicTraceEvent(
+        ConnRemoteAddrAdded,
+        "[conn][%p] New Remote IP: %!ADDR!",
+        Connection,
+        CASTED_CLOG_BYTEARRAY(
+            sizeof(ActivePath->Route.RemoteAddress),
+            &ActivePath->Route.RemoteAddress));
+// arg2 = arg2 = Connection = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
+            sizeof(ActivePath->Route.RemoteAddress),
+            &ActivePath->Route.RemoteAddress) = arg3
+----------------------------------------------------------*/
+#ifndef _clog_5_ARGS_TRACE_ConnRemoteAddrAdded
+#define _clog_5_ARGS_TRACE_ConnRemoteAddrAdded(uniqueId, encoded_arg_string, arg2, arg3, arg3_len)\
+tracepoint(CLOG_PATH_C, ConnRemoteAddrAdded , arg2, arg3_len, arg3);\
 
 #endif
 

--- a/src/generated/linux/path.c.clog.h.lttng.h
+++ b/src/generated/linux/path.c.clog.h.lttng.h
@@ -75,6 +75,25 @@ TRACEPOINT_EVENT(CLOG_PATH_C, PathQeoDisabled,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for IndicatePeerAddrChanged
+// [conn][%p] Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED
+// QuicTraceLogConnVerbose(
+        IndicatePeerAddrChanged,
+        Connection,
+        "Indicating QUIC_CONNECTION_EVENT_PEER_ADDRESS_CHANGED");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PATH_C, IndicatePeerAddrChanged,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for ConnPathInitialized
 // [conn][%p] Path[%hhu] Initialized
 // QuicTraceEvent(
@@ -92,6 +111,35 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathInitialized,
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
         ctf_integer(unsigned char, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for ConnRemoteAddrAdded
+// [conn][%p] New Remote IP: %!ADDR!
+// QuicTraceEvent(
+        ConnRemoteAddrAdded,
+        "[conn][%p] New Remote IP: %!ADDR!",
+        Connection,
+        CASTED_CLOG_BYTEARRAY(
+            sizeof(ActivePath->Route.RemoteAddress),
+            &ActivePath->Route.RemoteAddress));
+// arg2 = arg2 = Connection = arg2
+// arg3 = arg3 = CASTED_CLOG_BYTEARRAY(
+            sizeof(ActivePath->Route.RemoteAddress),
+            &ActivePath->Route.RemoteAddress) = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PATH_C, ConnRemoteAddrAdded,
+    TP_ARGS(
+        const void *, arg2,
+        unsigned int, arg3_len,
+        const void *, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
+        ctf_integer(unsigned int, arg3_len, arg3_len)
+        ctf_sequence(char, arg3, arg3, unsigned int, arg3_len)
     )
 )
 

--- a/src/generated/linux/path.c.clog.h.lttng.h
+++ b/src/generated/linux/path.c.clog.h.lttng.h
@@ -3,11 +3,11 @@
 
 /*----------------------------------------------------------
 // Decoder Ring for PathActiveFallback
-// [conn][%p] Path[%hhu] removed; falling back to Path[%hhu]
+// [conn][%p] Path[%u] removed; falling back to Path[%u]
 // QuicTraceLogConnInfo(
             PathActiveFallback,
             Connection,
-            "Path[%hhu] removed; falling back to Path[%hhu]",
+            "Path[%u] removed; falling back to Path[%u]",
             Path->ID,
             PathSet->Paths[FallbackIndex].ID);
 // arg1 = arg1 = Connection = arg1
@@ -17,12 +17,12 @@
 TRACEPOINT_EVENT(CLOG_PATH_C, PathActiveFallback,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3,
-        unsigned char, arg4), 
+        unsigned int, arg3,
+        unsigned int, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
-        ctf_integer(unsigned char, arg4, arg4)
+        ctf_integer(unsigned int, arg3, arg3)
+        ctf_integer(unsigned int, arg4, arg4)
     )
 )
 
@@ -30,11 +30,11 @@ TRACEPOINT_EVENT(CLOG_PATH_C, PathActiveFallback,
 
 /*----------------------------------------------------------
 // Decoder Ring for PathQeoEnabled
-// [conn][%p] Path[%hhu] QEO enabled
+// [conn][%p] Path[%u] QEO enabled
 // QuicTraceLogConnInfo(
                 PathQeoEnabled,
                 Connection,
-                "Path[%hhu] QEO enabled",
+                "Path[%u] QEO enabled",
                 Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
@@ -42,10 +42,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, PathActiveFallback,
 TRACEPOINT_EVENT(CLOG_PATH_C, PathQeoEnabled,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -53,11 +53,11 @@ TRACEPOINT_EVENT(CLOG_PATH_C, PathQeoEnabled,
 
 /*----------------------------------------------------------
 // Decoder Ring for PathQeoDisabled
-// [conn][%p] Path[%hhu] QEO disabled
+// [conn][%p] Path[%u] QEO disabled
 // QuicTraceLogConnInfo(
             PathQeoDisabled,
             Connection,
-            "Path[%hhu] QEO disabled",
+            "Path[%u] QEO disabled",
             Path->ID);
 // arg1 = arg1 = Connection = arg1
 // arg3 = arg3 = Path->ID = arg3
@@ -65,10 +65,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, PathQeoEnabled,
 TRACEPOINT_EVENT(CLOG_PATH_C, PathQeoDisabled,
     TP_ARGS(
         const void *, arg1,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -95,10 +95,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, IndicatePeerAddrChanged,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathInitialized
-// [conn][%p] Path[%hhu] Initialized
+// [conn][%p] Path[%u] Initialized
 // QuicTraceEvent(
         ConnPathInitialized,
-        "[conn][%p] Path[%hhu] Initialized",
+        "[conn][%p] Path[%u] Initialized",
         Connection,
         Path->ID);
 // arg2 = arg2 = Connection = arg2
@@ -107,10 +107,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, IndicatePeerAddrChanged,
 TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathInitialized,
     TP_ARGS(
         const void *, arg2,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -147,10 +147,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnRemoteAddrAdded,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathRemoved
-// [conn][%p] Path[%hhu] Removed
+// [conn][%p] Path[%u] Removed
 // QuicTraceEvent(
         ConnPathRemoved,
-        "[conn][%p] Path[%hhu] Removed",
+        "[conn][%p] Path[%u] Removed",
         Connection,
         Path->ID);
 // arg2 = arg2 = Connection = arg2
@@ -159,10 +159,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnRemoteAddrAdded,
 TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathRemoved,
     TP_ARGS(
         const void *, arg2,
-        unsigned char, arg3), 
+        unsigned int, arg3), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
     )
 )
 
@@ -170,10 +170,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathRemoved,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathValidated
-// [conn][%p] Path[%hhu] Validated (%hhu)
+// [conn][%p] Path[%u] Validated (%hhu)
 // QuicTraceEvent(
         ConnPathValidated,
-        "[conn][%p] Path[%hhu] Validated (%hhu)",
+        "[conn][%p] Path[%u] Validated (%hhu)",
         Connection,
         Path->ID,
         Reason);
@@ -184,11 +184,11 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathRemoved,
 TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathValidated,
     TP_ARGS(
         const void *, arg2,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned char, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned char, arg4, arg4)
     )
 )
@@ -197,10 +197,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathValidated,
 
 /*----------------------------------------------------------
 // Decoder Ring for ConnPathActive
-// [conn][%p] Path[%hhu] Set active (rebind=%hhu)
+// [conn][%p] Path[%u] Set active (rebind=%hhu)
 // QuicTraceEvent(
         ConnPathActive,
-        "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
+        "[conn][%p] Path[%u] Set active (rebind=%hhu)",
         Connection,
         ActivePath->ID,
         UdpPortChangeOnly);
@@ -211,11 +211,11 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathValidated,
 TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathActive,
     TP_ARGS(
         const void *, arg2,
-        unsigned char, arg3,
+        unsigned int, arg3,
         unsigned char, arg4), 
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
-        ctf_integer(unsigned char, arg3, arg3)
+        ctf_integer(unsigned int, arg3, arg3)
         ctf_integer(unsigned char, arg4, arg4)
     )
 )

--- a/src/inc/quic_datapath.h
+++ b/src/inc/quic_datapath.h
@@ -920,7 +920,7 @@ void
     _When_(Succeeded == FALSE, _Reserved_)
     _When_(Succeeded == TRUE, _In_reads_bytes_(6))
         const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     );
 
@@ -935,7 +935,7 @@ CxPlatResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     );
 
 //
@@ -946,7 +946,7 @@ QUIC_STATUS
 CxPlatResolveRoute(
     _In_ CXPLAT_SOCKET* Socket,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     );

--- a/src/manifest/MsQuicEtw.man
+++ b/src/manifest/MsQuicEtw.man
@@ -2210,7 +2210,7 @@
                 name="Connection"
                 />
             <data
-                inType="win:UInt8"
+                inType="win:UInt32"
                 name="PathID"
                 />
           </template>
@@ -2220,7 +2220,7 @@
                 name="Connection"
                 />
             <data
-                inType="win:UInt8"
+                inType="win:UInt32"
                 name="PathID"
                 />
             <data
@@ -2234,7 +2234,7 @@
                 name="Connection"
                 />
             <data
-                inType="win:UInt8"
+                inType="win:UInt32"
                 name="PathID"
                 />
             <data

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -1833,7 +1833,7 @@
     },
     "ConnPathActive": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Set active (rebind=%hhu)",
+      "TraceString": "[conn][%p] Path[%u] Set active (rebind=%hhu)",
       "UniqueId": "ConnPathActive",
       "splitArgs": [
         {
@@ -1841,7 +1841,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -1853,7 +1853,7 @@
     },
     "ConnPathInitialized": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Initialized",
+      "TraceString": "[conn][%p] Path[%u] Initialized",
       "UniqueId": "ConnPathInitialized",
       "splitArgs": [
         {
@@ -1861,7 +1861,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -1869,7 +1869,7 @@
     },
     "ConnPathRemoved": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Removed",
+      "TraceString": "[conn][%p] Path[%u] Removed",
       "UniqueId": "ConnPathRemoved",
       "splitArgs": [
         {
@@ -1877,7 +1877,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -1885,7 +1885,7 @@
     },
     "ConnPathValidated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Validated (%hhu)",
+      "TraceString": "[conn][%p] Path[%u] Validated (%hhu)",
       "UniqueId": "ConnPathValidated",
       "splitArgs": [
         {
@@ -1893,7 +1893,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -1905,7 +1905,7 @@
     },
     "ConnPathValidationTimeout": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] validation timed out",
+      "TraceString": "[conn][%p] Path[%u] validation timed out",
       "UniqueId": "ConnPathValidationTimeout",
       "splitArgs": [
         {
@@ -1913,7 +1913,7 @@
           "MacroVariableName": "arg2"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -4283,7 +4283,7 @@
     },
     "FailedRouteResolution": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Route resolution failed on Path[%hhu]. Switching paths...",
+      "TraceString": "[conn][%p] Route resolution failed on Path[%u]. Switching paths...",
       "UniqueId": "FailedRouteResolution",
       "splitArgs": [
         {
@@ -4291,7 +4291,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -7330,7 +7330,7 @@
     },
     "MtuDiscarded": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
+      "TraceString": "[conn][%p] Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u",
       "UniqueId": "MtuDiscarded",
       "splitArgs": [
         {
@@ -7338,7 +7338,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -7354,7 +7354,7 @@
     },
     "MtuIncorrectSize": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u",
+      "TraceString": "[conn][%p] Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u",
       "UniqueId": "MtuIncorrectSize",
       "splitArgs": [
         {
@@ -7362,7 +7362,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -7378,7 +7378,7 @@
     },
     "MtuPathInitialized": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
+      "TraceString": "[conn][%p] Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u",
       "UniqueId": "MtuPathInitialized",
       "splitArgs": [
         {
@@ -7386,7 +7386,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -7402,7 +7402,7 @@
     },
     "MtuSearchComplete": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu",
+      "TraceString": "[conn][%p] Path[%u] Mtu Discovery Entering Search Complete at MTU %hu",
       "UniqueId": "MtuSearchComplete",
       "splitArgs": [
         {
@@ -7410,7 +7410,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -7422,7 +7422,7 @@
     },
     "MtuSearching": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu",
+      "TraceString": "[conn][%p] Path[%u] Mtu Discovery Search Packet Sending with MTU %hu",
       "UniqueId": "MtuSearching",
       "splitArgs": [
         {
@@ -7430,7 +7430,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -8320,7 +8320,7 @@
     },
     "PathActiveFallback": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] removed; falling back to Path[%hhu]",
+      "TraceString": "[conn][%p] Path[%u] removed; falling back to Path[%u]",
       "UniqueId": "PathActiveFallback",
       "splitArgs": [
         {
@@ -8328,11 +8328,11 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg4"
         }
       ],
@@ -8340,7 +8340,7 @@
     },
     "PathDiscarded": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Removing invalid path[%hhu]",
+      "TraceString": "[conn][%p] Removing invalid path[%u]",
       "UniqueId": "PathDiscarded",
       "splitArgs": [
         {
@@ -8348,7 +8348,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -8372,7 +8372,7 @@
     },
     "PathMinMtuValidated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] Minimum MTU validated",
+      "TraceString": "[conn][%p] Path[%u] Minimum MTU validated",
       "UniqueId": "PathMinMtuValidated",
       "splitArgs": [
         {
@@ -8380,7 +8380,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -8388,7 +8388,7 @@
     },
     "PathMtuUpdated": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] MTU updated to %hu bytes",
+      "TraceString": "[conn][%p] Path[%u] MTU updated to %hu bytes",
       "UniqueId": "PathMtuUpdated",
       "splitArgs": [
         {
@@ -8396,7 +8396,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -8408,7 +8408,7 @@
     },
     "PathQeoDisabled": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] QEO disabled",
+      "TraceString": "[conn][%p] Path[%u] QEO disabled",
       "UniqueId": "PathQeoDisabled",
       "splitArgs": [
         {
@@ -8416,7 +8416,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -8424,7 +8424,7 @@
     },
     "PathQeoEnabled": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Path[%hhu] QEO enabled",
+      "TraceString": "[conn][%p] Path[%u] QEO enabled",
       "UniqueId": "PathQeoEnabled",
       "splitArgs": [
         {
@@ -8432,7 +8432,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         }
       ],
@@ -9618,7 +9618,7 @@
     },
     "RouteResolutionEnd": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+      "TraceString": "[conn][%p] Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
       "UniqueId": "RouteResolutionEnd",
       "splitArgs": [
         {
@@ -9626,7 +9626,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -9658,7 +9658,7 @@
     },
     "RouteResolutionStart": {
       "ModuleProperites": {},
-      "TraceString": "[conn][%p] Starting to look up neighbor on Path[%hhu] with status %u",
+      "TraceString": "[conn][%p] Starting to look up neighbor on Path[%u] with status %u",
       "UniqueId": "RouteResolutionStart",
       "splitArgs": [
         {
@@ -9666,7 +9666,7 @@
           "MacroVariableName": "arg1"
         },
         {
-          "DefinationEncoding": "hhu",
+          "DefinationEncoding": "u",
           "MacroVariableName": "arg3"
         },
         {
@@ -13879,29 +13879,29 @@
         "EncodingString": "[conn][%p] STATS: SendTotalPackets=%llu SendSuspectedLostPackets=%llu SendSpuriousLostPackets=%llu RecvTotalPackets=%llu RecvReorderedPackets=%llu RecvDroppedPackets=%llu RecvDuplicatePackets=%llu RecvDecryptionFailures=%llu"
       },
       {
-        "UniquenessHash": "0afbe643-9584-6130-adf3-9c1ec3825c5f",
+        "UniquenessHash": "66f6198a-daaa-0056-ec90-990d2a68e214",
         "TraceID": "ConnPathActive",
-        "EncodingString": "[conn][%p] Path[%hhu] Set active (rebind=%hhu)"
+        "EncodingString": "[conn][%p] Path[%u] Set active (rebind=%hhu)"
       },
       {
-        "UniquenessHash": "a324b00e-cfc4-4104-a6cf-c8e9b9cb2b01",
+        "UniquenessHash": "5f171456-e432-c390-03a6-19e2ddb6dc7c",
         "TraceID": "ConnPathInitialized",
-        "EncodingString": "[conn][%p] Path[%hhu] Initialized"
+        "EncodingString": "[conn][%p] Path[%u] Initialized"
       },
       {
-        "UniquenessHash": "7d00aaa7-7a44-2e9b-2a9f-5cd3e73cc4f3",
+        "UniquenessHash": "2434e22b-f84f-2df0-0e03-480ef7ee33dd",
         "TraceID": "ConnPathRemoved",
-        "EncodingString": "[conn][%p] Path[%hhu] Removed"
+        "EncodingString": "[conn][%p] Path[%u] Removed"
       },
       {
-        "UniquenessHash": "6c9a8375-720d-7df9-6e6e-179e99ac49e0",
+        "UniquenessHash": "a53b7ce2-3363-76c6-c75a-743dd27db5f3",
         "TraceID": "ConnPathValidated",
-        "EncodingString": "[conn][%p] Path[%hhu] Validated (%hhu)"
+        "EncodingString": "[conn][%p] Path[%u] Validated (%hhu)"
       },
       {
-        "UniquenessHash": "6ef76f38-b4df-cf7d-3197-b7e4d86471da",
+        "UniquenessHash": "1834eb9b-4a7a-4bfb-b745-1b78782557c0",
         "TraceID": "ConnPathValidationTimeout",
-        "EncodingString": "[conn][%p] Path[%hhu] validation timed out"
+        "EncodingString": "[conn][%p] Path[%u] validation timed out"
       },
       {
         "UniquenessHash": "c339eadc-2eef-8e45-4a51-1fc84a3c198e",
@@ -14659,9 +14659,9 @@
         "EncodingString": "[conn][%p] Cannot export keying material [Connected=%hhu, HandshakeComplete=%hhu, HasTls=%hhu]"
       },
       {
-        "UniquenessHash": "fff5ef57-9005-a7ec-fcbc-d630c6c812fa",
+        "UniquenessHash": "c699b6c6-8e43-8d4e-6b32-af73378811c7",
         "TraceID": "FailedRouteResolution",
-        "EncodingString": "[conn][%p] Route resolution failed on Path[%hhu]. Switching paths..."
+        "EncodingString": "[conn][%p] Route resolution failed on Path[%u]. Switching paths..."
       },
       {
         "UniquenessHash": "5e023c07-7bc3-8b2f-76d0-4a38701cef2d",
@@ -15484,29 +15484,29 @@
         "EncodingString": "[conn][%p] App configured max stream count of %hu (type=%hhu)."
       },
       {
-        "UniquenessHash": "1aa1d324-af31-356c-0738-863e209f6f21",
+        "UniquenessHash": "03564dae-539b-4e8a-57b6-a1a71a2fb9e0",
         "TraceID": "MtuDiscarded",
-        "EncodingString": "[conn][%p] Path[%hhu] Mtu Discovery Packet Discarded: size=%u, probe_count=%u"
+        "EncodingString": "[conn][%p] Path[%u] Mtu Discovery Packet Discarded: size=%u, probe_count=%u"
       },
       {
-        "UniquenessHash": "a20786c3-f6b7-176d-7e63-b6c558f7d394",
+        "UniquenessHash": "ddb7281d-8e2f-0851-34e0-3aa0173cb522",
         "TraceID": "MtuIncorrectSize",
-        "EncodingString": "[conn][%p] Path[%hhu] Mtu Discovery Received Out of Order: expected=%u received=%u"
+        "EncodingString": "[conn][%p] Path[%u] Mtu Discovery Received Out of Order: expected=%u received=%u"
       },
       {
-        "UniquenessHash": "3f758826-f3d7-22eb-b7df-0453cdad3bc8",
+        "UniquenessHash": "2751725a-a120-72cd-5e92-9a5d56b30b2d",
         "TraceID": "MtuPathInitialized",
-        "EncodingString": "[conn][%p] Path[%hhu] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u"
+        "EncodingString": "[conn][%p] Path[%u] Mtu Discovery Initialized: max_mtu=%u, cur/min_mtu=%u"
       },
       {
-        "UniquenessHash": "92ab8084-33fb-0565-da7b-d2278d05c642",
+        "UniquenessHash": "59d53545-f3fd-6288-5343-f7360c467c68",
         "TraceID": "MtuSearchComplete",
-        "EncodingString": "[conn][%p] Path[%hhu] Mtu Discovery Entering Search Complete at MTU %hu"
+        "EncodingString": "[conn][%p] Path[%u] Mtu Discovery Entering Search Complete at MTU %hu"
       },
       {
-        "UniquenessHash": "c7a85c07-7d70-b24f-313d-2db9a20333bd",
+        "UniquenessHash": "af061074-69c0-cf5d-d770-0aa63ac01629",
         "TraceID": "MtuSearching",
-        "EncodingString": "[conn][%p] Path[%hhu] Mtu Discovery Search Packet Sending with MTU %hu"
+        "EncodingString": "[conn][%p] Path[%u] Mtu Discovery Search Packet Sending with MTU %hu"
       },
       {
         "UniquenessHash": "7c8ed181-6e73-0552-43f1-7e00ce4948af",
@@ -15804,14 +15804,14 @@
         "EncodingString": "[conn][%p] Path[%hhu] Set active (rebind=%hhu)"
       },
       {
-        "UniquenessHash": "dbe0fbfc-98b0-3033-000e-dd52c892d6e1",
+        "UniquenessHash": "c9b1243d-9f3b-c990-fb47-cd81603f7ce5",
         "TraceID": "PathActiveFallback",
-        "EncodingString": "[conn][%p] Path[%hhu] removed; falling back to Path[%hhu]"
+        "EncodingString": "[conn][%p] Path[%u] removed; falling back to Path[%u]"
       },
       {
-        "UniquenessHash": "8843a66a-349f-e5a2-a63c-5120fb187f69",
+        "UniquenessHash": "41d39427-3e79-a800-a73b-7111c591ee12",
         "TraceID": "PathDiscarded",
-        "EncodingString": "[conn][%p] Removing invalid path[%hhu]"
+        "EncodingString": "[conn][%p] Removing invalid path[%u]"
       },
       {
         "UniquenessHash": "607e449d-59a9-9d66-fcd1-b0a2e12f1dc1",
@@ -15819,24 +15819,24 @@
         "EncodingString": "[conn][%p] Path[%hhu] Initialized"
       },
       {
-        "UniquenessHash": "cda9bb97-fd6c-a4a5-a61c-2e2931d2ce2c",
+        "UniquenessHash": "0c378220-a756-57a1-a654-1e19b56e34dd",
         "TraceID": "PathMinMtuValidated",
-        "EncodingString": "[conn][%p] Path[%hhu] Minimum MTU validated"
+        "EncodingString": "[conn][%p] Path[%u] Minimum MTU validated"
       },
       {
-        "UniquenessHash": "e4b7c3f7-0733-40b5-95d7-af81de6568ec",
+        "UniquenessHash": "360205d0-262e-37a7-4593-00e29dee9966",
         "TraceID": "PathMtuUpdated",
-        "EncodingString": "[conn][%p] Path[%hhu] MTU updated to %hu bytes"
+        "EncodingString": "[conn][%p] Path[%u] MTU updated to %hu bytes"
       },
       {
-        "UniquenessHash": "77bae646-5d83-b78d-08aa-24b36955b7e4",
+        "UniquenessHash": "cb0a6349-cde6-2fb5-342e-710b5811fd44",
         "TraceID": "PathQeoDisabled",
-        "EncodingString": "[conn][%p] Path[%hhu] QEO disabled"
+        "EncodingString": "[conn][%p] Path[%u] QEO disabled"
       },
       {
-        "UniquenessHash": "f27d6a99-3be1-a404-0883-01df858eb372",
+        "UniquenessHash": "86cd2be9-e6a8-22ac-38e6-da0332e2da32",
         "TraceID": "PathQeoEnabled",
-        "EncodingString": "[conn][%p] Path[%hhu] QEO enabled"
+        "EncodingString": "[conn][%p] Path[%u] QEO enabled"
       },
       {
         "UniquenessHash": "2e3024b8-4329-c124-05b3-9801c51b9346",
@@ -16234,14 +16234,14 @@
         "EncodingString": "[conn][%p] Restart (CompleteReset=%hhu)"
       },
       {
-        "UniquenessHash": "9bc1fa4d-99a3-dcfe-2650-d4effac253ba",
+        "UniquenessHash": "5fdf12c4-fd48-2676-0646-898b20379f54",
         "TraceID": "RouteResolutionEnd",
-        "EncodingString": "[conn][%p] Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx"
+        "EncodingString": "[conn][%p] Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx"
       },
       {
-        "UniquenessHash": "8662b462-9871-7631-034d-9d175232ab4f",
+        "UniquenessHash": "4fc6e02e-f085-ac20-635c-e7814d322c54",
         "TraceID": "RouteResolutionStart",
-        "EncodingString": "[conn][%p] Starting to look up neighbor on Path[%hhu] with status %u"
+        "EncodingString": "[conn][%p] Starting to look up neighbor on Path[%u] with status %u"
       },
       {
         "UniquenessHash": "ff41b02a-ac3e-3b07-30f1-3040e2416019",

--- a/src/platform/datapath_kqueue.c
+++ b/src/platform/datapath_kqueue.c
@@ -2151,7 +2151,7 @@ CxPlatResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     )
 {
     UNREFERENCED_PARAMETER(Context);
@@ -2165,7 +2165,7 @@ QUIC_STATUS
 CxPlatResolveRoute(
     _In_ CXPLAT_SOCKET* Socket,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     )

--- a/src/platform/datapath_raw_dummy.c
+++ b/src/platform/datapath_raw_dummy.c
@@ -266,7 +266,7 @@ RawResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     )
 {
     UNREFERENCED_PARAMETER(Context);
@@ -280,7 +280,7 @@ QUIC_STATUS
 RawResolveRoute(
     _In_ CXPLAT_SOCKET_RAW* Sock,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     )

--- a/src/platform/datapath_raw_socket.c
+++ b/src/platform/datapath_raw_socket.c
@@ -102,7 +102,7 @@ RawResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     )
 {
     QUIC_CONNECTION* Connection = (QUIC_CONNECTION*)Context;
@@ -111,7 +111,7 @@ RawResolveRouteComplete(
     QuicTraceLogConnInfo(
         RouteResolutionEnd,
         Connection,
-        "Route resolution completed on Path[%hhu] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+        "Route resolution completed on Path[%u] with L2 address %hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
         PathId,
         Route->NextHopLinkLayerAddress[0],
         Route->NextHopLinkLayerAddress[1],

--- a/src/platform/datapath_raw_socket_win.c
+++ b/src/platform/datapath_raw_socket_win.c
@@ -58,7 +58,7 @@ QUIC_STATUS
 RawResolveRoute(
     _In_ CXPLAT_SOCKET_RAW* Socket,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     )
@@ -166,7 +166,7 @@ RawResolveRoute(
     QuicTraceLogConnInfo(
         RouteResolutionStart,
         Context,
-        "Starting to look up neighbor on Path[%hhu] with status %u",
+        "Starting to look up neighbor on Path[%u] with status %u",
         PathId,
         Status);
     //

--- a/src/platform/datapath_raw_win.h
+++ b/src/platform/datapath_raw_win.h
@@ -19,6 +19,6 @@ typedef struct CXPLAT_ROUTE_RESOLUTION_OPERATION {
     CXPLAT_LIST_ENTRY WorkerLink;
     MIB_IPNET_ROW2 IpnetRow;
     void* Context;
-    uint8_t PathId;
+    uint32_t PathId;
     CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback;
 } CXPLAT_ROUTE_RESOLUTION_OPERATION;

--- a/src/platform/datapath_xplat.c
+++ b/src/platform/datapath_xplat.c
@@ -545,7 +545,7 @@ CxPlatResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     )
 {
     CXPLAT_DBG_ASSERT(Route->DatapathType != CXPLAT_DATAPATH_TYPE_NORMAL);
@@ -562,7 +562,7 @@ QUIC_STATUS
 CxPlatResolveRoute(
     _In_ CXPLAT_SOCKET* Socket,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     )

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -1340,7 +1340,7 @@ RawResolveRouteComplete(
     _In_ void* Context,
     _Inout_ CXPLAT_ROUTE* Route,
     _In_reads_bytes_(6) const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId
+    _In_ uint32_t PathId
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1348,7 +1348,7 @@ QUIC_STATUS
 RawResolveRoute(
     _In_ CXPLAT_SOCKET_RAW* Sock,
     _Inout_ CXPLAT_ROUTE* Route,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ void* Context,
     _In_ CXPLAT_ROUTE_RESOLUTION_CALLBACK_HANDLER Callback
     );

--- a/src/platform/unittest/DataPathTest.cpp
+++ b/src/platform/unittest/DataPathTest.cpp
@@ -519,7 +519,7 @@ ResolveRouteComplete(
     _When_(Succeeded == FALSE, _Reserved_)
     _When_(Succeeded == TRUE, _In_reads_bytes_(6))
         const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     )
 {

--- a/src/tools/attack/attack.cpp
+++ b/src/tools/attack/attack.cpp
@@ -103,7 +103,7 @@ ResolveRouteComplete(
     _When_(Succeeded == FALSE, _Reserved_)
     _When_(Succeeded == TRUE, _In_reads_bytes_(6))
         const uint8_t* PhysicalAddress,
-    _In_ uint8_t PathId,
+    _In_ uint32_t PathId,
     _In_ BOOLEAN Succeeded
     )
 {


### PR DESCRIPTION
## Description

Defers active-path changes until receive processing no longer holds pointers into the path array.

Receiving a valid packet containing non-probing frames on a path makes this path active.
However, setting a path as active moves it to the front of the path array, which can potentially invalidate pointers to paths.

To avoid this:
- track which path needs to be active
- only make it active once all packets in the receive operation are processed

The active path is mostly needed to *send* (it is by definition the path the connection uses to send packets), so it isn't a problem to defer the operation until the end of the receive loop. A side benefit is that it avoids multiple updates in sequence if multiple migrations would be triggered in a single receive operation.

## Testing

CI and local testing

## Documentation

No documentation impact.