### PR TITLE
[CP] Fix hostname validation with OpenSSL/QuicTLS (#6274)

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1873,6 +1873,35 @@ QuicConnStart(
         goto Exit;
     }
 
+    if (ServerName == NULL) {
+        //
+        // If a server name is not provided, use the IP address for server certificate validation.
+        //
+        QUIC_ADDR_STR RemoteAddressString;
+        if (!QuicAddrIpToString(&Path->Route.RemoteAddress, &RemoteAddressString)) {
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            QuicTraceEvent(
+                ConnError,
+                "[conn][%p] ERROR, %s.",
+                Connection,
+                "Failed to convert remote address to server name");
+            goto Exit;
+        }
+
+        const size_t ServerNameLength = strlen(RemoteAddressString.Address);
+        ServerName = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_SERVERNAME);
+        if (ServerName == NULL) {
+            Status = QUIC_STATUS_OUT_OF_MEMORY;
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "Server name",
+                ServerNameLength + 1);
+            goto Exit;
+        }
+        CxPlatCopyMemory((char*)ServerName, RemoteAddressString.Address, ServerNameLength + 1);
+    }
+
     QuicAddrSetPort(&Path->Route.RemoteAddress, ServerPort);
     QuicTraceEvent(
         ConnRemoteAddrAdded,

--- a/src/generated/linux/tls_schannel.c.clog.h
+++ b/src/generated/linux/tls_schannel.c.clog.h
@@ -481,11 +481,11 @@ tracepoint(CLOG_TLS_SCHANNEL_C, TlsError , arg2, arg3);\
 // Decoder Ring for TlsErrorStatus
 // [ tls][%p] ERROR, %u, %s.
 // QuicTraceEvent(
-                    TlsErrorStatus,
-                    "[ tls][%p] ERROR, %u, %s.",
-                    TlsContext->Connection,
-                    Status,
-                    "Convert SNI to unicode");
+                TlsErrorStatus,
+                "[ tls][%p] ERROR, %u, %s.",
+                TlsContext->Connection,
+                Status,
+                "Convert SNI to unicode");
 // arg2 = arg2 = TlsContext->Connection = arg2
 // arg3 = arg3 = Status = arg3
 // arg4 = arg4 = "Convert SNI to unicode" = arg4

--- a/src/generated/linux/tls_schannel.c.clog.h.lttng.h
+++ b/src/generated/linux/tls_schannel.c.clog.h.lttng.h
@@ -501,11 +501,11 @@ TRACEPOINT_EVENT(CLOG_TLS_SCHANNEL_C, TlsError,
 // Decoder Ring for TlsErrorStatus
 // [ tls][%p] ERROR, %u, %s.
 // QuicTraceEvent(
-                    TlsErrorStatus,
-                    "[ tls][%p] ERROR, %u, %s.",
-                    TlsContext->Connection,
-                    Status,
-                    "Convert SNI to unicode");
+                TlsErrorStatus,
+                "[ tls][%p] ERROR, %u, %s.",
+                TlsContext->Connection,
+                Status,
+                "Convert SNI to unicode");
 // arg2 = arg2 = TlsContext->Connection = arg2
 // arg3 = arg3 = Status = arg3
 // arg4 = arg4 = "Convert SNI to unicode" = arg4

--- a/src/inc/msquic_posix.h
+++ b/src/inc/msquic_posix.h
@@ -448,28 +448,50 @@ QuicAddr6FromString(
     _Out_ QUIC_ADDR* Addr
     )
 {
+    char TmpAddrStr[64];
     if (AddrStr[0] == '[') {
         const char* BracketEnd = strchr(AddrStr, ']');
         if (BracketEnd == NULL || *(BracketEnd+1) != ':') {
             return FALSE;
         }
 
-        char TmpAddrStr[64];
-        size_t AddrLength = BracketEnd - AddrStr - 1;
+        const size_t AddrLength = BracketEnd - AddrStr - 1;
         if (AddrLength >= sizeof(TmpAddrStr)) {
             return FALSE;
         }
         memcpy(TmpAddrStr, AddrStr + 1, AddrLength);
         TmpAddrStr[AddrLength] = '\0';
-
-        if (inet_pton(AF_INET6, TmpAddrStr, &Addr->Ipv6.sin6_addr) != 1) {
-            return FALSE;
-        }
         Addr->Ipv6.sin6_port = htons(atoi(BracketEnd+2));
     } else {
-        if (inet_pton(AF_INET6, AddrStr, &Addr->Ipv6.sin6_addr) != 1) {
+        const size_t AddrLength = strlen(AddrStr);
+        if (AddrLength >= sizeof(TmpAddrStr)) {
             return FALSE;
         }
+        //
+        // Copy the string including the null terminator.
+        //
+        memcpy(TmpAddrStr, AddrStr, AddrLength + 1);
+    }
+
+    Addr->Ipv6.sin6_scope_id = 0;
+    char* ScopeStart = strchr(TmpAddrStr, '%');
+    if (ScopeStart != NULL) {
+        *ScopeStart++ = '\0';
+        if (*ScopeStart == '\0') {
+            return FALSE;
+        }
+        do {
+            if (*ScopeStart < '0' || *ScopeStart > '9' ||
+                Addr->Ipv6.sin6_scope_id > (UINT32_MAX - (*ScopeStart - '0')) / 10) {
+                return FALSE;
+            }
+            Addr->Ipv6.sin6_scope_id =
+                Addr->Ipv6.sin6_scope_id * 10 + (uint32_t)(*ScopeStart++ - '0');
+        } while (*ScopeStart != '\0');
+    }
+
+    if (inet_pton(AF_INET6, TmpAddrStr, &Addr->Ipv6.sin6_addr) != 1) {
+        return FALSE;
     }
     Addr->Ip.sa_family = QUIC_ADDRESS_FAMILY_INET6;
     return TRUE;
@@ -508,9 +530,42 @@ CxPlatIsIpLiteral(
 // Represents an IP address and (optionally) port number as a string.
 //
 typedef struct QUIC_ADDR_STR {
-    char Address[64];
+    char Address[65];
 } QUIC_ADDR_STR;
 
+//
+// Formats only the IP literal, excluding the port and IPv6 brackets. For
+// example, an IPv6 address with port 443 is formatted as "2001:db8::1".
+//
+QUIC_INLINE
+BOOLEAN
+QuicAddrIpToString(
+    _In_ const QUIC_ADDR* Addr,
+    _Out_ QUIC_ADDR_STR* AddrStr
+    )
+{
+    const void* IpAddress;
+    AddrStr->Address[0] = '\0';
+    if (Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET) {
+        IpAddress = &Addr->Ipv4.sin_addr;
+    } else if (Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET6) {
+        IpAddress = &Addr->Ipv6.sin6_addr;
+    } else {
+        return FALSE;
+    }
+    return
+        inet_ntop(
+            Addr->Ip.sa_family,
+            IpAddress,
+            AddrStr->Address,
+            sizeof(AddrStr->Address)) != NULL;
+}
+
+//
+// Formats the complete endpoint, including a nonzero port and the brackets
+// required around IPv6 when a port is present. For example, an IPv6 address
+// with port 443 is formatted as "[2001:db8::1]:443".
+//
 QUIC_INLINE
 BOOLEAN
 QuicAddrToString(

--- a/src/inc/msquic_winkernel.h
+++ b/src/inc/msquic_winkernel.h
@@ -357,9 +357,36 @@ CxPlatIsIpLiteral(
 // Represents an IP address and (optionally) port number as a string.
 //
 typedef struct QUIC_ADDR_STR {
-    char Address[64];
+    char Address[65];
 } QUIC_ADDR_STR;
 
+//
+// Formats only the IP literal, excluding the port and IPv6 brackets. For
+// example, an IPv6 address with port 443 is formatted as "2001:db8::1".
+//
+QUIC_INLINE
+BOOLEAN
+QuicAddrIpToString(
+    _In_ const QUIC_ADDR* Addr,
+    _Out_ QUIC_ADDR_STR* AddrStr
+    )
+{
+    AddrStr->Address[0] = '\0';
+    if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET) {
+        RtlIpv4AddressToStringA(&Addr->Ipv4.sin_addr, AddrStr->Address);
+    } else if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET6) {
+        RtlIpv6AddressToStringA(&Addr->Ipv6.sin6_addr, AddrStr->Address);
+    } else {
+        return FALSE;
+    }
+    return TRUE;
+}
+
+//
+// Formats the complete endpoint, including a nonzero port and the brackets
+// required around IPv6 when a port is present. For example, an IPv6 address
+// with port 443 is formatted as "[2001:db8::1]:443".
+//
 QUIC_INLINE
 BOOLEAN
 QuicAddrToString(

--- a/src/inc/msquic_winuser.h
+++ b/src/inc/msquic_winuser.h
@@ -315,6 +315,43 @@ QuicAddrHash(
 #define QUIC_LOCALHOST_FOR_AF(Af) "localhost"
 
 //
+// Represents an IP address and (optionally) port number as a string.
+//
+typedef struct QUIC_ADDR_STR {
+    char Address[65];
+} QUIC_ADDR_STR;
+
+//
+// Formats only the IP literal, excluding the port and IPv6 brackets. For
+// example, an IPv6 address with port 443 is formatted as "2001:db8::1".
+//
+QUIC_INLINE
+_Success_(return != FALSE)
+BOOLEAN
+QuicAddrIpToString(
+    _In_ const QUIC_ADDR* Addr,
+    _Out_ QUIC_ADDR_STR* AddrStr
+    )
+{
+    const void* IpAddress;
+    AddrStr->Address[0] = '\0';
+    if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET) {
+        IpAddress = &Addr->Ipv4.sin_addr;
+    } else if (Addr->si_family == QUIC_ADDRESS_FAMILY_INET6) {
+        IpAddress = &Addr->Ipv6.sin6_addr;
+    } else {
+        return FALSE;
+    }
+    // The Rtl address-to-string functions are not supported by GameCore.
+    return
+        InetNtopA(
+            Addr->si_family,
+            (void*)IpAddress,
+            AddrStr->Address,
+            sizeof(AddrStr->Address)) != NULL;
+}
+
+//
 // Rtl String API's are not allowed in gamecore
 //
 #if WINAPI_FAMILY != WINAPI_FAMILY_GAMES
@@ -365,12 +402,10 @@ CxPlatIsIpLiteral(
 }
 
 //
-// Represents an IP address and (optionally) port number as a string.
+// Formats the complete endpoint, including a nonzero port and the brackets
+// required around IPv6 when a port is present. For example, an IPv6 address
+// with port 443 is formatted as "[2001:db8::1]:443".
 //
-typedef struct QUIC_ADDR_STR {
-    char Address[64];
-} QUIC_ADDR_STR;
-
 QUIC_INLINE
 _Success_(return != FALSE)
 BOOLEAN

--- a/src/inc/quic_tls.h
+++ b/src/inc/quic_tls.h
@@ -174,7 +174,7 @@ typedef struct CXPLAT_TLS_CONFIG {
     uint16_t TPType;
 
     //
-    // Name of the server we are connecting to (client side only).
+    // Name of the server we are connecting to (required on client side).
     //
     const char* ServerName;
 

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -25,6 +25,7 @@ Abstract:
 #include "openssl/rsa.h"
 #include "openssl/ssl.h"
 #include "openssl/x509.h"
+#include "openssl/x509v3.h"
 #ifdef _WIN32
 #pragma warning(pop)
 #endif
@@ -119,9 +120,9 @@ typedef struct CXPLAT_TLS {
     const uint8_t* AlpnBuffer;
 
     //
-    // Pointer to the Server Name Indication (SNI) string.
+    // Server name used for SNI and certificate validation.
     //
-    const char* SNI;
+    const char* ServerName;
 
     //
     // OpenSSL SSL object used for the TLS handshake and encryption.
@@ -1018,7 +1019,7 @@ CxPlatTlsCertificateVerifyCallback(
                     CxPlatCertVerifyRawCertificate(
                         OpenSSLCertBuffer,
                         OpenSSLCertLength,
-                        TlsContext->SNI,
+                        TlsContext->ServerName,
                         TlsContext->SecConfig->Flags,
                         IsDeferredValidationOrClientAuth?
                             (uint32_t*)&ValidationResult :
@@ -2476,6 +2477,7 @@ CxPlatTlsInitialize(
     BIO *ossl_bio = NULL;
 
     CXPLAT_DBG_ASSERT(Config->HkdfLabels);
+    CXPLAT_DBG_ASSERT(Config->IsServer || Config->ServerName != NULL);
     if (Config->SecConfig == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -2509,35 +2511,30 @@ CxPlatTlsInitialize(
         "TLS context Created");
 
     if (!Config->IsServer) {
-
-        if (Config->ServerName != NULL) {
-
-            ServerNameLength = (uint16_t)strnlen(Config->ServerName, QUIC_MAX_SNI_LENGTH);
-            if (ServerNameLength == QUIC_MAX_SNI_LENGTH) {
-                QuicTraceEvent(
-                    TlsError,
-                    "[ tls][%p] ERROR, %s.",
-                    TlsContext->Connection,
-                    "SNI Too Long");
-                Status = QUIC_STATUS_INVALID_PARAMETER;
-                goto Exit;
-            }
-
-            if (!CxPlatIsIpLiteral(Config->ServerName)) {
-                TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
-                if (TlsContext->SNI == NULL) {
-                    QuicTraceEvent(
-                        AllocFailure,
-                        "Allocation of '%s' failed. (%llu bytes)",
-                        "SNI",
-                        ServerNameLength + 1);
-                    Status = QUIC_STATUS_OUT_OF_MEMORY;
-                    goto Exit;
-                }
-
-                memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
-            }
+        ServerNameLength = (uint16_t)strnlen(Config->ServerName, QUIC_MAX_SNI_LENGTH);
+        if (ServerNameLength == QUIC_MAX_SNI_LENGTH) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Server name too long");
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            goto Exit;
         }
+
+        TlsContext->ServerName =
+            CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
+        if (TlsContext->ServerName == NULL) {
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "Server name",
+                ServerNameLength + 1);
+            Status = QUIC_STATUS_OUT_OF_MEMORY;
+            goto Exit;
+        }
+
+        memcpy((char*)TlsContext->ServerName, Config->ServerName, ServerNameLength + 1);
     }
 
     //
@@ -2612,7 +2609,34 @@ CxPlatTlsInitialize(
         SSL_set_accept_state(TlsContext->Ssl);
     } else {
         SSL_set_connect_state(TlsContext->Ssl);
-        SSL_set_tlsext_host_name(TlsContext->Ssl, TlsContext->SNI);
+        X509_VERIFY_PARAM* VerifyParam = SSL_get0_param(TlsContext->Ssl);
+        X509_VERIFY_PARAM_set_hostflags(
+            VerifyParam,
+            X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+
+        BOOLEAN IsIpLiteral =
+            X509_VERIFY_PARAM_set1_ip_asc(VerifyParam, TlsContext->ServerName) == 1;
+        if (!IsIpLiteral &&
+            X509_VERIFY_PARAM_set1_host(VerifyParam, TlsContext->ServerName, 0) != 1) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Setting certificate reference identity failed");
+            Status = QUIC_STATUS_TLS_ERROR;
+            goto Exit;
+        }
+
+        if (!IsIpLiteral &&
+            SSL_set_tlsext_host_name(TlsContext->Ssl, TlsContext->ServerName) != 1) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Setting SNI failed");
+            Status = QUIC_STATUS_TLS_ERROR;
+            goto Exit;
+        }
         SSL_set_alpn_protos(TlsContext->Ssl, TlsContext->AlpnBuffer, TlsContext->AlpnBufferLength);
     }
 
@@ -2725,9 +2749,9 @@ CxPlatTlsUninitialize(
             TlsContext->Connection,
             "Cleaning up");
 
-        if (TlsContext->SNI != NULL) {
-            CXPLAT_FREE(TlsContext->SNI, QUIC_POOL_TLS_SNI);
-            TlsContext->SNI = NULL;
+        if (TlsContext->ServerName != NULL) {
+            CXPLAT_FREE(TlsContext->ServerName, QUIC_POOL_TLS_SNI);
+            TlsContext->ServerName = NULL;
         }
 
         if (TlsContext->Ssl != NULL) {

--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -27,6 +27,7 @@ Abstract:
 #include "openssl/rsa.h"
 #include "openssl/ssl.h"
 #include "openssl/x509.h"
+#include "openssl/x509v3.h"
 #ifdef _WIN32
 #pragma warning(pop)
 #endif
@@ -123,9 +124,9 @@ typedef struct CXPLAT_TLS {
     const uint8_t* AlpnBuffer;
 
     //
-    // On client side stores a NULL terminated SNI.
+    // Server name used for SNI and certificate validation.
     //
-    const char* SNI;
+    const char* ServerName;
 
     //
     // Ssl - A SSL object associated with the connection.
@@ -267,7 +268,7 @@ CxPlatTlsCertificateVerifyCallback(
                     CxPlatCertVerifyRawCertificate(
                         OpenSSLCertBuffer,
                         OpenSSLCertLength,
-                        TlsContext->SNI,
+                        TlsContext->ServerName,
                         TlsContext->SecConfig->Flags,
                         IsDeferredValidationOrClientAuth?
                             (uint32_t*)&ValidationResult :
@@ -1661,6 +1662,7 @@ CxPlatTlsInitialize(
     UNREFERENCED_PARAMETER(State);
 
     CXPLAT_DBG_ASSERT(Config->HkdfLabels);
+    CXPLAT_DBG_ASSERT(Config->IsServer || Config->ServerName != NULL);
     if (Config->SecConfig == NULL) {
         Status = QUIC_STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -1694,35 +1696,30 @@ CxPlatTlsInitialize(
         "TLS context Created");
 
     if (!Config->IsServer) {
-
-        if (Config->ServerName != NULL) {
-
-            ServerNameLength = (uint16_t)strnlen(Config->ServerName, QUIC_MAX_SNI_LENGTH);
-            if (ServerNameLength == QUIC_MAX_SNI_LENGTH) {
-                QuicTraceEvent(
-                    TlsError,
-                    "[ tls][%p] ERROR, %s.",
-                    TlsContext->Connection,
-                    "SNI Too Long");
-                Status = QUIC_STATUS_INVALID_PARAMETER;
-                goto Exit;
-            }
-
-            if (!CxPlatIsIpLiteral(Config->ServerName)) {
-                TlsContext->SNI = CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
-                if (TlsContext->SNI == NULL) {
-                    QuicTraceEvent(
-                        AllocFailure,
-                        "Allocation of '%s' failed. (%llu bytes)",
-                        "SNI",
-                        ServerNameLength + 1);
-                    Status = QUIC_STATUS_OUT_OF_MEMORY;
-                    goto Exit;
-                }
-
-                memcpy((char*)TlsContext->SNI, Config->ServerName, ServerNameLength + 1);
-            }
+        ServerNameLength = (uint16_t)strnlen(Config->ServerName, QUIC_MAX_SNI_LENGTH);
+        if (ServerNameLength == QUIC_MAX_SNI_LENGTH) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Server name too long");
+            Status = QUIC_STATUS_INVALID_PARAMETER;
+            goto Exit;
         }
+
+        TlsContext->ServerName =
+            CXPLAT_ALLOC_NONPAGED(ServerNameLength + 1, QUIC_POOL_TLS_SNI);
+        if (TlsContext->ServerName == NULL) {
+            QuicTraceEvent(
+                AllocFailure,
+                "Allocation of '%s' failed. (%llu bytes)",
+                "Server name",
+                ServerNameLength + 1);
+            Status = QUIC_STATUS_OUT_OF_MEMORY;
+            goto Exit;
+        }
+
+        memcpy((char*)TlsContext->ServerName, Config->ServerName, ServerNameLength + 1);
     }
 
     //
@@ -1746,7 +1743,34 @@ CxPlatTlsInitialize(
         SSL_set_accept_state(TlsContext->Ssl);
     } else {
         SSL_set_connect_state(TlsContext->Ssl);
-        SSL_set_tlsext_host_name(TlsContext->Ssl, TlsContext->SNI);
+        X509_VERIFY_PARAM* VerifyParam = SSL_get0_param(TlsContext->Ssl);
+        X509_VERIFY_PARAM_set_hostflags(
+            VerifyParam,
+            X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+
+        BOOLEAN IsIpLiteral =
+            X509_VERIFY_PARAM_set1_ip_asc(VerifyParam, TlsContext->ServerName) == 1;
+        if (!IsIpLiteral &&
+            X509_VERIFY_PARAM_set1_host(VerifyParam, TlsContext->ServerName, 0) != 1) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Setting certificate reference identity failed");
+            Status = QUIC_STATUS_TLS_ERROR;
+            goto Exit;
+        }
+
+        if (!IsIpLiteral &&
+            SSL_set_tlsext_host_name(TlsContext->Ssl, TlsContext->ServerName) != 1) {
+            QuicTraceEvent(
+                TlsError,
+                "[ tls][%p] ERROR, %s.",
+                TlsContext->Connection,
+                "Setting SNI failed");
+            Status = QUIC_STATUS_TLS_ERROR;
+            goto Exit;
+        }
         SSL_set_alpn_protos(TlsContext->Ssl, TlsContext->AlpnBuffer, TlsContext->AlpnBufferLength);
     }
 
@@ -1846,9 +1870,9 @@ CxPlatTlsUninitialize(
             TlsContext->Connection,
             "Cleaning up");
 
-        if (TlsContext->SNI != NULL) {
-            CXPLAT_FREE(TlsContext->SNI, QUIC_POOL_TLS_SNI);
-            TlsContext->SNI = NULL;
+        if (TlsContext->ServerName != NULL) {
+            CXPLAT_FREE(TlsContext->ServerName, QUIC_POOL_TLS_SNI);
+            TlsContext->ServerName = NULL;
         }
 
         if (TlsContext->Ssl != NULL) {

--- a/src/platform/tls_schannel.c
+++ b/src/platform/tls_schannel.c
@@ -1542,6 +1542,7 @@ CxPlatTlsInitialize(
     CXPLAT_TLS* TlsContext = NULL;
 
     CXPLAT_DBG_ASSERT(Config->HkdfLabels);
+    CXPLAT_DBG_ASSERT(Config->IsServer || Config->ServerName != NULL);
 
     if (Config->IsServer != !(Config->SecConfig->Flags & QUIC_CREDENTIAL_FLAG_CLIENT)) {
         QuicTraceEvent(
@@ -1819,23 +1820,22 @@ CxPlatTlsWriteDataToSchannel(
         // side, and have a few special differences in this code path.
         //
         CXPLAT_DBG_ASSERT(TlsContext->IsServer == FALSE);
+        CXPLAT_DBG_ASSERT(TlsContext->SNI != NULL);
 
-        if (TlsContext->SNI != NULL) {
 #ifdef _KERNEL_MODE
-            TargetServerName = &ServerName;
-            QUIC_STATUS Status = CxPlatTlsUtf8ToUnicodeString(TlsContext->SNI, TargetServerName, QUIC_POOL_TLS_SNI);
+        TargetServerName = &ServerName;
+        QUIC_STATUS Status = CxPlatTlsUtf8ToUnicodeString(TlsContext->SNI, TargetServerName, QUIC_POOL_TLS_SNI);
 #else
-            QUIC_STATUS Status = CxPlatUtf8ToWideChar(TlsContext->SNI, QUIC_POOL_TLS_SNI, &TargetServerName);
+        QUIC_STATUS Status = CxPlatUtf8ToWideChar(TlsContext->SNI, QUIC_POOL_TLS_SNI, &TargetServerName);
 #endif
-            if (QUIC_FAILED(Status)) {
-                QuicTraceEvent(
-                    TlsErrorStatus,
-                    "[ tls][%p] ERROR, %u, %s.",
-                    TlsContext->Connection,
-                    Status,
-                    "Convert SNI to unicode");
-                return CXPLAT_TLS_RESULT_ERROR;
-            }
+        if (QUIC_FAILED(Status)) {
+            QuicTraceEvent(
+                TlsErrorStatus,
+                "[ tls][%p] ERROR, %u, %s.",
+                TlsContext->Connection,
+                Status,
+                "Convert SNI to unicode");
+            return CXPLAT_TLS_RESULT_ERROR;
         }
 
         //

--- a/src/platform/unittest/PlatformTest.cpp
+++ b/src/platform/unittest/PlatformTest.cpp
@@ -29,39 +29,128 @@ CxPlatEventQDequeueAndReturn(
     return Result;
 }
 
-struct PlatformTest : public ::testing::TestWithParam<int32_t>
-{
-};
-
 TEST(PlatformTest, QuicAddrParsing)
 {
     struct TestEntry {
         const char* Input;
+        uint16_t DefaultPort;
         int Family;
-        unsigned short Port;
+        uint16_t ExpectedPort;
+        uint32_t ExpectedScope;
+        uint8_t ExpectedAddress[16];
     };
 
-    TestEntry TestData[] = {
-        { "::", QUIC_ADDRESS_FAMILY_INET6, 0 },
-        { "fe80::9c3a:b64d:6249:1de8", QUIC_ADDRESS_FAMILY_INET6, 0 },
-        { "[::1]:80", QUIC_ADDRESS_FAMILY_INET6, 80 },
-        { "127.0.0.1", QUIC_ADDRESS_FAMILY_INET, 0 },
-        { "127.0.0.1:90", QUIC_ADDRESS_FAMILY_INET, 90 }
+    const TestEntry TestData[] = {
+        { "0.0.0.0", 0, QUIC_ADDRESS_FAMILY_INET, 0, 0, { 0, 0, 0, 0 } },
+        { "127.0.0.1", 443, QUIC_ADDRESS_FAMILY_INET, 443, 0, { 127, 0, 0, 1 } },
+        { "127.0.0.1:90", 443, QUIC_ADDRESS_FAMILY_INET, 90, 0, { 127, 0, 0, 1 } },
+        { "255.255.255.255:65535", 0, QUIC_ADDRESS_FAMILY_INET, 65535, 0, { 255, 255, 255, 255 } },
+        { "::", 0, QUIC_ADDRESS_FAMILY_INET6, 0, 0, {} },
+        { "::1", 443, QUIC_ADDRESS_FAMILY_INET6, 443, 0,
+          { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } },
+        { "[::1]:80", 443, QUIC_ADDRESS_FAMILY_INET6, 80, 0,
+          { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } },
+        { "::ffff:192.0.2.128", 0, QUIC_ADDRESS_FAMILY_INET6, 0, 0,
+          { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 0, 2, 128 } },
+        { "fe80::9c3a:b64d:6249:1de8%3", 0, QUIC_ADDRESS_FAMILY_INET6, 0, 3,
+          { 254, 128, 0, 0, 0, 0, 0, 0, 156, 58, 182, 77, 98, 73, 29, 232 } },
+        { "[fe80::9c3a:b64d:6249:1de8%3]:443", 0, QUIC_ADDRESS_FAMILY_INET6, 443, 3,
+          { 254, 128, 0, 0, 0, 0, 0, 0, 156, 58, 182, 77, 98, 73, 29, 232 } },
+        { "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535", 0,
+          QUIC_ADDRESS_FAMILY_INET6, 65535, UINT32_MAX,
+          { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 } }
     };
 
-    QUIC_ADDR Addr;
-    QUIC_ADDR_STR AddrStr = { 0 };
-
-    for (int i = 0; i < (int)(sizeof(TestData) / sizeof(struct TestEntry)); i++) {
-        CxPlatZeroMemory(&Addr, sizeof(QUIC_ADDR));
-        TestEntry* entry = &TestData[i];
-
-        ASSERT_TRUE(QuicAddrFromString(entry->Input, entry->Port, &Addr));
-        ASSERT_EQ(entry->Port, QuicAddrGetPort(&Addr));
-        ASSERT_EQ(entry->Family, QuicAddrGetFamily(&Addr));
-        ASSERT_TRUE(QuicAddrToString(&Addr, &AddrStr));
-        ASSERT_EQ(0, strcmp(entry->Input, AddrStr.Address));
+    for (const auto& Entry : TestData) {
+        QUIC_ADDR Addr{};
+        ASSERT_TRUE(QuicAddrFromString(Entry.Input, Entry.DefaultPort, &Addr)) << Entry.Input;
+        ASSERT_EQ(Entry.ExpectedPort, QuicAddrGetPort(&Addr)) << Entry.Input;
+        ASSERT_EQ(Entry.Family, QuicAddrGetFamily(&Addr)) << Entry.Input;
+        if (Entry.Family == QUIC_ADDRESS_FAMILY_INET6) {
+            ASSERT_EQ(Entry.ExpectedScope, Addr.Ipv6.sin6_scope_id) << Entry.Input;
+        }
+        const void* ActualAddress =
+            Entry.Family == QUIC_ADDRESS_FAMILY_INET ?
+                (void*)&Addr.Ipv4.sin_addr :
+                (void*)&Addr.Ipv6.sin6_addr;
+        ASSERT_EQ(
+            0,
+            memcmp(
+                Entry.ExpectedAddress,
+                ActualAddress,
+                Entry.Family == QUIC_ADDRESS_FAMILY_INET ? 4 : 16)) << Entry.Input;
     }
+
+    QUIC_ADDR Addr{};
+    ASSERT_FALSE(QuicAddrFromString("fe80::1%", 0, &Addr));
+    ASSERT_FALSE(QuicAddrFromString("fe80::1%abc", 0, &Addr));
+    ASSERT_FALSE(QuicAddrFromString("fe80::1%4294967296", 0, &Addr));
+}
+
+TEST(PlatformTest, QuicAddrToString)
+{
+    struct TestEntry {
+        const char* Input;
+        const char* Expected;
+    };
+
+    const TestEntry TestData[] = {
+        { "0.0.0.0", "0.0.0.0" },
+        { "127.0.0.1:443", "127.0.0.1:443" },
+        { "127.0.0.1:90", "127.0.0.1:90" },
+        { "255.255.255.255:65535", "255.255.255.255:65535" },
+        { "::", "::" },
+        { "[::1]:443", "[::1]:443" },
+        { "[::1]:80", "[::1]:80" },
+        { "::ffff:192.0.2.128", "::ffff:192.0.2.128" },
+        { "fe80::9c3a:b64d:6249:1de8%3", "fe80::9c3a:b64d:6249:1de8" },
+        { "[fe80::9c3a:b64d:6249:1de8%3]:443", "[fe80::9c3a:b64d:6249:1de8]:443" },
+        // Maximum scope, port and uncompressed IPv6 literal.
+        { "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535",
+          "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535" }
+    };
+
+    static_assert(sizeof(((QUIC_ADDR_STR*)nullptr)->Address) == 65);
+    for (const auto& Entry : TestData) {
+        QUIC_ADDR Addr{};
+        QUIC_ADDR_STR AddrStr{};
+        ASSERT_TRUE(QuicAddrFromString(Entry.Input, 0, &Addr)) << Entry.Input;
+        ASSERT_TRUE(QuicAddrToString(&Addr, &AddrStr));
+        ASSERT_STREQ(Entry.Expected, AddrStr.Address) << Entry.Input;
+    }
+}
+
+TEST(PlatformTest, QuicAddrIpToString)
+{
+    struct TestEntry {
+        const char* Input;
+        const char* Expected;
+    };
+
+    const TestEntry TestData[] = {
+        { "0.0.0.0", "0.0.0.0" },
+        { "127.0.0.1:443", "127.0.0.1" },
+        { "255.255.255.255:65535", "255.255.255.255" },
+        { "[::]:65535", "::" },
+        { "[::1]:443", "::1" },
+        { "[::ffff:192.0.2.128]:443", "::ffff:192.0.2.128" },
+        { "[fe80::9c3a:b64d:6249:1de8%3]:443", "fe80::9c3a:b64d:6249:1de8" },
+        // Maximum scope, port and uncompressed IPv6 literal.
+        { "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535",
+          "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" }
+    };
+
+    for (const auto& Entry : TestData) {
+        QUIC_ADDR Addr{};
+        QUIC_ADDR_STR AddrStr{};
+        ASSERT_TRUE(QuicAddrFromString(Entry.Input, 0, &Addr)) << Entry.Input;
+        ASSERT_TRUE(QuicAddrIpToString(&Addr, &AddrStr));
+        ASSERT_STREQ(Entry.Expected, AddrStr.Address) << Entry.Input;
+    }
+
+    QUIC_ADDR InvalidAddr{};
+    QUIC_ADDR_STR AddrStr{};
+    ASSERT_FALSE(QuicAddrIpToString(&InvalidAddr, &AddrStr));
 }
 
 TEST(PlatformTest, CxPlatIsIpLiteral)

--- a/src/platform/unittest/TlsTest.cpp
+++ b/src/platform/unittest/TlsTest.cpp
@@ -346,7 +346,8 @@ protected:
             CXPLAT_SEC_CONFIG* SecConfiguration,
             bool MultipleAlpns = false,
             uint16_t TPLen = 64,
-            QUIC_BUFFER* Ticket = nullptr
+            QUIC_BUFFER* Ticket = nullptr,
+            const char* ServerName = "localhost"
             )
         {
             CXPLAT_TLS_CONFIG Config = {0};
@@ -360,7 +361,7 @@ protected:
                 (uint8_t*)CXPLAT_ALLOC_NONPAGED(CxPlatTlsTPHeaderSize + TPLen, QUIC_POOL_TLS_TRANSPARAMS);
             Config.LocalTPLength = CxPlatTlsTPHeaderSize + TPLen;
             Config.Connection = (QUIC_CONNECTION*)this;
-            Config.ServerName = "localhost";
+            Config.ServerName = ServerName;
             if (Ticket) {
                 ASSERT_NE(nullptr, Ticket->Buffer);
                 //ASSERT_NE((uint32_t)0, Ticket->Length);
@@ -1484,6 +1485,27 @@ TEST_F(TlsTest, DeferredCertificateValidationAllow)
 }
 
 #ifdef QUIC_ENABLE_CA_CERTIFICATE_FILE_TESTS
+TEST_F(TlsTest, ServerCertificateReferenceIdentityMismatch)
+{
+    CxPlatClientSecConfigCa ClientConfig(
+        QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE);
+    CxPlatServerSecConfigCa ServerConfig(
+        QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE);
+
+    for (const char* ServerName : {"not-localhost", "127.0.0.1"}) {
+        TlsContext ServerContext, ClientContext;
+        ClientContext.InitializeClient(ClientConfig, false, 64, nullptr, ServerName);
+        ServerContext.InitializeServer(ServerConfig);
+        DoHandshake(
+            ServerContext,
+            ClientContext,
+            DefaultFragmentSize,
+            false,
+            false,
+            true);
+    }
+}
+
 TEST_F(TlsTest, DeferredCertificateValidationAllowCa)
 {
     CxPlatClientSecConfigCa ClientConfig(

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -228,11 +228,11 @@ pub type QUIC_XDP_MAP_HANDLE = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct QUIC_ADDR_STR {
-    pub Address: [::std::os::raw::c_char; 64usize],
+    pub Address: [::std::os::raw::c_char; 65usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_ADDR_STR"][::std::mem::size_of::<QUIC_ADDR_STR>() - 64usize];
+    ["Size of QUIC_ADDR_STR"][::std::mem::size_of::<QUIC_ADDR_STR>() - 65usize];
     ["Alignment of QUIC_ADDR_STR"][::std::mem::align_of::<QUIC_ADDR_STR>() - 1usize];
     ["Offset of field: QUIC_ADDR_STR::Address"]
         [::std::mem::offset_of!(QUIC_ADDR_STR, Address) - 0usize];

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -227,11 +227,11 @@ pub type QUIC_XDP_MAP_HANDLE = HANDLE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct QUIC_ADDR_STR {
-    pub Address: [::std::os::raw::c_char; 64usize],
+    pub Address: [::std::os::raw::c_char; 65usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of QUIC_ADDR_STR"][::std::mem::size_of::<QUIC_ADDR_STR>() - 64usize];
+    ["Size of QUIC_ADDR_STR"][::std::mem::size_of::<QUIC_ADDR_STR>() - 65usize];
     ["Alignment of QUIC_ADDR_STR"][::std::mem::align_of::<QUIC_ADDR_STR>() - 1usize];
     ["Offset of field: QUIC_ADDR_STR::Address"]
         [::std::mem::offset_of!(QUIC_ADDR_STR, Address) - 0usize];


### PR DESCRIPTION
## Description

Addresses https://microsoft.visualstudio.com/OS/_workitems/edit/62840655

When using the OpenSSL or QuicTLS backends, the target hostname was not properly validated against the server certificate.
`X509_VERIFY_PARAM_set1_host` and `X509_VERIFY_PARAM_set1_ip_asc` are now properly called.

The server name provided to `ConnectionStart` is used for the validation, if it isn't provided, the target IP address is used instead.

## Testing

CI. Manual testing validating a connection succeeds and fail as expected against various certificate matching or not the hostname and/or IP.
New automated test cases will be added in a follow up.

## Documentation

N/A
