### PR TITLE
Use SOCK_CLOEXEC for Linux datapath sockets

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -461,7 +461,7 @@ CxPlatSocketContextInitialize(
         socket(
             AF_INET6,
             (SocketType == CXPLAT_SOCKET_UDP ? SOCK_DGRAM : SOCK_STREAM) |
-                SOCK_NONBLOCK,
+                SOCK_NONBLOCK | SOCK_CLOEXEC,
             SocketType == CXPLAT_SOCKET_UDP ? IPPROTO_UDP : IPPROTO_TCP);
     if (SocketContext->SocketFd == INVALID_SOCKET) {
         Status = errno;

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -639,7 +639,7 @@ CxPlatSocketContextInitialize(
         socket(
             AF_INET6,
             (SocketType == CXPLAT_SOCKET_UDP ? SOCK_DGRAM : SOCK_STREAM) |
-                SOCK_NONBLOCK,
+                SOCK_NONBLOCK | SOCK_CLOEXEC,
             SocketType == CXPLAT_SOCKET_UDP ? IPPROTO_UDP : IPPROTO_TCP);
     if (SocketContext->SocketFd == INVALID_SOCKET) {
         Status = errno;

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -131,9 +131,9 @@ CxPlatDataPathCalculateFeatureSupport(
     RecvMsg.msg_control = RecvControlBuffer;
     RecvMsg.msg_controllen = sizeof(RecvControlBuffer);
 #define VERIFY(X) if (!(X)) { goto Error; }
-    SendSocket = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+    SendSocket = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_UDP);
     VERIFY(SendSocket != INVALID_SOCKET)
-    RecvSocket = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+    RecvSocket = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_UDP);
     VERIFY(RecvSocket != INVALID_SOCKET)
     VERIFY(setsockopt(SendSocket, IPPROTO_IP, IP_PKTINFO, &PktInfoEnabled, sizeof(PktInfoEnabled)) != SOCKET_ERROR)
     VERIFY(setsockopt(RecvSocket, IPPROTO_IP, IP_PKTINFO, &PktInfoEnabled, sizeof(PktInfoEnabled)) != SOCKET_ERROR)


### PR DESCRIPTION
## Description

Use SOCK_CLOEXEC when creating Linux datapath sockets so they are not inherited across exec.

This updates:
- epoll datapath sockets
- io_uring datapath sockets
- Linux feature-detection UDP sockets

Refs #4980

## Testing

- Linux epoll build: passed
- Linux io_uring build: passed
- DataPath tests: 32 passed, 4 skipped because they require DuoNic/XDP hardware
- Full platform test run had one unrelated existing TLS certificate-file failure because no PfxPath was provided