### PR TITLE
Fix TCP socket teardown race

### DIFF
--- a/src/platform/datapath_epoll.c
+++ b/src/platform/datapath_epoll.c
@@ -1013,7 +1013,8 @@ CxPlatSocketContextUninitialize(
             //
             // For TCP sockets, we should shutdown the socket before closing it.
             //
-            SocketContext->Binding->DisconnectIndicated = TRUE;
+            (void)InterlockedCompareExchange(
+                &SocketContext->Binding->DisconnectIndicated, TRUE, FALSE);
             if (shutdown(SocketContext->SocketFd, SHUT_RDWR) != 0) {
                 int Errno = errno;
                 if (Errno != ENOTCONN) {
@@ -1934,8 +1935,8 @@ CxPlatSocketReceiveTcpData(
         int NumberOfBytesTransferred = read(SocketContext->SocketFd, Buffer, SocketContext->Binding->RecvBufLen);
 
         if (NumberOfBytesTransferred == 0) {
-            if (!SocketContext->Binding->DisconnectIndicated) {
-                SocketContext->Binding->DisconnectIndicated = TRUE;
+            if (InterlockedCompareExchange(
+                    &SocketContext->Binding->DisconnectIndicated, TRUE, FALSE) == FALSE) {
                 SocketContext->Binding->Datapath->TcpHandlers.Connect(
                     SocketContext->Binding,
                     SocketContext->Binding->ClientContext,

--- a/src/platform/datapath_iouring.c
+++ b/src/platform/datapath_iouring.c
@@ -1170,7 +1170,8 @@ CxPlatSocketContextUninitialize(
             //
             // For TCP sockets, we should shutdown the socket before closing it.
             //
-            SocketContext->Binding->DisconnectIndicated = TRUE;
+            (void)InterlockedCompareExchange(
+                &SocketContext->Binding->DisconnectIndicated, TRUE, FALSE);
             if (shutdown(SocketContext->SocketFd, SHUT_RDWR) != 0) {
                 int Errno = errno;
                 if (Errno != ENOTCONN) {
@@ -1476,8 +1477,8 @@ CxPlatSocketHandleErrors(
                     }
                 }
             } else {
-                if (!SocketContext->Binding->DisconnectIndicated) {
-                    SocketContext->Binding->DisconnectIndicated = TRUE;
+                if (InterlockedCompareExchange(
+                        &SocketContext->Binding->DisconnectIndicated, TRUE, FALSE) == FALSE) {
                     SocketContext->Binding->Datapath->TcpHandlers.Connect(
                         SocketContext->Binding,
                         SocketContext->Binding->ClientContext,

--- a/src/platform/datapath_linux.c
+++ b/src/platform/datapath_linux.c
@@ -267,8 +267,8 @@ CxPlatSocketHandleError(
             }
         }
     } else {
-        if (!SocketContext->Binding->DisconnectIndicated) {
-            SocketContext->Binding->DisconnectIndicated = TRUE;
+        if (InterlockedCompareExchange(
+                &SocketContext->Binding->DisconnectIndicated, TRUE, FALSE) == FALSE) {
             SocketContext->Binding->Datapath->TcpHandlers.Connect(
                 SocketContext->Binding,
                 SocketContext->Binding->ClientContext,

--- a/src/platform/datapath_winuser.c
+++ b/src/platform/datapath_winuser.c
@@ -2601,7 +2601,7 @@ CxPlatSocketContextUninitialize(
         //
         // For TCP sockets, we should shutdown the socket before closing it.
         //
-        SocketProc->Parent->DisconnectIndicated = TRUE;
+        InterlockedExchange(&SocketProc->Parent->DisconnectIndicated, TRUE);
         if (shutdown(SocketProc->Socket, SD_BOTH) == SOCKET_ERROR) {
             int WsaError = WSAGetLastError();
             if (WsaError != WSAENOTCONN) {
@@ -3411,8 +3411,8 @@ CxPlatDataPathTcpRecvComplete(
         // Error from shutdown, silently ignore. Return immediately so the
         // receive doesn't get reposted.
         //
-        if (!SocketProc->Parent->DisconnectIndicated) {
-            SocketProc->Parent->DisconnectIndicated = TRUE;
+        if (InterlockedCompareExchange(
+                &SocketProc->Parent->DisconnectIndicated, TRUE, FALSE) == FALSE) {
             SocketProc->Parent->Datapath->TcpHandlers.Connect(
                 SocketProc->Parent,
                 SocketProc->Parent->ClientContext,
@@ -3425,8 +3425,8 @@ CxPlatDataPathTcpRecvComplete(
     } else if (IoResult == QUIC_STATUS_SUCCESS) {
 
         if (NumberOfBytesTransferred == 0) {
-            if (!SocketProc->Parent->DisconnectIndicated) {
-                SocketProc->Parent->DisconnectIndicated = TRUE;
+            if (InterlockedCompareExchange(
+                    &SocketProc->Parent->DisconnectIndicated, TRUE, FALSE) == FALSE) {
                 SocketProc->Parent->Datapath->TcpHandlers.Connect(
                     SocketProc->Parent,
                     SocketProc->Parent->ClientContext,

--- a/src/platform/platform_internal.h
+++ b/src/platform/platform_internal.h
@@ -573,20 +573,9 @@ typedef struct CXPLAT_SOCKET {
     uint8_t HasFixedRemoteAddress : 1;
 
     //
-    // Flag indicates the socket indicated a disconnect event.
-    //
-    uint8_t DisconnectIndicated : 1;
-
-    //
     // Flag indicates the binding is being used for PCP.
     //
     uint8_t PcpBinding : 1;
-
-    //
-    // Debug flags.
-    //
-    uint8_t Uninitialized : 1;
-    uint8_t Freed : 1;
 
     //
     // This flag determines whether or not we instantiate an auxiliary TCP
@@ -599,6 +588,17 @@ typedef struct CXPLAT_SOCKET {
     uint8_t RawSocketAvailable : 1;
 
     uint8_t SkipCreatingOsSockets : 1;
+
+    //
+    // Flag indicates the socket indicated a disconnect event.
+    //
+    LONG DisconnectIndicated;
+
+    //
+    // Debug flags.
+    //
+    uint8_t Uninitialized;
+    uint8_t Freed;
 
     //
     // Per-processor socket contexts.
@@ -887,25 +887,25 @@ typedef struct CXPLAT_SOCKET {
     BOOLEAN HasFixedRemoteAddress : 1;
 
     //
-    // Flag indicates the socket indicated a disconnect event.
-    //
-    uint8_t DisconnectIndicated : 1;
-
-    //
     // Flag indicates the binding is being used for PCP.
     //
     BOOLEAN PcpBinding : 1;
-
-#if DEBUG
-    uint8_t Uninitialized : 1;
-    uint8_t Freed : 1;
-#endif
 
     uint8_t ReserveAuxTcpSockForQtip : 1;                  // Quic over TCP
 
     uint8_t RawSocketAvailable : 1;
 
     uint8_t SkipCreatingOsSockets : 1;
+
+    //
+    // Flag indicates the socket indicated a disconnect event.
+    //
+    long DisconnectIndicated;
+
+#if DEBUG
+    uint8_t Uninitialized;
+    uint8_t Freed;
+#endif
 
     //
     // Set of socket contexts one per proc.


### PR DESCRIPTION
## Description

Fix a TCP socket teardown race where disconnect completion and socket deletion could concurrently update packed bitfields, clearing lifecycle state and triggering `Socket->Uninitialized` assertions.

The issue was observed in a few CI runs, like https://github.com/microsoft/msquic/actions/runs/33264182747/job/99131943013?p

- Store disconnect indication in independently addressable, naturally aligned storage.
- Atomically transition disconnect indication so the callback is delivered at most once.
- Keep standalone lifecycle fields after the packed flag block.
- Apply the fix to Windows WinSock and Linux epoll/io_uring datapaths.

## Testing

- Windows x64 Debug Schannel build.
- `DataPathTest/DataPathTest.TcpDataClient/4` repeated 500 times.
- Linux epoll and io_uring datapath objects compiled with warnings treated as errors.

## Documentation

No documentation impact.