### PR TITLE
[Mirror #16575346] Bump ubuntu from `4fbb8e6` to `33ceb71` in /.docker/ubuntu-24.04

### DIFF
--- a/.docker/ubuntu-24.04/Dockerfile
+++ b/.docker/ubuntu-24.04/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS base
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/microsoft/msquic
 


### PR DESCRIPTION
Mirrored from internal ADO PR #16575346 by Dependabot

Internal PR: https://dev.azure.com/microsoft/undock/_git/msquic/pullrequest/16575346