### PR TITLE
[Mirror #16698452] Bump ubuntu from `0e0a0fc` to `2edbbc5` in /.docker/ubuntu-22.04

### DIFF
--- a/.docker/ubuntu-22.04/Dockerfile
+++ b/.docker/ubuntu-22.04/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982 AS base
+FROM ubuntu:22.04@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc AS base
 
 LABEL org.opencontainers.image.source=https://github.com/microsoft/msquic
 


### PR DESCRIPTION
Mirrored from internal ADO PR #16698452 by Dependabot

Internal PR: https://dev.azure.com/microsoft/undock/_git/msquic/pullrequest/16698452