### PR TITLE
[CP] Fix TLS send buffer growth overflow (#6216)

### DIFF
--- a/src/platform/tls_quictls.c
+++ b/src/platform/tls_quictls.c
@@ -559,7 +559,12 @@ CxPlatTlsAddHandshakeDataCallback(
         (uint64_t)Length,
         (uint32_t)Level);
 
-    if (Length + TlsState->BufferLength > 0xF000) {
+    //
+    // Cap the buffer at 0x8000, the largest power of two that fits a uint16_t,
+    // so the doubling growth below cannot overflow.
+    //
+    size_t RequiredBufferLength = Length + TlsState->BufferLength;
+    if (RequiredBufferLength > 0x8000) {
         QuicTraceEvent(
             TlsError,
             "[ tls][%p] ERROR, %s.",
@@ -569,13 +574,13 @@ CxPlatTlsAddHandshakeDataCallback(
         return -1;
     }
 
-    if (Length + TlsState->BufferLength > (size_t)TlsState->BufferAllocLength) {
+    if (RequiredBufferLength > (size_t)TlsState->BufferAllocLength) {
         //
         // Double the allocated buffer length until there's enough room for the
         // new data.
         //
         uint16_t NewBufferAllocLength = TlsState->BufferAllocLength;
-        while (Length + TlsState->BufferLength > (size_t)NewBufferAllocLength) {
+        while (RequiredBufferLength > (size_t)NewBufferAllocLength) {
             NewBufferAllocLength <<= 1;
         }
 


### PR DESCRIPTION
## Description

Prevent OpenSSL and QuicTLS handshake buffer growth from wrapping at 32 KiB and hanging the worker thread. Preserve the existing 60 KiB limit.
 Fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/62825957/
## Testing

NA
## Documentation

NA

<!-- Companion PR for release/2.6: #6295 -->
