### PR TITLE
Defer destination CID replacement

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5442,31 +5442,6 @@ QuicConnRecvPostProcessing(
             // sent back out.
             //
 
-            if (CurrentPath->DestCid == NULL ||
-                (PeerUpdatedCid && CurrentPath->DestCid->CID.Length != 0)) {
-                //
-                // TODO - What if the peer (client) only sends a single CID and
-                // rebinding happens? Should we support using the same CID over?
-                //
-                QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
-                if (NewDestCid == NULL) {
-                    QuicTraceEvent(
-                        ConnError,
-                        "[conn][%p] ERROR, %s.",
-                        Connection,
-                        "No unused CID for new path");
-                    CurrentPath->GotValidPacket = FALSE; // Don't have a new CID to use!!!
-                    CurrentPath->DestCid = NULL;
-                    return;
-                }
-                CXPLAT_DBG_ASSERT(NewDestCid != CurrentPath->DestCid);
-                CurrentPath->DestCid = NewDestCid;
-                QUIC_CID_SET_PATH(Connection, CurrentPath->DestCid, CurrentPath);
-                CurrentPath->DestCid->CID.UsedLocally = TRUE;
-            }
-
-            CXPLAT_DBG_ASSERT(CurrentPath->DestCid != NULL);
-            QuicPathValidate(CurrentPath);
             CurrentPath->SendChallenge = TRUE;
             CurrentPath->PathValidationStartTime = CxPlatTimeUs64();
 
@@ -5899,8 +5874,21 @@ QuicConnRecvDatagrams(
         }
     }
 
-    if (!QuicPathSetUpdateDestCids(PathSet, Connection)) {
-        return;
+    //
+    // If the peer has migrated to a new path, provide a destination CID to the new path if needed.
+    // If none is available, reject the migration.
+    //
+    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    if (PathSet->NextActivePathId != ActivePath->ID) {
+        uint8_t NextActivePathIndex;
+        QUIC_PATH* NextActivePath =
+            QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
+        CXPLAT_DBG_ASSERT(NextActivePath != NULL);
+        if (NextActivePath->DestCid == NULL &&
+            !QuicPathUpdateDestCid(Connection, NextActivePath))
+        {
+            PathSet->NextActivePathId = ActivePath->ID;
+        }
     }
 
     //
@@ -5908,6 +5896,8 @@ QuicConnRecvDatagrams(
     // This invalidates pointers to paths.
     //
     QuicPathUpdateActive(Connection);
+
+    QuicPathUpdateDestCids(PathSet, Connection);
 
     if (!Connection->State.UpdateWorker && Connection->State.Connected &&
         !Connection->State.ShutdownComplete && RecvState.UpdatePartitionId) {

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1107,13 +1107,11 @@ QuicConnRetireCurrentDestCid(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
+void
 QuicConnOnRetirePriorToUpdated(
     _In_ QUIC_CONNECTION* Connection
     )
 {
-    BOOLEAN ReplaceRetiredCids = FALSE;
-
     for (CXPLAT_LIST_ENTRY* Entry = Connection->DestCids.Flink;
             Entry != &Connection->DestCids;
             Entry = Entry->Flink) {
@@ -1127,78 +1125,8 @@ QuicConnOnRetirePriorToUpdated(
             continue;
         }
 
-        if (DestCid->CID.UsedLocally) {
-            ReplaceRetiredCids = TRUE;
-        }
-
-        QUIC_CID_CLEAR_PATH(DestCid);
         QuicConnRetireCid(Connection, DestCid);
     }
-
-    return ReplaceRetiredCids;
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
-QuicConnReplaceRetiredCids(
-    _In_ QUIC_CONNECTION* Connection
-    )
-{
-    QUIC_PATH_SET* PathSet = &Connection->Paths;
-    CXPLAT_DBG_ASSERT(PathSet->Count <= QUIC_MAX_PATH_COUNT);
-    for (uint8_t i = 0; i < PathSet->Count; ++i) {
-        QUIC_PATH* Path = &PathSet->Paths[i];
-        if (Path->DestCid == NULL || !Path->DestCid->CID.Retired) {
-            continue;
-        }
-
-        QUIC_CID_VALIDATE_NULL(Connection, Path->DestCid); // Previously cleared on retire.
-        QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
-        if (NewDestCid == NULL) {
-            if (Path->IsActive) {
-                QuicTraceEvent(
-                    ConnError,
-                    "[conn][%p] ERROR, %s.",
-                    Connection,
-                    "Active path has no replacement for retired CID");
-                QuicConnSilentlyAbort(Connection); // Must silently abort because we can't send anything now.
-                return FALSE;
-            }
-            QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
-                Connection,
-                "Non-active path has no replacement for retired CID.");
-            //
-            // A path pending deferred activation is still considered non-active here and
-            // may be removed. CID replacement will be deferred in the next stack layer.
-            //
-            CXPLAT_DBG_ASSERT(i != 0);
-            QuicPathRemove(Connection, i--);
-            continue;
-        }
-
-        CXPLAT_DBG_ASSERT(NewDestCid != Path->DestCid);
-        Path->DestCid = NewDestCid;
-        QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
-        Path->DestCid->CID.UsedLocally = TRUE;
-        Path->InitiatedCidUpdate = TRUE;
-        QuicPathValidate(Path);
-    }
-
-#if DEBUG
-    for (CXPLAT_LIST_ENTRY* Entry = Connection->DestCids.Flink;
-            Entry != &Connection->DestCids;
-            Entry = Entry->Flink) {
-        QUIC_CID_LIST_ENTRY* DestCid =
-            CXPLAT_CONTAINING_RECORD(
-                Entry,
-                QUIC_CID_LIST_ENTRY,
-                Link);
-        CXPLAT_DBG_ASSERT(!DestCid->CID.Retired || DestCid->AssignedPath == NULL);
-    }
-#endif
-
-    return TRUE;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -5058,10 +4986,9 @@ QuicConnRecvFrames(
                 break; // Ignore frame if we are closed.
             }
 
-            BOOLEAN ReplaceRetiredCids = FALSE;
             if (Connection->RetirePriorTo < Frame.RetirePriorTo) {
                 Connection->RetirePriorTo = Frame.RetirePriorTo;
-                ReplaceRetiredCids = QuicConnOnRetirePriorToUpdated(Connection);
+                QuicConnOnRetirePriorToUpdated(Connection);
             }
 
             if (QuicConnGetDestCidFromSeq(Connection, Frame.Sequence, FALSE) == NULL) {
@@ -5076,11 +5003,7 @@ QuicConnRecvFrames(
                         "Allocation of '%s' failed. (%llu bytes)",
                         "new DestCid",
                         sizeof(QUIC_CID_LIST_ENTRY) + Frame.Length);
-                    if (ReplaceRetiredCids) {
-                        QuicConnSilentlyAbort(Connection);
-                    } else {
-                        QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, NULL);
-                    }
+                    QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, NULL);
                     return FALSE;
                 }
 
@@ -5109,17 +5032,9 @@ QuicConnRecvFrames(
                         "[conn][%p] ERROR, %s.",
                         Connection,
                         "Peer exceeded CID limit");
-                    if (ReplaceRetiredCids) {
-                        QuicConnSilentlyAbort(Connection);
-                    } else {
-                        QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
-                    }
+                    QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
                     return FALSE;
                 }
-            }
-
-            if (ReplaceRetiredCids && !QuicConnReplaceRetiredCids(Connection)) {
-                return FALSE;
             }
 
             AckEliciting = TRUE;
@@ -5982,6 +5897,10 @@ QuicConnRecvDatagrams(
                 PathSet->Paths[i].ID);
             QuicPathRemove(Connection, (uint8_t)i);
         }
+    }
+
+    if (!QuicPathSetUpdateDestCids(PathSet, Connection)) {
+        return;
     }
 
     //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1100,7 +1100,9 @@ QuicConnRetireCurrentDestCid(
     CXPLAT_DBG_ASSERT(Path->DestCid != NewDestCid);
     QUIC_CID_LIST_ENTRY* OldDestCid = Path->DestCid;
     QUIC_CID_CLEAR_PATH(Path->DestCid);
-    QuicConnRetireCid(Connection, Path->DestCid);
+    if (!OldDestCid->CID.Retired) {
+        QuicConnRetireCid(Connection, OldDestCid);
+    }
     Path->DestCid = NewDestCid;
     QUIC_CID_SET_PATH(Connection, Path->DestCid, Path);
     QUIC_CID_VALIDATE_NULL(Connection, OldDestCid);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5889,21 +5889,6 @@ QuicConnRecvDatagrams(
     }
 
     //
-    // If the peer has migrated to a new path, provide a destination CID to the new path if needed.
-    // If none is available, reject the migration.
-    //
-    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
-    if (PathSet->NextActivePathId != ActivePath->ID) {
-        uint8_t NextActivePathIndex;
-        QUIC_PATH* NextActivePath =
-            QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
-        CXPLAT_DBG_ASSERT(NextActivePath != NULL);
-        if (!QuicPathUpdateDestCid(Connection, NextActivePath)) {
-            PathSet->NextActivePathId = ActivePath->ID;
-        }
-    }
-
-    //
     // The active path might have changed, update it.
     // This invalidates pointers to paths.
     //

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1076,6 +1076,10 @@ QuicConnRetireCurrentDestCid(
     _In_ QUIC_PATH* Path
     )
 {
+    if (Path->DestCid == NULL) {
+        return TRUE;
+    }
+
     if (Path->DestCid->CID.Length == 0) {
         QuicTraceLogConnVerbose(
             ZeroLengthCidRetire,

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1107,11 +1107,13 @@ QuicConnRetireCurrentDestCid(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-void
+BOOLEAN
 QuicConnOnRetirePriorToUpdated(
     _In_ QUIC_CONNECTION* Connection
     )
 {
+    BOOLEAN RetiredUsedCid = FALSE;
+
     for (CXPLAT_LIST_ENTRY* Entry = Connection->DestCids.Flink;
             Entry != &Connection->DestCids;
             Entry = Entry->Flink) {
@@ -1125,8 +1127,11 @@ QuicConnOnRetirePriorToUpdated(
             continue;
         }
 
+        RetiredUsedCid |= DestCid->CID.UsedLocally;
         QuicConnRetireCid(Connection, DestCid);
     }
+
+    return RetiredUsedCid;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -4986,9 +4991,10 @@ QuicConnRecvFrames(
                 break; // Ignore frame if we are closed.
             }
 
+            BOOLEAN RetiredUsedCid = FALSE;
             if (Connection->RetirePriorTo < Frame.RetirePriorTo) {
                 Connection->RetirePriorTo = Frame.RetirePriorTo;
-                QuicConnOnRetirePriorToUpdated(Connection);
+                RetiredUsedCid = QuicConnOnRetirePriorToUpdated(Connection);
             }
 
             if (QuicConnGetDestCidFromSeq(Connection, Frame.Sequence, FALSE) == NULL) {
@@ -5003,7 +5009,11 @@ QuicConnRecvFrames(
                         "Allocation of '%s' failed. (%llu bytes)",
                         "new DestCid",
                         sizeof(QUIC_CID_LIST_ENTRY) + Frame.Length);
-                    QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, NULL);
+                    if (RetiredUsedCid) {
+                        QuicConnSilentlyAbort(Connection);
+                    } else {
+                        QuicConnFatalError(Connection, QUIC_STATUS_OUT_OF_MEMORY, NULL);
+                    }
                     return FALSE;
                 }
 
@@ -5032,7 +5042,11 @@ QuicConnRecvFrames(
                         "[conn][%p] ERROR, %s.",
                         Connection,
                         "Peer exceeded CID limit");
-                    QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+                    if (RetiredUsedCid) {
+                        QuicConnSilentlyAbort(Connection);
+                    } else {
+                        QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+                    }
                     return FALSE;
                 }
             }
@@ -5884,9 +5898,7 @@ QuicConnRecvDatagrams(
         QUIC_PATH* NextActivePath =
             QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
         CXPLAT_DBG_ASSERT(NextActivePath != NULL);
-        if (NextActivePath->DestCid == NULL &&
-            !QuicPathUpdateDestCid(Connection, NextActivePath))
-        {
+        if (!QuicPathUpdateDestCid(Connection, NextActivePath)) {
             PathSet->NextActivePathId = ActivePath->ID;
         }
     }

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -5878,7 +5878,7 @@ QuicConnRecvDatagrams(
     // If the peer has migrated to a new path, provide a destination CID to the new path if needed.
     // If none is available, reject the migration.
     //
-    QUIC_PATH* ActivePath = QuicPathSetGetActivePath(PathSet);
+    QUIC_PATH* ActivePath = QuicPathGetActive(PathSet);
     if (PathSet->NextActivePathId != ActivePath->ID) {
         uint8_t NextActivePathIndex;
         QUIC_PATH* NextActivePath =

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1047,6 +1047,10 @@ QuicConnRetireCid(
     _In_ QUIC_CID_LIST_ENTRY* DestCid
     )
 {
+    if (DestCid->CID.Retired) {
+        return;
+    }
+
     QuicTraceEvent(
         ConnDestCidRemoved,
         "[conn][%p] (SeqNum=%llu) Removed Destination CID: %!CID!",
@@ -1100,9 +1104,7 @@ QuicConnRetireCurrentDestCid(
     CXPLAT_DBG_ASSERT(Path->DestCid != NewDestCid);
     QUIC_CID_LIST_ENTRY* OldDestCid = Path->DestCid;
     QUIC_CID_CLEAR_PATH(Path->DestCid);
-    if (!OldDestCid->CID.Retired) {
-        QuicConnRetireCid(Connection, OldDestCid);
-    }
+    QuicConnRetireCid(Connection, OldDestCid);
     Path->DestCid = NewDestCid;
     QUIC_CID_SET_PATH(Connection, Path->DestCid, Path);
     QUIC_CID_VALIDATE_NULL(Connection, OldDestCid);

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1261,6 +1261,15 @@ QuicConnGenerateNewSourceCids(
     );
 
 //
+// Get an unused destination CID from the list provided by the peer.
+//
+_IRQL_requires_max_(PASSIVE_LEVEL)
+QUIC_CID_LIST_ENTRY*
+QuicConnGetUnusedDestCid(
+    _In_ const QUIC_CONNECTION* Connection
+    );
+
+//
 // Retires the currently used destination connection ID.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -88,14 +88,14 @@ QuicPathUpdateDestCid(
         return TRUE;
     }
 
-    if (Path->DestCid != NULL) {
-        QUIC_CID_CLEAR_PATH(Path->DestCid);
-        Path->DestCid = NULL;
-    }
-
     QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
     if (NewDestCid == NULL) {
         return FALSE;
+    }
+
+    if (Path->DestCid != NULL) {
+        QUIC_CID_CLEAR_PATH(Path->DestCid);
+        Path->DestCid = NULL;
     }
 
     Path->DestCid = NewDestCid;
@@ -537,8 +537,8 @@ QuicPathSetActive(
         QuicCongestionControlReset(&Connection->CongestionControl, FALSE);
     }
     Connection->Paths.NextActivePathId = ActivePath->ID;
-    CXPLAT_DBG_ASSERT(Path->DestCid != NULL);
-    CXPLAT_DBG_ASSERT(!Path->DestCid->CID.Retired);
+    CXPLAT_DBG_ASSERT(ActivePath->DestCid != NULL);
+    CXPLAT_DBG_ASSERT(!ActivePath->DestCid->CID.Retired);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -207,6 +207,68 @@ QuicPathRemove(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicPathSetUpdateDestCids(
+    _In_ QUIC_PATH_SET* PathSet,
+    _In_ QUIC_CONNECTION* Connection
+    )
+{
+    for (uint8_t i = 0; i < PathSet->Count; ++i) {
+        QUIC_PATH* Path = &PathSet->Paths[i];
+        if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
+            continue;
+        }
+
+        if (Path->DestCid != NULL) {
+            QUIC_CID_CLEAR_PATH(Path->DestCid);
+            Path->DestCid = NULL;
+        }
+
+        QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
+        if (NewDestCid == NULL) {
+            if (Path->IsActive || Path->ID == PathSet->NextActivePathId) {
+                QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Active path has no replacement for retired CID");
+                QuicConnSilentlyAbort(Connection);
+                return FALSE;
+            }
+
+            QuicTraceLogConnWarning(
+                NonActivePathCidRetired,
+                Connection,
+                "Non-active path has no replacement for retired CID.");
+            CXPLAT_DBG_ASSERT(i != 0);
+            QuicPathRemove(Connection, i--);
+            continue;
+        }
+
+        Path->DestCid = NewDestCid;
+        QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
+        Path->DestCid->CID.UsedLocally = TRUE;
+        Path->InitiatedCidUpdate = TRUE;
+        QuicPathValidate(Path);
+    }
+
+#if DEBUG
+    for (CXPLAT_LIST_ENTRY* Entry = Connection->DestCids.Flink;
+            Entry != &Connection->DestCids;
+            Entry = Entry->Flink) {
+        QUIC_CID_LIST_ENTRY* DestCid =
+            CXPLAT_CONTAINING_RECORD(
+                Entry,
+                QUIC_CID_LIST_ENTRY,
+                Link);
+        CXPLAT_DBG_ASSERT(!DestCid->CID.Retired || DestCid->AssignedPath == NULL);
+    }
+#endif
+
+    return TRUE;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathSetAllowance(
     _In_ QUIC_CONNECTION* Connection,

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -208,48 +208,62 @@ QuicPathRemove(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
-QuicPathSetUpdateDestCids(
+QuicPathUpdateDestCid(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_PATH* Path
+    )
+{
+    if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
+        return TRUE;
+    }
+
+    if (Path->DestCid != NULL) {
+        QUIC_CID_CLEAR_PATH(Path->DestCid);
+        Path->DestCid = NULL;
+    }
+
+    QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
+    if (NewDestCid == NULL) {
+        return FALSE;
+    }
+
+    Path->DestCid = NewDestCid;
+    QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
+    Path->DestCid->CID.UsedLocally = TRUE;
+    Path->InitiatedCidUpdate = TRUE;
+    QuicPathValidate(Path);
+    return TRUE;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathUpdateDestCids(
     _In_ QUIC_PATH_SET* PathSet,
     _In_ QUIC_CONNECTION* Connection
     )
 {
     for (uint8_t i = 0; i < PathSet->Count; ++i) {
         QUIC_PATH* Path = &PathSet->Paths[i];
-        if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
+        if (QuicPathUpdateDestCid(Connection, Path)) {
             continue;
         }
 
-        if (Path->DestCid != NULL) {
-            QUIC_CID_CLEAR_PATH(Path->DestCid);
-            Path->DestCid = NULL;
-        }
-
-        QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
-        if (NewDestCid == NULL) {
-            if (Path->IsActive || Path->ID == PathSet->NextActivePathId) {
-                QuicTraceEvent(
-                    ConnError,
-                    "[conn][%p] ERROR, %s.",
-                    Connection,
-                    "Active path has no replacement for retired CID");
-                QuicConnSilentlyAbort(Connection);
-                return FALSE;
-            }
-
-            QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
+        if (Path->IsActive) {
+            QuicTraceEvent(
+                ConnError,
+                "[conn][%p] ERROR, %s.",
                 Connection,
-                "Non-active path has no replacement for retired CID.");
-            CXPLAT_DBG_ASSERT(i != 0);
-            QuicPathRemove(Connection, i--);
-            continue;
+                "Active path has no replacement for retired CID");
+            QuicConnSilentlyAbort(Connection);
+            return;
         }
 
-        Path->DestCid = NewDestCid;
-        QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
-        Path->DestCid->CID.UsedLocally = TRUE;
-        Path->InitiatedCidUpdate = TRUE;
-        QuicPathValidate(Path);
+        QuicTraceLogConnWarning(
+            NonActivePathCidRetired,
+            Connection,
+            "Non-active path has no replacement for retired CID.");
+        CXPLAT_DBG_ASSERT(i != 0);
+        QuicPathRemove(Connection, i--);
     }
 
 #if DEBUG
@@ -264,8 +278,6 @@ QuicPathSetUpdateDestCids(
         CXPLAT_DBG_ASSERT(!DestCid->CID.Retired || DestCid->AssignedPath == NULL);
     }
 #endif
-
-    return TRUE;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -77,6 +77,14 @@ QuicPathSetActive(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
+BOOLEAN
+QuicPathUpdateDestCid(
+    _In_ QUIC_CONNECTION* Connection,
+    _Inout_ QUIC_PATH* Path
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathUpdateActive(
     _In_ QUIC_CONNECTION* Connection
@@ -88,6 +96,20 @@ QuicPathUpdateActive(
         // The active path hasn't changed, nothing to do.
         //
         return;
+    }
+
+    //
+    // A path needs a usable destination CID before it can become active.
+    //
+    {
+        uint8_t NextActivePathIndex;
+        QUIC_PATH* NextActivePath =
+            QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
+        CXPLAT_DBG_ASSERT(NextActivePath != NULL);
+        if (!QuicPathUpdateDestCid(Connection, NextActivePath)) {
+            PathSet->NextActivePathId = QuicPathGetActive(PathSet)->ID;
+            return;
+        }
     }
 
     QuicPathSetActive(Connection, PathSet->NextActivePathId);
@@ -207,10 +229,11 @@ QuicPathRemove(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
 BOOLEAN
 QuicPathUpdateDestCid(
     _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
+    _Inout_ QUIC_PATH* Path
     )
 {
     if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
@@ -263,7 +286,11 @@ QuicPathUpdateDestCids(
             Connection,
             "Non-active path has no replacement for retired CID.");
         CXPLAT_DBG_ASSERT(i != 0);
-        QuicPathRemove(Connection, i--);
+        QuicPathRemove(Connection, i);
+        //
+        // Reprocess this index because removal shifted the remaining paths down.
+        //
+        --i;
     }
 
 #if DEBUG

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -82,7 +82,29 @@ BOOLEAN
 QuicPathUpdateDestCid(
     _In_ QUIC_CONNECTION* Connection,
     _Inout_ QUIC_PATH* Path
-    );
+    )
+{
+    if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
+        return TRUE;
+    }
+
+    if (Path->DestCid != NULL) {
+        QUIC_CID_CLEAR_PATH(Path->DestCid);
+        Path->DestCid = NULL;
+    }
+
+    QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
+    if (NewDestCid == NULL) {
+        return FALSE;
+    }
+
+    Path->DestCid = NewDestCid;
+    QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
+    Path->DestCid->CID.UsedLocally = TRUE;
+    Path->InitiatedCidUpdate = TRUE;
+    QuicPathValidate(Path);
+    return TRUE;
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 void
@@ -101,15 +123,13 @@ QuicPathUpdateActive(
     //
     // A path needs a usable destination CID before it can become active.
     //
-    {
-        uint8_t NextActivePathIndex;
-        QUIC_PATH* NextActivePath =
-            QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
-        CXPLAT_DBG_ASSERT(NextActivePath != NULL);
-        if (!QuicPathUpdateDestCid(Connection, NextActivePath)) {
-            PathSet->NextActivePathId = QuicPathGetActive(PathSet)->ID;
-            return;
-        }
+    uint8_t NextActivePathIndex;
+    QUIC_PATH* NextActivePath =
+        QuicConnGetPathByID(Connection, PathSet->NextActivePathId, &NextActivePathIndex);
+    CXPLAT_DBG_ASSERT(NextActivePath != NULL);
+    if (!QuicPathUpdateDestCid(Connection, NextActivePath)) {
+        PathSet->NextActivePathId = QuicPathGetActive(PathSet)->ID;
+        return;
     }
 
     QuicPathSetActive(Connection, PathSet->NextActivePathId);
@@ -225,36 +245,6 @@ QuicPathRemove(
     PathSet->Count--;
     // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound): False positive: new index is valid.
     PathSet->Paths[PathSet->Count].InUse = FALSE;
-    return TRUE;
-}
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-static
-BOOLEAN
-QuicPathUpdateDestCid(
-    _In_ QUIC_CONNECTION* Connection,
-    _Inout_ QUIC_PATH* Path
-    )
-{
-    if (Path->DestCid != NULL && !Path->DestCid->CID.Retired) {
-        return TRUE;
-    }
-
-    if (Path->DestCid != NULL) {
-        QUIC_CID_CLEAR_PATH(Path->DestCid);
-        Path->DestCid = NULL;
-    }
-
-    QUIC_CID_LIST_ENTRY* NewDestCid = QuicConnGetUnusedDestCid(Connection);
-    if (NewDestCid == NULL) {
-        return FALSE;
-    }
-
-    Path->DestCid = NewDestCid;
-    QUIC_CID_SET_PATH(Connection, NewDestCid, Path);
-    Path->DestCid->CID.UsedLocally = TRUE;
-    Path->InitiatedCidUpdate = TRUE;
-    QuicPathValidate(Path);
     return TRUE;
 }
 

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -269,13 +269,6 @@ QuicPathRemove(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-BOOLEAN
-QuicPathUpdateDestCid(
-    _In_ QUIC_CONNECTION* Connection,
-    _In_ QUIC_PATH* Path
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathUpdateDestCids(
     _In_ QUIC_PATH_SET* PathSet,

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -270,7 +270,14 @@ QuicPathRemove(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN
-QuicPathSetUpdateDestCids(
+QuicPathUpdateDestCid(
+    _In_ QUIC_CONNECTION* Connection,
+    _In_ QUIC_PATH* Path
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+QuicPathUpdateDestCids(
     _In_ QUIC_PATH_SET* PathSet,
     _In_ QUIC_CONNECTION* Connection
     );

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -269,6 +269,13 @@ QuicPathRemove(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+BOOLEAN
+QuicPathSetUpdateDestCids(
+    _In_ QUIC_PATH_SET* PathSet,
+    _In_ QUIC_CONNECTION* Connection
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 void
 QuicPathSetAllowance(
     _In_ QUIC_CONNECTION* Connection,

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -376,24 +376,6 @@ tracepoint(CLOG_CONNECTION_C, NoReplacementCidForRetire , arg1);\
 
 
 /*----------------------------------------------------------
-// Decoder Ring for NonActivePathCidRetired
-// [conn][%p] Non-active path has no replacement for retired CID.
-// QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
-                Connection,
-                "Non-active path has no replacement for retired CID.");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-#ifndef _clog_3_ARGS_TRACE_NonActivePathCidRetired
-#define _clog_3_ARGS_TRACE_NonActivePathCidRetired(uniqueId, arg1, encoded_arg_string)\
-tracepoint(CLOG_CONNECTION_C, NonActivePathCidRetired , arg1);\
-
-#endif
-
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for IgnoreUnreachable
 // [conn][%p] Ignoring received unreachable event (inline)
 // QuicTraceLogConnWarning(

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -382,25 +382,6 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, NoReplacementCidForRetire,
 
 
 /*----------------------------------------------------------
-// Decoder Ring for NonActivePathCidRetired
-// [conn][%p] Non-active path has no replacement for retired CID.
-// QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
-                Connection,
-                "Non-active path has no replacement for retired CID.");
-// arg1 = arg1 = Connection = arg1
-----------------------------------------------------------*/
-TRACEPOINT_EVENT(CLOG_CONNECTION_C, NonActivePathCidRetired,
-    TP_ARGS(
-        const void *, arg1), 
-    TP_FIELDS(
-        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
-    )
-)
-
-
-
-/*----------------------------------------------------------
 // Decoder Ring for IgnoreUnreachable
 // [conn][%p] Ignoring received unreachable event (inline)
 // QuicTraceLogConnWarning(

--- a/src/generated/linux/path.c.clog.h
+++ b/src/generated/linux/path.c.clog.h
@@ -37,9 +37,9 @@ extern "C" {
 // Decoder Ring for NonActivePathCidRetired
 // [conn][%p] Non-active path has no replacement for retired CID.
 // QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
-                Connection,
-                "Non-active path has no replacement for retired CID.");
+            NonActivePathCidRetired,
+            Connection,
+            "Non-active path has no replacement for retired CID.");
 // arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 #ifndef _clog_3_ARGS_TRACE_NonActivePathCidRetired
@@ -199,10 +199,10 @@ tracepoint(CLOG_PATH_C, ConnPathRemoved , arg2, arg3);\
 // Decoder Ring for ConnError
 // [conn][%p] ERROR, %s.
 // QuicTraceEvent(
-                    ConnError,
-                    "[conn][%p] ERROR, %s.",
-                    Connection,
-                    "Active path has no replacement for retired CID");
+                ConnError,
+                "[conn][%p] ERROR, %s.",
+                Connection,
+                "Active path has no replacement for retired CID");
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = "Active path has no replacement for retired CID" = arg3
 ----------------------------------------------------------*/

--- a/src/generated/linux/path.c.clog.h
+++ b/src/generated/linux/path.c.clog.h
@@ -14,6 +14,10 @@
 #include "path.c.clog.h.lttng.h"
 #endif
 #include <lttng/tracepoint-event.h>
+#ifndef _clog_MACRO_QuicTraceLogConnWarning
+#define _clog_MACRO_QuicTraceLogConnWarning  1
+#define QuicTraceLogConnWarning(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
+#endif
 #ifndef _clog_MACRO_QuicTraceLogConnInfo
 #define _clog_MACRO_QuicTraceLogConnInfo  1
 #define QuicTraceLogConnInfo(a, ...) _clog_CAT(_clog_ARGN_SELECTOR(__VA_ARGS__), _clog_CAT(_,a(#a, __VA_ARGS__)))
@@ -29,6 +33,24 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/*----------------------------------------------------------
+// Decoder Ring for NonActivePathCidRetired
+// [conn][%p] Non-active path has no replacement for retired CID.
+// QuicTraceLogConnWarning(
+                NonActivePathCidRetired,
+                Connection,
+                "Non-active path has no replacement for retired CID.");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_NonActivePathCidRetired
+#define _clog_3_ARGS_TRACE_NonActivePathCidRetired(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_PATH_C, NonActivePathCidRetired , arg1);\
+
+#endif
+
+
+
+
 /*----------------------------------------------------------
 // Decoder Ring for PathActiveFallback
 // [conn][%p] Path[%u] removed; falling back to Path[%u]
@@ -167,6 +189,26 @@ tracepoint(CLOG_PATH_C, ConnRemoteAddrAdded , arg2, arg3_len, arg3);\
 #ifndef _clog_4_ARGS_TRACE_ConnPathRemoved
 #define _clog_4_ARGS_TRACE_ConnPathRemoved(uniqueId, encoded_arg_string, arg2, arg3)\
 tracepoint(CLOG_PATH_C, ConnPathRemoved , arg2, arg3);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for ConnError
+// [conn][%p] ERROR, %s.
+// QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Active path has no replacement for retired CID");
+// arg2 = arg2 = Connection = arg2
+// arg3 = arg3 = "Active path has no replacement for retired CID" = arg3
+----------------------------------------------------------*/
+#ifndef _clog_4_ARGS_TRACE_ConnError
+#define _clog_4_ARGS_TRACE_ConnError(uniqueId, encoded_arg_string, arg2, arg3)\
+tracepoint(CLOG_PATH_C, ConnError , arg2, arg3);\
 
 #endif
 

--- a/src/generated/linux/path.c.clog.h.lttng.h
+++ b/src/generated/linux/path.c.clog.h.lttng.h
@@ -5,9 +5,9 @@
 // Decoder Ring for NonActivePathCidRetired
 // [conn][%p] Non-active path has no replacement for retired CID.
 // QuicTraceLogConnWarning(
-                NonActivePathCidRetired,
-                Connection,
-                "Non-active path has no replacement for retired CID.");
+            NonActivePathCidRetired,
+            Connection,
+            "Non-active path has no replacement for retired CID.");
 // arg1 = arg1 = Connection = arg1
 ----------------------------------------------------------*/
 TRACEPOINT_EVENT(CLOG_PATH_C, NonActivePathCidRetired,
@@ -191,10 +191,10 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathRemoved,
 // Decoder Ring for ConnError
 // [conn][%p] ERROR, %s.
 // QuicTraceEvent(
-                    ConnError,
-                    "[conn][%p] ERROR, %s.",
-                    Connection,
-                    "Active path has no replacement for retired CID");
+                ConnError,
+                "[conn][%p] ERROR, %s.",
+                Connection,
+                "Active path has no replacement for retired CID");
 // arg2 = arg2 = Connection = arg2
 // arg3 = arg3 = "Active path has no replacement for retired CID" = arg3
 ----------------------------------------------------------*/

--- a/src/generated/linux/path.c.clog.h.lttng.h
+++ b/src/generated/linux/path.c.clog.h.lttng.h
@@ -2,6 +2,25 @@
 
 
 /*----------------------------------------------------------
+// Decoder Ring for NonActivePathCidRetired
+// [conn][%p] Non-active path has no replacement for retired CID.
+// QuicTraceLogConnWarning(
+                NonActivePathCidRetired,
+                Connection,
+                "Non-active path has no replacement for retired CID.");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PATH_C, NonActivePathCidRetired,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for PathActiveFallback
 // [conn][%p] Path[%u] removed; falling back to Path[%u]
 // QuicTraceLogConnInfo(
@@ -163,6 +182,29 @@ TRACEPOINT_EVENT(CLOG_PATH_C, ConnPathRemoved,
     TP_FIELDS(
         ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
         ctf_integer(unsigned int, arg3, arg3)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for ConnError
+// [conn][%p] ERROR, %s.
+// QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Active path has no replacement for retired CID");
+// arg2 = arg2 = Connection = arg2
+// arg3 = arg3 = "Active path has no replacement for retired CID" = arg3
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_PATH_C, ConnError,
+    TP_ARGS(
+        const void *, arg2,
+        const char *, arg3), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg2, (uint64_t)arg2)
+        ctf_string(arg3, arg3)
     )
 )
 


### PR DESCRIPTION
## Description

Defers destination CID replacement and path removal until receive processing no longer holds path pointers. Pending migration paths receive CID priority; migration is canceled when no CID is available, then remaining paths are updated or removed safely. Preserves silent abort behavior when an in-use CID was retired before frame processing fails.

## Testing

Debug x64 Schannel build. Focused migration, rebinding, and path-validation tests (308 cases).

## Documentation

No documentation impact.