### PR TITLE
[CP] Added Transport parameters extension validation in openssl (#6225)

### DIFF
--- a/src/generated/linux/tls_openssl.c.clog.h
+++ b/src/generated/linux/tls_openssl.c.clog.h
@@ -154,6 +154,24 @@ tracepoint(CLOG_TLS_OPENSSL_C, OpenSslNoMatchingAlpn , arg1);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for OpenSslMissingTransportParameters
+// [conn][%p] No transport parameters received
+// QuicTraceLogConnError(
+                        OpenSslMissingTransportParameters,
+                        TlsContext->Connection,
+                        "No transport parameters received");
+// arg1 = arg1 = TlsContext->Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_OpenSslMissingTransportParameters
+#define _clog_3_ARGS_TRACE_OpenSslMissingTransportParameters(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_TLS_OPENSSL_C, OpenSslMissingTransportParameters , arg1);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for OpenSslHandshakeDataStart
 // [conn][%p] Writing Handshake data starts at %u
 // QuicTraceLogConnInfo(

--- a/src/generated/linux/tls_openssl.c.clog.h.lttng.h
+++ b/src/generated/linux/tls_openssl.c.clog.h.lttng.h
@@ -140,6 +140,25 @@ TRACEPOINT_EVENT(CLOG_TLS_OPENSSL_C, OpenSslNoMatchingAlpn,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for OpenSslMissingTransportParameters
+// [conn][%p] No transport parameters received
+// QuicTraceLogConnError(
+                        OpenSslMissingTransportParameters,
+                        TlsContext->Connection,
+                        "No transport parameters received");
+// arg1 = arg1 = TlsContext->Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_TLS_OPENSSL_C, OpenSslMissingTransportParameters,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for OpenSslHandshakeDataStart
 // [conn][%p] Writing Handshake data starts at %u
 // QuicTraceLogConnInfo(

--- a/src/platform/tls_openssl.c
+++ b/src/platform/tls_openssl.c
@@ -747,6 +747,15 @@ static int QuicTlsGotTp(SSL *S, const unsigned char *Params,
 
     UNREFERENCED_PARAMETER(Arg);
 
+    if (ParamsLen == 0 || Params == NULL) {
+        return 0;
+    }
+
+    if (AData->PeerTp != NULL) {
+        return AData->PeerTpLen == ParamsLen &&
+            memcmp(AData->PeerTp, Params, ParamsLen) == 0;
+    }
+
     AData->PeerTp = CXPLAT_ALLOC_NONPAGED(ParamsLen,
                                            QUIC_POOL_TLS_TRANSPARAMS);
     if (AData->PeerTp == NULL) {
@@ -3314,6 +3323,20 @@ more_handshake:
                         OpenSslNoMatchingAlpn,
                         TlsContext->Connection,
                         "Failed to find a matching ALPN");
+                    TlsContext->ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
+                    goto Exit;
+                }
+
+                //
+                // By this point, OpenSSL should have called QuicTlsGotTp, which stores
+                // a non-NULL PeerTp and sets PeerTPReceived. Fail the handshake if the
+                // required transport parameters were not processed.
+                //
+                if (!TlsContext->PeerTPReceived) {
+                    QuicTraceLogConnError(
+                        OpenSslMissingTransportParameters,
+                        TlsContext->Connection,
+                        "No transport parameters received");
                     TlsContext->ResultFlags |= CXPLAT_TLS_RESULT_ERROR;
                     goto Exit;
                 }


### PR DESCRIPTION
## Description
Validate peer transport parameters during client handshake completion in the OpenSSL QUIC TLS path before accepting the connection. This preserves the required RFC behavior for QUIC transport parameter handling and ensures the peer transport parameter callback is only invoked after successful validation.

https://microsoft.visualstudio.com/OS/_workitems/edit/62258561/

## Testing

## Documentation
