### PR TITLE
Validate stream receive buffer size

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -426,6 +426,13 @@ QuicSettingApply(
         const QUIC_SETTINGS_INTERNAL* Source
     )
 {
+    if (Source->IsSet.StreamRecvBufferDefault &&
+        (!Destination->IsSet.StreamRecvBufferDefault || OverWrite) &&
+        (!IS_POWER_OF_TWO(Source->StreamRecvBufferDefault) ||
+         Source->StreamRecvBufferDefault < QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE)) {
+        return FALSE;
+    }
+
     if (Source->IsSet.SendBufferingEnabled && (!Destination->IsSet.SendBufferingEnabled || OverWrite)) {
         Destination->SendBufferingEnabled = Source->SendBufferingEnabled;
         Destination->IsSet.SendBufferingEnabled = TRUE;
@@ -577,9 +584,6 @@ QuicSettingApply(
         Destination->IsSet.StreamRecvWindowUnidiDefault = TRUE;
     }
     if (Source->IsSet.StreamRecvBufferDefault && (!Destination->IsSet.StreamRecvBufferDefault || OverWrite)) {
-        if (Source->StreamRecvBufferDefault < QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE) {
-            return FALSE;
-        }
         Destination->StreamRecvBufferDefault = Source->StreamRecvBufferDefault;
         Destination->IsSet.StreamRecvBufferDefault = TRUE;
     }

--- a/src/core/unittest/SettingsTest.cpp
+++ b/src/core/unittest/SettingsTest.cpp
@@ -322,6 +322,21 @@ TEST(SettingsTest, StreamRecvWindowDefaultGetsOverridenByIndividualLimits)
     ASSERT_EQ(Destination.StreamRecvWindowUnidiDefault, Source.StreamRecvWindowUnidiDefault);
 }
 
+TEST(SettingsTest, StreamRecvBufferDefaultRejectsInvalidSizesWithoutChanges)
+{
+    QUIC_SETTINGS_INTERNAL Source;
+    QUIC_SETTINGS_INTERNAL Destination;
+    CxPlatZeroMemory(&Source, sizeof(Source));
+    CxPlatZeroMemory(&Destination, sizeof(Destination));
+    QuicSettingsSetDefault(&Destination);
+
+    Source.IsSet.StreamRecvBufferDefault = 1;
+    Source.StreamRecvBufferDefault = QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE + 1;
+
+    ASSERT_FALSE(QuicSettingApply(&Destination, TRUE, TRUE, &Source));
+    ASSERT_EQ(Destination.StreamRecvBufferDefault, QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE);
+}
+
 // TEST(SettingsTest, TestAllVersionSettingsFieldsGet)
 // {
 //     QUIC_VERSION_SETTINGS Settings;

--- a/src/test/lib/ApiTest.cpp
+++ b/src/test/lib/ApiTest.cpp
@@ -2066,8 +2066,12 @@ void SettingApplyTests(HQUIC Handle, uint32_t Param, bool AllowMtuEcnChanges = t
     }
 
     {
-        struct TestSpec Spec[] = {{0, QUIC_STATUS_INVALID_PARAMETER},
-                                  {QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE,  QUIC_STATUS_SUCCESS}};
+        struct TestSpec Spec[] = {
+            {0, QUIC_STATUS_INVALID_PARAMETER},
+            {QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE + 1, QUIC_STATUS_INVALID_PARAMETER},
+            {QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE, QUIC_STATUS_SUCCESS},
+            {2 * QUIC_DEFAULT_STREAM_RECV_BUFFER_SIZE, QUIC_STATUS_SUCCESS}
+        };
         QUIC_SETTINGS Settings{0};
         Settings.IsSet.StreamRecvBufferDefault = TRUE;
         for (auto &Data: Spec) {


### PR DESCRIPTION
## Description

Reject `StreamRecvBufferDefault` values that are not powers of two before they reach receive-buffer initialization. This aligns public settings application with persisted-settings validation and prevents the assertion exposed by the randomized settings coverage in #6204.

Failure: https://github.com/microsoft/msquic/actions/runs/33798384900/job/100793494460?pr=6204

## Testing

- `msquiccoretest.exe --gtest_filter='SettingsTest.StreamRecv*'`
- `msquictest.exe --gtest_filter='ParameterValidation.ValidateConfigurationParam:ParameterValidation.ValidateConnectionParam'`

Added core coverage that verifies invalid input leaves destination settings unchanged, plus public configuration and connection API coverage for invalid and valid buffer sizes.

## Documentation

No documentation impact.