### PR TITLE
Track CID path assignments by stable ID

### DIFF
--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -132,30 +132,32 @@ typedef struct QUIC_CID_LIST_ENTRY {
     CXPLAT_LIST_ENTRY Link;
     uint8_t ResetToken[QUIC_STATELESS_RESET_TOKEN_LENGTH];
 #ifdef DEBUG
-    QUIC_PATH* AssignedPath;
+    uint16_t AssignedPathId;
 #endif
     QUIC_CID CID;
 
 } QUIC_CID_LIST_ENTRY;
 
 #if DEBUG
-#define QUIC_CID_SET_PATH(Conn, Cid, Path)                                      \
-    do {                                                                        \
-        CXPLAT_DBG_ASSERT(!Cid->CID.Retired);                                   \
-        CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL); Cid->AssignedPath = Path; \
-        for (int PathIdx = Conn->Paths.Count - 1; PathIdx > 0; PathIdx--) {     \
-            if (Path != &Conn->Paths.Paths[PathIdx])                            \
-                CXPLAT_DBG_ASSERT(Conn->Paths.Paths[PathIdx].DestCid != Cid);   \
-            }                                                                   \
-        }                                                                       \
+#define QUIC_CID_SET_PATH(Conn, Cid, Path)                                          \
+    do {                                                                            \
+        CXPLAT_DBG_ASSERT(!(Cid)->CID.Retired);                                      \
+        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT16_MAX);                      \
+        (Cid)->AssignedPathId = (Path)->ID;                                          \
+        for (int PathIdx = (Conn)->Paths.Count - 1; PathIdx >= 0; PathIdx--) {       \
+            if ((Path)->ID != (Conn)->Paths.Paths[PathIdx].ID) {                     \
+                CXPLAT_DBG_ASSERT((Conn)->Paths.Paths[PathIdx].DestCid != (Cid));    \
+            }                                                                       \
+        }                                                                           \
+    }                                                                               \
     while (0)
-#define QUIC_CID_CLEAR_PATH(Cid) Cid->AssignedPath = NULL
-#define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                       \
-    do {                                                                        \
-        CXPLAT_DBG_ASSERT(Cid->AssignedPath == NULL);                           \
-        for (int PathIdx = Conn->Paths.Count - 1; PathIdx > 0; PathIdx--) {     \
-            CXPLAT_DBG_ASSERT(Conn->Paths.Paths[PathIdx].DestCid != Cid);       \
-        }                                                                       \
+#define QUIC_CID_CLEAR_PATH(Cid) (Cid)->AssignedPathId = UINT16_MAX
+#define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                        \
+    do {                                                                         \
+        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT16_MAX);                  \
+        for (int PathIdx = (Conn)->Paths.Count - 1; PathIdx >= 0; PathIdx--) {   \
+            CXPLAT_DBG_ASSERT((Conn)->Paths.Paths[PathIdx].DestCid != (Cid));    \
+        }                                                                        \
     } while (0)
 #else
 #define QUIC_CID_SET_PATH(Conn, Cid, Path) UNREFERENCED_PARAMETER(Cid)

--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -132,6 +132,9 @@ typedef struct QUIC_CID_LIST_ENTRY {
     CXPLAT_LIST_ENTRY Link;
     uint8_t ResetToken[QUIC_STATELESS_RESET_TOKEN_LENGTH];
 #ifdef DEBUG
+    //
+    // ID of the path this CID was first assigned to, or UINT32_MAX if unused.
+    //
     uint32_t AssignedPathId;
 #endif
     QUIC_CID CID;
@@ -151,17 +154,14 @@ typedef struct QUIC_CID_LIST_ENTRY {
         }                                                                           \
     }                                                                               \
     while (0)
-#define QUIC_CID_CLEAR_PATH(Cid) (Cid)->AssignedPathId = UINT32_MAX
 #define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                        \
     do {                                                                         \
-        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT32_MAX);                  \
         for (int PathIdx = (Conn)->Paths.Count - 1; PathIdx >= 0; PathIdx--) {   \
             CXPLAT_DBG_ASSERT((Conn)->Paths.Paths[PathIdx].DestCid != (Cid));    \
         }                                                                        \
     } while (0)
 #else
 #define QUIC_CID_SET_PATH(Conn, Cid, Path) UNREFERENCED_PARAMETER(Cid)
-#define QUIC_CID_CLEAR_PATH(Cid) UNREFERENCED_PARAMETER(Cid)
 #define QUIC_CID_VALIDATE_NULL(Conn, Cid) UNREFERENCED_PARAMETER(Cid)
 #endif
 
@@ -248,7 +248,9 @@ QuicCidNewRandomDestination(
             QUIC_POOL_CIDLIST);
 
     if (Entry != NULL) {
-        QUIC_CID_CLEAR_PATH(Entry);
+#ifdef DEBUG
+        Entry->AssignedPathId = UINT32_MAX;
+#endif
         CxPlatZeroMemory(&Entry->CID, sizeof(Entry->CID));
         Entry->CID.Length = QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH;
         CxPlatRandom(QUIC_MIN_INITIAL_CONNECTION_ID_LENGTH, Entry->CID.Data);
@@ -277,7 +279,9 @@ QuicCidNewDestination(
             QUIC_POOL_CIDLIST);
 
     if (Entry != NULL) {
-        QUIC_CID_CLEAR_PATH(Entry);
+#ifdef DEBUG
+        Entry->AssignedPathId = UINT32_MAX;
+#endif
         CxPlatZeroMemory(&Entry->CID, sizeof(Entry->CID));
         Entry->CID.Length = Length;
         if (Length != 0) {

--- a/src/core/cid.h
+++ b/src/core/cid.h
@@ -132,7 +132,7 @@ typedef struct QUIC_CID_LIST_ENTRY {
     CXPLAT_LIST_ENTRY Link;
     uint8_t ResetToken[QUIC_STATELESS_RESET_TOKEN_LENGTH];
 #ifdef DEBUG
-    uint16_t AssignedPathId;
+    uint32_t AssignedPathId;
 #endif
     QUIC_CID CID;
 
@@ -142,7 +142,7 @@ typedef struct QUIC_CID_LIST_ENTRY {
 #define QUIC_CID_SET_PATH(Conn, Cid, Path)                                          \
     do {                                                                            \
         CXPLAT_DBG_ASSERT(!(Cid)->CID.Retired);                                      \
-        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT16_MAX);                      \
+        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT32_MAX);                      \
         (Cid)->AssignedPathId = (Path)->ID;                                          \
         for (int PathIdx = (Conn)->Paths.Count - 1; PathIdx >= 0; PathIdx--) {       \
             if ((Path)->ID != (Conn)->Paths.Paths[PathIdx].ID) {                     \
@@ -151,10 +151,10 @@ typedef struct QUIC_CID_LIST_ENTRY {
         }                                                                           \
     }                                                                               \
     while (0)
-#define QUIC_CID_CLEAR_PATH(Cid) (Cid)->AssignedPathId = UINT16_MAX
+#define QUIC_CID_CLEAR_PATH(Cid) (Cid)->AssignedPathId = UINT32_MAX
 #define QUIC_CID_VALIDATE_NULL(Conn, Cid)                                        \
     do {                                                                         \
-        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT16_MAX);                  \
+        CXPLAT_DBG_ASSERT((Cid)->AssignedPathId == UINT32_MAX);                  \
         for (int PathIdx = (Conn)->Paths.Count - 1; PathIdx >= 0; PathIdx--) {   \
             CXPLAT_DBG_ASSERT((Conn)->Paths.Paths[PathIdx].DestCid != (Cid));    \
         }                                                                        \

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1103,7 +1103,6 @@ QuicConnRetireCurrentDestCid(
 
     CXPLAT_DBG_ASSERT(Path->DestCid != NewDestCid);
     QUIC_CID_LIST_ENTRY* OldDestCid = Path->DestCid;
-    QUIC_CID_CLEAR_PATH(Path->DestCid);
     QuicConnRetireCid(Connection, OldDestCid);
     Path->DestCid = NewDestCid;
     QUIC_CID_SET_PATH(Connection, Path->DestCid, Path);

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -294,7 +294,7 @@ QuicPathUpdateDestCids(
                 Link);
         CXPLAT_DBG_ASSERT(
             !DestCid->CID.Retired ||
-            DestCid->AssignedPathId == UINT16_MAX);
+            DestCid->AssignedPathId == UINT32_MAX);
     }
 #endif
 }

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -94,7 +94,6 @@ QuicPathUpdateDestCid(
     }
 
     if (Path->DestCid != NULL) {
-        QUIC_CID_CLEAR_PATH(Path->DestCid);
         Path->DestCid = NULL;
     }
 
@@ -229,12 +228,6 @@ QuicPathRemove(
         Index = FallbackIndex;
     }
 
-#if DEBUG
-    if (PathSet->Paths[Index].DestCid) {
-        QUIC_CID_CLEAR_PATH(PathSet->Paths[Index].DestCid);
-    }
-#endif
-
     if (Index + 1 < PathSet->Count) {
         CxPlatMoveMemory(
             PathSet->Paths + Index,
@@ -292,9 +285,9 @@ QuicPathUpdateDestCids(
                 Entry,
                 QUIC_CID_LIST_ENTRY,
                 Link);
-        CXPLAT_DBG_ASSERT(
-            !DestCid->CID.Retired ||
-            DestCid->AssignedPathId == UINT32_MAX);
+        if (DestCid->CID.Retired) {
+            QUIC_CID_VALIDATE_NULL(Connection, DestCid);
+        }
     }
 #endif
 }

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -292,7 +292,9 @@ QuicPathUpdateDestCids(
                 Entry,
                 QUIC_CID_LIST_ENTRY,
                 Link);
-        CXPLAT_DBG_ASSERT(!DestCid->CID.Retired || DestCid->AssignedPath == NULL);
+        CXPLAT_DBG_ASSERT(
+            !DestCid->CID.Retired ||
+            DestCid->AssignedPathId == UINT16_MAX);
     }
 #endif
 }

--- a/src/core/path.h
+++ b/src/core/path.h
@@ -192,7 +192,7 @@ typedef struct QUIC_PATH {
     CXPLAT_DBG_ASSERT( \
         (Path)->DestCid == NULL || \
         (Path)->DestCid->CID.Length == 0 || \
-        ((Path)->DestCid->AssignedPath == (Path) && \
+        ((Path)->DestCid->AssignedPathId == (Path)->ID && \
          (Path)->DestCid->CID.UsedLocally))
 #else
 #define QuicPathValidate(Path) UNREFERENCED_PARAMETER(Path)


### PR DESCRIPTION
## Description

Replace debug-only destination CID ownership pointers with stable path IDs. Record the path ID when a CID is first assigned and retain it after detachment so dumps preserve which path used the CID, while live validation continues to ensure retired CIDs are no longer referenced by any path.

## Testing

- Debug x64 Schannel build
- Focused IPv4 and IPv6 path tests covering local path changes, rebinding, and path-validation timeout behavior

## Documentation

No documentation impact. This changes debug-only tracking and validation.